### PR TITLE
Fixed missing initialization of StaticApplicationContext in SpringFactory

### DIFF
--- a/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
+++ b/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
@@ -17,6 +17,7 @@ public class SpringFactory implements ObjectFactory {
 
     public SpringFactory() {
         stepDefContext = new StaticApplicationContext();
+        stepDefContext.refresh();
         appContext = new ClassPathXmlApplicationContext(new String[]{"context.xml"}, stepDefContext);
     }
 


### PR DESCRIPTION
StaticApplicationContext would throw an Exception due to a missing initialization step in SpringFactory's constructor. Calling stepDefContext.refresh() fixes the problem.
