### PR TITLE
Issue #436 - Configured surefire to use UTF-8 for Hellesøy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,7 @@
                         <argLine>-Duser.language=en</argLine>
                         <argLine>-Xmx1024m</argLine>
                         <argLine>-XX:MaxPermSize=256m</argLine>
+                        <argLine>-Dfile.encoding=UTF-8</argLine>
                         <useFile>false</useFile>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Fix for issue #436 (okay, I'm going to stop submitting issues and following up with a pull request a few minutes later now)
