### PR TITLE
Remove forced UTC timezone

### DIFF
--- a/core/src/main/java/cucumber/runtime/converters/CalendarConverter.java
+++ b/core/src/main/java/cucumber/runtime/converters/CalendarConverter.java
@@ -4,7 +4,6 @@ import java.text.Format;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
-import java.util.TimeZone;
 
 public class CalendarConverter extends TimeConverter<Calendar> {
     public CalendarConverter(Locale locale) {
@@ -14,7 +13,7 @@ public class CalendarConverter extends TimeConverter<Calendar> {
     @Override
     protected Object transform(Format format, String argument) {
         Date date = (Date) super.transform(format, argument);
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"), locale);
+        Calendar cal = Calendar.getInstance(locale);
         cal.setTime(date);
         return cal;
     }

--- a/core/src/main/java/cucumber/runtime/converters/TimeConverter.java
+++ b/core/src/main/java/cucumber/runtime/converters/TimeConverter.java
@@ -11,12 +11,10 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import static java.util.Arrays.asList;
 
 public abstract class TimeConverter<T> extends ConverterWithFormat<T> {
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
     protected final Locale locale;
     private final List<DateFormat> formats = new ArrayList<DateFormat>();
     private SimpleDateFormat onlyFormat;
@@ -38,7 +36,6 @@ public abstract class TimeConverter<T> extends ConverterWithFormat<T> {
 
     protected void add(DateFormat dateFormat) {
         dateFormat.setLenient(false);
-        dateFormat.setTimeZone(UTC);
         formats.add(dateFormat);
     }
 
@@ -49,7 +46,6 @@ public abstract class TimeConverter<T> extends ConverterWithFormat<T> {
     public void setOnlyFormat(String dateFormatString, Locale locale) {
         onlyFormat = new SimpleDateFormat(dateFormatString, locale);
         onlyFormat.setLenient(false);
-        onlyFormat.setTimeZone(UTC);
     }
 
     public void removeOnlyFormat() {

--- a/core/src/test/java/cucumber/runtime/converters/StandardConvertersTest.java
+++ b/core/src/test/java/cucumber/runtime/converters/StandardConvertersTest.java
@@ -8,14 +8,11 @@ import java.math.BigInteger;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class StandardConvertersTest {
-
-    private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
     @Test
     public void shouldThrowInformativeErrorMessageWhenTransformationFails() {
@@ -56,7 +53,7 @@ public class StandardConvertersTest {
     }
 
     private Date getDateToTest() {
-        Calendar calendar = Calendar.getInstance(UTC);
+        Calendar calendar = Calendar.getInstance();
         calendar.set(2011, 10, 29, 0, 0, 0);
         calendar.set(Calendar.MILLISECOND, 0);
         return calendar.getTime();

--- a/core/src/test/java/cucumber/table/FromDataTableTest.java
+++ b/core/src/test/java/cucumber/table/FromDataTableTest.java
@@ -28,7 +28,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -242,7 +241,6 @@ public class FromDataTableTest {
         Calendar sidsBirthday = Calendar.getInstance();
         sidsBirthday.set(1957, 4, 10, 0, 0, 0);
         sidsBirthday.set(Calendar.MILLISECOND, 0);
-        sidsBirthday.setTimeZone(TimeZone.getTimeZone("UTC"));
         return sidsBirthday.getTime();
     }
 
@@ -250,7 +248,6 @@ public class FromDataTableTest {
         Calendar sidsDeathcal = Calendar.getInstance();
         sidsDeathcal.set(1979, 1, 2, 0, 0, 0);
         sidsDeathcal.set(Calendar.MILLISECOND, 0);
-        sidsDeathcal.setTimeZone(TimeZone.getTimeZone("UTC"));
         return sidsDeathcal;
     }
 

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/DatesSteps.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/DatesSteps.java
@@ -3,6 +3,7 @@ package cucumber.runtime.java.picocontainer;
 import cucumber.DateFormat;
 import cucumber.annotation.en.Given;
 import cucumber.annotation.en.Then;
+import cucumber.runtime.PendingException;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -14,37 +15,38 @@ import static org.junit.Assert.assertEquals;
 public class DatesSteps {
     private Date date;
 
-    @Given("^the date is (.+)$")
-    public void the_date_is(@DateFormat("yyyy/MM/dd") Date date) {
+    @Given("^the ISO date is (.+)$")
+    public void the_iso_date_is(@DateFormat("yyyy-MM-dd'T'HH:mm:ss") Date date) {
         this.date = date;
     }
 
-    @Given("^the iso date is (.+)$")
-    public void the_iso_date_is(@DateFormat("yyyy-MM-dd'T'HH:mm:ss") Date date) {
-        this.date = toMidnight(date);
+    @Given("^the simple date is (.+)$")
+    public void the_simple_date_is(@DateFormat("yyyy/MM/dd") Date date) {
+        this.date = date;
     }
 
-    @Given("^the iso calendar is (\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2})$")
-    public void the_iso_calendar_is(@DateFormat("yyyy-MM-dd'T'HH:mm:ss") Calendar cal) {
-        this.date = toMidnight(cal);
+    @Given("^the ISO date with timezone is (.+$)")
+    public void the_ISO_date_with_timezone_is(@DateFormat("yyyy-MM-dd'T'HH:mm:ss, z") Date date) {
+        this.date = date;
     }
 
-    private Date toMidnight(Date date) {
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.US);
+
+    @Then("^the date should be viewed in (.+) as (\\d+), (\\d+), (\\d+), (\\d+), (\\d+), (\\d+)$")
+    public void the_date_should_be_decomposed_as(String timeZone, int year, int month, int day, int hours,
+                                                 int minutes, int seconds) {
+        Calendar cal;
+        if (timeZone.equals("default")) {
+            cal = Calendar.getInstance(TimeZone.getDefault());
+        } else {
+            cal = Calendar.getInstance(TimeZone.getTimeZone(timeZone));
+        }
+        cal.setLenient(false);
         cal.setTime(date);
-        return toMidnight(cal);
-    }
-
-    private Date toMidnight(Calendar cal) {
-        cal.set(Calendar.HOUR_OF_DAY, 0);
-        cal.set(Calendar.MINUTE, 0);
-        cal.set(Calendar.SECOND, 0);
-        cal.set(Calendar.MILLISECOND, 0);
-        return cal.getTime();
-    }
-
-    @Then("^the date should be (.+)$")
-    public void the_date_should_be(@DateFormat("MMM dd yyyy") Date date) {
-        assertEquals(this.date, date);
+        assertEquals(year, cal.get(Calendar.YEAR));
+        assertEquals(month, cal.get(Calendar.MONTH) + 1); //calendar month are 0 based
+        assertEquals(day, cal.get(Calendar.DAY_OF_MONTH));
+        assertEquals(hours, cal.get(Calendar.HOUR_OF_DAY));
+        assertEquals(minutes, cal.get(Calendar.MINUTE));
+        assertEquals(seconds, cal.get(Calendar.SECOND));
     }
 }

--- a/picocontainer/src/test/resources/cucumber/runtime/java/picocontainer/dates.feature
+++ b/picocontainer/src/test/resources/cucumber/runtime/java/picocontainer/dates.feature
@@ -1,17 +1,27 @@
 Feature: Dates
 
-  Scenario: A pretty date
-    Given the date is 2011/10/25
-    Then the date should be Oct 25 2011
 
-  Scenario: An ISO 8601 date
-    Given the iso date is 2012-03-01T06:54:14
-    Then the date should be Mar 1 2012
+  Scenario Outline: Parsing dates with simple a format (yyyy/MM/dd)
+    Given the simple date is <input date>
+    Then the date should be viewed in <timezone> as <year>, <month>, <day>, <hours>, <minutes>, <seconds>
 
-  Scenario: An ISO 8601 date as Calendar
-    Given the iso calendar is 2012-03-01T06:54:14
-    Then the date should be Mar 1 2012
+  Examples:
+    | input date | year | month | day | hours | minutes | seconds | timezone |
+    | 2012/03/01 | 2012 | 3     | 1   | 0     | 0       | 0       | default  |
 
-  Scenario: Another ISO 8601 date as Calendar
-    Given the iso calendar is 2013-03-01T06:54:14
-    Then the date should be Mar 1 2013
+  Scenario Outline: Parsing dates with an ISO format (yyyy-MM-dd'T'HH:mm:ss)
+    Given the ISO date is <input date>
+    Then the date should be viewed in <timezone> as <year>, <month>, <day>, <hours>, <minutes>, <seconds>
+
+  Examples:
+    | input date          | timezone | year | month | day | hours | minutes | seconds |
+    | 2012-03-01T06:54:14 | default  | 2012 | 3     | 1   | 6     | 54      | 14      |
+
+  Scenario Outline: Parsing dates with a format including timezone (yyyy-MM-dd'T'HH:mm:ss, z)
+    Given the ISO date with timezone is <input date>
+    Then the date should be viewed in <timezone> as <year>, <month>, <day>, <hours>, <minutes>, <seconds>
+
+  Examples:
+    | input date               | timezone | year | month | day | hours | minutes | seconds |
+    | 2008-12-31T23:59:59, PST | PST      | 2008 | 12    | 31  | 23    | 59      | 59      |
+    | 2008-12-31T23:59:59, PST | UTC      | 2009 | 1     | 1   | 7     | 59      | 59      |


### PR DESCRIPTION
Cucumber shouldn't hard code the timezone. I've had issues with that since i'm located in France, all my dates aren't at midnight which is cumbersome. I removed the timezone assignations and wrote new scenarios in dates.feature. The tests still pass with any custom timezone passed to the VM.
