### PR TITLE
throw exception when unsupported options are passed

### DIFF
--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -75,7 +75,7 @@ public class RuntimeOptions {
             String arg = args.remove(0).trim();
 
             if (arg.equals("--help") || arg.equals("-h")) {
-                System.out.println(USAGE);
+                printUsage();
                 System.exit(0);
             } else if (arg.equals("--version") || arg.equals("-v")) {
                 System.out.println(VERSION);
@@ -100,6 +100,9 @@ public class RuntimeOptions {
                 String nextArg = args.remove(0);
                 Pattern patternFilter = Pattern.compile(nextArg);
                 parsedFilters.add(patternFilter);
+            } else if (arg.startsWith("-")) {
+                printUsage();
+                throw new CucumberException("Unknown option: " + arg);
             } else {
                 PathWithLines pathWithLines = new PathWithLines(arg);
                 featurePaths.add(pathWithLines.path);
@@ -110,6 +113,11 @@ public class RuntimeOptions {
             filters.clear();
             filters.addAll(parsedFilters);
         }
+    }
+
+    private void printUsage()
+    {
+        System.out.println(USAGE);
     }
 
     public List<CucumberFeature> cucumberFeatures(ResourceLoader resourceLoader) {

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -11,6 +11,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class RuntimeOptionsTest {
     @Test
@@ -153,4 +154,15 @@ public class RuntimeOptionsTest {
         RuntimeOptions runtimeOptions = new RuntimeOptions(properties, "--strict");
         assertFalse(runtimeOptions.strict);
     }
+
+    @Test
+    public void fail_on_unsupported_options() {
+        try {
+            new RuntimeOptions(new Properties(), "-concreteUnsupportedOption", "somewhere", "somewhere_else");
+            fail();
+        } catch (CucumberException e) {
+            assertEquals("Unknown option: -concreteUnsupportedOption", e.getMessage());
+        }
+    }
+
 }

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -164,11 +164,11 @@ public class RuntimeTest {
     }
 
     private Runtime createStrictRuntime() {
-        return createRuntime("-g anything", "--strict");
+        return createRuntime("-g", "anything", "--strict");
     }
 
     private Runtime createNonStrictRuntime() {
-        return createRuntime("-g anything");
+        return createRuntime("-g", "anything");
     }
 
     private Runtime createRuntime(String... runtimeArgs) {


### PR DESCRIPTION
when options starting with a dash are passed which aren't handled specifically, the usages are printed to system.out and an exception is thrown

Issue #463
