### PR TITLE
Normalize the filenames using NFD to make things happy on multiple OS

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -76,7 +76,7 @@ def templateSource = new File(project.baseDir, "src${File.separator}main${File.s
 
 I18n.all.each { i18n ->
     i18n.codeKeywords.each { kw ->
-        def normalized_kw =  Normalizer.normalize(kw,  Normalizer.Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}+", "")
+        def normalized_kw =  Normalizer.normalize(kw,  Normalizer.Form.NFD)
         def binding = ["i18n":i18n, "kw":normalized_kw]
         template = engine.createTemplate(templateSource).make(binding)
         def file = new File(project.baseDir, "target${File.separator}generated-sources${File.separator}i18n${File.separator}java${File.separator}cucumber${File.separator}annotation${File.separator}${i18n.underscoredIsoCode}${File.separator}${normalized_kw}.java")


### PR DESCRIPTION
Citing this insanity:
http://stackoverflow.com/questions/3610013/file-listfiles-mangles-unicode-names-with-jdk-6-unicode-normalization-issues

Builds fine for me on a linux jdk7 box. Need a test on a Mac JDK7 box to be sure that it'll work just fine.

I normalized the filename and the class name using the same logic found in the Jython template.
