### PR TITLE
Diffing tables doesn't work when delta span multiple lines

### DIFF
--- a/core/src/test/java/cucumber/runtime/table/TableDifferTest.java
+++ b/core/src/test/java/cucumber/runtime/table/TableDifferTest.java
@@ -20,6 +20,34 @@ public class TableDifferTest {
         return TableParser.parse(source, null);
     }
 
+    private DataTable otherTableWithTwoConsecutiveRowsDeleted() {
+        String source = "" +
+                "| Aslak | aslak@email.com | 123 |\n" +
+                "| Ni    | ni@email.com    | 654 |\n";
+        return TableParser.parse(source, null);
+
+    }
+
+    private DataTable otherTableWithTwoConsecutiveRowsChanged() {
+        String source = "" +
+                "| Aslak | aslak@email.com  | 123 |\n" +
+                "| Joe   | joe@NOSPAM.com   | 234 |\n" +
+                "| Bryan | bryan@NOSPAM.org | 456 |\n" +
+                "| Ni    | ni@email.com     | 654 |\n";
+        return TableParser.parse(source, null);
+    }
+
+    private DataTable otherTableWithTwoConsecutiveRowsInserted() {
+        String source = "" +
+                "| Aslak | aslak@email.com      | 123 |\n" +
+                "| Joe   | joe@email.com        | 234 |\n" +
+                "| Doe   | joe@email.com        | 234 |\n" +
+                "| Foo   | schnickens@email.net | 789 |\n" +
+                "| Bryan | bryan@email.org      | 456 |\n" +
+                "| Ni    | ni@email.com         | 654 |\n";
+        return TableParser.parse(source, null);
+    }
+
     private DataTable otherTableWithDeletedAndInserted() {
         String source = "" +
                 "| Aslak | aslak@email.com      | 123 |\n" +
@@ -58,6 +86,7 @@ public class TableDifferTest {
             throw e;
         }
     }
+
 
     @Test(expected = TableDiffException.class)
     public void shouldFindNewLinesAtEnd() {
@@ -105,21 +134,68 @@ public class TableDifferTest {
     public void should_not_fail_with_out_of_memory() {
         DataTable expected = TableParser.parse("" +
                 "| I'm going to work |\n", null);
-
         List<List<String>> actual = new ArrayList<List<String>>();
-
         actual.add(asList("I just woke up"));
         actual.add(asList("I'm going to work"));
+        expected.diff(actual);
+    }
 
+    @Test(expected = TableDiffException.class)
+    public void should_diff_when_consecutive_deleted_lines() {
         try {
-            expected.diff(actual);
+            List<List<String>> other = otherTableWithTwoConsecutiveRowsDeleted().raw();
+            table().diff(other);
         } catch (TableDiffException e) {
-            String expectedDiff = "" +
+            String expected = "" +
                     "Tables were not identical:\n" +
-                    "    + | I just woke up |\n";
-            assertEquals(expectedDiff, e.getMessage());
+                    "      | Aslak | aslak@email.com | 123 |\n" +
+                    "    - | Joe   | joe@email.com   | 234 |\n" +
+                    "    - | Bryan | bryan@email.org | 456 |\n" +
+                    "      | Ni    | ni@email.com    | 654 |\n";
+            assertEquals(expected, e.getMessage());
             throw e;
         }
+
+    }
+
+    @Test(expected = TableDiffException.class)
+    public void should_diff_when_consecutive_changed_lines() {
+        try {
+            List<List<String>> other = otherTableWithTwoConsecutiveRowsChanged().raw();
+            table().diff(other);
+        } catch (TableDiffException e) {
+            String expected = "" +
+                    "Tables were not identical:\n" +
+                    "      | Aslak | aslak@email.com  | 123 |\n" +
+                    "    - | Joe   | joe@email.com    | 234 |\n" +
+                    "    - | Bryan | bryan@email.org  | 456 |\n" +
+                    "    + | Joe   | joe@NOSPAM.com   | 234 |\n" +
+                    "    + | Bryan | bryan@NOSPAM.org | 456 |\n" +
+                    "      | Ni    | ni@email.com     | 654 |\n";
+            assertEquals(expected, e.getMessage());
+            throw e;
+        }
+
+    }
+
+    @Test(expected = TableDiffException.class)
+    public void should_diff_when_consecutive_inserted_lines() {
+        try {
+            List<List<String>> other = otherTableWithTwoConsecutiveRowsInserted().raw();
+            table().diff(other);
+        } catch (TableDiffException e) {
+            String expected = "" +
+                    "Tables were not identical:\n" +
+                    "      | Aslak | aslak@email.com      | 123 |\n" +
+                    "      | Joe   | joe@email.com        | 234 |\n" +
+                    "    + | Doe   | joe@email.com        | 234 |\n" +
+                    "    + | Foo   | schnickens@email.net | 789 |\n" +
+                    "      | Bryan | bryan@email.org      | 456 |\n" +
+                    "      | Ni    | ni@email.com         | 654 |\n";
+            assertEquals(expected, e.getMessage());
+            throw e;
+        }
+
     }
 
     public static class TestPojo {
@@ -133,6 +209,7 @@ public class TableDifferTest {
             this.decisionCriteria = decisionCriteria;
         }
     }
+
 
     @Test
     public void diff_with_list_of_pojos_and_camelcase_header_mapping() {


### PR DESCRIPTION
We noticed this rather annoying issue :

Diffing 

``` gherkin
| Aslak | aslak@email.com | 123 |
| Joe   | joe@email.com   | 234 |
| Bryan | bryan@email.org | 456 |
| Ni    | ni@email.com    | 654 |
```

with 

``` gherkin
| Aslak | aslak@email.com | 123 |
| Ni    | ni@email.com    | 654 |
```

will return the following delta : 

``` gherkin
Tables were not identical:
      | Aslak | aslak@email.com | 123 |
    - | Joe   | joe@email.com   | 234 |
    - | Bryan | bryan@email.org | 456 |
      | Bryan | bryan@email.org | 456 |
      | Ni    | ni@email.com    | 654 |
```

Notice that the Bryan line is listed twice.

I want to tackle the issue but would like you to confirm this is unexpected ?
