### PR TITLE
Add hookpoints in Cucumber and GuiceFactory

### DIFF
--- a/guice/src/main/java/cucumber/runtime/java/guice/GuiceFactory.java
+++ b/guice/src/main/java/cucumber/runtime/java/guice/GuiceFactory.java
@@ -55,7 +55,12 @@ public class GuiceFactory implements ObjectFactory {
     }
 
     public void start() {
-        injector = Guice.createInjector(new CucumberModule(classes, modules));
+        injector = createInjector(new CucumberModule(classes, modules));
+    }
+
+    /** Create the injector. May be overriden to e.g. create an injector with a parent */
+    protected Injector createInjector(Module cucumberModule) {
+      return Guice.createInjector(cucumberModule);
     }
 
     public void stop() {

--- a/guice/src/test/java/cucumber/runtime/java/guice/GuiceFactoryTest.java
+++ b/guice/src/test/java/cucumber/runtime/java/guice/GuiceFactoryTest.java
@@ -1,5 +1,9 @@
 package cucumber.runtime.java.guice;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
 import cucumber.runtime.java.ObjectFactory;
 import org.junit.Test;
 
@@ -38,4 +42,34 @@ public class GuiceFactoryTest {
         assertSame(factory.getInstance(Mappings.class), factory.getInstance(Mappings.class));
         factory.stop();
     }
+
+    /** Testing a use case of {@link GuiceFactory#createInjector */
+    @Test
+    public void subclassCanProvideParentInjector() throws Exception {
+        // injector can come from anywhere
+        final DependencyFromParent dependencyFromParent = new DependencyFromParent();
+        final Injector parentInjector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(DependencyFromParent.class).toInstance(dependencyFromParent);
+            }
+        });
+
+        ObjectFactory factory = new GuiceFactory() {
+            @Override
+            protected Injector createInjector(Module cucumberModule) {
+                return parentInjector.createChildInjector(cucumberModule);
+            }
+        };
+        factory.start();
+        assertSame(dependencyFromParent, factory.getInstance(DependencyFromParent.class));
+        factory.stop();
+
+        // parent injector is reused
+        factory.start();
+        assertSame(dependencyFromParent, factory.getInstance(DependencyFromParent.class));
+        factory.stop();
+    }
+
+    private static class DependencyFromParent {}
 }

--- a/junit/src/main/java/cucumber/api/junit/Cucumber.java
+++ b/junit/src/main/java/cucumber/api/junit/Cucumber.java
@@ -59,11 +59,19 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
         RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
 
         ResourceLoader resourceLoader = new MultiLoader(classLoader);
-        ClassFinder classFinder = new ResourceLoaderClassFinder(resourceLoader, classLoader);
-        runtime = new Runtime(resourceLoader, classFinder, classLoader, runtimeOptions);
+        runtime = createRuntime(resourceLoader, classLoader, runtimeOptions);
 
         jUnitReporter = new JUnitReporter(runtimeOptions.reporter(classLoader), runtimeOptions.formatter(classLoader), runtimeOptions.isStrict());
         addChildren(runtimeOptions.cucumberFeatures(resourceLoader));
+    }
+
+    /**
+     * Create the Runtime. Can be overridden to customize the runtime or backend.
+     */
+    protected Runtime createRuntime(ResourceLoader resourceLoader, ClassLoader classLoader,
+        RuntimeOptions runtimeOptions) throws InitializationError, IOException {
+      ClassFinder classFinder = new ResourceLoaderClassFinder(resourceLoader, classLoader);
+      return new Runtime(resourceLoader, classFinder, classLoader, runtimeOptions);
     }
 
     @Override


### PR DESCRIPTION
Use case: Create a subclass of Cucumber that creates a subclass of
GuiceFactory that creates an injector that has the injector of the
application being tested as its parent.
That way:
- The application stays in control of its own lifecycle (it can create its
  own injector), but steps are still scoped by scenario.
- Step classes can get injected by dependencies from the application
- The application's injector can be created once and shared between
  multiple scenarios to improve performance

I need these hook points for one particular case, but I made them as general as I could to fit other use cases:
- The createRuntime method in the junit Cucumber runner can be used to customize anything about the Runtime, Backends, ObjectFactories,... The problem I faced here is that the automatic configuration by classpath scanning sometimes just doesn't work out. (Because it only allows one ObjectFactory on the classpath; so you cannot extend one, and all tests in the same module are forced to use the same one).
- the overridable createInjector method allows having a parent injector (my use case) but also e.g. adding override modules, changing the injector's stage,...
