### PR TITLE
Fixed issue #211. 

### DIFF
--- a/junit/src/main/java/cucumber/junit/ExecutionUnitRunner.java
+++ b/junit/src/main/java/cucumber/junit/ExecutionUnitRunner.java
@@ -37,7 +37,8 @@ class ExecutionUnitRunner extends ParentRunner<Step> {
 
     @Override
     protected Description describeChild(Step step) {
-        return Description.createSuiteDescription(step.getKeyword() + step.getName() + "(" + getName() + ")");
+        int stepNumber = cucumberScenario.getSteps().indexOf(step);
+        return Description.createSuiteDescription(step.getKeyword() + step.getName() + "(" + getName() + ", Step: " + stepNumber + ")");
     }
 
     @Override

--- a/junit/src/test/java/cucumber/junit/ExecutionUnitRunnerTest.java
+++ b/junit/src/test/java/cucumber/junit/ExecutionUnitRunnerTest.java
@@ -1,0 +1,41 @@
+package cucumber.junit;
+
+import static org.junit.Assert.*;
+
+import gherkin.formatter.model.Step;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import cucumber.io.ClasspathResourceLoader;
+import cucumber.runtime.model.CucumberFeature;
+import cucumber.runtime.model.CucumberScenario;
+
+public class ExecutionUnitRunnerTest {
+    @Test
+    public void shouldAssignUnequalDescriptionsToDifferentOccurrencesOfSameStepInAScenario() throws Exception {
+        List<CucumberFeature> features =
+            CucumberFeature.load(
+                new ClasspathResourceLoader(this.getClass().getClassLoader()),
+                Arrays.asList(new String[] { "cucumber/junit/feature_with_same_steps_in_scenario.feature" }), 
+                Collections.emptyList());
+        
+        ExecutionUnitRunner runner = 
+            new ExecutionUnitRunner(
+                    null, 
+                    (CucumberScenario)features.get(0).getFeatureElements().get(0), 
+                    null);
+        
+        // fish out the two occurrences of the same step and check whether we really got them
+        Step stepOccurrence1 = runner.getChildren().get(0);
+        Step stepOccurrence2 = runner.getChildren().get(2);
+        assertEquals(stepOccurrence1.getName(), stepOccurrence2.getName());
+        
+        assertFalse("Descriptions must not be equal.",
+                runner.describeChild(stepOccurrence1)
+                    .equals(runner.describeChild(stepOccurrence2)));
+    }
+}

--- a/junit/src/test/resources/cucumber/junit/feature_with_same_steps_in_scenario.feature
+++ b/junit/src/test/resources/cucumber/junit/feature_with_same_steps_in_scenario.feature
@@ -1,0 +1,7 @@
+Feature: Scenario with same step occurring twice
+  Scenario:
+    When foo
+    Then bar
+    
+    When foo
+    Then baz


### PR DESCRIPTION
JUnit Descriptions for steps now include the step number within the enclosing scenario, making them unique.
