### PR TITLE
Got rid of Maven Shade Plugin wherever it was possible.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -85,13 +85,13 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
+                <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                    <archive>
+                        <manifest>
                             <mainClass>cucumber.api.cli.Main</mainClass>
-                        </transformer>
-                    </transformers>
+                        </manifest>
+                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -24,12 +24,10 @@
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>gherkin</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.groovy</groupId>

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -20,12 +20,10 @@
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>gherkin</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jruby</groupId>

--- a/jython/pom.xml
+++ b/jython/pom.xml
@@ -20,12 +20,10 @@
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>gherkin</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.python</groupId>

--- a/picocontainer/pom.xml
+++ b/picocontainer/pom.xml
@@ -20,12 +20,10 @@
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>gherkin</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.picocontainer</groupId>
@@ -52,10 +50,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
Artefacts which still have need to use the plugin:

```
- cucumber-groovy
- cucumber-jython
- cucumber-jruby
```

The PR is related to #518 and #520 issues.

Also, the `cucumber-core` artefact can't be used as standalone jar at the moment because of the `java.lang.NoClassDefFoundError: gherkin/util/FixJava`.
Maybe that would be appropriate to create something like `cucumber-standalone` or `cucumber-cli` artefact which has all needed shaded artefacts/jars.
