### PR TITLE
Correct JUnit notification for background steps

### DIFF
--- a/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
+++ b/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
@@ -8,6 +8,7 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.ParentRunner;
 import org.junit.runners.model.InitializationError;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,12 +22,17 @@ public class ExecutionUnitRunner extends ParentRunner<Step> {
     private final JUnitReporter jUnitReporter;
     private Description description;
     private final Map<Step, Description> stepDescriptions = new HashMap<Step, Description>();
+    private final List<Step> runnerSteps = new ArrayList<Step>();
 
     public ExecutionUnitRunner(Runtime runtime, CucumberScenario cucumberScenario, JUnitReporter jUnitReporter) throws InitializationError {
         super(ExecutionUnitRunner.class);
         this.runtime = runtime;
         this.cucumberScenario = cucumberScenario;
         this.jUnitReporter = jUnitReporter;
+    }
+
+    public List<Step> getRunnerSteps() {
+    	return runnerSteps;
     }
 
     @Override
@@ -56,11 +62,13 @@ public class ExecutionUnitRunner extends ParentRunner<Step> {
                             backgroundStep.getDocString()
                     );
                     description.addChild(describeChild(copy));
+                    runnerSteps.add(copy);
                 }
             }
 
             for (Step step : getChildren()) {
                 description.addChild(describeChild(step));
+                runnerSteps.add(step);
             }
         }
         return description;

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -1,6 +1,7 @@
 package cucumber.runtime.junit;
 
 import cucumber.api.PendingException;
+import cucumber.runtime.CucumberException;
 import gherkin.formatter.Formatter;
 import gherkin.formatter.Reporter;
 import gherkin.formatter.model.Background;
@@ -56,9 +57,19 @@ public class JUnitReporter implements Reporter, Formatter {
     }
 
     public void match(Match match) {
-        Description description = executionUnitRunner.describeChild(steps.remove(0));
+        Step runnerStep = fetchAndCheckRunnerStep();
+        Description description = executionUnitRunner.describeChild(runnerStep);
         stepNotifier = new EachTestNotifier(runNotifier, description);
         reporter.match(match);
+    }
+
+    private Step fetchAndCheckRunnerStep() {
+        Step scenarioStep = steps.remove(0);
+        Step runnerStep = executionUnitRunner.getRunnerSteps().remove(0);
+        if (!scenarioStep.getName().equals(runnerStep.getName())) {
+            throw new CucumberException("Expected step: \"" + scenarioStep.getName() + "\" got step: \"" + runnerStep.getName() + "\"");
+        }
+        return runnerStep;
     }
 
     @Override

--- a/junit/src/test/java/cucumber/runtime/junit/ExecutionUnitRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/ExecutionUnitRunnerTest.java
@@ -1,12 +1,19 @@
 package cucumber.runtime.junit;
 
+import cucumber.runtime.FeatureBuilder;
 import cucumber.runtime.io.ClasspathResourceLoader;
+import cucumber.runtime.io.Resource;
 import cucumber.runtime.model.CucumberFeature;
 import cucumber.runtime.model.CucumberScenario;
 import gherkin.formatter.model.Step;
 import org.junit.Test;
 import org.junit.runner.Description;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -65,4 +72,65 @@ public class ExecutionUnitRunnerTest {
         assertEquals("description includes scenario name as class name", runner.getName(), stepDescription.getClassName());
         assertEquals("description includes step keyword and name as method name", step.getKeyword() + step.getName(), stepDescription.getMethodName());
     }
+
+    @Test
+    public void shouldPopulateRunnerStepsWithStepsUsedInStepDescriptions() throws Exception {
+        CucumberFeature cucumberFeature = feature("featurePath", "" +
+                "Feature: feature name\n" +
+                "  Background:\n" +
+                "    Given background step\n" +
+                "  Scenario:\n" +
+                "    Then scenario name\n");
+
+        ExecutionUnitRunner runner = new ExecutionUnitRunner(
+                null,
+                (CucumberScenario) cucumberFeature.getFeatureElements().get(0),
+                null
+        );
+
+        // fish out the data from runner
+        Description runnerDescription = runner.getDescription();
+        Description backgroundStepDescription = runnerDescription.getChildren().get(0);
+        Description scenarioStepDescription = runnerDescription.getChildren().get(1);
+        Step runnerBackgroundStep = runner.getRunnerSteps().get(0);
+        Step runnerScenarioStep = runner.getRunnerSteps().get(1);
+
+        assertDescriptionHasStepAsUniqueId(backgroundStepDescription, runnerBackgroundStep);
+        assertDescriptionHasStepAsUniqueId(scenarioStepDescription, runnerScenarioStep);
+    }
+
+    private void assertDescriptionHasStepAsUniqueId(Description stepDescription, Step step) {
+        // Note, JUnit uses the the serializable parameter (in this case the step)
+        // as the unique id when comparing Descriptions
+        assertEquals(stepDescription, Description.createTestDescription("", "", step));
+    }
+
+    private CucumberFeature feature(final String path, final String source) throws IOException {
+        ArrayList<CucumberFeature> cucumberFeatures = new ArrayList<CucumberFeature>();
+        FeatureBuilder featureBuilder = new FeatureBuilder(cucumberFeatures);
+        featureBuilder.parse(new Resource() {
+            @Override
+            public String getPath() {
+                return path;
+            }
+
+            @Override
+            public InputStream getInputStream() {
+                try {
+                    return new ByteArrayInputStream(source.getBytes("UTF-8"));
+                } catch (UnsupportedEncodingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public String getClassName() {
+                throw new UnsupportedOperationException();
+            }
+        }, new ArrayList<Object>());
+        featureBuilder.close();
+        return cucumberFeatures.get(0);
+    }
+
+
 }


### PR DESCRIPTION
The background steps are copied in the ExecutionUnitRunner for each scenario in a feature with background. This is done to make them unique for each scenario, so that the JUnit notification later will not be ambiguous. When the background steps are executed, it is the original ones that are executed. If the background steps are not 'converted' from the original steps to the copies made earlier, when performing the actual JUnit notifications for an execution unit (scenario), then the background step appear as Unrooted test in the Eclipse JUnit tab:
![cucumber-junit-error](https://f.cloud.github.com/assets/2105308/1950127/4e0dd730-8136-11e3-9fd3-8012420fbe57.JPG)

This PR change the JUnitReporter to use the steps copied, and now stored, in the ExecutionUnitRunner, as base for the JUnit notification. Then the background steps appear correctly in the Eclipse JUnit tab:
![cucumber-junit-error-fixed](https://f.cloud.github.com/assets/2105308/1950132/aa68113a-8136-11e3-8a6e-2cfe3ef12d7f.JPG)

Fixes: #659.
