### PR TITLE
For cucumber/cucumber-jvm#304

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/FormatterFactory.java
+++ b/core/src/main/java/cucumber/runtime/formatter/FormatterFactory.java
@@ -9,6 +9,7 @@ import gherkin.formatter.JSONPrettyFormatter;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
@@ -39,8 +40,19 @@ public class FormatterFactory {
         put("usage", UsageFormatter.class);
     }};
     private static final Pattern FORMATTER_WITH_FILE_PATTERN = Pattern.compile("([^:]+):(.*)");
-    private Appendable defaultOut = System.out;
+    private Appendable defaultOut = new NonCloseableStdoutWriter();
 
+    static class NonCloseableStdoutWriter extends OutputStreamWriter {
+        NonCloseableStdoutWriter() {
+            super(System.out);
+        }
+        @Override
+        public void close() throws IOException {
+            // We have no intention to close System.out
+        }
+    }
+    
+    
     public Formatter create(String formatterString) {
         Matcher formatterWithFile = FORMATTER_WITH_FILE_PATTERN.matcher(formatterString);
         String formatterName;

--- a/core/src/test/java/cucumber/runtime/formatter/FormatterFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/FormatterFactoryTest.java
@@ -7,9 +7,12 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.hamcrest.CoreMatchers.*;
 
 public class FormatterFactoryTest {
     private FormatterFactory fc = new FormatterFactory();
@@ -69,7 +72,7 @@ public class FormatterFactoryTest {
     @Test
     public void instantiates_single_custom_appendable_formatter_with_stdout() {
         WantsAppendable formatter = (WantsAppendable) fc.create("cucumber.runtime.formatter.FormatterFactoryTest$WantsAppendable");
-        assertEquals(System.out, formatter.out);
+        assertThat(formatter.out, is(instanceOf(OutputStreamWriter.class)));
         try {
             fc.create("cucumber.runtime.formatter.FormatterFactoryTest$WantsAppendable");
             fail();
@@ -81,7 +84,7 @@ public class FormatterFactoryTest {
     @Test
     public void instantiates_custom_appendable_formatter_with_stdout_and_file() throws IOException {
         WantsAppendable formatter = (WantsAppendable) fc.create("cucumber.runtime.formatter.FormatterFactoryTest$WantsAppendable");
-        assertEquals(System.out, formatter.out);
+        assertThat(formatter.out, is(instanceOf(OutputStreamWriter.class)));
 
         WantsAppendable formatter2 = (WantsAppendable) fc.create("cucumber.runtime.formatter.FormatterFactoryTest$WantsAppendable:" + TempDir.createTempFile().getAbsolutePath());
         assertEquals(UTF8FileWriter.class, formatter2.out.getClass());


### PR DESCRIPTION
Changes in  `FormatterFactory`.
Changed `defaultOut` to a wrapper, which will not close `System.out`
