### PR TITLE
For issue #186. Cucumber tries to instantiate parent classes via Spring

### DIFF
--- a/java/src/main/java/cucumber/runtime/java/JavaBackend.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaBackend.java
@@ -78,14 +78,13 @@ public class JavaBackend implements Backend {
         return snippetGenerator.getSnippet(step);
     }
 
-    void addStepDefinition(Annotation annotation, Method method) {
+    void addStepDefinition(Annotation annotation, Class<?> candidateClass, Method method) {
         try {
             Method regexpMethod = annotation.getClass().getMethod("value");
             String regexpString = (String) regexpMethod.invoke(annotation);
             if (regexpString != null) {
                 Pattern pattern = Pattern.compile(regexpString);
-                Class<?> clazz = method.getDeclaringClass();
-                objectFactory.addClass(clazz);
+                objectFactory.addClass(candidateClass);
                 glue.addStepDefinition(new JavaStepDefinition(method, pattern, objectFactory));
             }
         } catch (NoSuchMethodException e) {
@@ -97,9 +96,8 @@ public class JavaBackend implements Backend {
         }
     }
 
-    void addHook(Annotation annotation, Method method) {
-        Class<?> clazz = method.getDeclaringClass();
-        objectFactory.addClass(clazz);
+    void addHook(Annotation annotation, Class<?> candidateClass, Method method) {
+        objectFactory.addClass(candidateClass);
 
         Order order = method.getAnnotation(Order.class);
         int hookOrder = (order == null) ? Integer.MAX_VALUE : order.value();

--- a/java/src/test/java/cucumber/runtime/java/ClasspathMethodScannerTest.java
+++ b/java/src/test/java/cucumber/runtime/java/ClasspathMethodScannerTest.java
@@ -1,0 +1,41 @@
+package cucumber.runtime.java;
+
+import static java.util.Arrays.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import cucumber.annotation.Before;
+import cucumber.io.ClasspathResourceLoader;
+import cucumber.runtime.Glue;
+import cucumber.runtime.java.test2.Stepdefs2;
+
+public class ClasspathMethodScannerTest {
+
+    @Test
+    public void loadGlue_should_not_try_to_instantiate_super_classes() {
+
+        ClasspathMethodScanner classpathMethodScanner = new ClasspathMethodScanner(new ClasspathResourceLoader(Thread.currentThread()
+                .getContextClassLoader()));
+
+        ObjectFactory factory = Mockito.mock(ObjectFactory.class);
+        Glue world = Mockito.mock(Glue.class);
+        JavaBackend backend = new JavaBackend(factory);
+        Whitebox.setInternalState(backend, "glue", world);
+
+        // this delegates to classpathMethodScanner.scan which we test
+        classpathMethodScanner.scan(backend, asList("cucumber/runtime/java/test2"));
+
+        verify(factory, times(1)).addClass(Stepdefs2.class);
+        verifyNoMoreInteractions(factory);
+    }
+
+    public static class BaseStepDefs {
+
+        @Before
+        public void m() {
+        }
+    }
+}

--- a/java/src/test/java/cucumber/runtime/java/JavaHookTest.java
+++ b/java/src/test/java/cucumber/runtime/java/JavaHookTest.java
@@ -44,7 +44,7 @@ public class JavaHookTest {
     @Test
     public void before_hooks_get_registered() throws Exception {
         backend.buildWorld();
-        backend.addHook(BEFORE.getAnnotation(Before.class), BEFORE);
+        backend.addHook(BEFORE.getAnnotation(Before.class), HasHooks.class, BEFORE);
         JavaHookDefinition hookDef = (JavaHookDefinition) glue.getBeforeHooks().get(0);
         assertEquals(0, glue.getAfterHooks().size());
         assertEquals(BEFORE, hookDef.getMethod());
@@ -53,7 +53,7 @@ public class JavaHookTest {
     @Test
     public void after_hooks_get_registered() throws Exception {
         backend.buildWorld();
-        backend.addHook(AFTER.getAnnotation(After.class), AFTER);
+        backend.addHook(AFTER.getAnnotation(After.class), HasHooks.class, AFTER);
         JavaHookDefinition hookDef = (JavaHookDefinition) glue.getAfterHooks().get(0);
         assertEquals(0, glue.getBeforeHooks().size());
         assertEquals(AFTER, hookDef.getMethod());
@@ -62,7 +62,7 @@ public class JavaHookTest {
     @Test
     public void hook_order_gets_registered() {
         backend.buildWorld();
-        backend.addHook(AFTER.getAnnotation(After.class), AFTER);
+        backend.addHook(AFTER.getAnnotation(After.class), HasHooks.class, AFTER);
         HookDefinition hookDef = glue.getAfterHooks().get(0);
         assertEquals(1, hookDef.getOrder());
     }
@@ -70,7 +70,7 @@ public class JavaHookTest {
     @Test
     public void hook_with_no_order_is_last() {
         backend.buildWorld();
-        backend.addHook(BEFORE.getAnnotation(Before.class), BEFORE);
+        backend.addHook(BEFORE.getAnnotation(Before.class), HasHooks.class, BEFORE);
         HookDefinition hookDef = glue.getBeforeHooks().get(0);
         assertEquals(Integer.MAX_VALUE, hookDef.getOrder());
     }
@@ -78,7 +78,7 @@ public class JavaHookTest {
     @Test
     public void matches_matching_tags() {
         backend.buildWorld();
-        backend.addHook(BEFORE.getAnnotation(Before.class), BEFORE);
+        backend.addHook(BEFORE.getAnnotation(Before.class), HasHooks.class, BEFORE);
         HookDefinition before = glue.getBeforeHooks().get(0);
         assertTrue(before.matches(asList("@bar", "@zap")));
     }
@@ -86,7 +86,7 @@ public class JavaHookTest {
     @Test
     public void does_not_match_non_matching_tags() {
         backend.buildWorld();
-        backend.addHook(BEFORE.getAnnotation(Before.class), BEFORE);
+        backend.addHook(BEFORE.getAnnotation(Before.class), HasHooks.class, BEFORE);
         HookDefinition before = glue.getBeforeHooks().get(0);
         assertFalse(before.matches(asList("@bar")));
     }

--- a/java/src/test/java/cucumber/runtime/java/JavaStepDefinitionTest.java
+++ b/java/src/test/java/cucumber/runtime/java/JavaStepDefinitionTest.java
@@ -1,15 +1,12 @@
 package cucumber.runtime.java;
 
-import cucumber.annotation.en.Given;
-import cucumber.io.ClasspathResourceLoader;
-import cucumber.runtime.AmbiguousStepDefinitionsException;
-import cucumber.runtime.Glue;
-import cucumber.runtime.Runtime;
+import static java.util.Arrays.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 import gherkin.I18n;
 import gherkin.formatter.Reporter;
 import gherkin.formatter.model.Comment;
 import gherkin.formatter.model.Step;
-import org.junit.Test;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -17,10 +14,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
+import org.junit.Test;
+
+import cucumber.annotation.en.Given;
+import cucumber.io.ClasspathResourceLoader;
+import cucumber.runtime.AmbiguousStepDefinitionsException;
+import cucumber.runtime.Glue;
+import cucumber.runtime.Runtime;
 
 
 public class JavaStepDefinitionTest {
@@ -52,8 +52,8 @@ public class JavaStepDefinitionTest {
 
     @Test(expected = AmbiguousStepDefinitionsException.class)
     public void throws_ambiguous_when_two_matches_are_found() throws Throwable {
-        backend.addStepDefinition(FOO.getAnnotation(Given.class), FOO);
-        backend.addStepDefinition(BAR.getAnnotation(Given.class), BAR);
+        backend.addStepDefinition(FOO.getAnnotation(Given.class), Defs.class, FOO);
+        backend.addStepDefinition(BAR.getAnnotation(Given.class), Defs.class, BAR);
 
         Reporter reporter = mock(Reporter.class);
         runtime.buildBackendWorlds();
@@ -63,7 +63,7 @@ public class JavaStepDefinitionTest {
 
     @Test
     public void does_not_throw_ambiguous_when_nothing_is_ambiguous() throws Throwable {
-        backend.addStepDefinition(FOO.getAnnotation(Given.class), FOO);
+        backend.addStepDefinition(FOO.getAnnotation(Given.class), Defs.class, FOO);
 
         Reporter reporter = mock(Reporter.class);
         runtime.buildBackendWorlds();

--- a/java/src/test/java/cucumber/runtime/java/test2/Stepdefs2.java
+++ b/java/src/test/java/cucumber/runtime/java/test2/Stepdefs2.java
@@ -1,0 +1,6 @@
+package cucumber.runtime.java.test2;
+
+import cucumber.runtime.java.ClasspathMethodScannerTest;
+
+public class Stepdefs2 extends ClasspathMethodScannerTest.BaseStepDefs {
+}


### PR DESCRIPTION
As requested I've created failing test:
java/src/test/java/cucumber/runtime/java/ClasspathMethodScannerTest.java
java/src/test/java/cucumber/runtime/java/test2/Stepdefs2.java

To fix the bug, I've passed additions parameter "Class<?> candidateClass" to JavaBackend.addHook and JavaBackend.addStepDefinition methods. Fixed affected test cases.

While running build I've noticed that cucumber-spring test cases broke. That was because some inner class with hooks was discovered. Not sure if those should be ignored or instantiated by creating parent class first. To be safe I've just "replaced" such classes with their super classes. That is what happening in current implementation.
See following ClasspathMethodScanner chunk of code for details:

```
            while (candidateClass.getEnclosingClass() != null && !Modifier.isStatic(candidateClass.getModifiers())
                    && candidateClass != Object.class) {
                // those can't be instantiated without container class present.
                candidateClass = candidateClass.getSuperclass();
```
