### PR TITLE
Restore ability to diff with another DataTable

### DIFF
--- a/core/src/main/java/cucumber/api/DataTable.java
+++ b/core/src/main/java/cucumber/api/DataTable.java
@@ -143,7 +143,7 @@ public class DataTable {
      * @param other the other table to diff with.
      * @throws TableDiffException if the tables are different.
      */
-    void diff(DataTable other) throws TableDiffException {
+    public void diff(DataTable other) throws TableDiffException {
         new TableDiffer(this, other).calculateDiffs();
     }
 


### PR DESCRIPTION
Made DataTable.diff(DataTable) public.

Alternative is to use non-api TableDiffer.calculateDiff
I didn't add any tests since this is broadening scope of api.
