### PR TITLE
Fixed generated Scala snippets

### DIFF
--- a/scala/src/main/scala/cucumber/runtime/ScalaSnippet.scala
+++ b/scala/src/main/scala/cucumber/runtime/ScalaSnippet.scala
@@ -10,7 +10,7 @@ class ScalaSnippetGenerator extends Snippet {
   def template() =
     "{0}(\"\"\"{1}\"\"\")'{' ({3}) =>\n" +
       "  //// {4}\n" +
-      "  throw new PendingException()\n"
+      "  throw new PendingException()\n" +
       "'}'"
 
   def tableHint() = null


### PR DESCRIPTION
There was no "}" at the end of generated snippets for Scala.

Sample:

<pre>
You can implement missing steps with the snippets below:

Then("""^the result is (\d+)$"""){ (arg0:Int) =>
  //// Express the Regexp above with the code you wish you had
  throw new PendingException()
</pre>


instead of

<pre>
You can implement missing steps with the snippets below:

Then("""^the result is (\d+)$"""){ (arg0:Int) =>
  //// Express the Regexp above with the code you wish you had
  throw new PendingException()
}
</pre>
