### PR TITLE
The cucumber.options system property should only override specified options.

### DIFF
--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -11,6 +11,7 @@ import static java.util.Arrays.asList;
 import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 public class RuntimeOptionsTest {
     @Test
@@ -90,4 +91,44 @@ public class RuntimeOptionsTest {
         assertEquals(asList("lookatme"), options.glue);
     }
 
+    @Test
+    public void ensure_glue_is_set_with_system_properties() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--tags @foo");
+        RuntimeOptions runtimeOptions = new RuntimeOptions(properties, "--glue", "somewhere");
+        assertEquals(asList("somewhere"), runtimeOptions.glue);
+    }
+
+    @Test
+    public void ensure_feature_is_set_with_system_properties() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--tags @foo");
+        RuntimeOptions runtimeOptions = new RuntimeOptions(properties, "somewhere");
+        assertEquals(asList("somewhere"), runtimeOptions.featurePaths);
+    }
+
+    @Test
+    public void can_be_reset() {
+        RuntimeOptions runtimeOptions = new RuntimeOptions(new Properties(), 
+                "--format", "pretty",
+                "--glue", "someglue",
+                "--tags", "@foo",
+                "--strict",
+                "--dryRun",
+                "--monochrome",
+                "path");
+
+        runtimeOptions.reset();
+        assertRuntimeOptionsReset(runtimeOptions);
+    }
+
+    private void assertRuntimeOptionsReset(RuntimeOptions runtimeOptions) {
+        assertFalse(runtimeOptions.strict);
+        assertFalse(runtimeOptions.monochrome);
+        assertFalse(runtimeOptions.dryRun);
+        assertTrue(runtimeOptions.filters.isEmpty());
+        assertTrue(runtimeOptions.featurePaths.isEmpty());
+        assertTrue(runtimeOptions.formatters.isEmpty());
+        assertNull(runtimeOptions.dotCucumber);
+    }
 }

--- a/junit/src/main/java/cucumber/junit/RuntimeOptionsFactory.java
+++ b/junit/src/main/java/cucumber/junit/RuntimeOptionsFactory.java
@@ -6,7 +6,6 @@ import cucumber.runtime.RuntimeOptions;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 
 class RuntimeOptionsFactory {
     private Class clazz;
@@ -29,7 +28,6 @@ class RuntimeOptionsFactory {
         addName(options, args);
 
         RuntimeOptions runtimeOptions = new RuntimeOptions(System.getProperties(), args.toArray(new String[args.size()]));
-        resetGlueAndPath(runtimeOptions);
 
         return runtimeOptions;
     }
@@ -109,16 +107,6 @@ class RuntimeOptionsFactory {
             Collections.addAll(args, options.features());
         } else {
             args.add(MultiLoader.CLASSPATH_SCHEME + packagePath(clazz));
-        }
-    }
-
-    private void resetGlueAndPath(RuntimeOptions runtimeOptions) {
-        if (runtimeOptions.glue.isEmpty()) {
-            runtimeOptions.glue.add(MultiLoader.CLASSPATH_SCHEME + packagePath(clazz));
-        }
-
-        if (runtimeOptions.featurePaths.isEmpty()) {
-            runtimeOptions.featurePaths.add(MultiLoader.CLASSPATH_SCHEME + packagePath(clazz));
         }
     }
 

--- a/junit/src/test/java/cucumber/junit/RuntimeOptionsFactoryTest.java
+++ b/junit/src/test/java/cucumber/junit/RuntimeOptionsFactoryTest.java
@@ -10,7 +10,6 @@ import java.util.regex.Pattern;
 
 import static cucumber.junit.RuntimeOptionsFactory.packageName;
 import static cucumber.junit.RuntimeOptionsFactory.packagePath;
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -69,47 +68,6 @@ public class RuntimeOptionsFactoryTest {
     @Test
     public void finds_path_for_class_in_toplevel_package() {
         assertEquals("", packageName("TopLevelClass"));
-    }
-
-    @Test
-    public void ensure_glue_is_set_with_system_properties() {
-        System.setProperty("cucumber.options", "--tags @foo");
-        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(MultipleNames.class);
-        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
-
-        assertEquals(asList(String.format("classpath:%s", packagePath(MultipleNames.class))), runtimeOptions.glue);
-    }
-
-    @Test
-    public void ensure_feature_is_set_with_system_properties() {
-        System.setProperty("cucumber.options", "--tags @foo");
-        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(MultipleNames.class);
-        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
-
-        assertEquals(asList(String.format("classpath:%s", packagePath(MultipleNames.class))), runtimeOptions.featurePaths);
-    }
-
-    @Test
-    public void override_glue_when_system_properties() {
-        System.setProperty("cucumber.options", "--glue someglue");
-        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(MultipleNames.class);
-        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
-
-        assertEquals(asList("someglue"), runtimeOptions.glue);
-    }
-
-    @Test
-    public void override_feature_path_when_system_properties() {
-        System.setProperty("cucumber.options", "somepath");
-        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(MultipleNames.class);
-        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
-
-        assertEquals(asList("somepath"), runtimeOptions.featurePaths);
-    }
-
-    @After
-    public void unsetCucumberSystemProperty() {
-        System.clearProperty("cucumber.options");
     }
 
     @Cucumber.Options(strict = true)


### PR DESCRIPTION
When setting the "cucumber.options" system property, all the cucumber options
are overridden, including glue and feature path.  This is an issue for junit
for two reasons:
- This is against the logic currently present in RuntimeOptionsFactory which
  sets glue and feature path to default values based on the JUnit test case
  if they are not set by @Cucumber.Options.
- This makes the definition of cucumber.options in a Maven pom file awkward,
  as you have to re-define glue and feature path as a system property, even if
  you have correctly defined the path to the resource folder containing
  feature files.
