### PR TITLE
TableDiff with list of pojos: camelcase convert of column names to field names

### DIFF
--- a/core/src/main/java/cucumber/table/xstream/ComplexTypeWriter.java
+++ b/core/src/main/java/cucumber/table/xstream/ComplexTypeWriter.java
@@ -3,6 +3,8 @@ package cucumber.table.xstream;
 import java.util.ArrayList;
 import java.util.List;
 
+import cucumber.table.CamelCaseStringConverter;
+
 import static java.util.Arrays.asList;
 
 public class ComplexTypeWriter extends CellWriter {
@@ -23,11 +25,12 @@ public class ComplexTypeWriter extends CellWriter {
 
     @Override
     public List<String> getValues() {
+      CamelCaseStringConverter converter = new CamelCaseStringConverter();
         if (columnNames.size() > 0) {
             String[] explicitFieldValues = new String[columnNames.size()];
             int n = 0;
             for (String columnName : columnNames) {
-                int index = fieldNames.indexOf(columnName);
+                int index = fieldNames.indexOf(converter.map(columnName));
                 if (index == -1) {
                     explicitFieldValues[n] = "";
                 } else {

--- a/core/src/test/java/cucumber/table/TableDifferTest.java
+++ b/core/src/test/java/cucumber/table/TableDifferTest.java
@@ -2,6 +2,7 @@ package cucumber.table;
 
 import org.junit.Test;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -120,4 +121,33 @@ public class TableDifferTest {
             throw e;
         }
     }
+    @Test
+    public void diff_with_list_of_pojos_and_camelcase_header_mapping() {
+        String source = "" +
+          "| id | Given Name |\n" +
+          "| 1  | me   |\n" +
+          "| 2  | you  |\n" +
+          "| 3  | jdoe |\n";
+        
+        DataTable expected = TableParser.parse(source, null);
+
+        List<TestPojo> actual = new ArrayList<TestPojo>();
+        actual.add(new TestPojo(1,"me",123));
+        actual.add(new TestPojo(2,"you",222));
+        actual.add(new TestPojo(3,"jdoe",34545));
+        expected.diff(actual);
+    }
 }
+
+class TestPojo {
+    Integer id;
+    String givenName;
+    int   decisionCriteria;
+
+    public TestPojo(Integer id, String givenName , int decisionCriteria) {
+      this.id = id;
+      this.givenName = givenName;
+      this.decisionCriteria = decisionCriteria;
+    }
+}
+


### PR DESCRIPTION
Example:

```
@Given("pattern$")
public void given_method(List<pojo> input) {
...
}

List<pojo> calculated;

@Then("^phrase...:$")
public void then_phrase(DataTable expected) throws Throwable {
     expected.diff(calculated);
} 
```

Diff fails, if column headers in the expected table are not written exactly the same as the field members of the pojo (even if expected and calculated are equal). 

In contrast, in the @Given implementation cucumber does convert column headings to field names (camelCase).

It would be more consistent, if the same mapping rules were applied to the conversion DataDable <-> list of pojos

The present pull request contains a column header -> fieldname mapping in the ComplexTypeWriter used in the diff method.
