### PR TITLE
PrintSummary show execution details

### DIFF
--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -42,6 +42,8 @@ public class Runtime implements UnreportedStepExecutor {
     private final ResourceLoader resourceLoader;
     private final ClassLoader classLoader;
 
+    private int featuresRun = 0;
+    
     //TODO: These are really state machine variables, and I'm not sure the runtime is the best place for this state machine
     //They really should be created each time a scenario is run, not in here
     private boolean skipNextStep = false;
@@ -79,8 +81,10 @@ public class Runtime implements UnreportedStepExecutor {
      * This is the main entry point. Used from CLI, but not from JUnit.
      */
     public void run() {
-        for (CucumberFeature cucumberFeature : runtimeOptions.cucumberFeatures(resourceLoader)) {
+    	featuresRun = 0;
+    	for (CucumberFeature cucumberFeature : runtimeOptions.cucumberFeatures(resourceLoader)) {
             run(cucumberFeature);
+            featuresRun++;
         }
         Formatter formatter = runtimeOptions.formatter(classLoader);
 
@@ -270,5 +274,9 @@ public class Runtime implements UnreportedStepExecutor {
 
     public void writeStepdefsJson() throws IOException {
         glue.writeStepdefsJson(runtimeOptions.featurePaths, runtimeOptions.dotCucumber);
+    }
+    
+    public int getfeaturesRun(){
+    	return featuresRun;
     }
 }

--- a/core/src/main/java/cucumber/runtime/snippets/SummaryPrinter.java
+++ b/core/src/main/java/cucumber/runtime/snippets/SummaryPrinter.java
@@ -14,6 +14,7 @@ public class SummaryPrinter {
         out.println();
         printErrors(runtime);
         printSnippets(runtime);
+        printExecution(runtime);
     }
 
     private void printErrors(cucumber.runtime.Runtime runtime) {
@@ -33,5 +34,12 @@ public class SummaryPrinter {
                 out.println(snippet);
             }
         }
+    }
+    
+    private void printExecution(cucumber.runtime.Runtime runtime){
+    	out.println(String.format("Total features: %s, Failures: %s, Skipped: %s",
+    			runtime.getfeaturesRun() 
+    	    	,runtime.getErrors().size(),
+    	    	runtime.getSnippets().size()));
     }
 }


### PR DESCRIPTION
Add an execution summary at the end of the run to resemble maven results display. My company is migrating from previous version of cucumber and some team mates would like to see this feature implemented.
Thank you
