### PR TITLE
Output embedded text in HTML report

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
@@ -135,12 +135,17 @@ class HTMLFormatter implements Formatter, Reporter {
 
     @Override
     public void embedding(String mimeType, byte[] data) {
-        // Creating a file instead of using data urls to not clutter the js file
-        String extension = MIME_TYPES_EXTENSIONS.get(mimeType);
-        if (extension != null) {
-            StringBuilder fileName = new StringBuilder("embedded").append(embeddedIndex++).append(".").append(extension);
-            writeBytesAndClose(data, reportFileOutputStream(fileName.toString()));
-            jsFunctionCall("embedding", mimeType, fileName);
+        if(mimeType.startsWith("text/")) {
+            // just pass straight to the formatter to output in the html
+            jsFunctionCall("embedding", mimeType, new String(data));
+        } else {
+            // Creating a file instead of using data urls to not clutter the js file
+            String extension = MIME_TYPES_EXTENSIONS.get(mimeType);
+            if (extension != null) {
+                StringBuilder fileName = new StringBuilder("embedded").append(embeddedIndex++).append(".").append(extension);
+                writeBytesAndClose(data, reportFileOutputStream(fileName.toString()));
+                jsFunctionCall("embedding", mimeType, fileName);
+            }
         }
     }
 

--- a/core/src/test/java/cucumber/runtime/formatter/HTMLFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/HTMLFormatterTest.java
@@ -65,6 +65,7 @@ public class HTMLFormatterTest {
     public void included_embedding() throws IOException {
         String reportJs = FixJava.readReader(new InputStreamReader(new URL(outputDir, "report.js").openStream(), "UTF-8"));
         assertContains("formatter.embedding(\"image/png\", \"embedded0.png\");", reportJs);
+        assertContains("formatter.embedding(\"text/plain\", \"dodgy stack trace here\");", reportJs);
     }
 
     private void assertContains(String substring, String string) {
@@ -78,6 +79,7 @@ public class HTMLFormatterTest {
         f.uri("some\\windows\\path\\some.feature");
         f.scenario(new Scenario(Collections.<Comment>emptyList(), Collections.<Tag>emptyList(), "Scenario", "some cukes", "", 10, "id"));
         f.embedding("image/png", "fakedata".getBytes("US-ASCII"));
+        f.embedding("text/plain", "dodgy stack trace here".getBytes("US-ASCII"));
         f.done();
         f.close();
     }


### PR DESCRIPTION
The formatter in cucumber-html already supports embedding content
with mime-types starting with "text/" into the HTML report -
this just makes cucumber-jvm not swallow the text content before
it gets that far.
