### PR TITLE
Cucumber-clojure adding after hook to before

### DIFF
--- a/clojure/src/main/clj/cucumber/runtime/clj.clj
+++ b/clojure/src/main/clj/cucumber/runtime/clj.clj
@@ -105,7 +105,7 @@
                                  (filter #(= "invoke" (.getName %)))
                                  (map #(count (.getParameterTypes %)))
                                  (apply max))]
-    (.addBeforeHook
+    (.addAfterHook
      @glue
      (reify
        HookDefinition


### PR DESCRIPTION
The After hook for clojure was adding to the before hook by mistake.
