### PR TITLE
Fixed NullPointerException in ClasspathMethodScanner when having interface in glue code package

### DIFF
--- a/java/src/main/java/cucumber/runtime/java/ClasspathMethodScanner.java
+++ b/java/src/main/java/cucumber/runtime/java/ClasspathMethodScanner.java
@@ -24,12 +24,14 @@ public class ClasspathMethodScanner {
         for (String gluePath : gluePaths) {
             String packageName = gluePath.replace('/', '.').replace('\\', '.'); // Sometimes the gluePath will be a path, not a package
             for (Class<?> glueCodeClass : resourceLoader.getDescendants(Object.class, packageName)) {
-                while (glueCodeClass != Object.class && !Utils.isInstantiable(glueCodeClass)) {
-                    // those can't be instantiated without container class present.
-                    glueCodeClass = glueCodeClass.getSuperclass();
-                }
-                for (Method method : glueCodeClass.getMethods()) {
-                    scan(glueCodeClass, method, cucumberAnnotationClasses, javaBackend);
+                if (!glueCodeClass.isInterface()) {
+                    while (glueCodeClass != Object.class && !Utils.isInstantiable(glueCodeClass)) {
+                        // those can't be instantiated without container class present.
+                        glueCodeClass = glueCodeClass.getSuperclass();
+                    }
+                    for (Method method : glueCodeClass.getMethods()) {
+                        scan(glueCodeClass, method, cucumberAnnotationClasses, javaBackend);
+                    }
                 }
             }
         }

--- a/java/src/test/java/cucumber/runtime/java/test2/Stepdefs2.java
+++ b/java/src/test/java/cucumber/runtime/java/test2/Stepdefs2.java
@@ -3,4 +3,6 @@ package cucumber.runtime.java.test2;
 import cucumber.runtime.java.ClasspathMethodScannerTest;
 
 public class Stepdefs2 extends ClasspathMethodScannerTest.BaseStepDefs {
+    public interface Interface1 {
+    }
 }


### PR DESCRIPTION
Hi,

I've got NullPointerException  when having interface definition in java glue code package. Fixed this by ignoring interfaces while scanning glue code. I didn't write any additional tests  for this issue - because ClasspathMethodScannerTest failed after adding interface and passed after fix
