### PR TITLE
Guice in multi module/class loader setup

### DIFF
--- a/guice/src/main/java/cucumber/runtime/java/guice/GuiceFactory.java
+++ b/guice/src/main/java/cucumber/runtime/java/guice/GuiceFactory.java
@@ -39,7 +39,7 @@ public class GuiceFactory implements ObjectFactory {
 
     private static Properties loadCucumberGuiceProperties() throws IOException {
         Properties properties = new Properties();
-        InputStream inputStream = GuiceFactory.class.getClassLoader().getResourceAsStream("cucumber-guice.properties");
+        InputStream inputStream = GuiceFactory.class.getResourceAsStream("/cucumber-guice.properties");
         if (inputStream != null) {
             try {
                 properties.load(inputStream);


### PR DESCRIPTION
The cucumber-guice.properties get's loaded from the wrong place in my setup due to having multiple versions of it in different jars and loading all the jars at the same time.

The supplied change makes it work.
