### PR TITLE
JRuby: Fix for optional arguments in step definitions.

### DIFF
--- a/jruby/src/main/java/cucumber/runtime/jruby/JRubyStepDefinition.java
+++ b/jruby/src/main/java/cucumber/runtime/jruby/JRubyStepDefinition.java
@@ -53,7 +53,11 @@ public class JRubyStepDefinition implements StepDefinition {
     public void execute(Object[] args) throws Throwable {
         IRubyObject[] jrybyArgs = new IRubyObject[args.length];
         for (int i = 0; i < args.length; i++) {
-            jrybyArgs[i] = stepdef.getRuntime().newString((String) args[i]);
+            if (args[i] != null) {
+                jrybyArgs[i] = stepdef.getRuntime().newString((String) args[i]);
+            } else {
+                jrybyArgs[i] = null;
+            }
         }
         stepdef.callMethod("execute", jrybyArgs);
     }

--- a/jruby/src/test/resources/cucumber/runtime/jruby/test/stepdefs.rb
+++ b/jruby/src/test/resources/cucumber/runtime/jruby/test/stepdefs.rb
@@ -4,7 +4,24 @@ Given /I have (\d+) "(.?*)" in my belly/ do |n, what|
 end
 
 Then /^I am "([^"]*)"$/ do |mood|
-  if ("happy" != mood || @n < 4) 
+  if ("happy" != mood || @n < 4)
     raise("Not happy, only #{@n} #{@what}")
   end
 end
+
+Given /^Something( with an optional argument)?$/ do |argument|
+  @argument = argument
+end
+
+Then /^the argument should be null$/ do
+    if (@argument != nil)
+        raise("Argument should be nil")
+    end
+end
+
+Then /^the argument should not be null$/ do
+    if (@argument == nil)
+        raise("Argument should not be nil")
+    end
+end
+

--- a/jruby/src/test/resources/cukes.feature
+++ b/jruby/src/test/resources/cukes.feature
@@ -2,3 +2,12 @@ Feature: Cukes
   Scenario: in the belly
     Given I have 4 "cukes" in my belly
     Then I am "happy"
+
+  Scenario: Optional arguments, argument present
+    Given Something with an optional argument
+     Then the argument should not be null
+
+  Scenario: Optional arguments, argument not present
+    Given Something
+     Then the argument should be null
+


### PR DESCRIPTION
Hey there guys,

I found something in cucumber-jruby which works in cuke4duke (and normal ruby cucumber), but not currently in cucumber-jvm. Now I love working with cucumber on the JVM (i think you guys have an excellent project here), so here is my attempted explanation and fix of the problem in question:

When you have a regex with an optional argument, cucumber-jruby currently explodes. So for example, in normal cucumber (or through cuke4duke), the following step def:

   Given /^something( with an optional value "(.*)")? do |arg1, arg2|
   end

This step def would be triggered by both of the following gherkin texts:

```
 Given something
 Given something with an optional value "some_value"
```

In the first example, both args will be null, in the second form, they have values. Then in ruby depending on whether the value is "truthey" or not you proceed from there, using something like @value = arg2 || "some default value".

This pull request is my attempt at making this work, to improve compatibility with normal cucumber and/or cuke4duke.
## Here is the commit message:

An optional regex argument should be handled correctly, for example:

```
Given ^/Something( with an optional argument)?$/ do |arg|
end
```

If the regex can match the first argument, the value should be passed
through. If it cannot, the regex match is still succesfull, and the arg
needs to have a placeholder value - nil in JRuby's case.

Previously, the .newString() call in JRubyStepDefinition would explode
in the execute() method where the arguments are converted from the
Object [] array to IRubyObjects.

A simple check-for-null seems to fix the problem.
