### PR TITLE
HTML Formatter generates incorrect Javascript

### DIFF
--- a/core/src/main/java/cucumber/formatter/HTMLFormatter.java
+++ b/core/src/main/java/cucumber/formatter/HTMLFormatter.java
@@ -47,7 +47,7 @@ public class HTMLFormatter implements Formatter, Reporter {
     public void uri(String uri) {
         if (firstFeature) {
             out.append("$(document).ready(function() {").append("var ")
-                    .append(JS_FORMATTER_VAR).append(" = new CucumberHTML.DOMFormatter($('.cucumber-report'));");
+                    .append(JS_FORMATTER_VAR).append(" = new Cucumber.DOMFormatter($('.cucumber-report'));");
             firstFeature = false;
         }
         writeToJsReport("uri", "'" + uri + "'");


### PR DESCRIPTION
The HTML Formatter generated a javascript file
with a instantiation of the class 'CucumberHTML'.
The actual name of the class is 'Cucumber'
