### PR TITLE
Let the JUnitFormatter mark skipped tests as failures in strict mode

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/StrictAware.java
+++ b/core/src/main/java/cucumber/runtime/formatter/StrictAware.java
@@ -1,0 +1,5 @@
+package cucumber.runtime.formatter;
+
+public interface StrictAware {
+    public void setStrict(boolean strict);
+}

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -2,6 +2,12 @@ package cucumber.runtime;
 
 import org.junit.Test;
 
+import cucumber.runtime.formatter.ColorAware;
+import cucumber.runtime.formatter.FormatterFactory;
+import cucumber.runtime.formatter.StrictAware;
+
+import gherkin.formatter.Formatter;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Properties;
@@ -12,6 +18,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 public class RuntimeOptionsTest {
     @Test
@@ -165,4 +175,25 @@ public class RuntimeOptionsTest {
         }
     }
 
+    @Test
+    public void set_monochrome_on_color_aware_formatters() throws Exception {
+        FormatterFactory factory = mock(FormatterFactory.class);
+        Formatter colorAwareFormatter = mock(Formatter.class, withSettings().extraInterfaces(ColorAware.class));
+        when(factory.create("progress")).thenReturn(colorAwareFormatter);
+
+        new RuntimeOptions(new Properties(), factory, "--monochrome", "--format", "progress");
+
+        verify((ColorAware)colorAwareFormatter).setMonochrome(true);
+    }
+
+    @Test
+    public void set_strict_on_strict_aware_formatters() throws Exception {
+        FormatterFactory factory = mock(FormatterFactory.class);
+        Formatter strictAwareFormatter = mock(Formatter.class, withSettings().extraInterfaces(StrictAware.class));
+        when(factory.create("junit:out/dir")).thenReturn(strictAwareFormatter);
+
+        new RuntimeOptions(new Properties(), factory, "--strict", "--format", "junit:out/dir");
+
+        verify((StrictAware)strictAwareFormatter).setStrict(true);
+    }
 }

--- a/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
@@ -45,12 +45,26 @@ public class JUnitFormatterTest {
         assertXmlEqual("cucumber/runtime/formatter/JUnitFormatterTest_3.report.xml", report);
     }
 
+    @Test
+    public void featureSimpleStrictTest() throws Exception {
+        boolean strict = true;
+        File report = runFeaturesWithJunitFormatter(asList("cucumber/runtime/formatter/JUnitFormatterTest_1.feature"), strict);
+        assertXmlEqual("cucumber/runtime/formatter/JUnitFormatterTest_1_strict.report.xml", report);
+    }
+
     private File runFeaturesWithJunitFormatter(final List<String> featurePaths) throws IOException {
+        return runFeaturesWithJunitFormatter(featurePaths, false);
+    }
+
+    private File runFeaturesWithJunitFormatter(final List<String> featurePaths, boolean strict) throws IOException {
         File report = File.createTempFile("cucumber-jvm-junit", "xml");
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final ClasspathResourceLoader resourceLoader = new ClasspathResourceLoader(classLoader);
 
         List<String> args = new ArrayList<String>();
+        if (strict) {
+            args.add("--strict");
+        }
         args.add("--format");
         args.add("junit:" + report.getAbsolutePath());
         args.addAll(featurePaths);

--- a/core/src/test/resources/cucumber/runtime/formatter/JUnitFormatterTest_1_strict.report.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/JUnitFormatterTest_1_strict.report.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testsuite tests="2" failures="2">
+    <testcase classname="Feature_1" name="Scenario_1" time="0">
+        <failure message="The scenario has pending or undefined step(s)"><![CDATA[Given step_1................................................................undefined
+When step_2.................................................................undefined
+Then step_3.................................................................undefined
+]]></failure>
+    </testcase>
+    <testcase classname="Feature_1" name="Scenario_2" time="0">
+        <failure message="The scenario has pending or undefined step(s)"><![CDATA[Given step_1................................................................undefined
+When step_2.................................................................undefined
+Then step_3.................................................................undefined
+]]></failure>
+    </testcase>
+</testsuite>


### PR DESCRIPTION
Let the option strict make the JUnitFormatter to mark skipped tests as failures.

Use a new interface StrictAware to determine which formatters the strict option should be passed to, following the example of the interface ColorAware determining which formatters the monochrome option is sent to.
