### PR TITLE
Modified Runtime Options to split cucumber.options on words ignoring spaces in single quotes

### DIFF
--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.ResourceBundle;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static cucumber.runtime.model.CucumberFeature.load;
@@ -40,7 +41,7 @@ public class RuntimeOptions {
 
         parse(new ArrayList<String>(asList(argv)));
         if (properties.containsKey("cucumber.options")) {
-            parse(new ArrayList<String>(asList(properties.getProperty("cucumber.options").split(" "))));
+            parse(cucumberOptionsSplit(properties.getProperty("cucumber.options")));
         }
 
         if (formatters.isEmpty()) {
@@ -54,7 +55,20 @@ public class RuntimeOptions {
         }
     }
 
-    private void parse(List<String> args) {
+    private List<String> cucumberOptionsSplit(String property) {
+    	List<String> matchList = new ArrayList<String>();
+    	Pattern regex = Pattern.compile("[^\\s']+|'([^']*)'");
+    	Matcher regexMatcher = regex.matcher(property);
+    	while (regexMatcher.find()) {
+    		if (regexMatcher.group(1) != null)
+      	       matchList.add(regexMatcher.group(1));
+    		else 
+     	       matchList.add(regexMatcher.group());
+    	} 
+    	return matchList;
+	}
+
+	private void parse(List<String> args) {
         List<Object> parsedFilters = new ArrayList<Object>();
         while (!args.isEmpty()) {
             String arg = args.remove(0);

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -1,5 +1,7 @@
 package cucumber.runtime;
 
+import net.sourceforge.cobertura.ant.Regex;
+
 import org.junit.Test;
 
 import java.io.File;
@@ -71,7 +73,37 @@ public class RuntimeOptionsTest {
         Pattern actualPattern = (Pattern) options.filters.iterator().next();
         assertEquals(someName, actualPattern.pattern());
     }
-
+    
+    @Test
+    public void name_with_spaces() {
+        String someName = "some Name";
+        RuntimeOptions options = new RuntimeOptions(new Properties(), "--name", someName);
+        Pattern actualPattern = (Pattern) options.filters.iterator().next();
+        assertEquals(someName, actualPattern.pattern());
+    } 
+    
+    @Test
+    public void ensure_name_with_spaces_works_with_cucumber_options() {
+        String someName = "some Name";
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--name '" + someName + "'");
+        RuntimeOptions options = new RuntimeOptions(properties);
+        Pattern actualPattern = (Pattern) options.filters.iterator().next();
+        assertEquals(someName, actualPattern.pattern());
+    }
+    
+    @Test
+    public void ensure_multiple_cucumber_options_with_spaces_parse_correctly() {
+        String someName = "some Name";
+        String somePath = "some file\\path";
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--name '" + someName + "'" + " --dotcucumber '" + somePath + "'");
+        RuntimeOptions options = new RuntimeOptions(properties);
+        Pattern actualPattern = (Pattern) options.filters.iterator().next();
+        assertEquals(someName, actualPattern.pattern());
+        assertEquals(new File(somePath), options.dotCucumber);
+    }
+    
     @Test
     public void name_short() {
         String someName = "someName";


### PR DESCRIPTION
Added a private method (cucumberOptionsSplit) to RuntimeOptions to split
on spaces or strings encased in single quotes.

This is a solution to this issue:
[Issue 379: Scenario --name not working for names with quotes and multiple words](https://github.com/cucumber/cucumber-jvm/issues/379)
