### PR TITLE
fix for #424 checking for dry run option before running hooks.

### DIFF
--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -180,9 +180,11 @@ public class Runtime implements UnreportedStepExecutor {
     }
 
     private void runHooks(List<HookDefinition> hooks, Reporter reporter, Set<Tag> tags, boolean isBefore) {
-        for (HookDefinition hook : hooks) {
-            runHookIfTagsMatch(hook, reporter, tags, isBefore);
-        }
+    	if (!runtimeOptions.dryRun) {
+	    	for (HookDefinition hook : hooks) {
+	            runHookIfTagsMatch(hook, reporter, tags, isBefore);
+	        }
+    	}
     }
 
     private void runHookIfTagsMatch(HookDefinition hook, Reporter reporter, Set<Tag> tags, boolean isBefore) {


### PR DESCRIPTION
Solution for issue #424 .  Checks the dry-run flag before running hooks.  If dry run is set hooks will not run.
