### PR TITLE
Fix wrong level of sourcepath for java annotations

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -41,6 +41,11 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${basedir}/target/generated-sources/i18n/java</directory>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
IntelliJ detects the sourcepath as target/generated-sources/i18n instead of target/generated-sources/i18n/java
