### PR TITLE
Restructured JUnit class/method name reporting

### DIFF
--- a/core/src/main/java/cucumber/runtime/model/CucumberTagStatement.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberTagStatement.java
@@ -19,13 +19,13 @@ public abstract class CucumberTagStatement extends StepContainer {
     CucumberTagStatement(CucumberFeature cucumberFeature, TagStatement gherkinModel) {
         super(cucumberFeature, gherkinModel);
         this.gherkinModel = gherkinModel;
-        this.visualName = gherkinModel.getKeyword() + ": " + gherkinModel.getName();
+        this.visualName = gherkinModel.getKeyword() + ": " + gherkinModel.getName() + "."+ gherkinModel.getKeyword();
     }
 
     CucumberTagStatement(CucumberFeature cucumberFeature, TagStatement gherkinModel, Row example) {
         super(cucumberFeature, gherkinModel);
         this.gherkinModel = gherkinModel;
-        this.visualName = "| " + join(example.getCells(), " | ") + " |";
+        this.visualName = gherkinModel.getKeyword() + ": " + gherkinModel.getName() +"."+"| " + join(example.getCells(), " | ") + " |";
     }
 
     protected Set<Tag> tagsAndInheritedTags() {

--- a/junit/src/main/java/cucumber/runtime/junit/ExamplesRunner.java
+++ b/junit/src/main/java/cucumber/runtime/junit/ExamplesRunner.java
@@ -31,6 +31,11 @@ class ExamplesRunner extends Suite {
     }
 
     @Override
+    protected List<Runner> getChildren() {
+        return super.getChildren();
+    }
+
+    @Override
     protected String getName() {
         return cucumberExamples.getExamples().getKeyword() + ": " + cucumberExamples.getExamples().getName();
     }

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -44,7 +44,10 @@ public class JUnitReporter implements Reporter, Formatter {
         this.stepNotifier = null;
         this.ignoredStep = false;
 
-        executionUnitNotifier = new EachTestNotifier(runNotifier, executionUnitRunner.getDescription());
+        //We don't want the scenario itself visible in the JUnit results as it is redundant, only its steps
+        //Provide the executionUnitNotifier with a new (non-null) RunNotifier to effectively
+        //ignore its notifications
+        executionUnitNotifier = new EachTestNotifier(new RunNotifier(), executionUnitRunner.getDescription());
         executionUnitNotifier.fireTestStarted();
     }
 

--- a/junit/src/main/java/cucumber/runtime/junit/ScenarioOutlineRunner.java
+++ b/junit/src/main/java/cucumber/runtime/junit/ScenarioOutlineRunner.java
@@ -3,12 +3,14 @@ package cucumber.runtime.junit;
 import cucumber.runtime.Runtime;
 import cucumber.runtime.model.CucumberExamples;
 import cucumber.runtime.model.CucumberScenarioOutline;
+
 import org.junit.runner.Description;
 import org.junit.runner.Runner;
 import org.junit.runners.Suite;
 import org.junit.runners.model.InitializationError;
 
 import java.util.ArrayList;
+import java.util.List;
 
 class ScenarioOutlineRunner extends Suite {
     private final CucumberScenarioOutline cucumberScenarioOutline;
@@ -20,6 +22,11 @@ class ScenarioOutlineRunner extends Suite {
         for (CucumberExamples cucumberExamples : cucumberScenarioOutline.getCucumberExamplesList()) {
             getChildren().add(new ExamplesRunner(runtime, cucumberExamples, jUnitReporter));
         }
+    }
+
+    @Override
+    protected List<Runner> getChildren() {
+        return super.getChildren();
     }
 
     @Override

--- a/junit/src/test/java/cucumber/runtime/junit/ExecutionUnitRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/ExecutionUnitRunnerTest.java
@@ -62,7 +62,7 @@ public class ExecutionUnitRunnerTest {
         Description runnerDescription = runner.getDescription();
         Description stepDescription = runnerDescription.getChildren().get(0);
 
-        assertEquals("description includes scenario name as class name", runner.getName(), stepDescription.getClassName());
+        assertEquals("description includes scenario keyword and name as class name", runner.getDescription().getDisplayName(), stepDescription.getClassName());
         assertEquals("description includes step keyword and name as method name", step.getKeyword() + step.getName(), stepDescription.getMethodName());
     }
 }

--- a/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
@@ -3,7 +3,10 @@ package cucumber.runtime.junit;
 import cucumber.api.PendingException;
 import gherkin.formatter.Formatter;
 import gherkin.formatter.Reporter;
+import gherkin.formatter.model.Match;
 import gherkin.formatter.model.Result;
+import gherkin.formatter.model.Step;
+
 import org.junit.Test;
 import org.junit.internal.runners.model.EachTestNotifier;
 import org.junit.runner.Description;
@@ -14,6 +17,7 @@ import org.mockito.Matchers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,6 +27,7 @@ public class JUnitReporterTest {
 
     private JUnitReporter jUnitReporter;
     private RunNotifier runNotifier;
+    private ExecutionUnitRunner executionUnitRunner;
 
     @Test
     public void resultWithError() {
@@ -33,6 +38,10 @@ public class JUnitReporterTest {
 
         Description description = mock(Description.class);
         createRunNotifier(description);
+
+        when(executionUnitRunner.describeChild(any(Step.class))).thenReturn(description);
+        jUnitReporter.step(mock(Step.class));
+        jUnitReporter.match(mock(Match.class));
 
         jUnitReporter.result(result);
 
@@ -159,7 +168,7 @@ public class JUnitReporterTest {
 
     private void createRunNotifier(Description description) {
         runNotifier = mock(RunNotifier.class);
-        ExecutionUnitRunner executionUnitRunner = mock(ExecutionUnitRunner.class);
+        executionUnitRunner = mock(ExecutionUnitRunner.class);
         when(executionUnitRunner.getDescription()).thenReturn(description);
         jUnitReporter.startExecutionUnit(executionUnitRunner, runNotifier);
     }

--- a/junit/src/test/java/cucumber/runtime/junit/ScenarioOutlineRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/ScenarioOutlineRunnerTest.java
@@ -1,0 +1,47 @@
+package cucumber.runtime.junit;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+
+import cucumber.runtime.io.ClasspathResourceLoader;
+import cucumber.runtime.model.CucumberFeature;
+import cucumber.runtime.model.CucumberScenario;
+import cucumber.runtime.model.CucumberScenarioOutline;
+import gherkin.formatter.model.Step;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ScenarioOutlineRunnerTest {
+    @Test
+    public void shouldIncludeExampleRowAsClassNameInStepDescriptions() throws Exception {
+        List<CucumberFeature> features = CucumberFeature.load(
+                new ClasspathResourceLoader(this.getClass().getClassLoader()),
+                asList("cucumber/runtime/junit/feature_with_same_steps_in_different_scenarios.feature"),
+                Collections.emptyList()
+        );
+
+        ScenarioOutlineRunner runner = new ScenarioOutlineRunner(
+                null,
+                (CucumberScenarioOutline) features.get(0).getFeatureElements().get(2),
+                null
+        );
+
+        // fish out the data from runner
+        ExecutionUnitRunner executionUnitRunner = ((ExecutionUnitRunner)((ExamplesRunner)(runner.getChildren().get(0))).getChildren().get(0));
+        Step step = executionUnitRunner.getChildren().get(0);
+        Description runnerDescription = executionUnitRunner.getDescription();
+        Description stepDescription = runnerDescription.getChildren().get(0);
+
+        System.out.println(runner.getDescription().getDisplayName());
+        assertEquals(
+                "description includes scenario outline keyword and example row as class name, and is properly escaped",
+                "Scenario Outline: third.| {example} 1,2 |", stepDescription.getClassName());
+        assertEquals("description includes step keyword and name as method name, and is properly escaped", "When {example} 1,2 {step}",
+                stepDescription.getMethodName());
+    }
+}

--- a/junit/src/test/resources/cucumber/runtime/junit/feature_with_same_steps_in_different_scenarios.feature
+++ b/junit/src/test/resources/cucumber/runtime/junit/feature_with_same_steps_in_different_scenarios.feature
@@ -6,3 +6,11 @@ Feature: In cucumber.junit
   Scenario: second
     When step
     Then another step
+
+  Scenario Outline: third
+    When <example> (step)
+    Then another step
+
+  Examples:
+    | example       |
+    | (example) 1.2 |


### PR DESCRIPTION
I propose the following slight tweaks to the way the scenarios/steps are mentioned in the name and classname attributes of the JUnit XML report:
“Scenario( Outline): <scenario name>” map to the ‘package’ of the JUnit reported classname
“|<example row>|” or “Scenario” map to the class name of the JUnit reported classname
“<step keyword> step description” map to the name of the JUnit reported test case

The main reason for this change is to have a more structured view in a JUnit based test overview page like that of Jenkins, where on the 1st page a list of packages (=scenario names) is shown. Clicking on a package shows all test classes (=examples, or just 'Scenario' if it isn't an outline scenario) in that package. Clicking on a class shows all test methods (=steps of that scenario).

Also, failing tests are shown on the overview page with their complete package.classname.testmethod description and with this mapping, it is instantly clear which step of which scenario (example) has failed.

In order to make sure the parsing of packages (substring of 0 - <index of last dot> in classname) and JUnit internal distinction of class and method in its description goes alright, the following character replacements are done in the scenario and descriptions and example rows:
. translates to ,
( translates to {
) translates to }

Finally, the redundant reporting on the scenario itself has been removed.
