### PR TITLE
AbstractTestNGCucumberTests runs each feature as separate test

### DIFF
--- a/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
+++ b/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
@@ -1,8 +1,9 @@
 package cucumber.api.testng;
 
 import cucumber.runtime.model.CucumberFeature;
-import gherkin.formatter.model.Feature;
-import org.testng.annotations.*;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +25,7 @@ public abstract class AbstractTestNGCucumberTests {
     }
 
     /**
-     * @return returns two dimensional array of {@link AbstractTestNGCucumberTests.CucumberFeatureWrapper} objects.
+     * @return returns two dimensional array of {@link CucumberFeatureWrapper} objects.
      */
     @DataProvider
     public Object[][] features() {
@@ -36,24 +37,4 @@ public abstract class AbstractTestNGCucumberTests {
         return featuresList.toArray(new Object[][]{});
     }
 
-    /**
-     * The only purpose of this class is to provide custom {@linkplain #toString()},
-     * making TestNG reports look more descriptive.
-     */
-    public static class CucumberFeatureWrapper {
-        private final CucumberFeature cucumberFeature;
-
-        public CucumberFeatureWrapper(CucumberFeature cucumberFeature) {
-            this.cucumberFeature = cucumberFeature;
-        }
-
-        public CucumberFeature getCucumberFeature() {
-            return cucumberFeature;
-        }
-
-        @Override
-        public String toString() {
-            return cucumberFeature.getGherkinFeature().getName();
-        }
-    }
 }

--- a/testng/src/main/java/cucumber/api/testng/CucumberFeatureWrapper.java
+++ b/testng/src/main/java/cucumber/api/testng/CucumberFeatureWrapper.java
@@ -1,0 +1,26 @@
+package cucumber.api.testng;
+
+import cucumber.runtime.model.CucumberFeature;
+
+/**
+ * The only purpose of this class is to provide custom {@linkplain #toString()},
+ * making TestNG reports look more descriptive.
+ *
+ * @see AbstractTestNGCucumberTests#feature(cucumber.api.testng.CucumberFeatureWrapper)
+ */
+class CucumberFeatureWrapper {
+    private final CucumberFeature cucumberFeature;
+
+    public CucumberFeatureWrapper(CucumberFeature cucumberFeature) {
+        this.cucumberFeature = cucumberFeature;
+    }
+
+    public CucumberFeature getCucumberFeature() {
+        return cucumberFeature;
+    }
+
+    @Override
+    public String toString() {
+        return cucumberFeature.getGherkinFeature().getName();
+    }
+}

--- a/testng/src/test/java/cucumber/api/testng/BatmanTest.java
+++ b/testng/src/test/java/cucumber/api/testng/BatmanTest.java
@@ -1,0 +1,14 @@
+package cucumber.api.testng;
+
+import cucumber.api.CucumberOptions;
+import org.testng.annotations.Test;
+
+/**
+ * This test is intentionally disabled, as it serves only as a part of {@link cucumber.api.testng.TestNGCucumberRunnerTest}
+ *
+ * @see cucumber.api.testng.TestNGCucumberRunnerTest
+ */
+@CucumberOptions(features = "src/test/resources/cucumber/api/testng/batman")
+@Test(groups = "batman", enabled = false)
+public class BatmanTest extends AbstractTestNGCucumberTests {
+}

--- a/testng/src/test/java/cucumber/api/testng/TestNGCucumberRunnerTest.java
+++ b/testng/src/test/java/cucumber/api/testng/TestNGCucumberRunnerTest.java
@@ -1,0 +1,25 @@
+package cucumber.api.testng;
+
+import cucumber.runtime.model.CucumberFeature;
+import cucumber.runtime.testng.RunCukesTest;
+import org.testng.*;
+import org.testng.annotations.*;
+
+import java.util.List;
+
+public class TestNGCucumberRunnerTest {
+    private TestNGCucumberRunner testNGCucumberRunner;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        testNGCucumberRunner = new TestNGCucumberRunner(RunCukesTest.class);
+    }
+
+    @Test
+    public void getFeatures() throws Exception {
+        List<CucumberFeature> features = testNGCucumberRunner.getFeatures();
+
+        Assert.assertFalse(features.isEmpty());
+        Assert.assertEquals(features.size(), 3, "All features associated with RunCukesTest are loaded");
+    }
+}

--- a/testng/src/test/java/cucumber/api/testng/TestNGCucumberRunnerTest.java
+++ b/testng/src/test/java/cucumber/api/testng/TestNGCucumberRunnerTest.java
@@ -1,10 +1,13 @@
 package cucumber.api.testng;
 
 import cucumber.runtime.model.CucumberFeature;
-import cucumber.runtime.testng.RunCukesTest;
-import org.testng.*;
-import org.testng.annotations.*;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
+import java.io.File;
+import java.io.FilenameFilter;
+import java.net.URL;
 import java.util.List;
 
 public class TestNGCucumberRunnerTest {
@@ -12,14 +15,30 @@ public class TestNGCucumberRunnerTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
-        testNGCucumberRunner = new TestNGCucumberRunner(RunCukesTest.class);
+        testNGCucumberRunner = new TestNGCucumberRunner(BatmanTest.class);
     }
 
     @Test
     public void getFeatures() throws Exception {
         List<CucumberFeature> features = testNGCucumberRunner.getFeatures();
 
-        Assert.assertFalse(features.isEmpty());
-        Assert.assertEquals(features.size(), 3, "All features associated with RunCukesTest are loaded");
+        int numberOfFeatures = getNumberOfFeatures();
+
+        Assert.assertEquals(features.size(), numberOfFeatures,
+                "Not all features associated with " + BatmanTest.class.getSimpleName() + " were loaded. ");
+    }
+
+    /**
+     * @return number of feature files in "cucumber/api/testng/batman" folder
+     */
+    private int getNumberOfFeatures() {
+        URL fileURL = this.getClass().getClassLoader().getResource("cucumber/api/testng/batman");
+        assert fileURL != null;
+        return new File(fileURL.getFile()).listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith(".feature");
+            }
+        }).length;
     }
 }

--- a/testng/src/test/resources/cucumber/api/testng/batman/bulletproof.feature
+++ b/testng/src/test/resources/cucumber/api/testng/batman/bulletproof.feature
@@ -1,0 +1,7 @@
+Feature: Bulletproof costume
+
+  Scenario: Bullets fired at Batman
+    Given I'm Batman
+    And I'm wearing my bat costume
+    When The Joker fires at me
+    Then bullets fly the other direction out of sheer terror

--- a/testng/src/test/resources/cucumber/api/testng/batman/millionaire.feature
+++ b/testng/src/test/resources/cucumber/api/testng/batman/millionaire.feature
@@ -1,0 +1,8 @@
+Feature: Millionaire
+  Background: Batman is rich
+    Given Batman's parents were rich
+
+  Scenario: Batman can buy expensive cars
+    Given I'm Batman
+    When I buy 10 Rolls Royce "Phantoms"
+    Then my bank account balance is positive

--- a/testng/src/test/resources/cucumber/api/testng/batman/readme.txt
+++ b/testng/src/test/resources/cucumber/api/testng/batman/readme.txt
@@ -1,0 +1,1 @@
+TestNGCucumberRunnerTest depends on number of features here.

--- a/testng/src/test/resources/cucumber/api/testng/batman/softNature.feature
+++ b/testng/src/test/resources/cucumber/api/testng/batman/softNature.feature
@@ -1,0 +1,9 @@
+Feature: Soft nature
+  Background: Difficult childhood
+    When Batman was a child
+    Then his parents were murdered
+
+  Scenario: Batman cries when asked about parents
+    Given I'm Batman
+    When Robin says "Where are your parents?"
+    Then I cry


### PR DESCRIPTION
Previously AbstractTestNGCucumberTests reported all features as a single test, making it a little bit difficult to understand which feature have failed scenarios.
With this change AbstractTestNGCucumberTests uses TestNG data provider to generate separate tests for each feature.

Test output is  much nicer, especially in IDE.
Compare [old](http://pichost.me/1637920/) to [new](http://pichost.me/1637919/). Both are screenshots from IntelliJ Idea running java-calculator-testng example.

Exiting API of TestNGCucumberRunner is kept unchanged.