### PR TITLE
Issue #2 Ensuring features are parsed before formatters are initialised

### DIFF
--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
@@ -105,7 +105,7 @@ public class RuntimeOptionsFactoryTest {
         RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(SubClassWithFormatter.class, new Class[]{CucumberOptions.class});
         RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
 
-        List<Formatter> formatters = runtimeOptions.getFormatters();
+        List<Formatter> formatters = runtimeOptions.formatters();
         assertEquals(2, formatters.size());
         assertTrue(formatters.get(0) instanceof PrettyFormatter);
         assertTrue(formatters.get(1) instanceof JSONFormatter);

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -76,7 +76,7 @@ public class RuntimeOptionsTest {
     @Test
     public void creates_formatter() {
         RuntimeOptions options = new RuntimeOptions(asList("--format", "html:some/dir", "--glue", "somewhere"));
-        assertEquals("cucumber.runtime.formatter.HTMLFormatter", options.getFormatters().get(0).getClass().getName());
+        assertEquals("cucumber.runtime.formatter.HTMLFormatter", options.formatters().get(0).getClass().getName());
     }
 
     @Test
@@ -218,7 +218,8 @@ public class RuntimeOptionsTest {
         Formatter colorAwareFormatter = mock(Formatter.class, withSettings().extraInterfaces(ColorAware.class));
         when(factory.create("progress")).thenReturn(colorAwareFormatter);
 
-        new RuntimeOptions(new Env(), factory, asList("--monochrome", "--format", "progress"));
+        RuntimeOptions options = new RuntimeOptions(new Env(), factory, asList("--monochrome", "--format", "progress"));
+        options.formatters();
 
         verify((ColorAware) colorAwareFormatter).setMonochrome(true);
     }
@@ -229,7 +230,8 @@ public class RuntimeOptionsTest {
         Formatter strictAwareFormatter = mock(Formatter.class, withSettings().extraInterfaces(StrictAware.class));
         when(factory.create("junit:out/dir")).thenReturn(strictAwareFormatter);
 
-        new RuntimeOptions(new Env(), factory, asList("--strict", "--format", "junit:out/dir"));
+        RuntimeOptions options = new RuntimeOptions(new Env(), factory, asList("--strict", "--format", "junit:out/dir"));
+        options.formatters();
 
         verify((StrictAware) strictAwareFormatter).setStrict(true);
     }

--- a/junit/src/main/java/cucumber/api/junit/Cucumber.java
+++ b/junit/src/main/java/cucumber/api/junit/Cucumber.java
@@ -62,8 +62,9 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
         ClassFinder classFinder = new ResourceLoaderClassFinder(resourceLoader, classLoader);
         runtime = new Runtime(resourceLoader, classFinder, classLoader, runtimeOptions);
 
+        final List<CucumberFeature> cucumberFeatures = runtimeOptions.cucumberFeatures(resourceLoader);
         jUnitReporter = new JUnitReporter(runtimeOptions.reporter(classLoader), runtimeOptions.formatter(classLoader), runtimeOptions.isStrict());
-        addChildren(runtimeOptions.cucumberFeatures(resourceLoader));
+        addChildren(cucumberFeatures);
     }
 
     @Override

--- a/junit/src/test/java/cucumber/runtime/junit/CucumberTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/CucumberTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 public class CucumberTest {
@@ -57,6 +58,16 @@ public class CucumberTest {
             fail("Expecting error");
         } catch (CucumberException e) {
             assertEquals("Error parsing feature file cucumber/runtime/error/lexer_error.feature", e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testThatFileIsNotCreatedOnParsingError() throws Exception {
+        try {
+            new Cucumber(FormatterWithLexerErrorFeature.class);
+            fail("Expecting error");
+        } catch (CucumberException e){
+            assertFalse("File is created despite Lexor Error", new File("lexor_error_feature.json").exists());
         }
     }
 
@@ -110,4 +121,10 @@ public class CucumberTest {
     private class LexerErrorFeature {
 
     }
+    
+    @CucumberOptions(features = {"classpath:cucumber/runtime/error/lexer_error.feature"}, format = {"json:lexor_error_feature.json"})
+    private class FormatterWithLexerErrorFeature {
+
+    }
+
 }


### PR DESCRIPTION
Following the discussion in https://github.com/cucumber/cucumber-jvm/pull/651 it was suggested that reports should not be created until we know if there are syntax errors.

The formatters that use a URLOutputStream with a file protocol will all create their report files when the factory creates the formatter which at the moment is done when RuntimeOptions are created

I have added a test to demonstrate this and attempted to fix it.
See https://github.com/tmullender/cucumber-jvm/issues/2 for some explanation of the approach
