### PR TITLE
Fix Cucumber reports for cucumber-android

### DIFF
--- a/android/src/main/java/cucumber/api/android/CucumberInstrumentation.java
+++ b/android/src/main/java/cucumber/api/android/CucumberInstrumentation.java
@@ -92,7 +92,6 @@ public class CucumberInstrumentation extends Instrumentation {
         final List<CucumberFeature> cucumberFeatures = runtimeOptions.cucumberFeatures(resourceLoader);
         final int numberOfTests = TestCaseCounter.countTestCasesOf(cucumberFeatures);
 
-        runtimeOptions.getFormatters().clear();
         runtimeOptions.getFormatters().add(new AndroidInstrumentationReporter(runtime, this, numberOfTests));
         runtimeOptions.getFormatters().add(new AndroidLogcatReporter(TAG));
 

--- a/examples/android/cukeulator-test/libs/README.md
+++ b/examples/android/cukeulator-test/libs/README.md
@@ -12,6 +12,7 @@ and the required jars will **automatically be downloaded.**
 * cucumber-picocontainer (shouldn't be necessary)
 * picocontainer-2.14.3 (shouldn't be necessary)
 * gherkin-2.12.1 (shouldn't be necessary)
+* cucumber-html (only required for HTML reports)
 
 
 * To download the release versions run `ant -f init.xml`.


### PR DESCRIPTION
This PR enables standard **Cucumber reports** using the `format` parameter of `CucumberOptions` by
- Not clearing the list of formatters prior to adding AndroidFormatter
- Correctly assigning reporter and formatter before feature execution

Reports will be stored on the device.

Example:
`@CucumberOptions(features = "features", format = {"pretty", "html:/data/data/com.mypackage/cucumber-html", "json:/data/data/com.mypackage/cucumber.json"})`

This will generate an **HTML report** in the cucumber-html directory and a **JSON report**. The `pretty` formatter writes to `System.out`, which will appear as nicely colored output in your logcat, given you use a color aware terminal. See [Cucumber Reports](http://cukes.info/reports.html) for supported formatters/reporters.

After test execution reports can be pulled from the device:
`adb pull /data/data/com.mypackage/cucumber-html`
`adb pull /data/data/com.mypackage/cucumber.json`

You can also write reports to the SD card.

Note that the html reporter requires the cucumber-html jar in the libs directory of your Android test project.
