### PR TITLE
Support @Pending on injected spring beans

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,16 @@
                 <version>3.1.1.RELEASE</version>
             </dependency>
             <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-aop</artifactId>
+                <version>3.1.1.RELEASE</version>
+            </dependency>
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjweaver</artifactId>
+                <version>1.6.8</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
                 <version>3.0</version>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -23,7 +23,18 @@
             <artifactId>spring-tx</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjweaver</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
+        
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-junit</artifactId>

--- a/spring/src/main/java/cucumber/runtime/java/spring/hooks/PendingAnnotationInterceptor.java
+++ b/spring/src/main/java/cucumber/runtime/java/spring/hooks/PendingAnnotationInterceptor.java
@@ -1,0 +1,37 @@
+package cucumber.runtime.java.spring.hooks;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+import cucumber.annotation.Pending;
+import cucumber.runtime.PendingException;
+
+public class PendingAnnotationInterceptor implements MethodInterceptor {
+	
+	/**
+	 * This is a {@link MethodInterceptor}, a kind of advice in AOP (aspect orient programming) that is wrapped around a method.
+	 * 
+     * Meaning, that after an AOP mechanism has manipulated byte code, or in the case of Spring AOP, constructed a JDK 1.4 {@link java.lang.reflect.Proxy} 
+     * or a {@link net.sf.cglib.proxy.Proxy} Proxy, the target method is not directly invoked by callers, but that the logic is delegated to the {@link MethodInterceptor#invoke(MethodInvocation)} method,
+     * which will allow the target method to be called, or not, depending on the {@link MethodInterceptor#invoke(MethodInvocation)} method's logic.
+     *   
+     * This intercepter will always throw an PendingException, and should only be applied to methods on objects with a {@link Pending} annotation.
+     *
+     * Typical spring usage would look like:<br/>
+     * <pre>
+     * 
+     *&lt;aop:config&gt;    
+     *   &lt;aop:advisor pointcut="@annotation(cucumber.annotation.Pending)" advice-ref="cucumber_throwsPendingException"/&gt;
+     *&lt;/aop:config&gt;
+     *  
+     *&lt;bean id="cucumber_throwsPendingException" class="cucumber.runtime.java.spring.hooks.PendingAnnotationInterceptor"/&gt;
+     *    
+     * </pre>   
+     * 
+	 */
+	public Object invoke(MethodInvocation invocation) throws Throwable {
+		Pending pending = invocation.getThis().getClass().getMethod(invocation.getMethod().getName(), invocation.getMethod().getParameterTypes()).getAnnotation(Pending.class);
+        throw new PendingException("On class: "+invocation.getThis().getClass() + " method: "+invocation.getMethod().getName()+" with Message "+ pending.value()) ;
+	}
+	
+}

--- a/spring/src/main/resources/cucumber/runtime/java/spring/cucumber-glue.xml
+++ b/spring/src/main/resources/cucumber/runtime/java/spring/cucumber-glue.xml
@@ -2,9 +2,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
-    <bean id="glueCodeScope" class="cucumber.runtime.java.spring.GlueCodeScope">
-    </bean>
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd">
+
+    <bean id="glueCodeScope" class="cucumber.runtime.java.spring.GlueCodeScope"/>
 
     <bean id="glueCodeScopeConfigurer" class="org.springframework.beans.factory.config.CustomScopeConfigurer">
         <property name="scopes">
@@ -14,5 +15,11 @@
         </property>
     </bean>
     <context:annotation-config/>
+
+    <aop:config>    
+       <aop:advisor pointcut="@annotation(cucumber.annotation.Pending)" advice-ref="cucumber_throwsPendingException"/>
+    </aop:config>
+  
+    <bean id="cucumber_throwsPendingException" class="cucumber.runtime.java.spring.hooks.PendingAnnotationInterceptor"/>
 
 </beans>

--- a/spring/src/test/java/cucumber/runtime/java/spring/hooks/Belly.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/hooks/Belly.java
@@ -1,0 +1,5 @@
+package cucumber.runtime.java.spring.hooks;
+
+public interface Belly {
+	public int getCukes();
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/hooks/PendingBelly.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/hooks/PendingBelly.java
@@ -1,0 +1,21 @@
+package cucumber.runtime.java.spring.hooks;
+
+import cucumber.annotation.Pending;
+
+/**
+ * Implements an interface to be able to use jdk 1.4 proxies at runtime, instead of cglib.
+ */
+public class PendingBelly implements Belly {
+	
+	public static final String NO_BELLY = "TODO: I have not cuke storage in my belly :(";
+	
+    @Pending(NO_BELLY)
+    public void setCukes(int cukes) {
+    }
+    
+    @Pending(NO_BELLY)
+    public int getCukes() {
+    	return 0;
+    }
+
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/hooks/PendingInterceptorTest.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/hooks/PendingInterceptorTest.java
@@ -1,0 +1,28 @@
+package cucumber.runtime.java.spring.hooks;
+
+import org.junit.Test;
+
+import cucumber.runtime.PendingException;
+import cucumber.runtime.java.ObjectFactory;
+import cucumber.runtime.java.spring.SpringFactory;
+
+import static org.junit.Assert.assertTrue;
+
+public class PendingInterceptorTest {
+
+    @Test
+    public void pendingBellyShouldThrowPendingException() {
+        final ObjectFactory factory = new SpringFactory();
+        Belly belly = factory.getInstance(Belly.class);
+        boolean pendingExceptionThrown = false;
+        try {
+          belly.getCukes();
+        } catch (PendingException pe){
+          assertTrue(pe.getMessage().contains(PendingBelly.class.getName()));
+          assertTrue(pe.getMessage().contains("getCukes"));
+          assertTrue(pe.getMessage().contains(PendingBelly.NO_BELLY));
+          pendingExceptionThrown = true;
+        }
+        assertTrue(pendingExceptionThrown);
+    }
+}

--- a/spring/src/test/resources/applicationContext.xml
+++ b/spring/src/test/resources/applicationContext.xml
@@ -6,6 +6,8 @@
 
     <bean id="bellyBean" class="cucumber.runtime.java.spring.BellyBean"/>
 
+    <bean id="pendingBelly" class="cucumber.runtime.java.spring.hooks.PendingBelly"/>
+
     <bean id="placeholderConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
             <property name="properties">
                 <props>


### PR DESCRIPTION
Support for Pending annotations on spring beans, allows stepdefs to support injected dependencies, which are not fully implemented.   Important if you have multiple instances which may be injected in to the stepdef.
