### PR TITLE
Let JUnitReporter fire event(s) on the step notifier for every step

### DIFF
--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -106,7 +106,9 @@ public class JUnitReporter implements Reporter, Formatter {
 
     private void addFailureOrIgnoreStep(Result result) {
         if (strict) {
+            stepNotifier.fireTestStarted();
             addFailure(result);
+            stepNotifier.fireTestFinished();
         } else {
             ignoredStep = true;
             stepNotifier.fireTestIgnored();

--- a/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
@@ -76,8 +76,8 @@ public class JUnitReporterTest {
 
         jUnitReporter.result(Result.UNDEFINED);
 
-        verify(stepNotifier, times(0)).fireTestStarted();
-        verify(stepNotifier, times(0)).fireTestFinished();
+        verify(stepNotifier, times(1)).fireTestStarted();
+        verify(stepNotifier, times(1)).fireTestFinished();
         verifyAddFailureWithPendingException(stepNotifier);
         verifyAddFailureWithPendingException(executionUnitNotifier);
         verify(stepNotifier, times(0)).fireTestIgnored();
@@ -121,8 +121,8 @@ public class JUnitReporterTest {
 
         jUnitReporter.result(result);
 
-        verify(stepNotifier, times(0)).fireTestStarted();
-        verify(stepNotifier, times(0)).fireTestFinished();
+        verify(stepNotifier, times(1)).fireTestStarted();
+        verify(stepNotifier, times(1)).fireTestFinished();
         verifyAddFailureWithPendingException(stepNotifier);
         verifyAddFailureWithPendingException(executionUnitNotifier);
         verify(stepNotifier, times(0)).fireTestIgnored();


### PR DESCRIPTION
In strict mode the JUnitReporter currently does not fire any event on the step notifier for undefined or pending steps (neither fireTestIgnored, nor fireTestStarted and fireTestFinished is called). Therefore the JUnit runner of Eclipse display wrong run count when this occurs.

![junitrun](https://f.cloud.github.com/assets/2105308/1894632/4910de5a-7af4-11e3-869b-9dec4c5afbe7.JPG)

The JUnitReporter should for each call to Result either call fireTestIgnored, or call fireTestStarted and fireTestFinished on the step notifier. In strict mode undefined and pending steps should be treated as failed steps, so fireTestStarted and fireTestFinished should be called on the step notifier.
