### PR TITLE
JRuby: Fix require not working because of lack of standard libraries.

### DIFF
--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>org.jruby</groupId>
-            <artifactId>jruby</artifactId>
+            <artifactId>jruby-complete</artifactId>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>

--- a/jruby/src/test/resources/cucumber/runtime/jruby/test/stepdefs.rb
+++ b/jruby/src/test/resources/cucumber/runtime/jruby/test/stepdefs.rb
@@ -1,12 +1,14 @@
+require 'test/unit'
+include Test::Unit::Assertions
+
 Given /I have (\d+) "(.?*)" in my belly/ do |n, what|
   @n = n.to_i
   @what = what
 end
 
 Then /^I am "([^"]*)"$/ do |mood|
-  if ("happy" != mood || @n < 4)
-    raise("Not happy, only #{@n} #{@what}")
-  end
+  assert_equal("happy", mood, "Should be happy, only #{mood}!")
+  assert_equal(4, @n, "Need 4 cukes, only #{@n}!");
 end
 
 Given /^Something( with an optional argument)?$/ do |argument|
@@ -14,14 +16,10 @@ Given /^Something( with an optional argument)?$/ do |argument|
 end
 
 Then /^the argument should be nil/ do
-  if (!@argument.nil?)
-    raise("Argument should be nil")
-  end
+  assert_equal(nil, @argument, "Argument should be nil")
 end
 
 Then /^the argument should not be nil/ do
-  if (@argument.nil?)
-    raise("Argument should not be nil")
-  end
+  assert_not_nil(@argument, "Argument should not be nil")
 end
 

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
             </dependency>
             <dependency>
                 <groupId>org.jruby</groupId>
-                <artifactId>jruby</artifactId>
+                <artifactId>jruby-complete</artifactId>
                 <version>1.6.3</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
This pull request fixes Issue #3.

The org.jruby.jruby maven dependency only gives you a barebones JRuby
interpreter - much of the ruby "standard library" is not available
within the package. jruby-complete gives you the same interpreter but
adds the "standard library" which is packaged inside the JAR.

Obviously this comes at a price (current jruby-complete is about 10mb)
but to do anything proper wrt to Jruby steps I would think it is
necessary to at least have the standard lib.

Could perhaps be worthwhile investigating whether to cut it down a bit,
but for now this fixes the "requires" problem in Issue #3.
