### PR TITLE
Fix test failure when running on non-english computer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,16 @@
                 </executions>
             </plugin>
 
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <argLine>-Duser.language=en</argLine>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>


### PR DESCRIPTION
mvn clean install doesn't work in a freshly cloned repo on a french computer.
HTMLFormatterTest fails at line 54 because the expected message is internationalized (in french).
This patch forces the language to english when running tests. Everything works fine with it. 
