### PR TITLE
Add support for enums in stepdefs

### DIFF
--- a/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
@@ -3,6 +3,7 @@ package cucumber.runtime;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.ConverterLookup;
 import com.thoughtworks.xstream.converters.SingleValueConverter;
+import cucumber.runtime.converters.EnumConverter;
 import cucumber.runtime.converters.LocalizedXStreams;
 import cucumber.runtime.converters.TimeConverter;
 import cucumber.table.DataTable;
@@ -84,6 +85,8 @@ public class StepDefinitionMatch extends Match {
                 timeConverter = TimeConverter.getInstance(parameterType, locale);
                 timeConverter.setOnlyFormat(parameterType.getDateFormat(), locale);
                 converter = timeConverter;
+            } else if (parameterType.getParameterClass().isEnum()) {
+                converter = new EnumConverter(locale, (Class<? extends Enum>) parameterType.getParameterClass());
             } else {
                 // TODO: We might get a lookup that doesn't implement SingleValueConverter
                 // Need to throw a more friendly exception in that case.

--- a/core/src/main/java/cucumber/runtime/converters/ConverterWithEnumFormat.java
+++ b/core/src/main/java/cucumber/runtime/converters/ConverterWithEnumFormat.java
@@ -1,0 +1,76 @@
+package cucumber.runtime.converters;
+
+import java.text.FieldPosition;
+import java.text.Format;
+import java.text.ParsePosition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class ConverterWithEnumFormat<T extends Enum> extends ConverterWithFormat<T> {
+
+    private final List<Format> formats = new ArrayList<Format>();
+    private Locale locale;
+    private Class<? extends Enum> typeClass;
+
+    public ConverterWithEnumFormat(Locale locale, Class<? extends Enum> enumClass) {
+        super(new Class[]{enumClass});
+        this.locale = locale;
+        this.typeClass = enumClass;
+        formats.add(new LowercaseFormat());
+        formats.add(new UppercaseFormat());
+        formats.add(new CapitalizeFormat());
+    }
+
+
+    @Override
+    public T fromString(String string) {
+        T s = super.fromString(string);
+        return s == null ? null : s;
+    }
+
+    @Override
+    public List<Format> getFormats() {
+        return formats;
+    }
+
+    private class LowercaseFormat extends Format {
+
+        @Override
+        public StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos) {
+            return toAppendTo.append(String.valueOf(obj));
+        }
+
+        @Override
+        public Object parseObject(String source, ParsePosition pos) {
+            return source == null ? null : Enum.valueOf(typeClass, source.toLowerCase(locale));
+        }
+    }
+
+    private class UppercaseFormat extends Format {
+        @Override
+        public StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos) {
+            return toAppendTo.append(String.valueOf(obj));
+        }
+
+        @Override
+        public Object parseObject(String source, ParsePosition pos) {
+            return source == null ? null : Enum.valueOf(typeClass, source.toUpperCase(locale));
+        }
+    }
+
+    private class CapitalizeFormat extends Format {
+        @Override
+        public StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos) {
+            return toAppendTo.append(String.valueOf(obj));
+        }
+
+        @Override
+        public Object parseObject(String source, ParsePosition pos) {
+            String firstLetter = source.substring(0, 1);
+            String restOfTheString = source.substring(1, source.length());
+            return source == null ? null : Enum.valueOf(typeClass, firstLetter.toUpperCase(locale) + restOfTheString);
+        }
+    }
+
+}

--- a/core/src/main/java/cucumber/runtime/converters/EnumConverter.java
+++ b/core/src/main/java/cucumber/runtime/converters/EnumConverter.java
@@ -1,0 +1,10 @@
+package cucumber.runtime.converters;
+
+import java.util.Locale;
+
+public class EnumConverter extends ConverterWithEnumFormat<Enum> {
+
+    public EnumConverter(Locale locale, Class<? extends Enum> enumClass) {
+        super(locale, enumClass);
+    }
+}

--- a/core/src/test/java/cucumber/runtime/converters/StandardConvertersTest.java
+++ b/core/src/test/java/cucumber/runtime/converters/StandardConvertersTest.java
@@ -115,4 +115,23 @@ public class StandardConvertersTest {
         assertEquals(expected, new BigIntegerConverter(Locale.US).fromString("8589934592"));
         assertEquals(expected, new BigIntegerConverter(Locale.US).fromString("8,589,934,592"));
     }
+
+    @Test
+    public void shouldTransformEnums() {
+        EnumConverter enumConverter = new EnumConverter(Locale.US, Color.class);
+        assertEquals(Color.GREEN, enumConverter.fromString("GREEN"));
+        assertEquals(Color.GREEN, enumConverter.fromString("Green"));
+        assertEquals(Color.GREEN, enumConverter.fromString("GrEeN"));
+        assertEquals(Color.RED, enumConverter.fromString("red"));
+    }
+
+    @Test(expected = ConversionException.class)
+    public void shouldNotTransformEnum() {
+        EnumConverter enumConverter = new EnumConverter(Locale.US, Color.class);
+        enumConverter.fromString("GRIN");
+    }
+
+    public static enum Color {
+        RED, GREEN, BLUE
+    }
 }

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/EnumsSteps.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/EnumsSteps.java
@@ -1,0 +1,42 @@
+package cucumber.runtime.java.picocontainer;
+
+import cucumber.annotation.Before;
+import cucumber.annotation.en.Given;
+import cucumber.annotation.en.Then;
+import cucumber.annotation.en.When;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class EnumsSteps {
+
+    private Color color;
+
+    @Before()
+    public void clearColor() {
+        this.color = null;
+    }
+
+    @Given("^I want to recognize colors as enums$")
+    public void I_want_to_recognize_colors_as_enums() {
+    }
+
+    @When("^i use the (.*) in a step$")
+    public void i_use_the_color_in_a_step(Color color) {
+    }
+
+    @Then("^it should be recognized as enum$")
+    public void it_should_be_recognized_as_enum() {
+    }
+
+
+    public static class ColorRecognized {
+        public Color color;
+        public boolean recognized;
+    }
+
+    public static enum Color {
+        RED, BLUE, GREEN
+    }
+}

--- a/picocontainer/src/test/resources/cucumber/runtime/java/picocontainer/enums.feature
+++ b/picocontainer/src/test/resources/cucumber/runtime/java/picocontainer/enums.feature
@@ -1,0 +1,14 @@
+Feature: Java Enums
+
+  Scenario Outline: color should be recognized as an enum
+    Given I want to recognize colors as enums
+    When i use the <color> in a step
+    Then it should be recognized as enum
+
+  Examples:
+    | color |
+    | Red   |
+    | red   |
+    | RED   |
+    | ReD   |
+


### PR DESCRIPTION
Fixes #217

I added unit tests in StandardConvertersTest & acceptance tests in enums.feature in picocontainer module.

I don't know how to test for failures in cucumber. For example if I wanted to add REEED in the example table in enums.failure, cucumber will fail with an exception (which is normal) how do i declare it as expected ?
