### PR TITLE
Fix quoting of generated Clojure snippets

### DIFF
--- a/clojure/src/main/clj/cucumber/runtime/clj.clj
+++ b/clojure/src/main/clj/cucumber/runtime/clj.clj
@@ -1,4 +1,5 @@
 (ns cucumber.runtime.clj
+  (:require (clojure [string :as str]))
   (:import (cucumber.runtime CucumberException
                              JdkPatternArgumentMatcher
                              StepDefinition
@@ -26,11 +27,12 @@
        "  (comment  {4}  )\n"
        "  (throw (cucumber.runtime.PendingException.)))\n"))
     (arguments [_ argumentTypes]
-      (SnippetGenerator/untypedArguments argumentTypes))
+      (str/replace (SnippetGenerator/untypedArguments argumentTypes)
+                   "," ""))
     (namedGroupStart [_] nil)
     (namedGroupEnd [_] nil)
     (escapePattern [_ pattern]
-      (str pattern))))
+      (str/replace (str pattern) "\"" "\\\""))))
 
 (def snippet-generator (SnippetGenerator. (clojure-snippet)))
 

--- a/clojure/src/test/java/cucumber/runtime/clojure/ClojureSnippet.java
+++ b/clojure/src/test/java/cucumber/runtime/clojure/ClojureSnippet.java
@@ -25,7 +25,7 @@ public class ClojureSnippet implements Snippet {
 
     @Override
     public String arguments(List<Class<?>> argumentTypes) {
-        return untypedArguments(argumentTypes);
+        return untypedArguments(argumentTypes).replaceAll(",", "");
     }
 
     @Override
@@ -40,6 +40,6 @@ public class ClojureSnippet implements Snippet {
 
     @Override
     public String escapePattern(String pattern) {
-        return pattern;
+        return pattern.replaceAll("\"", "\\\\\"");
     }
 }

--- a/clojure/src/test/java/cucumber/runtime/clojure/ClojureSnippetTest.java
+++ b/clojure/src/test/java/cucumber/runtime/clojure/ClojureSnippetTest.java
@@ -20,7 +20,7 @@ public class ClojureSnippetTest {
         Step step = new Step(NO_COMMENTS, "Given ", "I have 4 cukes in my \"big\" belly", 0, null, null);
         String snippet = new SnippetGenerator(new ClojureSnippet()).getSnippet(step);
         String expected = "" +
-                "(Given #\"^I have (\\d+) cukes in my \"([^\"]*)\" belly$\" [arg1, arg2]\n" +
+                "(Given #\"^I have (\\d+) cukes in my \\\"([^\\\"]*)\\\" belly$\" [arg1 arg2]\n" +
                 "  (comment  Express the Regexp above with the code you wish you had  )\n" +
                 "  (throw (cucumber.runtime.PendingException.)))\n";
         assertEquals(expected, snippet);


### PR DESCRIPTION
The double quote character must be quoted within a Clojure #"..."
regular expression.

Also drop the comma in the parameter list of generated snippets to
match the conventions of defn.
