### PR TITLE
Use Clojure's 'is' macro instead of 'assert' for testing.

### DIFF
--- a/examples/clojure_cukes/test/features/step_definitions/cuke_steps.clj
+++ b/examples/clojure_cukes/test/features/step_definitions/cuke_steps.clj
@@ -8,4 +8,4 @@
       (eat (repeat (read-string n) thing)))
 
 (Then #"^I am \"([^\"]*)\"$" [mood-name]
-      (assert (= (name (mood)) mood-name)))
+      (is (= (name (mood)) mood-name)))


### PR DESCRIPTION
The 'assert' function is designed for use with functions' pre and post
assertions, and throws an actual exception when it fails. The 'is'
macro, on the other hand, produces expected output regarding failed
expectations in the code.
