### PR TITLE
Issue #76 - adding support for AfterClass and BeforeClass annotations.

### DIFF
--- a/core/src/main/java/cucumber/runtime/Glue.java
+++ b/core/src/main/java/cucumber/runtime/Glue.java
@@ -7,6 +7,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import cucumber.runtime.HookDefinition;
+import cucumber.runtime.StaticHookDefinition;
+import cucumber.runtime.StepDefinition;
+import cucumber.runtime.StepDefinitionMatch;
+
 
 //TODO: now that this is just basically a java bean storing values
 // I don't think it needs an interface anymore...
@@ -18,10 +23,18 @@ public interface Glue {
 
     void addAfterHook(HookDefinition hookDefinition);
 
+    void addBeforeClassHook(StaticHookDefinition hookDefinition);
+    
+    void addAfterClassHook(StaticHookDefinition hookDefinition);
+    
     List<HookDefinition> getBeforeHooks();
 
     List<HookDefinition> getAfterHooks();
 
+    List<StaticHookDefinition> getBeforeClassHooks();
+
+    List<StaticHookDefinition> getAfterClassHooks();
+    
     StepDefinitionMatch stepDefinitionMatch(String uri, Step step, I18n i18n);
 
     void writeStepdefsJson(List<String> featurePaths, File dotCucumber) throws IOException;

--- a/core/src/main/java/cucumber/runtime/RuntimeGlue.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeGlue.java
@@ -1,10 +1,7 @@
 package cucumber.runtime;
 
-import cucumber.io.FileResourceLoader;
-import cucumber.runtime.autocomplete.MetaStepdef;
-import cucumber.runtime.autocomplete.StepdefGenerator;
-import cucumber.runtime.converters.LocalizedXStreams;
-import cucumber.runtime.model.CucumberFeature;
+import static cucumber.runtime.model.CucumberFeature.load;
+import static java.util.Collections.emptyList;
 import gherkin.I18n;
 import gherkin.deps.com.google.gson.Gson;
 import gherkin.deps.com.google.gson.GsonBuilder;
@@ -20,8 +17,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static cucumber.runtime.model.CucumberFeature.load;
-import static java.util.Collections.emptyList;
+import cucumber.io.FileResourceLoader;
+import cucumber.runtime.autocomplete.MetaStepdef;
+import cucumber.runtime.autocomplete.StepdefGenerator;
+import cucumber.runtime.converters.LocalizedXStreams;
+import cucumber.runtime.model.CucumberFeature;
 
 public class RuntimeGlue implements Glue {
     private static final List<Object> NO_FILTERS = emptyList();
@@ -29,7 +29,9 @@ public class RuntimeGlue implements Glue {
     private final Map<String, StepDefinition> stepDefinitionsByPattern = new TreeMap<String, StepDefinition>();
     private final List<HookDefinition> beforeHooks = new ArrayList<HookDefinition>();
     private final List<HookDefinition> afterHooks = new ArrayList<HookDefinition>();
-
+    private final List<StaticHookDefinition> beforeClassHooks = new ArrayList<StaticHookDefinition>();
+    private final List<StaticHookDefinition> afterClassHooks = new ArrayList<StaticHookDefinition>();
+    
     private final UndefinedStepsTracker tracker;
     private final LocalizedXStreams localizedXStreams;
 
@@ -58,6 +60,18 @@ public class RuntimeGlue implements Glue {
         afterHooks.add(hookDefinition);
         Collections.sort(afterHooks, new HookComparator(false));
     }
+    
+    @Override
+    public void addBeforeClassHook(StaticHookDefinition hookDefinition) {
+        beforeClassHooks.add(hookDefinition);
+        Collections.sort(beforeClassHooks, new StaticHookComparator(false));
+    }
+
+    @Override
+    public void addAfterClassHook(StaticHookDefinition hookDefinition) {
+        afterClassHooks.add(hookDefinition);
+        Collections.sort(afterClassHooks, new StaticHookComparator(false));
+    }
 
     @Override
     public List<HookDefinition> getBeforeHooks() {
@@ -67,6 +81,17 @@ public class RuntimeGlue implements Glue {
     @Override
     public List<HookDefinition> getAfterHooks() {
         return afterHooks;
+    }
+    
+    
+    @Override
+    public List<StaticHookDefinition> getBeforeClassHooks() {
+        return beforeClassHooks;
+    }
+
+    @Override
+    public List<StaticHookDefinition> getAfterClassHooks() {
+        return afterClassHooks;
     }
 
     @Override

--- a/core/src/main/java/cucumber/runtime/StaticHookComparator.java
+++ b/core/src/main/java/cucumber/runtime/StaticHookComparator.java
@@ -1,0 +1,17 @@
+package cucumber.runtime;
+
+import java.util.Comparator;
+
+public final class StaticHookComparator implements Comparator<StaticHookDefinition> {
+    final boolean ascending;
+
+    public StaticHookComparator(boolean ascending) {
+        this.ascending = ascending;
+    }
+
+    @Override
+    public int compare(StaticHookDefinition hook1, StaticHookDefinition hook2) {
+        int comparison = hook1.getOrder() - hook2.getOrder();
+        return ascending ? comparison : -comparison;
+    }
+}

--- a/core/src/main/java/cucumber/runtime/StaticHookDefinition.java
+++ b/core/src/main/java/cucumber/runtime/StaticHookDefinition.java
@@ -1,0 +1,13 @@
+package cucumber.runtime;
+
+import gherkin.formatter.model.Tag;
+
+import java.util.Collection;
+
+public interface StaticHookDefinition {
+    void execute() throws Throwable;
+
+    boolean matches(Collection<Tag> tags);
+
+    int getOrder();
+}

--- a/java/src/main/java/cucumber/annotation/AfterClass.java
+++ b/java/src/main/java/cucumber/annotation/AfterClass.java
@@ -1,0 +1,15 @@
+package cucumber.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AfterClass {
+    /**
+     * @return a tag expression
+     */
+    String[] value() default {};
+}

--- a/java/src/main/java/cucumber/annotation/BeforeClass.java
+++ b/java/src/main/java/cucumber/annotation/BeforeClass.java
@@ -1,0 +1,15 @@
+package cucumber.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface BeforeClass {
+    /**
+     * @return a tag expression
+     */
+    String[] value() default {};
+}

--- a/java/src/main/java/cucumber/runtime/java/ClasspathMethodScanner.java
+++ b/java/src/main/java/cucumber/runtime/java/ClasspathMethodScanner.java
@@ -1,16 +1,18 @@
 package cucumber.runtime.java;
 
-import cucumber.annotation.After;
-import cucumber.annotation.Before;
-import cucumber.annotation.Order;
-import cucumber.io.ClasspathResourceLoader;
-import cucumber.runtime.CucumberException;
-import cucumber.runtime.Utils;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
+
+import cucumber.annotation.After;
+import cucumber.annotation.AfterClass;
+import cucumber.annotation.Before;
+import cucumber.annotation.BeforeClass;
+import cucumber.annotation.Order;
+import cucumber.io.ClasspathResourceLoader;
+import cucumber.runtime.CucumberException;
+import cucumber.runtime.Utils;
 
 class ClasspathMethodScanner {
 
@@ -73,7 +75,10 @@ class ClasspathMethodScanner {
 
     private boolean isHookAnnotation(Annotation annotation) {
         Class<? extends Annotation> annotationClass = annotation.annotationType();
-        return annotationClass.equals(Before.class) || annotationClass.equals(After.class);
+        return annotationClass.equals(Before.class) || 
+                annotationClass.equals(After.class) ||
+                annotationClass.equals(BeforeClass.class) ||
+                annotationClass.equals(AfterClass.class);
     }
 
     private boolean isStepdefAnnotation(Annotation annotation) {

--- a/java/src/main/java/cucumber/runtime/java/JavaStaticHookDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaStaticHookDefinition.java
@@ -1,0 +1,53 @@
+package cucumber.runtime.java;
+
+import static java.util.Arrays.asList;
+import gherkin.TagExpression;
+import gherkin.formatter.model.Tag;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+import cucumber.runtime.CucumberException;
+import cucumber.runtime.StaticHookDefinition;
+
+public class JavaStaticHookDefinition implements StaticHookDefinition {
+
+    private final Method method;
+    private final TagExpression tagExpression;
+    private final int order;
+
+    public JavaStaticHookDefinition(Method method, String[] tagExpressions, int order) {
+        this.method = method;
+        tagExpression = new TagExpression(asList(tagExpressions));
+        this.order = order;
+    }
+
+    Method getMethod() {
+        return method;
+    }
+
+    @Override
+    public void execute() throws Throwable {
+        Object[] args = new Object[0];
+
+        try {
+            method.invoke(null, args);
+        } catch (IllegalArgumentException e) {
+            throw new CucumberException("Can't invoke " + new MethodFormat().format(method));
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        }
+    }
+
+    @Override
+    public boolean matches(Collection<Tag> tags) {
+        return tagExpression.eval(tags);
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
+    }
+
+}

--- a/java/src/test/java/cucumber/runtime/java/JavaBackendTest.java
+++ b/java/src/test/java/cucumber/runtime/java/JavaBackendTest.java
@@ -1,23 +1,25 @@
 package cucumber.runtime.java;
 
-import cucumber.fallback.runtime.java.DefaultJavaObjectFactory;
-import cucumber.runtime.CucumberException;
-import cucumber.runtime.Glue;
-import cucumber.runtime.HookDefinition;
-import cucumber.runtime.StepDefinition;
-import cucumber.runtime.StepDefinitionMatch;
-import cucumber.runtime.java.test.Stepdefs;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
 import gherkin.I18n;
 import gherkin.formatter.model.Step;
-import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import cucumber.fallback.runtime.java.DefaultJavaObjectFactory;
+import cucumber.runtime.CucumberException;
+import cucumber.runtime.Glue;
+import cucumber.runtime.HookDefinition;
+import cucumber.runtime.StaticHookDefinition;
+import cucumber.runtime.StepDefinition;
+import cucumber.runtime.StepDefinitionMatch;
+import cucumber.runtime.java.test.Stepdefs;
 
 public class JavaBackendTest {
     @Test(expected = CucumberException.class)
@@ -53,6 +55,26 @@ public class JavaBackendTest {
 
         @Override
         public void addAfterHook(HookDefinition hookDefinition) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addBeforeClassHook(StaticHookDefinition hookDefinition) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addAfterClassHook(StaticHookDefinition hookDefinition) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<StaticHookDefinition> getBeforeClassHooks() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<StaticHookDefinition> getAfterClassHooks() {
             throw new UnsupportedOperationException();
         }
 

--- a/java/src/test/java/cucumber/runtime/java/JavaStepDefinitionTest.java
+++ b/java/src/test/java/cucumber/runtime/java/JavaStepDefinitionTest.java
@@ -1,19 +1,17 @@
 package cucumber.runtime.java;
 
-import cucumber.annotation.en.Given;
-import cucumber.io.ClasspathResourceLoader;
-import cucumber.runtime.AmbiguousStepDefinitionsException;
-import cucumber.runtime.Glue;
-import cucumber.runtime.Runtime;
-import cucumber.runtime.RuntimeOptions;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import gherkin.I18n;
 import gherkin.formatter.Reporter;
 import gherkin.formatter.model.Comment;
 import gherkin.formatter.model.Result;
 import gherkin.formatter.model.Step;
 import gherkin.formatter.model.Tag;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -21,12 +19,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import cucumber.annotation.en.Given;
+import cucumber.io.ClasspathResourceLoader;
+import cucumber.runtime.AmbiguousStepDefinitionsException;
+import cucumber.runtime.Glue;
+import cucumber.runtime.Runtime;
+import cucumber.runtime.RuntimeOptions;
 
 public class JavaStepDefinitionTest {
     private static final List<Comment> NO_COMMENTS = Collections.emptyList();

--- a/junit/src/main/java/cucumber/junit/FeatureRunner.java
+++ b/junit/src/main/java/cucumber/junit/FeatureRunner.java
@@ -1,21 +1,25 @@
 package cucumber.junit;
 
+import static cucumber.junit.DescriptionFactory.createDescription;
+import gherkin.formatter.model.Feature;
+import gherkin.formatter.model.Tag;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.InitializationError;
+
 import cucumber.runtime.CucumberException;
 import cucumber.runtime.Runtime;
 import cucumber.runtime.model.CucumberFeature;
 import cucumber.runtime.model.CucumberScenario;
 import cucumber.runtime.model.CucumberScenarioOutline;
 import cucumber.runtime.model.CucumberTagStatement;
-import gherkin.formatter.model.Feature;
-import org.junit.runner.Description;
-import org.junit.runner.notification.RunNotifier;
-import org.junit.runners.ParentRunner;
-import org.junit.runners.model.InitializationError;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static cucumber.junit.DescriptionFactory.createDescription;
 
 public class FeatureRunner extends ParentRunner<ParentRunner> {
     private final List<ParentRunner> children = new ArrayList<ParentRunner>();
@@ -69,7 +73,13 @@ public class FeatureRunner extends ParentRunner<ParentRunner> {
     public void run(RunNotifier notifier) {
         jUnitReporter.uri(cucumberFeature.getUri());
         jUnitReporter.feature(cucumberFeature.getFeature());
+        Set<Tag> tags = new HashSet<Tag>();
+        tags.addAll(cucumberFeature.getFeature().getTags());
+        
+        runtime.runBeforeClassHooks(jUnitReporter, tags);
         super.run(notifier);
+        runtime.runAfterClassHooks(jUnitReporter, tags);
+        
         jUnitReporter.eof();
     }
 


### PR DESCRIPTION
In core I introduced the notion of a StaticHookDefinition for AfterClass and BeforeClass Hooks. In the core these will execute before/after each feature in the Runtime.run(). In JUnit these run before and after in the FeatureRunner. These hooks are then implemented for Java as Annotations on static methods, I did not implement them for other languages but it should support doing so.
