### PR TITLE
Disable Travis snapshots deploy for pull requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -439,6 +439,33 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>travis-disable-deploy-by-default</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>env.TRAVIS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>travis-enable-deploy-if-not-pull-request</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>env.TRAVIS_PULL_REQUEST</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <properties>
+                <maven.deploy.skip>false</maven.deploy.skip>
+            </properties>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
As @brasmusson pointed out in #536, Travis should not try to deploy snapshots for pull requests. This pull request should enable deploy when they are merged only.

Some concerns:
- Anyone could re-enable it by commenting out those lines and sending a pull request
- Each artifact is deployed as soon as the tests pass, but I think they should be deployed only if the entire build succeeds (after_success phase)
