### PR TITLE
Fix for Issue #315

### DIFF
--- a/core/src/main/java/cucumber/formatter/JUnitFormatter.java
+++ b/core/src/main/java/cucumber/formatter/JUnitFormatter.java
@@ -80,7 +80,7 @@ public class JUnitFormatter implements Formatter, Reporter {
     public void done() {
         try {
             //set up a transformer
-            rootElement.setAttribute("failed", String.valueOf(rootElement.getElementsByTagName("failure").getLength()));
+            rootElement.setAttribute("failures", String.valueOf(rootElement.getElementsByTagName("failure").getLength()));
             TransformerFactory transfac = TransformerFactory.newInstance();
             Transformer trans = transfac.newTransformer();
             trans.setOutputProperty(OutputKeys.INDENT, "yes");


### PR DESCRIPTION
The formatter was setting an attribute "failed," but ant (and I'm
assuming other CLI tools) look for a "failures" attribute.
