### PR TITLE
Java-Helloworld: use dependencies from Cucumber-JVM pom, update formatters

### DIFF
--- a/examples/java-helloworld/pom.xml
+++ b/examples/java-helloworld/pom.xml
@@ -2,9 +2,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>info.cukes</groupId>
+    <parent>
+        <groupId>info.cukes</groupId>
+        <artifactId>cucumber-jvm</artifactId>
+        <relativePath>../../pom.xml</relativePath>
+        <version>1.1.4-SNAPSHOT</version>
+    </parent>
+
     <artifactId>java-helloworld</artifactId>
-    <version>1.1.3</version>
     <packaging>jar</packaging>
     <name>Examples: Java Hello World</name>
 
@@ -36,13 +41,11 @@
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-java</artifactId>
-            <version>1.1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>1.1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -54,7 +57,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/java-helloworld/src/test/java/cucumber/examples/java/helloworld/RunCukesTest.java
+++ b/examples/java-helloworld/src/test/java/cucumber/examples/java/helloworld/RunCukesTest.java
@@ -4,6 +4,6 @@ import cucumber.api.junit.Cucumber;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@Cucumber.Options(format = {"html:target/cucumber-html-report", "json-pretty:target/cucumber-json-report.json"})
+@Cucumber.Options(format = {"pretty", "html:target/cucumber-html-report", "json:target/cucumber-json-report.json"})
 public class RunCukesTest {
 }

--- a/examples/java-helloworld/src/test/resources/cucumber/examples/java/helloworld/helloworld.feature
+++ b/examples/java-helloworld/src/test/resources/cucumber/examples/java/helloworld/helloworld.feature
@@ -17,7 +17,7 @@ Feature: Hello World
       | Soap  | 5     |
     When I print that list
     Then it should look like:
-    """
+      """
       1 Cocoa
       2 Milk
       5 Soap


### PR DESCRIPTION
Inherit the dependencies from the Cucumber-JVM pom (as the java-calculator example already does), since the 1.1.4-SNAPSHOT version then will be used, the pretty formatter can be used again.
Use the json formatter instead of json-pretty formatter (which has been removed). Put back the pretty formatter (which now works again).
Adjust the shopping list scenario not to expect blanks in the beginning of each line.
