### PR TITLE
Transform ISO-Latin-1 special characters while sanitizing function name

### DIFF
--- a/core/src/main/java/cucumber/runtime/snippets/SnippetGenerator.java
+++ b/core/src/main/java/cucumber/runtime/snippets/SnippetGenerator.java
@@ -86,7 +86,20 @@ public final class SnippetGenerator {
                 sanitized.append(SUBST);
             }
         }
-        return sanitized.toString();
+        return sanitized.toString().replaceAll("[ÁÀÂÄÃÅ]", "A")
+                .replaceAll("[Ç]", "C").replaceAll("[Ð]", "D")
+                .replaceAll("[ÉÈÊË]", "E").replaceAll("[ÍÌÎÏ]", "I")
+                .replaceAll("[Ñ]", "N").replaceAll("[ÓÒÔÖÕØ]", "O")
+                .replaceAll("[ÚÙÛÜ]", "U").replaceAll("[ÝŸ]", "Y")
+                .replaceAll("[Æ]", "AE").replaceAll("[Œ]", "OE")
+                .replaceAll("[Š]", "Sh").replaceAll("[Ž]", "Zh")
+                .replaceAll("[áàâäãå]", "a").replaceAll("[ç]", "c")
+                .replaceAll("[ð]", "d").replaceAll("[éèêë]", "e")
+                .replaceAll("[íìîï]", "i").replaceAll("[ñ]", "n")
+                .replaceAll("[óòôöõø]", "o").replaceAll("[úùûü]", "u")
+                .replaceAll("[ýÿ]", "y").replaceAll("[æ]", "ae")
+                .replaceAll("[œ]", "oe").replaceAll("[š]", "sh")
+                .replaceAll("[ž]", "zh");
     }
 
     private String withNamedGroups(String snippetPattern) {

--- a/core/src/test/java/cucumber/runtime/snippets/SnippetGeneratorTest.java
+++ b/core/src/test/java/cucumber/runtime/snippets/SnippetGeneratorTest.java
@@ -1,0 +1,49 @@
+﻿package cucumber.runtime.snippets;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SnippetGeneratorTest {
+
+    private SnippetGenerator snippetGenerator;
+
+    @Before
+    public void setup() {
+        snippetGenerator = new SnippetGenerator(null);
+    }
+
+    @Test
+    public void test_SanitizeFunctionName_using_a_standard_english_sentence() {
+        String functionName = " simple step_def  I'd like to write,  as is ";
+        String expectedSanitizedFunctionName = "simple_step_def_I_d_like_to_write_as_is";
+        assertEquals(expectedSanitizedFunctionName,
+                snippetGenerator.sanitizeFunctionName(functionName));
+    }
+
+    @Test
+    public void test_SanitizeFunctionName_using_several_underscores() {
+        String functionName = "_  _one_ word _or two__words_  _ ";
+        String expectedSanitizedFunctionName = "__one_word__or_two__words__";
+        assertEquals(expectedSanitizedFunctionName,
+                snippetGenerator.sanitizeFunctionName(functionName));
+    }
+
+    @Test
+    public void test_SanitizeFunctionName_using_latin_specific_characters() {
+        String functionName = " une étape,  un maître, un hôte  en français sans être exhaustif ";
+        String expectedSanitizedFunctionName = "une_etape_un_maitre_un_hote_en_francais_sans_etre_exhaustif";
+        assertEquals(expectedSanitizedFunctionName,
+                snippetGenerator.sanitizeFunctionName(functionName));
+    }
+
+    @Test
+    public void test_SanitizeFunctionName_ISO_IEC_8859_1_characters() {
+        String functionName = "ÁáÀàÂâÄäÃãÅåÇçÐðÉéÈèÊêËëÍíÌìÎîÏïÑñÓóÒòÔôÖöÕõØøÚúÙùÛûÜüÝýŸÿÆæŒœŠšŽž";
+        String expectedSanitizedFunctionName = "AaAaAaAaAaAaCcDdEeEeEeEeIiIiIiIiNnOoOoOoOoOoOoUuUuUuUuYyYyAEaeOEoeShshZhzh";
+        assertEquals(expectedSanitizedFunctionName,
+                snippetGenerator.sanitizeFunctionName(functionName));
+    }
+
+}


### PR DESCRIPTION
I need to replace ISO-Latin-1 characters such as 'é' or 'ç' by english charset equivalent ones 'e' and 'c' so that those specific latin characters are not used in java method names.
