### PR TITLE
Log a warning when more than one IoC dependency is found in the classpath

### DIFF
--- a/core/src/main/java/cucumber/runtime/NoInstancesException.java
+++ b/core/src/main/java/cucumber/runtime/NoInstancesException.java
@@ -1,0 +1,12 @@
+package cucumber.runtime;
+
+public class NoInstancesException extends CucumberException {
+
+    public NoInstancesException(Class parentType) {
+        super(createMessage(parentType));
+    }
+
+    private static String createMessage(Class parentType) {
+        return String.format("Couldn't find a single implementation of " + parentType);
+    }
+}

--- a/core/src/main/java/cucumber/runtime/Reflections.java
+++ b/core/src/main/java/cucumber/runtime/Reflections.java
@@ -7,9 +7,6 @@ import java.util.HashSet;
 public class Reflections {
     private final ClassFinder classFinder;
 
-    public static final String NO_INSTANCES_MSG = "Couldn't find a single implementation of ";
-    public static final String TOO_MANY_INSTANCES_MSG = "Expected only one instance, but found too many";
-
     public Reflections(ClassFinder classFinder) {
         this.classFinder = classFinder;
     }
@@ -19,9 +16,9 @@ public class Reflections {
         if (instances.size() == 1) {
             return instances.iterator().next();
         } else if (instances.size() == 0) {
-            throw new CucumberException(NO_INSTANCES_MSG + parentType);
+            throw new NoInstancesException(parentType);
         } else {
-            throw new CucumberException(TOO_MANY_INSTANCES_MSG + ": " + instances);
+            throw new TooManyInstancesException(instances);
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/TooManyInstancesException.java
+++ b/core/src/main/java/cucumber/runtime/TooManyInstancesException.java
@@ -1,0 +1,14 @@
+package cucumber.runtime;
+
+import java.util.Collection;
+
+public class TooManyInstancesException extends CucumberException {
+
+    public TooManyInstancesException(Collection instances) {
+        super(createMessage(instances));
+    }
+
+    private static String createMessage(Collection instances) {
+        return String.format("Expected only one instance, but found too many: " + instances);
+    }
+}

--- a/java/src/main/java/cucumber/runtime/java/JavaBackend.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaBackend.java
@@ -2,14 +2,7 @@ package cucumber.runtime.java;
 
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
-import cucumber.runtime.Backend;
-import cucumber.runtime.ClassFinder;
-import cucumber.runtime.CucumberException;
-import cucumber.runtime.DuplicateStepDefinitionException;
-import cucumber.runtime.Glue;
-import cucumber.runtime.Reflections;
-import cucumber.runtime.UnreportedStepExecutor;
-import cucumber.runtime.Utils;
+import cucumber.runtime.*;
 import cucumber.runtime.io.MultiLoader;
 import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.io.ResourceLoaderClassFinder;
@@ -61,10 +54,10 @@ public class JavaBackend implements Backend {
         try {
             Reflections reflections = new Reflections(classFinder);
             objectFactory = reflections.instantiateExactlyOneSubclass(ObjectFactory.class, "cucumber.runtime", new Class[0], new Object[0]);
-        } catch (CucumberException ce) {
-            if (ce.getMessage().contains(Reflections.TOO_MANY_INSTANCES_MSG)) {
-                System.out.println(getMultipleObjectFactoryLogMessage());
-            }
+        } catch (TooManyInstancesException e) {
+            System.out.println(getMultipleObjectFactoryLogMessage());
+            objectFactory = new DefaultJavaObjectFactory();
+        } catch (NoInstancesException e) {
             objectFactory = new DefaultJavaObjectFactory();
         }
         return objectFactory;


### PR DESCRIPTION
It has happened to us that people put more than one IoC dependency into their classpath (e.g. cucumber-spring AND cucumber-guice) and suddenly their beans are not being wired correctly. This is because when Cucumber detects such situation it silently defaults to DefaultJavaObjectFactory which doesn't provide IoC features.

This pull request adds a warning so at least this situation can be spotted while reading the log.
