### PR TITLE
Implemented TestNG-compatible XML formatter.

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/FormatterFactory.java
+++ b/core/src/main/java/cucumber/runtime/formatter/FormatterFactory.java
@@ -34,6 +34,7 @@ public class FormatterFactory {
     private static final Map<String, Class<? extends Formatter>> FORMATTER_CLASSES = new HashMap<String, Class<? extends Formatter>>() {{
         put("null", NullFormatter.class);
         put("junit", JUnitFormatter.class);
+        put("testng", TestNGFormatter.class);
         put("html", HTMLFormatter.class);
         put("pretty", CucumberPrettyFormatter.class);
         put("progress", ProgressFormatter.class);

--- a/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
@@ -1,0 +1,318 @@
+package cucumber.runtime.formatter;
+
+import cucumber.runtime.CucumberException;
+import cucumber.runtime.io.URLOutputStream;
+import cucumber.runtime.io.UTF8OutputStreamWriter;
+import gherkin.formatter.Formatter;
+import gherkin.formatter.Reporter;
+import gherkin.formatter.model.Background;
+import gherkin.formatter.model.Examples;
+import gherkin.formatter.model.Feature;
+import gherkin.formatter.model.Match;
+import gherkin.formatter.model.Result;
+import gherkin.formatter.model.Scenario;
+import gherkin.formatter.model.ScenarioOutline;
+import gherkin.formatter.model.Step;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+class TestNGFormatter implements Formatter, Reporter, StrictAware {
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    private final Writer writer;
+    private final Document document;
+    private final Element results;
+    private final Element suite;
+    private final Element test;
+    private Element clazz;
+    private Element root;
+    private TestMethod testMethod;
+
+    public TestNGFormatter(URL url) throws IOException {
+        this.writer = new UTF8OutputStreamWriter(new URLOutputStream(url));
+        TestMethod.treatSkippedAsFailure = false;
+        try {
+            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            results = document.createElement("testng-results");
+            suite = document.createElement("suite");
+            test = document.createElement("test");
+            suite.appendChild(test);
+            results.appendChild(suite);
+            document.appendChild(results);
+        } catch (ParserConfigurationException e) {
+            throw new CucumberException("Error initializing DocumentBuilder.", e);
+        }
+    }
+
+    @Override
+    public void syntaxError(String state, String event, List<String> legalEvents, String uri, Integer line) {
+    }
+
+    @Override
+    public void setStrict(boolean strict) {
+        TestMethod.treatSkippedAsFailure = strict;
+    }
+
+    @Override
+    public void uri(String uri) {
+    }
+
+    @Override
+    public void feature(Feature feature) {
+        TestMethod.feature = feature;
+        clazz = document.createElement("class");
+        clazz.setAttribute("name", feature.getName());
+        test.appendChild(clazz);
+    }
+
+    @Override
+    public void scenarioOutline(ScenarioOutline scenarioOutline) {
+        testMethod = new TestMethod(null);
+    }
+
+    @Override
+    public void examples(Examples examples) {
+        TestMethod.examples = examples.getRows().size() - 1;
+    }
+
+    @Override
+    public void startOfScenarioLifeCycle(Scenario scenario) {
+        root = document.createElement("test-method");
+        clazz.appendChild(root);
+        testMethod = new TestMethod(scenario);
+        testMethod.start(root);
+    }
+
+    @Override
+    public void before(Match match, Result result) {
+        testMethod.hooks.add(result);
+    }
+
+    @Override
+    public void background(Background background) {
+    }
+
+    @Override
+    public void scenario(Scenario scenario) {
+    }
+
+    @Override
+    public void step(Step step) {
+        testMethod.steps.add(step);
+    }
+
+    @Override
+    public void match(Match match) {
+    }
+
+    @Override
+    public void result(Result result) {
+        testMethod.results.add(result);
+    }
+
+    @Override
+    public void embedding(String mimeType, byte[] data) {
+    }
+
+    @Override
+    public void write(String text) {
+    }
+
+    @Override
+    public void after(Match match, Result result) {
+        testMethod.hooks.add(result);
+    }
+
+    @Override
+    public void endOfScenarioLifeCycle(Scenario scenario) {
+        testMethod.finish(document, root);
+    }
+
+    @Override
+    public void eof() {
+    }
+
+    @Override
+    public void done() {
+        try {
+            results.setAttribute("total", String.valueOf(getElementsCountByAttribute(suite, "status", ".*")));
+            results.setAttribute("passed", String.valueOf(getElementsCountByAttribute(suite, "status", "PASS")));
+            results.setAttribute("failed", String.valueOf(getElementsCountByAttribute(suite, "status", "FAIL")));
+            results.setAttribute("skipped", String.valueOf(getElementsCountByAttribute(suite, "status", "SKIP")));
+            suite.setAttribute("name", TestNGFormatter.class.getName());
+            suite.setAttribute("duration-ms", getTotalDuration(suite.getElementsByTagName("test-method")));
+            test.setAttribute("name", TestNGFormatter.class.getName());
+            test.setAttribute("duration-ms", getTotalDuration(suite.getElementsByTagName("test-method")));
+
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            StreamResult streamResult = new StreamResult(writer);
+            DOMSource domSource = new DOMSource(document);
+            transformer.transform(domSource, streamResult);
+        } catch (TransformerException e) {
+            throw new CucumberException("Error transforming report.", e);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private int getElementsCountByAttribute(Node node, String attributeName, String attributeValue) {
+        int count = 0;
+
+        for (int i = 0; i < node.getChildNodes().getLength(); i++) {
+            count += getElementsCountByAttribute(node.getChildNodes().item(i), attributeName, attributeValue);
+        }
+
+        NamedNodeMap attributes = node.getAttributes();
+        if (attributes != null) {
+            Node namedItem = attributes.getNamedItem(attributeName);
+            if (namedItem != null && namedItem.getNodeValue().matches(attributeValue)) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private String getTotalDuration(NodeList testCaseNodes) {
+        long totalDuration = 0;
+        for (int i = 0; i < testCaseNodes.getLength(); i++) {
+            try {
+                String duration = testCaseNodes.item(i).getAttributes().getNamedItem("duration-ms").getNodeValue();
+                totalDuration += Long.parseLong(duration);
+            } catch (NumberFormatException e) {
+                throw new CucumberException(e);
+            } catch (NullPointerException e) {
+                throw new CucumberException(e);
+            }
+        }
+        return String.valueOf(totalDuration);
+    }
+
+    private static class TestMethod {
+
+        static Feature feature;
+        static int examples = 0;
+        static boolean treatSkippedAsFailure = false;
+        final List<Step> steps = new ArrayList<Step>();
+        final List<Result> results = new ArrayList<Result>();
+        final List<Result> hooks = new ArrayList<Result>();
+        final Scenario scenario;
+
+        private TestMethod(Scenario scenario) {
+            this.scenario = scenario;
+        }
+
+        private void start(Element element) {
+            element.setAttribute("name", examples > 0 ? scenario.getName() + "_" + examples-- : scenario.getName());
+            element.setAttribute("started-at", DATE_FORMAT.format(new Date()));
+        }
+
+        public void finish(Document doc, Element element) {
+            element.setAttribute("duration-ms", calculateTotalDurationString());
+            element.setAttribute("finished-at", DATE_FORMAT.format(new Date()));
+            StringBuilder stringBuilder = new StringBuilder();
+            addStepAndResultListing(stringBuilder);
+            Result skipped = null;
+            Result failed = null;
+            for (Result result : results) {
+                if ("failed".equals(result.getStatus())) {
+                    failed = result;
+                }
+                if ("undefined".equals(result.getStatus()) || "pending".equals(result.getStatus())) {
+                    skipped = result;
+                }
+            }
+            for (Result result : hooks) {
+                if (failed == null && "failed".equals(result.getStatus())) {
+                    failed = result;
+                }
+            }
+            if (failed != null) {
+                element.setAttribute("status", "FAIL");
+                StringWriter stringWriter = new StringWriter();
+                failed.getError().printStackTrace(new PrintWriter(stringWriter));
+                Element exception = createException(doc, failed.getError().getClass().getName(), stringBuilder.toString(), stringWriter.toString());
+                element.appendChild(exception);
+            } else if (skipped != null) {
+                if (treatSkippedAsFailure) {
+                    element.setAttribute("status", "FAIL");
+                    Element exception = createException(doc, "The scenario has pending or undefined step(s)", stringBuilder.toString(), "The scenario has pending or undefined step(s)");
+                    element.appendChild(exception);
+                } else {
+                    element.setAttribute("status", "SKIP");
+                }
+            } else {
+                element.setAttribute("status", "PASS");
+            }
+        }
+
+        private String calculateTotalDurationString() {
+            long totalDurationNanos = 0;
+            for (Result r : results) {
+                totalDurationNanos += r.getDuration() == null ? 0 : r.getDuration();
+            }
+            for (Result r : hooks) {
+                totalDurationNanos += r.getDuration() == null ? 0 : r.getDuration();
+            }
+            return String.valueOf(totalDurationNanos / 1000000);
+        }
+
+        private void addStepAndResultListing(StringBuilder sb) {
+            for (int i = 0; i < steps.size(); i++) {
+                int length = sb.length();
+                String resultStatus = "not executed";
+                if (i < results.size()) {
+                    resultStatus = results.get(i).getStatus();
+                }
+                sb.append(steps.get(i).getKeyword());
+                sb.append(steps.get(i).getName());
+                do {
+                    sb.append(".");
+                } while (sb.length() - length < 76);
+                sb.append(resultStatus);
+                sb.append("\n");
+            }
+        }
+
+        private Element createException(Document doc, String clazz, String message, String stacktrace) {
+            Element exceptionElement = doc.createElement("exception");
+            exceptionElement.setAttribute("class", clazz);
+
+            if (message != null) {
+                Element messageElement = doc.createElement("message");
+                messageElement.appendChild(doc.createCDATASection(message));
+                exceptionElement.appendChild(messageElement);
+            }
+
+            Element stacktraceElement = doc.createElement("full-stacktrace");
+            stacktraceElement.appendChild(doc.createCDATASection(stacktrace));
+            exceptionElement.appendChild(stacktraceElement);
+
+            return exceptionElement;
+        }
+    }
+}

--- a/core/src/test/java/cucumber/runtime/formatter/TestNGFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/TestNGFormatterTest.java
@@ -1,0 +1,292 @@
+package cucumber.runtime.formatter;
+
+import gherkin.formatter.model.Examples;
+import gherkin.formatter.model.ExamplesTableRow;
+import gherkin.formatter.model.Feature;
+import gherkin.formatter.model.Match;
+import gherkin.formatter.model.Result;
+import gherkin.formatter.model.Scenario;
+import gherkin.formatter.model.ScenarioOutline;
+import gherkin.formatter.model.Step;
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.Difference;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.util.Arrays;
+
+import static cucumber.runtime.Utils.toURL;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class TestNGFormatterTest {
+
+    @Test
+    public final void testScenarioWithUndefinedSteps() throws Exception {
+        final File tempFile = File.createTempFile("cucumber-jvm-testng", ".xml");
+        final TestNGFormatter formatter = new TestNGFormatter(toURL(tempFile.getAbsolutePath()));
+        formatter.feature(feature("feature"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("undefined"));
+        formatter.result(result("undefined"));
+        formatter.endOfScenarioLifeCycle(scenario("scenario"));
+        formatter.done();
+        assertXmlEqual("cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithUndefinedSteps.xml", tempFile);
+    }
+
+    @Test
+    public void testScenarioWithUndefinedStepsStrict() throws Exception {
+        final File tempFile = File.createTempFile("cucumber-jvm-testng", ".xml");
+        final TestNGFormatter formatter = new TestNGFormatter(toURL(tempFile.getAbsolutePath()));
+        formatter.setStrict(true);
+        formatter.feature(feature("feature"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("undefined"));
+        formatter.result(result("undefined"));
+        formatter.endOfScenarioLifeCycle(scenario("scenario"));
+        formatter.done();
+        assertXmlEqual("cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithUndefinedStepsStrict.xml", tempFile);
+    }
+
+    @Test
+    public final void testScenarioWithPendingSteps() throws Exception {
+        final File tempFile = File.createTempFile("cucumber-jvm-testng", ".xml");
+        final TestNGFormatter formatter = new TestNGFormatter(toURL(tempFile.getAbsolutePath()));
+        formatter.feature(feature("feature"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("pending"));
+        formatter.result(result("skipped"));
+        formatter.endOfScenarioLifeCycle(scenario("scenario"));
+        formatter.done();
+        assertXmlEqual("cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithPendingSteps.xml", tempFile);
+    }
+
+    @Test
+    public void testScenarioWithFailedSteps() throws Exception {
+        final File tempFile = File.createTempFile("cucumber-jvm-testng", ".xml");
+        final TestNGFormatter formatter = new TestNGFormatter(toURL(tempFile.getAbsolutePath()));
+        formatter.feature(feature("feature"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("failed", "message", "stacktrace"));
+        formatter.result(result("skipped"));
+        formatter.endOfScenarioLifeCycle(scenario("scenario"));
+        formatter.done();
+        assertXmlEqual("cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithFailedSteps.xml", tempFile);
+    }
+
+    @Test
+    public final void testScenarioWithPassedSteps() throws Exception {
+        final File tempFile = File.createTempFile("cucumber-jvm-testng", ".xml");
+        final TestNGFormatter formatter = new TestNGFormatter(toURL(tempFile.getAbsolutePath()));
+        formatter.feature(feature("feature"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("passed"));
+        formatter.result(result("passed"));
+        formatter.endOfScenarioLifeCycle(scenario("scenario"));
+        formatter.done();
+        assertXmlEqual("cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithPassedSteps.xml", tempFile);
+    }
+
+    @Test
+    public void testScenarioWithBackground() throws Exception {
+        final File tempFile = File.createTempFile("cucumber-jvm-testng", ".xml");
+        final TestNGFormatter formatter = new TestNGFormatter(toURL(tempFile.getAbsolutePath()));
+        formatter.feature(feature("feature"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario"));
+        formatter.step(step("keyword ", "background"));
+        formatter.step(step("keyword ", "background"));
+        formatter.result(result("undefined"));
+        formatter.result(result("undefined"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("undefined"));
+        formatter.result(result("undefined"));
+        formatter.endOfScenarioLifeCycle(scenario("scenario"));
+        formatter.done();
+        assertXmlEqual("cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithBackground.xml", tempFile);
+    }
+
+    @Test
+    public void testScenarioOutlineWithExamples() throws Exception {
+        final File tempFile = File.createTempFile("cucumber-jvm-testng", ".xml");
+        final TestNGFormatter formatter = new TestNGFormatter(toURL(tempFile.getAbsolutePath()));
+        formatter.feature(feature("feature"));
+        formatter.scenarioOutline(scenarioOutline());
+        formatter.step(step("keyword ", "outline"));
+        formatter.step(step("keyword ", "outline"));
+        formatter.examples(examples(3));
+        formatter.startOfScenarioLifeCycle(scenario("scenario"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("undefined"));
+        formatter.result(result("undefined"));
+        formatter.endOfScenarioLifeCycle(scenario("scenario"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("undefined"));
+        formatter.result(result("undefined"));
+        formatter.endOfScenarioLifeCycle(scenario("scenario"));
+        formatter.done();
+        assertXmlEqual("cucumber/runtime/formatter/TestNGFormatterTest_testScenarioOutlineWithExamples.xml", tempFile);
+    }
+
+    @Test
+    public void testDurationCalculationOfStepsAndHooks() throws Throwable {
+        final File tempFile = File.createTempFile("cucumber-jvm-testng", ".xml");
+        final TestNGFormatter formatter = new TestNGFormatter(toURL(tempFile.getAbsolutePath()));
+        formatter.feature(feature("feature_1"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario_1"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("passed", milliSeconds(1)));
+        formatter.result(result("passed", milliSeconds(1)));
+        formatter.endOfScenarioLifeCycle(scenario("scenario_1"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario_2"));
+        formatter.before(match(), result("passed", milliSeconds(1)));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("passed", milliSeconds(1)));
+        formatter.result(result("passed", milliSeconds(1)));
+        formatter.endOfScenarioLifeCycle(scenario("scenario_2"));
+        formatter.feature(feature("feature_2"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario_3"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("passed", milliSeconds(1)));
+        formatter.result(result("passed", milliSeconds(1)));
+        formatter.after(match(), result("passed", milliSeconds(1)));
+        formatter.endOfScenarioLifeCycle(scenario("scenario_3"));
+        formatter.done();
+        assertXmlEqual("cucumber/runtime/formatter/TestNGFormatterTest_testDurationCalculationOfStepsAndHooks.xml", tempFile);
+    }
+
+    @Test
+    public void testScenarioWithFailedBeforeHook() throws Throwable {
+        final File tempFile = File.createTempFile("cucumber-jvm-testng", ".xml");
+        final TestNGFormatter formatter = new TestNGFormatter(toURL(tempFile.getAbsolutePath()));
+        formatter.feature(feature("feature"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario"));
+        formatter.before(match(), result("failed", "message", "stacktrace"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("skipped"));
+        formatter.result(result("skipped"));
+        formatter.endOfScenarioLifeCycle(scenario("scenario"));
+        formatter.done();
+        assertXmlEqual("cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithFailedBeforeHook.xml", tempFile);
+    }
+
+    @Test
+    public void testScenarioWithFailedAfterHook() throws Throwable {
+        final File tempFile = File.createTempFile("cucumber-jvm-testng", ".xml");
+        final TestNGFormatter formatter = new TestNGFormatter(toURL(tempFile.getAbsolutePath()));
+        formatter.feature(feature("feature"));
+        formatter.startOfScenarioLifeCycle(scenario("scenario"));
+        formatter.step(step("keyword ", "step"));
+        formatter.step(step("keyword ", "step"));
+        formatter.result(result("passed"));
+        formatter.result(result("passed"));
+        formatter.after(match(), result("failed", "message", "stacktrace"));
+        formatter.endOfScenarioLifeCycle(scenario("scenario"));
+        formatter.done();
+        assertXmlEqual("cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithFailedAfterHook.xml", tempFile);
+    }
+
+    private void assertXmlEqual(String path, File file) throws IOException, ParserConfigurationException, SAXException {
+        XMLUnit.setIgnoreWhitespace(true);
+        InputStreamReader inputStreamReader = new InputStreamReader(Thread.currentThread().getContextClassLoader().getResourceAsStream(path), "UTF-8");
+        Diff diff = new Diff(inputStreamReader, new FileReader(file)) {
+            @Override
+            public int differenceFound(Difference difference) {
+                if (difference.getControlNodeDetail().getNode().getNodeName().matches("started-at|finished-at")) {
+                    return 0;
+                }
+                return super.differenceFound(difference);
+            }
+        };
+        assertTrue("XML files are similar " + diff.toString(), diff.identical());
+    }
+
+    private Feature feature(String featureName) {
+        Feature feature = mock(Feature.class);
+        when(feature.getName()).thenReturn(featureName);
+        return feature;
+    }
+
+    private ScenarioOutline scenarioOutline() {
+        return mock(ScenarioOutline.class);
+    }
+
+    private Examples examples(int size) {
+        Examples examples = mock(Examples.class);
+        when(examples.getRows()).thenReturn(Arrays.asList(new ExamplesTableRow[size]));
+        return examples;
+    }
+
+    private Scenario scenario(String scenarioName) {
+        Scenario scenario = mock(Scenario.class);
+        when(scenario.getName()).thenReturn(scenarioName);
+        return scenario;
+    }
+
+    private Step step(String keyword, String stepName) {
+        Step step = mock(Step.class);
+        when(step.getKeyword()).thenReturn(keyword);
+        when(step.getName()).thenReturn(stepName);
+        return step;
+    }
+
+    private Match match() {
+        return mock(Match.class);
+    }
+
+    private Result result(String status) {
+        return new Result(status, null, null);
+    }
+
+    private Result result(String status, Long duration) {
+        return new Result(status, duration, null);
+    }
+
+    private Result result(String status, String message, String stacktrace) {
+        return new Result(status, null, new TestNGException(message, stacktrace), null);
+    }
+
+    private Long milliSeconds(int milliSeconds) {
+        return milliSeconds * 1000000L;
+    }
+
+    private static class TestNGException extends Exception {
+
+        private final String stacktrace;
+
+        public TestNGException(String message, String stacktrace) {
+            super(message);
+            this.stacktrace = stacktrace;
+        }
+
+        @Override
+        public void printStackTrace(PrintWriter printWriter) {
+            printWriter.print(stacktrace);
+        }
+    }
+}

--- a/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testDurationCalculationOfStepsAndHooks.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testDurationCalculationOfStepsAndHooks.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testng-results total="3" passed="3" failed="0" skipped="0">
+    <suite name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="8">
+        <test name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="8">
+            <class name="feature_1">
+                <test-method name="scenario_1" status="PASS" duration-ms="2" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ"/>
+                <test-method name="scenario_2" status="PASS" duration-ms="3" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ"/>
+            </class>
+            <class name="feature_2">
+                <test-method name="scenario_3" status="PASS" duration-ms="3" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ"/>
+            </class>
+        </test>
+    </suite>
+</testng-results>

--- a/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioOutlineWithExamples.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioOutlineWithExamples.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testng-results total="2" passed="0" failed="0" skipped="2">
+    <suite name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+        <test name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+            <class name="feature">
+                <test-method name="scenario_2" status="SKIP" duration-ms="0" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ"/>
+                <test-method name="scenario_1" status="SKIP" duration-ms="0" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ"/>
+            </class>
+        </test>
+    </suite>
+</testng-results>

--- a/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithBackground.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithBackground.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testng-results total="1" passed="0" failed="0" skipped="1">
+    <suite name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+        <test name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+            <class name="feature">
+                <test-method name="scenario" status="SKIP" duration-ms="0" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ"/>
+            </class>
+        </test>
+    </suite>
+</testng-results>

--- a/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithFailedAfterHook.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithFailedAfterHook.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testng-results total="1" passed="0" failed="1" skipped="0">
+    <suite name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+        <test name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+            <class name="feature">
+                <test-method name="scenario" status="FAIL" duration-ms="0" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ">
+                    <exception class="cucumber.runtime.formatter.TestNGFormatterTest$TestNGException">
+                        <message><![CDATA[keyword step................................................................passed
+keyword step................................................................passed
+]]></message>
+                        <full-stacktrace><![CDATA[stacktrace]]></full-stacktrace>
+                    </exception>
+                </test-method>
+            </class>
+        </test>
+    </suite>
+</testng-results>

--- a/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithFailedBeforeHook.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithFailedBeforeHook.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testng-results total="1" passed="0" failed="1" skipped="0">
+    <suite name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+        <test name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+            <class name="feature">
+                <test-method name="scenario" status="FAIL" duration-ms="0" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ">
+                    <exception class="cucumber.runtime.formatter.TestNGFormatterTest$TestNGException">
+                        <message><![CDATA[keyword step................................................................skipped
+keyword step................................................................skipped
+]]></message>
+                        <full-stacktrace><![CDATA[stacktrace]]></full-stacktrace>
+                    </exception>
+                </test-method>
+            </class>
+        </test>
+    </suite>
+</testng-results>

--- a/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithFailedSteps.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithFailedSteps.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testng-results total="1" passed="0" failed="1" skipped="0">
+    <suite name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+        <test name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+            <class name="feature">
+                <test-method name="scenario" status="FAIL" duration-ms="0" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ">
+                    <exception class="cucumber.runtime.formatter.TestNGFormatterTest$TestNGException">
+                        <message><![CDATA[keyword step................................................................failed
+keyword step................................................................skipped
+]]></message>
+                        <full-stacktrace><![CDATA[stacktrace]]></full-stacktrace>
+                    </exception>
+                </test-method>
+            </class>
+        </test>
+    </suite>
+</testng-results>

--- a/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithPassedSteps.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithPassedSteps.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testng-results total="1" passed="1" failed="0" skipped="0">
+    <suite name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+        <test name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+            <class name="feature">
+                <test-method name="scenario" status="PASS" duration-ms="0" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ"/>
+            </class>
+        </test>
+    </suite>
+</testng-results>

--- a/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithPendingSteps.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithPendingSteps.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testng-results total="1" passed="0" failed="0" skipped="1">
+    <suite name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+        <test name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+            <class name="feature">
+                <test-method name="scenario" status="SKIP" duration-ms="0" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ"/>
+            </class>
+        </test>
+    </suite>
+</testng-results>

--- a/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithUndefinedSteps.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithUndefinedSteps.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testng-results total="1" passed="0" failed="0" skipped="1">
+    <suite name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+        <test name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+            <class name="feature">
+                <test-method name="scenario" status="SKIP" duration-ms="0" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ"/>
+            </class>
+        </test>
+    </suite>
+</testng-results>

--- a/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithUndefinedStepsStrict.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/TestNGFormatterTest_testScenarioWithUndefinedStepsStrict.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<testng-results total="1" passed="0" failed="1" skipped="0">
+    <suite name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+        <test name="cucumber.runtime.formatter.TestNGFormatter" duration-ms="0">
+            <class name="feature">
+                <test-method name="scenario" status="FAIL" duration-ms="0" started-at="yyyy-MM-ddTHH:mm:ssZ" finished-at="yyyy-MM-ddTHH:mm:ssZ">
+                    <exception class="The scenario has pending or undefined step(s)">
+                        <message><![CDATA[keyword step................................................................undefined
+keyword step................................................................undefined
+]]></message>
+                        <full-stacktrace><![CDATA[The scenario has pending or undefined step(s)]]></full-stacktrace>
+                    </exception>
+                </test-method>
+            </class>
+        </test>
+    </suite>
+</testng-results>


### PR DESCRIPTION
Once again :)

Hi there!
This class produces TestNG-compatible XML report, including date\time, duration and stacktraces if possible.
I used JUnitFormatter as an example with some modifications and simplifications.
All tests call formatter directly without using CucumberRuntime.
What about wrapping Exceptions with Mockito, latter does not allow wraping of getClass method so I had to use the real Exception object...