### PR TITLE
Fix for issues with Maven poms

### DIFF
--- a/clojure/pom.xml
+++ b/clojure/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>cucumber</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.4.3-SNAPSHOT</version>
     </parent>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>cucumber</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.4.3-SNAPSHOT</version>
     </parent>

--- a/cucumber-ant/pom.xml
+++ b/cucumber-ant/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>cucumber</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.4.3-SNAPSHOT</version>
     </parent>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>cucumber</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.4.3-SNAPSHOT</version>
     </parent>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>cucumber</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.4.3-SNAPSHOT</version>
     </parent>

--- a/ioke/pom.xml
+++ b/ioke/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>cucumber</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.4.3-SNAPSHOT</version>
     </parent>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>cucumber</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.4.3-SNAPSHOT</version>
     </parent>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
   <parent>
     <groupId>cucumber</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>cucumber-jvm</artifactId>
     <relativePath>../pom.xml</relativePath>
     <version>0.4.3-SNAPSHOT</version>
   </parent>

--- a/picocontainer/pom.xml
+++ b/picocontainer/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>cucumber</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.4.3-SNAPSHOT</version>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
                 <artifactId>cglib-nodep</artifactId>
                 <version>2.1_3</version>
             </dependency>
+            <dependency>
+                <groupId>cucumber</groupId>
+                <artifactId>core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>

--- a/rhino/pom.xml
+++ b/rhino/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>cucumber</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.4.3-SNAPSHOT</version>
     </parent>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>cucumber</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.4.3-SNAPSHOT</version>
     </parent>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>cucumber</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
         <version>0.4.3-SNAPSHOT</version>
     </parent>


### PR DESCRIPTION
Following commit fb0fdd5be750e4784bdc, the parent pom is now called cucumber-jvm.  This pull request updates the child poms to reflect this change.  It also adds the core jar to dependencies, so that the missing version tag in the children doesn’t cause errors with maven3.

Regards,
Sébastien.
