### PR TITLE
dashes are to be prefered to underscores.

### DIFF
--- a/examples/clojure_cukes/test/clojure_cukes/test/core.clj
+++ b/examples/clojure_cukes/test/clojure_cukes/test/core.clj
@@ -1,4 +1,4 @@
-(ns clojure_cukes.test.core
+(ns clojure-cukes.test.core
   (:use [clojure-cukes.core])
   (:use [clojure.test]))
 


### PR DESCRIPTION
but where a namespace has a dash, the corresponding file name should have a underscore.

this is due to '-' not being legal in jvm class names, and how clojure maps namespaces to .clj files and .class files
