### PR TITLE
The JSONFormatter should record before hooks in the next scenario

### DIFF
--- a/core/src/test/resources/cucumber/runtime/formatter/JSONPrettyFormatterTest.json
+++ b/core/src/test/resources/cucumber/runtime/formatter/JSONPrettyFormatterTest.json
@@ -99,15 +99,6 @@
       },
       {
         "id": "feature-3;scenariooutline-1",
-        "before": [
-          {
-            "result": {
-              "duration": 1234,
-              "status": "passed"
-            },
-            "match": {}
-          }
-        ],
         "description": "",
         "name": "ScenarioOutline_1",
         "keyword": "Scenario Outline",
@@ -389,6 +380,15 @@
       },
       {
         "id": "feature-3;scenario-2",
+        "before": [
+          {
+            "result": {
+              "duration": 1234,
+              "status": "passed"
+            },
+            "match": {}
+          }
+        ],
         "description": "",
         "name": "Scenario_2",
         "keyword": "Scenario",


### PR DESCRIPTION
For all but the before hooks executed before the first scenario, the JSONFormatter records them for the latest started scenario, instead of the scenario be to executed next. The before hook data is shifted up one scenario, so generally the first scenario will record two hook executions for each before hook, and the last scenario none.
