### PR TITLE
added constructor with additional GroovyShell parameter

### DIFF
--- a/groovy/src/main/java/cucumber/runtime/groovy/GroovyBackend.java
+++ b/groovy/src/main/java/cucumber/runtime/groovy/GroovyBackend.java
@@ -28,9 +28,13 @@ public class GroovyBackend implements Backend {
     private World world;
 
     public GroovyBackend(ResourceLoader resourceLoader) {
+        this (new GroovyShell(), resourceLoader);
+    }
+
+    public GroovyBackend(GroovyShell shell, ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
+        this.shell = shell;
         instance = this;
-        shell = new GroovyShell();
     }
 
     @Override


### PR DESCRIPTION
Hi,

I have added an alternative constructor to the GroovyBackend that makes it possible to provide a pre-configured GroovyShell to cucumber.

I use it to provide a shell to cucumber that has an extended classloader and binding. In my case a GroovyShell created by Grails. It allows me to call grails stuff in the step definitions.

Previously I "manually" extended the shell classpath in my code but having a constructor makes this a lot cleaner.

The additional constructor looks like a "general useful extension" to GroovyBackend. Would be nice to have it in the GroovyBackend api.

Usage example:
https://github.com/hauner/grails-cucumber/blob/master/src/groovy/grails/plugin/cucumber/Cucumber.groovy
