### PR TITLE
Fixed issue #532: JUnitFormatter does not throw exception in done() method.

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
@@ -97,7 +97,7 @@ class JUnitFormatter implements Formatter, Reporter {
             DOMSource source = new DOMSource(doc);
             trans.transform(source, result);
         } catch (TransformerException e) {
-            new CucumberException("Error while transforming.", e);
+            throw new CucumberException("Error while transforming.", e);
         }
     }
 


### PR DESCRIPTION
Just a little change I made while writing TestNGFormatter :)
It does not break any tests.
