### PR TITLE
Make a separate Travis job for android

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ jdk:
 matrix:
   include:
   - jdk: oraclejdk7
-    script: mvn -q deploy -P android --settings .travis-settings.xml -Dno.gem.deploy=true -Dandroid.device=test
+    script: mvn -q deploy --settings .travis-settings.xml -Dno.gem.deploy=true
+  - jdk: oraclejdk7
+    env: ANDROID=true
+    script: mvn -q deploy -P android -pl android --settings .travis-settings.xml -Dno.gem.deploy=true -Dandroid.device=test
     before_install:
       # Install base Android SDK
       - sudo apt-get update -qq


### PR DESCRIPTION
Two oraclejdk7 job are defined for Travis. One that builds, tests and deploys snapshots for all modules except the android module, and one that builds, tests and deploys snapshot for the android module. Given that Travis executes `mvn install -DskipTests=true -B` at the beginning to install the project's dependencies with Maven, the android job will actually build (but not test) all the modules.
The environment variable ANDROID=true which is specified for the android job is not used for anything other than identifying the android job among the two oraclejkd7 jobs in Travis build matrix list.
Fixes #581.
