### PR TITLE
fix maven version string

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add a dependency in your [POM](http://maven.apache.org/pom.html):
 <dependency>
     <groupId>info.cukes</groupId>
     <artifactId>cucumber-core</artifactId>
-    <version>1.0.0-RC6</version>
+    <version>1.0.0.RC6</version>
 </dependency>
 ```
 
@@ -49,7 +49,7 @@ There are more jars available - add the ones you need. (TODO: A guide on how to 
 Add a [dependency](http://ant.apache.org/ivy/history/latest-milestone/ivyfile/dependency.html) in your [ivy.xml](http://ant.apache.org/ivy/history/latest-milestone/ivyfile.html):
 
 ```xml
-    <dependency org="info.cukes" name="cucumber-core" rev="1.0.0-RC6"/>
+    <dependency org="info.cukes" name="cucumber-core" rev="1.0.0.RC6"/>
 ```
 
 Since the artifacts are released to Maven Central, the default Ivy configuration should pull them down automatically.


### PR DESCRIPTION
The version string in the README is 1.0.0-RC6, but it needs to be
1.0.0.RC6.
