### PR TITLE
Added support to define skipTags to explicitly skip the execution of scenarios

### DIFF
--- a/core/src/main/java/cucumber/api/CucumberOptions.java
+++ b/core/src/main/java/cucumber/api/CucumberOptions.java
@@ -37,6 +37,11 @@ public @interface CucumberOptions {
     String[] tags() default {};
 
     /**
+     * @return what tags in the features should be skipped explicitly
+     */
+    String[] skipTags() default {};
+
+    /**
      * @return what formatter(s) to use
      */
     String[] format() default {};

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -140,6 +140,13 @@ public class Runtime implements UnreportedStepExecutor {
         undefinedStepsTracker.reset();
         //TODO: this is the initial state of the state machine, it should not go here, but into something else
         skipNextStep = false;
+
+        for (Tag tag : tags) {
+            if (runtimeOptions.getSkipTags().contains(tag.getName())) {
+                skipNextStep = true;
+                break;
+            }
+        }
         scenarioResult = new ScenarioImpl(reporter, tags);
     }
 

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -5,6 +5,7 @@ import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.model.CucumberFeature;
 import cucumber.runtime.xstream.LocalizedXStreams;
 import gherkin.I18n;
+import gherkin.TagExpression;
 import gherkin.formatter.Argument;
 import gherkin.formatter.Formatter;
 import gherkin.formatter.Reporter;
@@ -139,14 +140,8 @@ public class Runtime implements UnreportedStepExecutor {
         }
         undefinedStepsTracker.reset();
         //TODO: this is the initial state of the state machine, it should not go here, but into something else
-        skipNextStep = false;
+        skipNextStep = runtimeOptions.getSkipTagsExpression().evaluate(tags);
 
-        for (Tag tag : tags) {
-            if (runtimeOptions.getSkipTags().contains(tag.getName())) {
-                skipNextStep = true;
-                break;
-            }
-        }
         scenarioResult = new ScenarioImpl(reporter, tags);
     }
 

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -31,6 +31,7 @@ public class RuntimeOptions {
     private final List<Object> lineFilters = new ArrayList<Object>();
     private final List<Formatter> formatters = new ArrayList<Formatter>();
     private final List<String> featurePaths = new ArrayList<String>();
+    private final List<String> skipTags = new ArrayList<String>();
     private final FormatterFactory formatterFactory;
     private URL dotCucumber;
     private boolean dryRun;
@@ -106,6 +107,8 @@ public class RuntimeOptions {
                 parsedGlue.add(gluePath);
             } else if (arg.equals("--tags") || arg.equals("-t")) {
                 parsedFilters.add(args.remove(0));
+            } else if (arg.equals("--skip-tags") || arg.equals("-k")) {
+                skipTags.add(args.remove(0));
             } else if (arg.equals("--format") || arg.equals("-f")) {
                 formatters.add(formatterFactory.create(args.remove(0)));
             } else if (arg.equals("--dotcucumber")) {
@@ -230,6 +233,10 @@ public class RuntimeOptions {
 
     public List<Object> getFilters() {
         return filters;
+    }
+
+    public List<String> getSkipTags() {
+        return skipTags;
     }
 
     public boolean isMonochrome() {

--- a/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
@@ -34,6 +34,7 @@ public class RuntimeOptionsFactory {
                     addDryRun(options, args);
                     addMonochrome(options, args);
                     addTags(options, args);
+                    addSkipTags(options, args);
                     addFormats(options, args);
                     addStrict(options, args);
                     addName(options, args);
@@ -83,6 +84,13 @@ public class RuntimeOptionsFactory {
         for (String tags : this.<String[]>invoke(options, "tags")) {
             args.add("--tags");
             args.add(tags);
+        }
+    }
+
+    private void addSkipTags(Annotation options, List<String> args) {
+        for (String skipTag : this.<String[]>invoke(options, "skipTags")) {
+            args.add("--skip-tags");
+            args.add(skipTag);
         }
     }
 

--- a/core/src/main/resources/cucumber/runtime/USAGE.txt
+++ b/core/src/main/resources/cucumber/runtime/USAGE.txt
@@ -7,6 +7,7 @@ Options:
                                        Built-in FORMAT types: junit, html, pretty, progress, json.
                                        FORMAT can also be a fully qualified class name.
     -t, --tags TAG_EXPRESSION          Only run scenarios tagged with tags matching TAG_EXPRESSION.
+    -k, --skip-tags TAG_EXPRESSION     Skip execution of scenarios tagged with tags matching TAG_EXPRESSION.
     -n, --name REGEXP                  Only run scenarios whose names match REGEXP.
     -d, --[no-]-dry-run                Skip execution of glue code.
     -m, --[no-]-monochrome             Don't colour terminal output.

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -56,6 +56,12 @@ public class RuntimeOptionsTest {
     }
 
     @Test
+    public void assigns_skip_tags() {
+        RuntimeOptions options = new RuntimeOptions("--skip-tags @keep_this");
+        assertEquals(Arrays.<Object>asList("@keep_this"), options.getSkipTags());
+    }
+
+    @Test
     public void strips_options() {
         RuntimeOptions options = new RuntimeOptions("  --glue  somewhere   somewhere_else");
         assertEquals(asList("somewhere_else"), options.getFeaturePaths());

--- a/core/src/test/java/cucumber/runtime/SkipTagsTest.java
+++ b/core/src/test/java/cucumber/runtime/SkipTagsTest.java
@@ -1,0 +1,64 @@
+package cucumber.runtime;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import cucumber.runtime.io.ClasspathResourceLoader;
+import cucumber.runtime.snippets.FunctionNameGenerator;
+import cucumber.runtime.xstream.LocalizedXStreams;
+import gherkin.formatter.Argument;
+import gherkin.formatter.model.Step;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SkipTagsTest {
+
+    @Test
+    public void skipTagsTest() throws Exception {
+        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        final ClasspathResourceLoader resourceLoader = new ClasspathResourceLoader(classLoader);
+        RuntimeGlue runtimeGlue = new RuntimeGlue(mock(UndefinedStepsTracker.class), mock(LocalizedXStreams.class));
+        runtimeGlue.addStepDefinition(new ArgumentMatchingStubStepDefinition("skip_test"));
+
+        List<String> args = new ArrayList<String>();
+        args.add("--monochrome");
+        args.add("--skip-tags");
+        args.add("@Skip");
+        args.add("cucumber/runtime/SkipTagsTest.feature");
+
+        RuntimeOptions runtimeOptions = new RuntimeOptions(args);
+
+        Backend backend = mock(Backend.class);
+        when(backend.getSnippet(any(Step.class), any(FunctionNameGenerator.class))).thenReturn("TEST SNIPPET");
+        final Runtime runtime = new Runtime(resourceLoader, classLoader, asList(backend), runtimeOptions, StopWatch.SYSTEM, runtimeGlue);
+        runtime.run();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        runtime.printStats(new PrintStream(baos));
+
+        assertThat(baos.toString(), startsWith(String.format(
+                "4 Scenarios (2 skipped, 2 passed)%n" +
+                        "12 Steps (6 skipped, 6 passed)%n")));
+    }
+
+    private static class ArgumentMatchingStubStepDefinition extends StubStepDefinition {
+        public ArgumentMatchingStubStepDefinition(String pattern) throws NoSuchMethodException {
+            super(new Object(), Object.class.getMethod("toString"), pattern);
+        }
+
+        @Override
+        public List<Argument> matchedArguments(Step step) {
+            return Collections.EMPTY_LIST;
+        }
+    }
+}

--- a/core/src/test/resources/cucumber/runtime/SkipTagsTest.feature
+++ b/core/src/test/resources/cucumber/runtime/SkipTagsTest.feature
@@ -1,0 +1,26 @@
+Feature: Skip Tags
+
+  Scenario: Ok
+    Given skip_tag_step_1
+    When skip_tag_step_2
+    Then skip_tag_step_3
+
+  @Skip
+  Scenario: Skipped
+    Given skip_tag_step_1
+    When skip_tag_step_2
+    Then skip_tag_step_3
+
+  Scenario Outline: ScenarioOutline_1
+    Given skip_tag_step_1 <skip>
+    When skip_tag_step_2 <skip>
+    Then skip_tag_step_3 <skip>
+
+  Examples:
+    | skip |
+    | Ok   |
+
+  @Skip
+  Examples:
+    | skip    |
+    | Skipped |

--- a/core/src/test/resources/cucumber/runtime/SkipTagsTest.feature
+++ b/core/src/test/resources/cucumber/runtime/SkipTagsTest.feature
@@ -1,5 +1,6 @@
 Feature: Skip Tags
 
+  @NeverSkip
   Scenario: Ok
     Given skip_tag_step_1
     When skip_tag_step_2
@@ -16,11 +17,13 @@ Feature: Skip Tags
     When skip_tag_step_2 <skip>
     Then skip_tag_step_3 <skip>
 
+  @AlsoNeverSkip
   Examples:
-    | skip |
-    | Ok   |
+    | skip    |
+    | Ok      |
+    | Also Ok |
 
-  @Skip
+  @SkipAlso
   Examples:
     | skip    |
     | Skipped |

--- a/junit/src/main/java/cucumber/api/junit/Cucumber.java
+++ b/junit/src/main/java/cucumber/api/junit/Cucumber.java
@@ -133,6 +133,11 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
         String[] tags() default {};
 
         /**
+         * @return what tags in the features should be skipped explicitly
+         */
+        String[] skipTags() default {};
+
+        /**
          * @return what formatter(s) to use
          */
         String[] format() default {};


### PR DESCRIPTION
This marks them and their steps as skipped instead of just not executing them which would be the case if ~@tag was used.

The rationale behind this is to provide a similar functionality as the @Ignore annotation on normal JUnit tests. These tests will not fail the build, but will be clearly visible in the JUnit reports. 

This might be useful for example when a Scenario or even just some example sets of a Scenario Outline are to be temporarily skipped while waiting for a known bug to be solved or when tests for a future sprint are already being defined while engineers are still busy finishing the implementation of the current stories.

Note that this change requires the merge of [this pull request](https://github.com/cucumber/gherkin/pull/286) to address an issue in the Gherkin Java parser where tags on example tables could go lost. Without that merge, tags made on the first n of n+1 example tables in one scenario outline would not be matched as they would be wiped from the internal model before the skip criteria would be checked. 
