### PR TITLE
RuntimeOptions should also clobber the formatters

### DIFF
--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -91,6 +91,8 @@ public class RuntimeOptions {
         List<Object> parsedLineFilters = new ArrayList<Object>();
         List<String> parsedFeaturePaths = new ArrayList<String>();
         List<String> parsedGlue = new ArrayList<String>();
+        List<Formatter> parsedFormatters = new ArrayList<Formatter>();
+        formatterFactory.reset();
 
         while (!args.isEmpty()) {
             String arg = args.remove(0).trim();
@@ -107,7 +109,7 @@ public class RuntimeOptions {
             } else if (arg.equals("--tags") || arg.equals("-t")) {
                 parsedFilters.add(args.remove(0));
             } else if (arg.equals("--format") || arg.equals("-f")) {
-                formatters.add(formatterFactory.create(args.remove(0)));
+                parsedFormatters.add(formatterFactory.create(args.remove(0)));
             } else if (arg.equals("--dotcucumber")) {
                 String urlOrPath = args.remove(0);
                 dotCucumber = Utils.toURL(urlOrPath);
@@ -146,6 +148,10 @@ public class RuntimeOptions {
         if (!parsedGlue.isEmpty()) {
             glue.clear();
             glue.addAll(parsedGlue);
+        }
+        if (!parsedFormatters.isEmpty()) {
+            formatters.clear();
+            formatters.addAll(parsedFormatters);
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/formatter/FormatterFactory.java
+++ b/core/src/main/java/cucumber/runtime/formatter/FormatterFactory.java
@@ -42,12 +42,11 @@ public class FormatterFactory {
         put("rerun", RerunFormatter.class);
     }};
     private static final Pattern FORMATTER_WITH_FILE_PATTERN = Pattern.compile("([^:]+):(.*)");
-    private Appendable defaultOut = new OutputStreamWriter(System.out) {
-        @Override
-        public void close() throws IOException {
-            // We have no intention to close System.out
-        }
-    };
+    private Appendable defaultOut = createDefaultOut();
+
+    public void reset() {
+        defaultOut = createDefaultOut();
+    }
 
     public Formatter create(String formatterString) {
         Matcher formatterWithFile = FORMATTER_WITH_FILE_PATTERN.matcher(formatterString);
@@ -156,5 +155,14 @@ public class FormatterFactory {
         } finally {
             defaultOut = null;
         }
+    }
+
+    private OutputStreamWriter createDefaultOut() {
+        return new OutputStreamWriter(System.out) {
+            @Override
+            public void close() throws IOException {
+                // We have no intention to close System.out
+            }
+        };
     }
 }

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -186,6 +186,24 @@ public class RuntimeOptionsTest {
     }
 
     @Test
+    public void clobbers_formatters_from_cli_if_formatters_specified_in_cucumber_options_property() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--format pretty");
+        RuntimeOptions runtimeOptions = new RuntimeOptions(new Env(properties), asList("--format", "progress"));
+        assertEquals(1, runtimeOptions.getFormatters().size());
+        assertEquals("cucumber.runtime.formatter.CucumberPrettyFormatter", runtimeOptions.getFormatters().get(0).getClass().getName());
+    }
+
+    @Test
+    public void preserves_formatters_from_cli_if_formatters_not_specified_in_cucumber_options_property() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "featurePath");
+        RuntimeOptions runtimeOptions = new RuntimeOptions(new Env(properties), asList("--format", "pretty"));
+        assertEquals(1, runtimeOptions.getFormatters().size());
+        assertEquals("cucumber.runtime.formatter.CucumberPrettyFormatter", runtimeOptions.getFormatters().get(0).getClass().getName());
+    }
+
+    @Test
     public void clobbers_line_filters_from_cli_if_features_specified_in_cucumber_options_property() {
         Properties properties = new Properties();
         properties.setProperty("cucumber.options", "new newer");


### PR DESCRIPTION
When overriding the arguments from the command line/`@CucumberOptions` annotation with `cucumber.options` system property, all options that can hold multiple value are clobbered if provided in system property, except for the formatters option. That is the glue paths, the feature paths and the tag/line/name filters are clobbered if provided in the system property, but not the formatters.

That the formatters should also be formatters is indicated in the [Specify a different formatter](https://github.com/cucumber/cucumber-jvm/tree/master/examples/java-helloworld#specify-a-different-formatter) section of the ReadMe file of the example java-helloworld. The current behaviour is more accurately describes as "Specify an additional formatter".
