### PR TITLE
Fix for issue #17: Cucumber replaces %20 when resolving jar paths on Windows

### DIFF
--- a/core/src/main/java/cucumber/resources/Decoder.java
+++ b/core/src/main/java/cucumber/resources/Decoder.java
@@ -1,0 +1,10 @@
+package cucumber.resources;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+public class Decoder {
+    public String decode(String string) throws UnsupportedEncodingException {
+        return URLDecoder.decode(string, "UTF-8");
+    }
+}

--- a/core/src/main/java/cucumber/resources/FilePathExtractor.java
+++ b/core/src/main/java/cucumber/resources/FilePathExtractor.java
@@ -1,8 +1,23 @@
 package cucumber.resources;
 
+import cucumber.runtime.CucumberException;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
 public class FilePathExtractor {
 
-    public static String filePath(String jarUrl) {
+    private Decoder decoder;
+
+    public FilePathExtractor() {
+        this(new Decoder());
+    }
+
+    public FilePathExtractor(Decoder decoder) {
+        this.decoder = decoder;
+    }
+
+    public String filePath(String jarUrl) {
         String pathWithProtocol = jarUrl.substring(0, jarUrl.indexOf("!/"));
         String[] segments = pathWithProtocol.split(":");
         // WINDOWS: jar:file:/C:/Users/ahellesoy/scm/cucumber-jvm/java/target/java-1.0.0-SNAPSHOT.jar
@@ -11,7 +26,11 @@ public class FilePathExtractor {
         return resolveEncodedBlanksInPath(pathToJar);
     }
 
-    public static String resolveEncodedBlanksInPath(String path) {
-        return path.replaceAll("%20", " ");
+    public String resolveEncodedBlanksInPath(String path) {
+        try {
+            return decoder.decode(path);
+        } catch (UnsupportedEncodingException e) {
+            throw new CucumberException("UTF-8 is not supported on your system. This should not be happening.", e);
+        }
     }
 }

--- a/core/src/main/java/cucumber/resources/Resources.java
+++ b/core/src/main/java/cucumber/resources/Resources.java
@@ -129,7 +129,7 @@ public class Resources {
 
     private static void scanJar(URL jarDir, PathWithLines pwl, String suffix, Consumer consumer) {
         String jarUrl = jarDir.toExternalForm();
-        String path = filePath(jarUrl);
+        String path = new FilePathExtractor().filePath(jarUrl);
         try {
             ZipFile jarFile = new ZipFile(path);
             Enumeration<? extends ZipEntry> entries = jarFile.entries();
@@ -154,7 +154,7 @@ public class Resources {
 
     private static String getPath(URL url) {
         String path = url.getPath();
-        return resolveEncodedBlanksInPath(path);
+        return new FilePathExtractor().resolveEncodedBlanksInPath(path);
     }
 
     private static void scanFilesystem(File rootDir, PathWithLines pathWithLines, String suffix, Consumer consumer) {

--- a/core/src/test/java/cucumber/runtime/FilePathExtractorTest.java
+++ b/core/src/test/java/cucumber/runtime/FilePathExtractorTest.java
@@ -1,18 +1,35 @@
 package cucumber.runtime;
 
+import cucumber.resources.Decoder;
 import cucumber.resources.FilePathExtractor;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.UnsupportedEncodingException;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.junit.matchers.JUnitMatchers.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+/**
+ * Tests for Issue #17
+ */
 public class FilePathExtractorTest {
+    public static final String anyString = "";
 
-    /** Test for Issue #17*/
     @Test
     public void replacesUrlEncodedBlanksWithActualBlanks() {
-        String pathToJar = FilePathExtractor.filePath("jar:file:/C:/path%20with%20blanks/actual.jar!/content.file");
+        String pathToJar = new FilePathExtractor().filePath("jar:file:/C:/path%20with%20blanks/actual.jar!/content.file");
         assertThat(pathToJar, not(containsString("%20")));
+    }
+
+    @Test(expected = CucumberException.class)
+    public void forwardsExceptionsAsCucumberExceptions() throws Exception {
+        Decoder decoder = mock(Decoder.class);
+        when(decoder.decode(anyString())).thenThrow(new UnsupportedEncodingException());
+        new FilePathExtractor(decoder).resolveEncodedBlanksInPath(anyString);
     }
 }


### PR DESCRIPTION
Fixed it (again), taking @aslakhellesoy's advice regarding UrlDecoder.

Once more, this is a very simple fix.
