### PR TITLE
Up the cucumber-scala Scala dependencies to 2.10.0-RC1 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,12 +121,12 @@
             <dependency>
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-library</artifactId>
-                <version>2.10.0-M6</version>
+                <version>2.10.0-RC1</version>
             </dependency>
             <dependency>
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-compiler</artifactId>
-                <version>2.10.0-M6</version>
+                <version>2.10.0-RC1</version>
             </dependency>
             <dependency>
                 <groupId>org.clojure</groupId>


### PR DESCRIPTION
Changed the dependency versions for scala-library and scala-compiler to the newly released 2.10.0-RC1 version.
