### PR TITLE
We need to flush our FileWriter's created in cucumber-core

### DIFF
--- a/core/src/main/java/cucumber/formatter/FormatterFactory.java
+++ b/core/src/main/java/cucumber/formatter/FormatterFactory.java
@@ -7,6 +7,8 @@ import gherkin.formatter.PrettyFormatter;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,6 +38,24 @@ public class FormatterFactory {
                     out = new FileWriter(file);
                 }
             }
+
+            //Only create a hook if it's a writer that we created.
+            if (out instanceof Writer) {
+                final Object hookable = out;
+                Runtime.getRuntime().addShutdownHook(new Thread() {
+                    @Override
+                    public void run() {
+                        Writer writer = (Writer) hookable;
+                        try {
+                            writer.flush();
+                        } catch (IOException e) {
+                            //Oh well? We're kind of shutting down now
+                        }
+                    }
+                });
+
+            }
+
             Class<Formatter> formatterClass = getFormatterClass(className);
             // TODO: Remove these if statements. We should fix PrettyFormatter and ProgressFormatter to only take a single Appendable arg.
             // Whether or not to use Monochrome is tricky. Maybe always enforce another 2nd argument for that

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -88,6 +88,10 @@
                                 <java jar="${maven.dependency.org.jruby.jruby-complete.jar.path}" fork="true" failonerror="true" newenvironment="true" maxmemory="512m">
                                     <arg value="-S" />
                                     <arg value="bin/cucumber-jvm" />
+                                    <arg value="-f" />
+                                    <arg value="json" />
+                                    <arg value="-o"/>
+                                    <arg value="target/jruby.json"/>
                                     <arg value="--glue" />
                                     <arg value="src/test/resources" />
                                     <arg value="src/test/resources" />


### PR DESCRIPTION
System.exit(int) doesn't appear to ensure that our FileWriters are flushed, and so any output configured to go to files, doesn't.

I found this bug (#172) when running against our project, barfing out JSON to a file to see what I could do with that in terms of reporting, and or giving it to someone else for ingestion.

Then, noticing that it didn't output all the data, I tried adding it to the jruby project in cucumber-jvm, just to have a smallish starting point. Turns out **nothing** was making it into the output file, but if I barfed to the console, everything showed up! Our file writers weren't being flushed.

This adds a shutdown hook only for the filewriters we create, and calls flush on them. I suppose it could call close, but flushing them seems to get the job done.

Opinions? Should we be doing this entirely differently?
