### PR TITLE
Cuke4Duke migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![Build Status](https://secure.travis-ci.org/cucumber/cucumber-jvm.png)](http://travis-ci.org/cucumber/cucumber-jvm)
 
 Cucumber-JVM is a pure Java implementation of Cucumber that supports the following programming languages:
@@ -189,4 +188,69 @@ Then release everything:
 mvn release:clean
 mvn --batch-mode -P release-sign-artifacts release:prepare -DautoVersionSubmodules=true -DdevelopmentVersion=1.0.0.RC21-SNAPSHOT
 mvn -P release-sign-artifacts release:perform
+```
+
+
+## Migration from Cuke4Duke
+
+### POM
+For those of you that have run Cuke4Duke via Maven in the past, and perhaps have a bulk of feature files to migrate, here is a quick guide to getting setup.
+
+The first step is getting the POM.xml in your project configured with the right artifacts. 
+
+Example Cucumber-JVM + Maven + Groovy CLI
+( http://pastebin.com/XEmhuxkK )
+
+This configuration will get you the following features:
+
+* Groovy-only: No Junit/Java code will be run
+* Tags: Multiple tags cannot be passed in from a JVM argument at this time, but multiple items can be added to the POM. Note that ~@ignore is in here by default, as an example. In addition, you can provide -DtagArgs="@tagname" to run any tag
+* Formats: the <format> property can be changed from 'pretty' to 'html', or 'progress'. 
+ * If html format is used, the --out parameter must be provided and set to a folder (relative to target) to dump the reports
+ * The previous example, with target/reports specified as the output dir: ( http://pastebin.com/GrWN3ULN )
+
+### Project structure
+
+Next you'll want to structure your feature and step definition files according to the Cucumber-JVM hierarchy (quite a bit different than Cuke4Duke in most cases)
+
+```
+src\
+  test\
+    resources\
+      featurefile.feature
+      com\
+        yourcompany\
+          stepdefinitions.groovy
+```
+
+### Step definition changes
+
+The only initial difference that will need to be made is to switch the metaclass mixin:
+
+```
+this.metaClass.mixin(cuke4duke.GroovyDsl)
+```
+over to the Cucumber-JVM way...
+```
+this.metaclass.mixin(cucumber.runtime.groovy.Hooks)
+this.metaclass.mixin(cucumber.runtime.groovy.EN) // utilize your language here
+```
+
+Past that, there may be slight differences in the groovy coding aspects, but nothing too earth shattering
+//TODO: Quantify what it takes to shatter an earth
+
+### Run it!
+
+To run all features:
+
+``` 
+mvn clean test
+
+```
+
+To specify a tag:
+
+``` 
+mvn clean test -DtagArg="@mytag"
+
 ```


### PR DESCRIPTION
Perhaps there's a better place to host this, but at the moment the README seems to be the general starting point for RTFM. I know it took me a lot of combing through the Cukes Google group to figure out how to configure things to run the way our team wanted, so I thought I'd pass it along. 
The only missing piece is how to have Java included, thus producing JUnit reports. I have this configuration as well, but it didn't seem to exactly fit in with the matra of 'migration', seeing that everyone coming over from Cuke4Duke will have pure Groovy code run via JRuby.

Hope it helps! 

P.S. Keep up the great work, we're loving the pure JVM implementation SOOO much better. 
