### PR TITLE
#154. Fixed the issue causing scala to break

### DIFF
--- a/core/src/main/java/cucumber/io/ClasspathResourceLoader.java
+++ b/core/src/main/java/cucumber/io/ClasspathResourceLoader.java
@@ -44,7 +44,7 @@ public class ClasspathResourceLoader implements ResourceLoader {
     public <T> Collection<? extends T> instantiateSubclasses(Class<T> parentType, String packagePath, Class[] constructorParams, Object[] constructorArgs) {
         Collection<T> result = new HashSet<T>();
         for (Class<? extends T> clazz : getDescendants(parentType, packagePath)) {
-            if (Utils.isInstantiable(clazz)) {
+            if (Utils.isInstantiable(clazz) && Utils.hasConstructor(clazz, constructorParams)) {
                 result.add(newInstance(constructorParams, constructorArgs, clazz));
             }
         }

--- a/core/src/main/java/cucumber/runtime/Utils.java
+++ b/core/src/main/java/cucumber/runtime/Utils.java
@@ -17,6 +17,15 @@ public class Utils {
     public static boolean isInstantiable(Class<?> clazz) {
         return Modifier.isPublic(clazz.getModifiers()) && !Modifier.isAbstract(clazz.getModifiers());
     }
+    
+    public static boolean hasConstructor(Class<?> clazz, Class[] paramTypes) {
+      try {
+        clazz.getConstructor(paramTypes);
+        return true;
+      } catch (NoSuchMethodException e) {
+        return false;
+      }
+    }
 
     public static String packagePath(Class clazz) {
         return packagePath(packageName(clazz.getName()));

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,11 @@
                 <artifactId>cucumber-picocontainer</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <!-- Not cooking scala, should not include it in the depends
             <dependency>
                 <groupId>info.cukes</groupId>
                 <artifactId>cucumber-scala</artifactId>
                 <version>${project.version}</version>
-            </dependency> -->
+            </dependency>
             <dependency>
                 <groupId>info.cukes</groupId>
                 <artifactId>gherkin</artifactId>
@@ -254,8 +253,8 @@
         <module>rhino</module>
         <module>java</module>
         <module>clojure</module>
+        <module>scala</module>
 
-        <!--<module>scala</module>-->
         <!--<module>openejb</module>-->
     </modules>
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -8,7 +8,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.0.RC7-SNAPSHOT</version>
+        <version>1.0.0.RC11-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-scala</artifactId>


### PR DESCRIPTION
This fix changes ClasspathResourceLoader.instantiateSubclasses to silently ignore classes of correct type but with wrong constructors. This was not directly a scala issue but more of a consequence of how scala represents certain things in bytecode (in this case, objects, even those defined inside methods will end up as classes)
