### PR TITLE
cucumber-jruby support for Before and After hooks

### DIFF
--- a/jruby/src/main/java/cucumber/runtime/jruby/JRubyBackend.java
+++ b/jruby/src/main/java/cucumber/runtime/jruby/JRubyBackend.java
@@ -48,14 +48,6 @@ public class JRubyBackend implements Backend {
     public void registerStepdef(RubyObject stepdef) {
         world.addStepDefinition(new JRubyStepDefinition(stepdef));
     }
-    
-    public void addBeforeHook(RubyObject body) {
-    	world.addBeforeHook(new JRubyHookDefinition(new String[0],body));
-    }
-    
-    public void addAfterHook(RubyObject body) {
-    	world.addAfterHook(new JRubyHookDefinition(new String[0],body));
-    }
 
     public void addBeforeHook(RubyObject body) {
         world.addBeforeHook(new JRubyHookDefinition(new String[0], body));


### PR DESCRIPTION
Added initial support for "Before" and "After" hooks to cucumber-jruby.
Functionality should be on par with cucumber-clojure.

88e91d40 has incorrect indentation in "JRubyHookDefinition.java" this is corrected in 
697c16f0    
