### PR TITLE
Escape regex characters in steps; fixes #204

### DIFF
--- a/core/src/main/java/cucumber/runtime/snippets/SnippetGenerator.java
+++ b/core/src/main/java/cucumber/runtime/snippets/SnippetGenerator.java
@@ -27,6 +27,14 @@ public final class SnippetGenerator {
             new ArgumentPattern(Pattern.compile("(\\d+)"), Integer.TYPE)
     };
     private static final Pattern GROUP_PATTERN = Pattern.compile("\\(");
+    private static final Pattern[] ESCAPE_PATTERNS = new Pattern[]{
+            Pattern.compile("\\$"),
+            Pattern.compile("\\("),
+            Pattern.compile("\\)"),
+            Pattern.compile("\\["),
+            Pattern.compile("\\]")
+    };
+
     private static final String HINT = "Express the Regexp above with the code you wish you had";
     private static final Character SUBST = '_';
 
@@ -42,6 +50,11 @@ public final class SnippetGenerator {
 
     protected String patternFor(String stepName) {
         String pattern = stepName;
+        for (Pattern escapePattern : ESCAPE_PATTERNS) {
+            Matcher m = escapePattern.matcher(pattern);
+            String replacement = Matcher.quoteReplacement(escapePattern.toString());
+            pattern = m.replaceAll(replacement);
+        }
         for (ArgumentPattern argumentPattern : argumentPatterns()) {
             pattern = argumentPattern.replaceMatchesWithGroups(pattern);
         }

--- a/java/src/test/java/cucumber/runtime/java/JavaSnippetTest.java
+++ b/java/src/test/java/cucumber/runtime/java/JavaSnippetTest.java
@@ -53,6 +53,36 @@ public class JavaSnippetTest {
         assertEquals(expected, snippetFor("the DI system receives a message saying \"{ dataIngestion: { feeds: [ feed: { merchantId: 666, feedId: 1, feedFileLocation: feed.csv } ] }\""));
     }
 
+    @Test
+    public void generatesSnippetWithEscapedDollarSigns() {
+        String expected = "" +
+                "@Given(\"^I have \\\\$(\\\\d+)$\")\n" +
+                "public void I_have_$(int arg1) {\n" +
+                "    // Express the Regexp above with the code you wish you had\n" +
+                "}\n";
+        assertEquals(expected, snippetFor("I have $5"));
+    }
+
+    @Test
+    public void generatesSnippetWithEscapedParentheses() {
+        String expected = "" +
+                "@Given(\"^I have (\\\\d+) cukes \\\\(maybe more\\\\)$\")\n" +
+                "public void I_have_cukes_maybe_more(int arg1) {\n" +
+                "    // Express the Regexp above with the code you wish you had\n" +
+                "}\n";
+        assertEquals(expected, snippetFor("I have 5 cukes (maybe more)"));
+    }
+
+    @Test
+    public void generatesSnippetWithEscapedBrackets() {
+        String expected = "" +
+                "@Given(\"^I have (\\\\d+) cukes \\\\[maybe more\\\\]$\")\n" +
+                "public void I_have_cukes_maybe_more(int arg1) {\n" +
+                "    // Express the Regexp above with the code you wish you had\n" +
+                "}\n";
+        assertEquals(expected, snippetFor("I have 5 cukes [maybe more]"));
+    }
+
     private String snippetFor(String name) {
         Step step = new Step(Collections.<Comment>emptyList(), "Given ", name, 0, null, null);
         return new SnippetGenerator(new JavaSnippet()).getSnippet(step);


### PR DESCRIPTION
The current rules for generating step definition templates for
undefined steps do not escape regular expression characters.  For
instance, the following step:

```
Given I have $5
```

...generates the following template:

```
@Given("^I have $(\\d+) in my account$")
```

Java sees the dollar sign as a regex end-of-string marker, and the
scenario won't run correctly.  This commit escapes dollar signs,
parentheses, and square brackets.  The step shown above will now be
correctly translated into a template as:

```
@Given("^I have \\$(\\d+) in my account$")
```

This commit changes the general SnippetGenerator.java file; it assumes
the set of special regular expression characters will be the same
across JVM languages.  This condition appears to hold for the currently
supported languages.  If this changes in the future, it should be
possible to wrap the list of escaped regex chars in a function that
can be overridden.
