### PR TITLE
Scenario Outlines: Replace tokens in the names of the generated "Example Scenario"s

### DIFF
--- a/core/src/main/java/cucumber/runtime/model/CucumberScenarioOutline.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberScenarioOutline.java
@@ -48,7 +48,10 @@ public class CucumberScenarioOutline extends CucumberTagStatement {
     }
 
     CucumberScenario createExampleScenario(ExamplesTableRow header, ExamplesTableRow example, List<Tag> examplesTags) {
-        Scenario exampleScenario = new Scenario(example.getComments(), examplesTags, getGherkinModel().getKeyword(), getGherkinModel().getName(), "", example.getLine(), example.getId());
+        // Make sure we replace the tokens in the name of the scenario
+        String exampleScenarioName = replaceTokens(new HashSet<Integer>(), header.getCells(), example.getCells(), getGherkinModel().getName());
+
+        Scenario exampleScenario = new Scenario(example.getComments(), examplesTags, getGherkinModel().getKeyword(), exampleScenarioName, "", example.getLine(), example.getId());
         CucumberScenario cucumberScenario = new CucumberScenario(cucumberFeature, cucumberBackground, exampleScenario, example);
         for (Step step : getSteps()) {
             cucumberScenario.step(createExampleStep(step, header, example));

--- a/core/src/test/java/cucumber/runtime/model/CucumberScenarioOutlineTest.java
+++ b/core/src/test/java/cucumber/runtime/model/CucumberScenarioOutlineTest.java
@@ -4,10 +4,13 @@ import gherkin.formatter.model.Comment;
 import gherkin.formatter.model.DataTableRow;
 import gherkin.formatter.model.DocString;
 import gherkin.formatter.model.ExamplesTableRow;
+import gherkin.formatter.model.ScenarioOutline;
 import gherkin.formatter.model.Step;
+import gherkin.formatter.model.Tag;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -15,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 
 public class CucumberScenarioOutlineTest {
     private static final List<Comment> C = new ArrayList<Comment>();
+    private static final List<Tag> T =  Collections.<Tag>emptyList();
 
     @Test
     public void replaces_tokens_in_step_names() {
@@ -38,5 +42,41 @@ public class CucumberScenarioOutlineTest {
 
         Step exampleStep = CucumberScenarioOutline.createExampleStep(outlineStep, new ExamplesTableRow(C, asList("n"), 1, ""), new ExamplesTableRow(C, asList("10"), 1, ""));
         assertEquals(asList("I", "have 10 cukes"), exampleStep.getRows().get(0).getCells());
-    }
+    }  
+
+    /***
+     * From a scenario outline, we create one or more "Example Scenario"s. This is composed
+     * of each step from the outline, with the tokens replaced with the pertient values 
+     * for the current example row. <p />
+     * 
+     * Each "Example Scenario" has a name. This was previously just a copy of the outline's
+     * name. However, we'd like to be able to support token replacement in the scenario too,
+     * for example:
+     * 
+     * <pre>
+     * Scenario Outline: Time offset check for <LOCATION_NAME>
+     * Given my local country is <LOCATION_NAME>
+     * When I compare the time difference to GMT
+     * Then the time offset should be <OFFSET>
+     *  
+     * Examples: 
+     * | LOCATION_NAME | OFFSET |
+     * | London        | 1      |
+     * | San Fran      | 8      |
+     * </pre>
+     * 
+     * Will create a scenario named "Time offset check for London" for the first row in the 
+     * examples table.
+     */
+    @Test
+    public void replaces_tokens_in_scenario_names() {
+        // Create Gherkin the outline itself ...
+        ScenarioOutline outline = new ScenarioOutline(C, T,"Scenario Outline", "Time offset check for <LOCATION_NAME>", "", new Integer(1), "");
+
+        // ... then the Cukes implementation
+        CucumberScenarioOutline cukeOutline = new CucumberScenarioOutline(null, null, outline);
+        CucumberScenario exampleScenario = cukeOutline.createExampleScenario(new ExamplesTableRow(C, asList("LOCATION_NAME"), 1, ""), new ExamplesTableRow(C, asList("London"), 1, ""), T);
+
+        assertEquals("Time offset check for London", exampleScenario.getGherkinModel().getName());
+    }  
 }


### PR DESCRIPTION
My changes are best illustrated with the following example scenario:

```
Scenario Outline: Time offset check for <LOCATION_NAME>
 Given my local country is <LOCATION_NAME>
 When I compare the time difference to GMT
 Then the time offset should be <OFFSET>

 Examples: 
  | LOCATION_NAME | OFFSET |
  | London        | 1      |
  | New York      | 4      |
  | San Fran      | 8      |
```

I was hoping in the generated report would have the LOCATION_NAME token substituted for the value of the example being run in the scenario outline name. However this is not happening - and each scenario outline has the name verbatim from the above: `Scenario Outline: Time offset check for <LOCATION_NAME>`.

This change simply runs the scenario name through `CucumberScenarioOutline.replaceTokens(...)` method to replace the tokens with the relevant values for each "Scenario Example" that is generated.

Fixes #510.
