### PR TITLE
Using spring @ContextHierarchy to manage multiple @ContextConfiguration's breaks with 1.1.5

### DIFF
--- a/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
+++ b/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.GenericXmlApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.TestContextManager;
 
 import cucumber.runtime.CucumberException;
@@ -168,6 +169,7 @@ public class SpringFactory implements ObjectFactory {
     }
 
     private boolean dependsOnSpringContext(Class<?> type) {
-        return type.isAnnotationPresent(ContextConfiguration.class);
+        return type.isAnnotationPresent(ContextConfiguration.class)
+            || type.isAnnotationPresent(ContextHierarchy.class);
     }
 }

--- a/spring/src/test/java/cucumber/runtime/java/spring/SpringFactoryTest.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/SpringFactoryTest.java
@@ -64,6 +64,18 @@ public class SpringFactoryTest {
     }
 
     @Test
+    public void shouldRespectContextHierarchyInStepDefs() {
+        final ObjectFactory factory = new SpringFactory();
+        factory.addClass(WithContextHierarchyAnnotation.class);
+        factory.start();
+        WithContextHierarchyAnnotation stepdef = factory.getInstance(WithContextHierarchyAnnotation.class);
+        factory.stop();
+
+        assertNotNull(stepdef);
+        assertTrue(stepdef.isAutowired());
+    }
+
+    @Test
     public void shouldRespectDirtiesContextAnnotationsInStepDefs() {
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(DirtiesContextBellyStepDefs.class);

--- a/spring/src/test/java/cucumber/runtime/java/spring/WithContextHierarchyAnnotation.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/WithContextHierarchyAnnotation.java
@@ -1,0 +1,22 @@
+package cucumber.runtime.java.spring;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+
+@ContextHierarchy(@ContextConfiguration("classpath:cucumber.xml"))
+public class WithContextHierarchyAnnotation {
+
+    private boolean autowired;
+
+    @Autowired
+    public void setAutowiredCollaborator(DummyComponent collaborator) {
+        autowired = true;
+    }
+
+    public boolean isAutowired() {
+        return autowired;
+    }
+
+}


### PR DESCRIPTION
The new version of SpringFactory includes the code:

``` java
    private boolean dependsOnSpringContext(Class<?> type) {
        return type.isAnnotationPresent(ContextConfiguration.class);
    }
```

This should probably be extended to:

``` java
    private boolean dependsOnSpringContext(Class<?> type) {
        return type.isAnnotationPresent(ContextConfiguration.class)
            || type.isAnnotationPresent(ContextHierarchy.class);
    }
```
