### PR TITLE
The PicoContainer instance can now be configured

### DIFF
--- a/picocontainer/pom.xml
+++ b/picocontainer/pom.xml
@@ -44,6 +44,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>net.sourceforge.cobertura</groupId>
             <artifactId>cobertura</artifactId>
             <scope>test</scope>

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/CustomPicoConfigurerFactory.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/CustomPicoConfigurerFactory.java
@@ -1,0 +1,28 @@
+package cucumber.runtime.java.picocontainer;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import cucumber.runtime.java.picocontainer.configuration.NoOpPicoConfigurer;
+import cucumber.runtime.java.picocontainer.configuration.PicoConfigurer;
+import cucumber.runtime.java.picocontainer.configuration.PicoConfigurerInstantiator;
+
+public class CustomPicoConfigurerFactory {
+
+    private PropertyLoader propertyLoader;
+
+    public CustomPicoConfigurerFactory(PropertyLoader propertyLoader) {
+        this.propertyLoader = propertyLoader;
+    }
+
+    public PicoConfigurer getConfigurer() throws IOException {
+        Properties properties = propertyLoader.getProperties();
+        String picoConfigurerClassName = properties.getProperty("picoConfigurer");
+        if (picoConfigurerClassName == null) {
+            return new NoOpPicoConfigurer();
+        }
+        PicoConfigurer delegateConfigurer = new PicoConfigurerInstantiator().instantiate(picoConfigurerClassName);
+        return new RunOncePicoConfigurer(delegateConfigurer);
+    }
+
+}

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/PicoFactory.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/PicoFactory.java
@@ -1,21 +1,69 @@
 package cucumber.runtime.java.picocontainer;
 
-import cucumber.runtime.java.ObjectFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+
 import org.picocontainer.MutablePicoContainer;
 import org.picocontainer.PicoBuilder;
 
-import java.lang.reflect.Constructor;
-import java.util.HashSet;
-import java.util.Set;
+import cucumber.runtime.java.ObjectFactory;
+import cucumber.runtime.java.picocontainer.configuration.NoOpPicoConfigurer;
+import cucumber.runtime.java.picocontainer.configuration.PicoConfigurer;
+import cucumber.runtime.java.picocontainer.configuration.PicoConfigurerInstantiator;
+import cucumber.runtime.java.picocontainer.configuration.PicoMapper;
 
-public class PicoFactory implements ObjectFactory {
+public class PicoFactory implements ObjectFactory, PicoMapper {
     private MutablePicoContainer pico;
     private final Set<Class<?>> classes = new HashSet<Class<?>>();
+    private final Map<Class<?>, Class<?>> componentKeyToImplementationClassMapping = new HashMap<Class<?>, Class<?>>();
+    private final PicoConfigurer customPicoConfigurer;
+    private boolean picoConfigurerHasRun = false;
+
+    public PicoFactory() throws IOException {
+        this(loadCucumberPicoProperties());
+    }
+
+    PicoFactory(Properties properties) {
+        String picoConfigurerClassName = properties.getProperty("picoConfigurer");
+        if (picoConfigurerClassName == null) {
+            customPicoConfigurer = new NoOpPicoConfigurer();
+        } else {
+            customPicoConfigurer = new PicoConfigurerInstantiator()
+                    .instantiate(picoConfigurerClassName);
+        }
+    }
+
+    private static Properties loadCucumberPicoProperties() throws IOException {
+        Properties properties = new Properties();
+        InputStream inputStream = PicoFactory.class.getResourceAsStream("/cucumber-picocontainer.properties");
+        if (inputStream != null) {
+            try {
+                properties.load(inputStream);
+            } finally {
+                inputStream.close();
+            }
+        }
+        return properties;
+    }
 
     public void start() {
+        if (!picoConfigurerHasRun) {
+            customPicoConfigurer.configure(this);
+            picoConfigurerHasRun = true;
+        }
         pico = new PicoBuilder().withCaching().build();
         for (Class<?> clazz : classes) {
             pico.addComponent(clazz);
+        }
+        for (Entry<Class<?>, Class<?>> mapping : componentKeyToImplementationClassMapping.entrySet()) {
+            pico.addComponent(mapping.getKey(), mapping.getValue());
         }
         pico.start();
     }
@@ -26,9 +74,16 @@ public class PicoFactory implements ObjectFactory {
     }
 
     public void addClass(Class<?> clazz) {
-        if (classes.add(clazz)) {
-            addConstructorDependencies(clazz);
+        if (!clazz.isInterface()) {
+            if (classes.add(clazz)) {
+                addConstructorDependencies(clazz);
+            }
         }
+    }
+
+    public void addClass(Class<?> componentKey, Class<?> implementation) {
+        componentKeyToImplementationClassMapping.put(componentKey, implementation);
+        addConstructorDependencies(implementation);
     }
 
     public <T> T getInstance(Class<T> type) {

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/PicoFactory.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/PicoFactory.java
@@ -1,22 +1,18 @@
 package cucumber.runtime.java.picocontainer;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Properties;
 import java.util.Set;
 
 import org.picocontainer.MutablePicoContainer;
 import org.picocontainer.PicoBuilder;
 
 import cucumber.runtime.java.ObjectFactory;
-import cucumber.runtime.java.picocontainer.configuration.NoOpPicoConfigurer;
 import cucumber.runtime.java.picocontainer.configuration.PicoConfigurer;
-import cucumber.runtime.java.picocontainer.configuration.PicoConfigurerInstantiator;
 import cucumber.runtime.java.picocontainer.configuration.PicoMapper;
 
 public class PicoFactory implements ObjectFactory, PicoMapper {
@@ -26,30 +22,12 @@ public class PicoFactory implements ObjectFactory, PicoMapper {
     private final PicoConfigurer customPicoConfigurer;
 
     public PicoFactory() throws IOException {
-        this(loadCucumberPicoProperties());
+        this(new CustomPicoConfigurerFactory(
+                new PropertyLoader("/cucumber-picocontainer.properties")));
     }
-
-    PicoFactory(Properties properties) {
-        String picoConfigurerClassName = properties.getProperty("picoConfigurer");
-        if (picoConfigurerClassName == null) {
-            customPicoConfigurer = new NoOpPicoConfigurer();
-        } else {
-            customPicoConfigurer = new RunOncePicoConfigurer(
-                    new PicoConfigurerInstantiator().instantiate(picoConfigurerClassName));
-        }
-    }
-
-    private static Properties loadCucumberPicoProperties() throws IOException {
-        Properties properties = new Properties();
-        InputStream inputStream = PicoFactory.class.getResourceAsStream("/cucumber-picocontainer.properties");
-        if (inputStream != null) {
-            try {
-                properties.load(inputStream);
-            } finally {
-                inputStream.close();
-            }
-        }
-        return properties;
+    
+    PicoFactory(CustomPicoConfigurerFactory configurerFactory) throws IOException {
+        customPicoConfigurer = configurerFactory.getConfigurer();
     }
 
     public void start() {

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/PicoFactory.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/PicoFactory.java
@@ -24,7 +24,6 @@ public class PicoFactory implements ObjectFactory, PicoMapper {
     private final Set<Class<?>> classes = new HashSet<Class<?>>();
     private final Map<Class<?>, Class<?>> componentKeyToImplementationClassMapping = new HashMap<Class<?>, Class<?>>();
     private final PicoConfigurer customPicoConfigurer;
-    private boolean picoConfigurerHasRun = false;
 
     public PicoFactory() throws IOException {
         this(loadCucumberPicoProperties());
@@ -35,8 +34,8 @@ public class PicoFactory implements ObjectFactory, PicoMapper {
         if (picoConfigurerClassName == null) {
             customPicoConfigurer = new NoOpPicoConfigurer();
         } else {
-            customPicoConfigurer = new PicoConfigurerInstantiator()
-                    .instantiate(picoConfigurerClassName);
+            customPicoConfigurer = new RunOncePicoConfigurer(
+                    new PicoConfigurerInstantiator().instantiate(picoConfigurerClassName));
         }
     }
 
@@ -54,10 +53,7 @@ public class PicoFactory implements ObjectFactory, PicoMapper {
     }
 
     public void start() {
-        if (!picoConfigurerHasRun) {
-            customPicoConfigurer.configure(this);
-            picoConfigurerHasRun = true;
-        }
+        customPicoConfigurer.configure(this);
         pico = new PicoBuilder().withCaching().build();
         for (Class<?> clazz : classes) {
             pico.addComponent(clazz);

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/PropertyLoader.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/PropertyLoader.java
@@ -1,0 +1,28 @@
+package cucumber.runtime.java.picocontainer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PropertyLoader {
+
+    private String resource;
+
+    public PropertyLoader(String resource) {
+        this.resource = resource;
+    }
+
+    public Properties getProperties() throws IOException {
+        Properties properties = new Properties();
+        InputStream inputStream = PropertyLoader.class.getResourceAsStream(resource);
+        if (inputStream != null) {
+            try {
+                properties.load(inputStream);
+            } finally {
+                inputStream.close();
+            }
+        }
+        return properties;
+    }
+
+}

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/RunOncePicoConfigurer.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/RunOncePicoConfigurer.java
@@ -1,0 +1,23 @@
+package cucumber.runtime.java.picocontainer;
+
+import cucumber.runtime.java.picocontainer.configuration.PicoConfigurer;
+import cucumber.runtime.java.picocontainer.configuration.PicoMapper;
+
+public class RunOncePicoConfigurer implements PicoConfigurer {
+
+    private PicoConfigurer delegateConfigurer;
+    private boolean invoked = false;
+
+    public RunOncePicoConfigurer(PicoConfigurer delegateConfigurer) {
+        this.delegateConfigurer = delegateConfigurer;
+    }
+
+    @Override
+    public void configure(PicoMapper picoMapper) {
+        if (!invoked) {
+            delegateConfigurer.configure(picoMapper);
+            invoked = true;
+        }
+    }
+
+}

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/configuration/NoOpPicoConfigurer.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/configuration/NoOpPicoConfigurer.java
@@ -1,0 +1,10 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+
+public class NoOpPicoConfigurer implements PicoConfigurer {
+
+    @Override
+    public void configure(PicoMapper picoMapper) {
+    }
+
+}

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurer.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurer.java
@@ -1,0 +1,6 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+
+public interface PicoConfigurer {
+    void configure(PicoMapper picoMapper);
+}

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurerInstantiationFailed.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurerInstantiationFailed.java
@@ -1,0 +1,13 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+import static java.text.MessageFormat.format;
+
+public class PicoConfigurerInstantiationFailed extends RuntimeException {
+
+    private static final long serialVersionUID = 975206168851096186L;
+
+    public PicoConfigurerInstantiationFailed(String configurerClassName, Exception e) {
+        super(format("Instantiation of ''{0}'' failed", configurerClassName), e);
+    }
+
+}

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurerInstantiator.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurerInstantiator.java
@@ -1,0 +1,13 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+public class PicoConfigurerInstantiator {
+
+    public PicoConfigurer instantiate(String configurerClassName) {
+        try {
+            return (PicoConfigurer) Class.forName(configurerClassName).newInstance();
+        } catch (Exception e) {
+            throw new PicoConfigurerInstantiationFailed(configurerClassName, e);
+        }
+    }
+
+}

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/configuration/PicoMapper.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/configuration/PicoMapper.java
@@ -1,0 +1,7 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+public interface PicoMapper {
+
+    void addClass(Class<?> componentKey, Class<?> implementation);
+
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/CustomPicoConfigurerFactoryTest.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/CustomPicoConfigurerFactoryTest.java
@@ -1,5 +1,6 @@
 package cucumber.runtime.java.picocontainer;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -23,7 +24,7 @@ public class CustomPicoConfigurerFactoryTest {
     public void shouldGiveUsANoOpConfigurerIfNoPropertyExists() throws Exception {
         Properties emptyProperties = new Properties();
         PicoConfigurer configurer = getConfigurerFromProperties(emptyProperties);
-        assertThat(configurer, is(NoOpPicoConfigurer.class));
+        assertThat(configurer, is(instanceOf(NoOpPicoConfigurer.class)));
     }
 
     @Test
@@ -32,7 +33,7 @@ public class CustomPicoConfigurerFactoryTest {
         properties.put("picoConfigurer", "cucumber.runtime.java.picocontainer.configuration.YourPicoConfigurer");
         PicoConfigurer configurer = getConfigurerFromProperties(properties);
 
-        assertThat(configurer, is(RunOncePicoConfigurer.class));
+        assertThat(configurer, is(instanceOf(RunOncePicoConfigurer.class)));
         assertThatYourPicoConfigurerIsDelegatedTo(configurer);
     }
 

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/CustomPicoConfigurerFactoryTest.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/CustomPicoConfigurerFactoryTest.java
@@ -1,0 +1,53 @@
+package cucumber.runtime.java.picocontainer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.junit.Test;
+
+import cucumber.runtime.java.picocontainer.configuration.GreeterImplementation;
+import cucumber.runtime.java.picocontainer.configuration.GreeterInterface;
+import cucumber.runtime.java.picocontainer.configuration.NoOpPicoConfigurer;
+import cucumber.runtime.java.picocontainer.configuration.PicoConfigurer;
+import cucumber.runtime.java.picocontainer.configuration.PicoMapper;
+
+public class CustomPicoConfigurerFactoryTest {
+
+    @Test
+    public void shouldGiveUsANoOpConfigurerIfNoPropertyExists() throws Exception {
+        Properties emptyProperties = new Properties();
+        PicoConfigurer configurer = getConfigurerFromProperties(emptyProperties);
+        assertThat(configurer, is(NoOpPicoConfigurer.class));
+    }
+
+    @Test
+    public void shouldGiveUsARunOnceConfigurerWrappingThePicoConfigurerSpecifiedInTheProperties() throws Exception {
+        Properties properties = new Properties();
+        properties.put("picoConfigurer", "cucumber.runtime.java.picocontainer.configuration.YourPicoConfigurer");
+        PicoConfigurer configurer = getConfigurerFromProperties(properties);
+
+        assertThat(configurer, is(RunOncePicoConfigurer.class));
+        assertThatYourPicoConfigurerIsDelegatedTo(configurer);
+    }
+
+    private PicoConfigurer getConfigurerFromProperties(Properties properties) throws IOException {
+        PropertyLoader propertyLoader = mock(PropertyLoader.class);
+        when(propertyLoader.getProperties()).thenReturn(properties);
+
+        CustomPicoConfigurerFactory configurerFactory = new CustomPicoConfigurerFactory(propertyLoader);
+        return configurerFactory.getConfigurer();
+    }
+
+    private void assertThatYourPicoConfigurerIsDelegatedTo(PicoConfigurer configurer) {
+        PicoMapper picoMapper = mock(PicoMapper.class);
+        configurer.configure(picoMapper);
+        verify(picoMapper).addClass(GreeterInterface.class, GreeterImplementation.class);
+    }
+
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/PicoFactoryTest.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/PicoFactoryTest.java
@@ -1,5 +1,6 @@
 package cucumber.runtime.java.picocontainer;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -52,7 +53,7 @@ public class PicoFactoryTest {
         factory.start();
 
         assertThat(factory.getInstance(GreeterInterface.class),
-                is(GreeterImplementation.class));
+                is(instanceOf(GreeterImplementation.class)));
     }
 
     @Test
@@ -71,7 +72,7 @@ public class PicoFactoryTest {
         factory.start();
 
         assertThat(factory.getInstance(GreeterInterface.class),
-                is(GreeterWithCollaborators.class));
+                is(instanceOf(GreeterWithCollaborators.class)));
     }
 
     private ObjectFactory aFactoryConfiguredWith(String configurer) throws Exception {

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/PicoFactoryTest.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/PicoFactoryTest.java
@@ -1,14 +1,23 @@
 package cucumber.runtime.java.picocontainer;
 
-import cucumber.runtime.java.ObjectFactory;
-import org.junit.Test;
-
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThat;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+import cucumber.runtime.java.ObjectFactory;
+import cucumber.runtime.java.picocontainer.configuration.CallCountingConfigurer;
+import cucumber.runtime.java.picocontainer.configuration.GreeterImplementation;
+import cucumber.runtime.java.picocontainer.configuration.GreeterInterface;
+import cucumber.runtime.java.picocontainer.configuration.GreeterWithCollaborators;
 
 public class PicoFactoryTest {
     @Test
-    public void shouldGiveUsNewInstancesForEachScenario() {
+    public void shouldGiveUsNewInstancesForEachScenario() throws Exception {
         ObjectFactory factory = new PicoFactory();
         factory.addClass(StepDefs.class);
 
@@ -24,6 +33,52 @@ public class PicoFactoryTest {
 
         assertNotNull(o1);
         assertNotSame(o1, o2);
+    }
+    
+    @Test
+    public void shouldIgnoreInterfacesAsTheyCanNotBeInstantiated() throws Exception {
+        ObjectFactory factory = new PicoFactory();
+        factory.addClass(MyInterface.class);
+        factory.start();
+    }
+
+    interface MyInterface {
+    }
+
+    @Test
+    public void shouldAllowConfigurationOfThePicoInstance() throws Exception {
+        ObjectFactory factory = aFactoryConfiguredWith("cucumber.runtime.java.picocontainer.configuration.YourPicoConfigurer");
+        factory.start();
+
+        assertThat(factory.getInstance(GreeterInterface.class),
+                is(GreeterImplementation.class));
+    }
+    
+    @Test
+    public void shoudlOnlyRunTheCustomPicoConfigurerOnce() throws Exception {
+        ObjectFactory factory = aFactoryConfiguredWith("cucumber.runtime.java.picocontainer.configuration.CallCountingConfigurer");
+        factory.start();
+        factory.stop();
+        factory.start();
+
+        assertThat(CallCountingConfigurer.timesRun, is(1));
+    }
+    
+    @Test
+    public void shouldAutowireDependenciesOfCustomConfiguredClass() throws Exception {
+        ObjectFactory factory = aFactoryConfiguredWith("cucumber.runtime.java.picocontainer.configuration.ConfiguredClassHasDepdendenciesConfigurer");
+        factory.start();
+
+        assertThat(factory.getInstance(GreeterInterface.class),
+                is(GreeterWithCollaborators.class));
+    }
+
+    private ObjectFactory aFactoryConfiguredWith(String configurer) {
+        Properties properties = new Properties();
+        properties.setProperty("picoConfigurer", configurer);
+
+        ObjectFactory factory = new PicoFactory(properties);
+        return factory;
     }
 
 }

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/PicoFactoryTest.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/PicoFactoryTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
 
+import java.io.IOException;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -34,7 +35,7 @@ public class PicoFactoryTest {
         assertNotNull(o1);
         assertNotSame(o1, o2);
     }
-    
+
     @Test
     public void shouldIgnoreInterfacesAsTheyCanNotBeInstantiated() throws Exception {
         ObjectFactory factory = new PicoFactory();
@@ -53,7 +54,7 @@ public class PicoFactoryTest {
         assertThat(factory.getInstance(GreeterInterface.class),
                 is(GreeterImplementation.class));
     }
-    
+
     @Test
     public void shoudlOnlyRunTheCustomPicoConfigurerOnce() throws Exception {
         ObjectFactory factory = aFactoryConfiguredWith("cucumber.runtime.java.picocontainer.configuration.CallCountingConfigurer");
@@ -63,7 +64,7 @@ public class PicoFactoryTest {
 
         assertThat(CallCountingConfigurer.timesRun, is(1));
     }
-    
+
     @Test
     public void shouldAutowireDependenciesOfCustomConfiguredClass() throws Exception {
         ObjectFactory factory = aFactoryConfiguredWith("cucumber.runtime.java.picocontainer.configuration.ConfiguredClassHasDepdendenciesConfigurer");
@@ -73,11 +74,16 @@ public class PicoFactoryTest {
                 is(GreeterWithCollaborators.class));
     }
 
-    private ObjectFactory aFactoryConfiguredWith(String configurer) {
-        Properties properties = new Properties();
+    private ObjectFactory aFactoryConfiguredWith(String configurer) throws Exception {
+        final Properties properties = new Properties();
         properties.setProperty("picoConfigurer", configurer);
 
-        ObjectFactory factory = new PicoFactory(properties);
+        ObjectFactory factory = new PicoFactory(new CustomPicoConfigurerFactory(new PropertyLoader("unused") {
+            @Override
+            public Properties getProperties() throws IOException {
+                return properties;
+            }
+        }));
         return factory;
     }
 

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/RunOncePicoConfigurerTest.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/RunOncePicoConfigurerTest.java
@@ -1,0 +1,26 @@
+package cucumber.runtime.java.picocontainer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import cucumber.runtime.java.picocontainer.configuration.PicoConfigurer;
+import cucumber.runtime.java.picocontainer.configuration.PicoMapper;
+
+public class RunOncePicoConfigurerTest {
+
+    @Test
+    public void onlyConfiguresPicoOnce() {
+        PicoMapper picoMapper = mock(PicoMapper.class);
+        PicoConfigurer delegateConfigurer = mock(PicoConfigurer.class);
+
+        RunOncePicoConfigurer runOncePicoConfigurer = new RunOncePicoConfigurer(delegateConfigurer);
+        runOncePicoConfigurer.configure(picoMapper);
+        runOncePicoConfigurer.configure(picoMapper);
+
+        verify(delegateConfigurer, times(1)).configure(picoMapper);
+    }
+
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/CallCountingConfigurer.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/CallCountingConfigurer.java
@@ -1,0 +1,15 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+import cucumber.runtime.java.picocontainer.configuration.PicoConfigurer;
+import cucumber.runtime.java.picocontainer.configuration.PicoMapper;
+
+public class CallCountingConfigurer implements PicoConfigurer {
+
+    public static int timesRun = 0;
+
+    @Override
+    public void configure(PicoMapper picoMapper) {
+        timesRun++;
+    }
+
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/ConfiguredClassHasDepdendenciesConfigurer.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/ConfiguredClassHasDepdendenciesConfigurer.java
@@ -1,0 +1,11 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+
+public class ConfiguredClassHasDepdendenciesConfigurer implements PicoConfigurer {
+
+    @Override
+    public void configure(PicoMapper picoMapper) {
+        picoMapper.addClass(GreeterInterface.class, GreeterWithCollaborators.class);
+    }
+
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/GreeterCollaborator.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/GreeterCollaborator.java
@@ -1,0 +1,4 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+public class GreeterCollaborator {
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/GreeterImplementation.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/GreeterImplementation.java
@@ -1,0 +1,9 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+public class GreeterImplementation implements GreeterInterface {
+
+    @Override
+    public String greet() {
+        return "Good day!";
+    }
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/GreeterInterface.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/GreeterInterface.java
@@ -1,0 +1,5 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+public interface GreeterInterface {
+    String greet();
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/GreeterWithCollaborators.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/GreeterWithCollaborators.java
@@ -1,0 +1,19 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+
+public class GreeterWithCollaborators implements GreeterInterface {
+
+    private GreeterCollaborator greeterCollaborator;
+
+    public GreeterWithCollaborators(GreeterCollaborator greeterCollaborator) {
+        this.greeterCollaborator = greeterCollaborator;
+    }
+
+    @Override
+    public String greet() {
+        if (greeterCollaborator == null) {
+            throw new IllegalStateException("Collaborator was null");
+        }
+        return "Complex Greeting";
+    }
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurerInstantiationFailedTest.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurerInstantiationFailedTest.java
@@ -1,0 +1,24 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class PicoConfigurerInstantiationFailedTest {
+
+    @Test
+    public void shouldFormatADescriptiveMessage() {
+        PicoConfigurerInstantiationFailed exception = new PicoConfigurerInstantiationFailed("bogus.class", null);
+        assertThat(exception.getMessage(),
+                is("Instantiation of 'bogus.class' failed"));
+    }
+
+    @Test
+    public void shouldIncludeTheOriginalThrowable() throws Exception {
+        Exception original = new RuntimeException("original");
+        PicoConfigurerInstantiationFailed exception = new PicoConfigurerInstantiationFailed("bogus.class", original);
+        assertThat(exception.getCause(), is((Throwable) original));
+    }
+
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurerInstantiatorTest.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurerInstantiatorTest.java
@@ -1,0 +1,39 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class PicoConfigurerInstantiatorTest {
+
+    private PicoConfigurerInstantiator instantiator = new PicoConfigurerInstantiator();
+
+    @Test
+    public void instantiates_configurer_by_fully_qualified_name() throws Exception {
+        assertThat(instantiate(YourPicoConfigurer.class),
+                is(instanceOf(YourPicoConfigurer.class)));
+    }
+
+    @Test(expected = PicoConfigurerInstantiationFailed.class)
+    public void fails_to_instantiate_non_existant_class() throws Exception {
+        instantiator.instantiate("some.bogus.Class");
+    }
+
+    @Test(expected = PicoConfigurerInstantiationFailed.class)
+    public void fails_to_instantiate_class_not_implementing_pico_configurer() throws Exception {
+        instantiate(String.class);
+    }
+
+    @Test(expected = PicoConfigurerInstantiationFailed.class)
+    public void fails_to_instantiate_class_with_private_constructor() throws Exception {
+        instantiate(PrivateConstructor.class);
+    }
+
+    private PicoConfigurer instantiate(Class<?> moduleClass) {
+        String moduleClassName = moduleClass.getCanonicalName();
+        return instantiator.instantiate(moduleClassName);
+    }
+
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurerStepdefs.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/PicoConfigurerStepdefs.java
@@ -1,0 +1,27 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+
+public class PicoConfigurerStepdefs {
+
+    private final GreeterInterface greeter;
+    private String greeting;
+
+    public PicoConfigurerStepdefs(GreeterInterface greeter) {
+        this.greeter = greeter;
+    }
+
+    @Given("^I am greeted$")
+    public void I_am_greeted() throws Throwable {
+        greeting = greeter.greet();
+    }
+
+    @Then("^the greeter configured in my custom PicoConfigurer is used$")
+    public void the_greeter_configured_in_my_custom_Pico_Configurer_is_used() throws Throwable {
+        assertThat(greeting, is(new GreeterImplementation().greet()));
+    }
+
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/PrivateConstructor.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/PrivateConstructor.java
@@ -1,0 +1,14 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+
+public class PrivateConstructor implements PicoConfigurer {
+
+    private PrivateConstructor() {
+    }
+
+    @Override
+    public void configure(PicoMapper picoMapper) {
+        throw new RuntimeException("Configure should not be called for: " + this.getClass().getName());
+    }
+
+}

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/YourPicoConfigurer.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/configuration/YourPicoConfigurer.java
@@ -1,0 +1,10 @@
+package cucumber.runtime.java.picocontainer.configuration;
+
+
+class YourPicoConfigurer implements PicoConfigurer {
+
+    @Override
+    public void configure(PicoMapper picoMapper) {
+        picoMapper.addClass(GreeterInterface.class, GreeterImplementation.class);
+    }
+}

--- a/picocontainer/src/test/resources/.cucumber/stepdefs.json
+++ b/picocontainer/src/test/resources/.cucumber/stepdefs.json
@@ -7,6 +7,16 @@
   {
     "steps": [
       {
+        "name": "I am greeted",
+        "args": []
+      }
+    ],
+    "source": "^I am greeted$",
+    "flags": ""
+  },
+  {
+    "steps": [
+      {
         "name": "I have 12 cukes in my belly",
         "args": [
           {
@@ -129,6 +139,16 @@
   {
     "steps": [],
     "source": "^the date should be viewed in (.+) as (\\d+), (\\d+), (\\d+), (\\d+), (\\d+), (\\d+)$",
+    "flags": ""
+  },
+  {
+    "steps": [
+      {
+        "name": "the greeter configured in my custom PicoConfigurer is used",
+        "args": []
+      }
+    ],
+    "source": "^the greeter configured in my custom PicoConfigurer is used$",
     "flags": ""
   },
   {

--- a/picocontainer/src/test/resources/cucumber-picocontainer.properties
+++ b/picocontainer/src/test/resources/cucumber-picocontainer.properties
@@ -1,0 +1,1 @@
+picoConfigurer=cucumber.runtime.java.picocontainer.configuration.YourPicoConfigurer

--- a/picocontainer/src/test/resources/cucumber/runtime/java/picocontainer/configuration/configuring_pico.feature
+++ b/picocontainer/src/test/resources/cucumber/runtime/java/picocontainer/configuration/configuring_pico.feature
@@ -1,0 +1,5 @@
+Feature: Configuring Pico Container
+
+  Scenario:
+    Given I am greeted
+    Then the greeter configured in my custom PicoConfigurer is used


### PR DESCRIPTION
I've had a go at issue #290

By implementing your own PicoConfigurer (and pointing to it from
cucumber-picocontainer.properties) you can add arbitrary mappings to the
MutablePicoContainer instance.

Particularly useful if you want to have Step Defs or other classes
depend on an interface. The implementation to use can be mapped in your
custom PicoConfigurer.

This work is based on the custom Module support in cucumber-guice.