### PR TITLE
increase snapshot versions after typo in mvn release-prepare

### DIFF
--- a/clojure/pom.xml
+++ b/clojure/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-clojure</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-core</artifactId>

--- a/examples/groovy-calculator/pom.xml
+++ b/examples/groovy-calculator/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>groovy-calculator</artifactId>

--- a/examples/java-calculator/pom.xml
+++ b/examples/java-calculator/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-calculator</artifactId>

--- a/examples/java-webbit-websockets-selenium/pom.xml
+++ b/examples/java-webbit-websockets-selenium/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-webbit-websockets-selenium</artifactId>

--- a/examples/scala-calculator/pom.xml
+++ b/examples/scala-calculator/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>scala-calculator</artifactId>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-groovy</artifactId>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-guice</artifactId>

--- a/ioke/pom.xml
+++ b/ioke/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-ioke</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-java</artifactId>

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-jruby</artifactId>

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-junit</artifactId>

--- a/jython/pom.xml
+++ b/jython/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-jython</artifactId>

--- a/openejb/pom.xml
+++ b/openejb/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-openejb</artifactId>

--- a/picocontainer/pom.xml
+++ b/picocontainer/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-picocontainer</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>info.cukes</groupId>
     <artifactId>cucumber-jvm</artifactId>
-    <version>1.0.12-SNAPSHOT</version>
+    <version>1.0.13-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Cucumber-JVM</name>
     <url>http://cukes.info/</url>

--- a/rhino/pom.xml
+++ b/rhino/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-rhino</artifactId>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-scala</artifactId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-spring</artifactId>

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.12-SNAPSHOT</version>
+        <version>1.0.13-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-weld</artifactId>


### PR DESCRIPTION
In the last mvn release-prepare process the version number for the next development iteration was not increased.
I updated the poms to include the increased version number.
