### PR TITLE
fixed & simplified groovy step snippets

### DIFF
--- a/groovy/src/main/java/cucumber/runtime/groovy/GroovySnippet.java
+++ b/groovy/src/main/java/cucumber/runtime/groovy/GroovySnippet.java
@@ -7,7 +7,7 @@ import java.util.List;
 public class GroovySnippet implements Snippet {
     @Override
     public String template() {
-        return "{0}(~\"{1}\") '{' {3}->\n" +
+        return "{0}(~''{1}'') '{' {3}->\n" +
                 "    // {4}\n" +
                 "    throw new PendingException()\n" +
                 "'}'\n";
@@ -46,6 +46,6 @@ public class GroovySnippet implements Snippet {
 
     @Override
     public String escapePattern(String pattern) {
-        return pattern.replaceAll("\"", "\\\\\"");
+        return pattern;
     }
 }

--- a/groovy/src/test/java/cucumber/runtime/groovy/GroovySnippetTest.java
+++ b/groovy/src/test/java/cucumber/runtime/groovy/GroovySnippetTest.java
@@ -20,7 +20,7 @@ public class GroovySnippetTest {
     @Test
     public void generatesPlainSnippet() {
         String expected = "" +
-                "Given(~\"^I have (\\d+) cukes in my \\\"([^\\\"]*)\\\" belly$\") { int arg1, String arg2 ->\n" +
+                "Given(~'^I have (\\d+) cukes in my \"([^\"]*)\" belly$') { int arg1, String arg2 ->\n" +
                 "    // Express the Regexp above with the code you wish you had\n" +
                 "    throw new PendingException()\n" +
                 "}\n";
@@ -30,7 +30,7 @@ public class GroovySnippetTest {
     @Test
     public void generatesCopyPasteReadyStepSnippetForNumberParameters() throws Exception {
         String expected = "" +
-                "Given(~\"^before (\\d+) after$\") { int arg1 ->\n" +
+                "Given(~'^before (\\d+) after$') { int arg1 ->\n" +
                 "    // Express the Regexp above with the code you wish you had\n" +
                 "    throw new PendingException()\n" +
                 "}\n";
@@ -41,7 +41,7 @@ public class GroovySnippetTest {
     @Test
     public void generatesCopyPasteReadySnippetWhenStepHasIllegalJavaIdentifierChars() {
         String expected = "" +
-                "Given(~\"^I have (\\d+) cukes in: my \\\"([^\\\"]*)\\\" red-belly!$\") { int arg1, String arg2 ->\n" +
+                "Given(~'^I have (\\d+) cukes in: my \"([^\"]*)\" red-belly!$') { int arg1, String arg2 ->\n" +
                 "    // Express the Regexp above with the code you wish you had\n" +
                 "    throw new PendingException()\n" +
                 "}\n";
@@ -52,7 +52,7 @@ public class GroovySnippetTest {
     @Test
     public void generatesCopyPasteReadySnippetWhenStepHasIntegersInsideStringParameter() {
         String expected = "" +
-                "Given(~\"^the DI system receives a message saying \\\"([^\\\"]*)\\\"$\") { String arg1 ->\n" +
+                "Given(~'^the DI system receives a message saying \"([^\"]*)\"$') { String arg1 ->\n" +
                 "    // Express the Regexp above with the code you wish you had\n" +
                 "    throw new PendingException()\n" +
                 "}\n";
@@ -62,7 +62,7 @@ public class GroovySnippetTest {
     @Test
     public void generatesSnippetWithEscapedDollarSigns() {
         String expected = "" +
-                "Given(~\"^I have \\$(\\d+)$\") { int arg1 ->\n" +
+                "Given(~'^I have \\$(\\d+)$') { int arg1 ->\n" +
                 "    // Express the Regexp above with the code you wish you had\n" +
                 "    throw new PendingException()\n" +
                 "}\n";
@@ -72,7 +72,7 @@ public class GroovySnippetTest {
     @Test
     public void generatesSnippetWithEscapedParentheses() {
         String expected = "" +
-                "Given(~\"^I have (\\d+) cukes \\(maybe more\\)$\") { int arg1 ->\n" +
+                "Given(~'^I have (\\d+) cukes \\(maybe more\\)$') { int arg1 ->\n" +
                 "    // Express the Regexp above with the code you wish you had\n" +
                 "    throw new PendingException()\n" +
                 "}\n";
@@ -82,7 +82,7 @@ public class GroovySnippetTest {
     @Test
     public void generatesSnippetWithEscapedBrackets() {
         String expected = "" +
-                "Given(~\"^I have (\\d+) cukes \\[maybe more\\]$\") { int arg1 ->\n" +
+                "Given(~'^I have (\\d+) cukes \\[maybe more\\]$') { int arg1 ->\n" +
                 "    // Express the Regexp above with the code you wish you had\n" +
                 "    throw new PendingException()\n" +
                 "}\n";
@@ -92,7 +92,7 @@ public class GroovySnippetTest {
     @Test
     public void generatesSnippetWithDocString() {
         String expected = "" +
-                "Given(~\"^I have:$\") { String arg1 ->\n" +
+                "Given(~'^I have:$') { String arg1 ->\n" +
                 "    // Express the Regexp above with the code you wish you had\n" +
                 "    throw new PendingException()\n" +
                 "}\n";
@@ -102,7 +102,7 @@ public class GroovySnippetTest {
     @Test
     public void generatesSnippetWithDataTable() {
         String expected = "" +
-                "Given(~\"^I have:$\") { DataTable arg1 ->\n" +
+                "Given(~'^I have:$') { DataTable arg1 ->\n" +
                 "    // Express the Regexp above with the code you wish you had\n" +
                 "    throw new PendingException()\n" +
                 "}\n";


### PR DESCRIPTION
the generated groovy snippets do not work out of the box:

``` groovy
When(~"^I run cucumber$") { -> ... }
```

Error: _Indentifier or code block expected, String end expected_

the `$` is a special character in groovy to embed an expression into a `GString`, ie. a double quoted string. To disable the  groovy `$` it has to be escaped...

``` groovy
When(~"^I run cucumber\$") { -> ... }
```

... or the string has to be quoted with single ticks (to make it a normal `String`) ...

``` groovy
When(~'^I run cucumber$') { -> ... }
```

Which has the advantage that the `"` does not have to be escaped as well. So it is possible to simplify

``` groovy
When(~"^I run cucumber with \"([^\"]*)\"\$") { String arg -> }
```

to:

``` groovy
When(~'^I run cucumber with "([^"]*)"$') { String arg -> }
```

I think everyone agrees that this is a lot better.. :-)
