### PR TITLE
Fix and improve CamelCaseFunctionNameSanitizer

### DIFF
--- a/core/src/main/java/cucumber/runtime/snippets/CamelCaseFunctionNameSanitizer.java
+++ b/core/src/main/java/cucumber/runtime/snippets/CamelCaseFunctionNameSanitizer.java
@@ -17,7 +17,7 @@ public class CamelCaseFunctionNameSanitizer implements FunctionNameSanitizer {
         sanitized.append(words[0].toLowerCase());
 
         for (int i = 1; i < words.length; i++) {
-            sanitized.append(capitalize(words[i].toLowerCase()));
+            sanitized.append(sanitizeWord(words[i]));
         }
 
         return sanitized.toString();
@@ -25,5 +25,29 @@ public class CamelCaseFunctionNameSanitizer implements FunctionNameSanitizer {
 
     private String capitalize(String line) {
         return line.length() > 0 ? Character.toUpperCase(line.charAt(0)) + line.substring(1) : "";
+    }
+
+    private boolean isUpperCaseAcronym(String word) {
+        if (word == null || word.length() < 2) {
+            return false;
+        }
+
+        for (char c : word.toCharArray()) {
+            if (Character.isLowerCase(c)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private String sanitizeWord(String word) {
+        if (word == null) {
+            return "";
+        } else if (word.length() == 2 && isUpperCaseAcronym(word)) {
+            return word;
+        } else {
+            return capitalize(isUpperCaseAcronym(word) ? word.toLowerCase() : word);
+        }
     }
 }

--- a/core/src/test/java/cucumber/runtime/snippets/CamelCaseFunctionNameSanitizerTest.java
+++ b/core/src/test/java/cucumber/runtime/snippets/CamelCaseFunctionNameSanitizerTest.java
@@ -14,13 +14,31 @@ public class CamelCaseFunctionNameSanitizerTest {
         String functionName = "I am a function name";
         String expected = "iAmAFunctionName";
         String actual = generator.sanitizeFunctionName(functionName);
-
         assertEquals(expected, actual);
 
         functionName = "Function name with multiple  spaces";
         expected = "functionNameWithMultipleSpaces";
         actual = generator.sanitizeFunctionName(functionName);
+        assertEquals(expected, actual);
 
+        functionName = "Function name with pascalCase word";
+        expected = "functionNameWithPascalCaseWord";
+        actual = generator.sanitizeFunctionName(functionName);
+        assertEquals(expected, actual);
+
+        functionName = "Function name with CamelCase word";
+        expected = "functionNameWithCamelCaseWord";
+        actual = generator.sanitizeFunctionName(functionName);
+        assertEquals(expected, actual);
+
+        functionName = "Function name with multi char acronym HTTP Server";
+        expected = "functionNameWithMultiCharAcronymHttpServer";
+        actual = generator.sanitizeFunctionName(functionName);
+        assertEquals(expected, actual);
+
+        functionName = "Function name with two char acronym US";
+        expected = "functionNameWithTwoCharAcronymUS";
+        actual = generator.sanitizeFunctionName(functionName);
         assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
This fixes a bug that occurs for steps with more than one capture group, for example
`Given I have "this" and "that"`
An attempt to sanitize the function name throws a `StringIndexOutOfBoundsException`.
I also improved the formatting for steps/function names that have acronyms and camel/pascal case words in them.

**Note:** This is a copy of https://github.com/cucumber/cucumber-jvm/pull/592 that I sent earlier, but from the wrong branch.
