### PR TITLE
Android: Prepare for Espresso support

### DIFF
--- a/android/src/main/java/cucumber/api/android/CucumberInstrumentation.java
+++ b/android/src/main/java/cucumber/api/android/CucumberInstrumentation.java
@@ -4,21 +4,21 @@ import android.app.Instrumentation;
 import android.os.Bundle;
 
 public class CucumberInstrumentation extends Instrumentation {
-    public static final String REPORT_VALUE_ID = CucumberInstrumentationHelper.REPORT_VALUE_ID;
-    public static final String REPORT_KEY_NUM_TOTAL = CucumberInstrumentationHelper.REPORT_KEY_NUM_TOTAL;
-    public static final String TAG = CucumberInstrumentationHelper.TAG;
-    private CucumberInstrumentationHelper helper = new CucumberInstrumentationHelper(this);
+    public static final String REPORT_VALUE_ID = CucumberInstrumentationCore.REPORT_VALUE_ID;
+    public static final String REPORT_KEY_NUM_TOTAL = CucumberInstrumentationCore.REPORT_KEY_NUM_TOTAL;
+    public static final String TAG = CucumberInstrumentationCore.TAG;
+    private CucumberInstrumentationCore instrumentationCore = new CucumberInstrumentationCore(this);
 
     @Override
     public void onCreate(Bundle arguments) {
         super.onCreate(arguments);
-        helper.onCreate(arguments);
+        instrumentationCore.onCreate(arguments);
         start();
     }
 
     @Override
     public void onStart() {
-        helper.onStart();
+        instrumentationCore.onStart();
     }
 
 }

--- a/android/src/main/java/cucumber/api/android/CucumberInstrumentationCore.java
+++ b/android/src/main/java/cucumber/api/android/CucumberInstrumentationCore.java
@@ -36,7 +36,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-public class CucumberInstrumentationHelper {
+public class CucumberInstrumentationCore {
     public static final String REPORT_VALUE_ID = "CucumberInstrumentation";
     public static final String REPORT_KEY_NUM_TOTAL = "numtests";
     public static final String TAG = "cucumber-android";
@@ -54,7 +54,7 @@ public class CucumberInstrumentationHelper {
     InstrumentationArguments instrumentationArguments;
     private Instrumentation instrumentation;
 
-    public CucumberInstrumentationHelper(Instrumentation instrumentation) {
+    public CucumberInstrumentationCore(Instrumentation instrumentation) {
         this.instrumentation = instrumentation;
     }
 


### PR DESCRIPTION
This PR aims at making it possible to also use the Espresso framework in step definitions.

I don't find Espresso officially published through Maven, which Cucumber-JVM uses both for CI builds and deployment. Therefore Espresso is not introduced as dependency, but the PR makes it really easy to write a custom Espresso runner locally. Using the CucumberInstrumentation works exactly as before.

A local runner like this, has been successfully tested in the [Cukeulator-test](https://github.com/cucumber/cucumber-jvm/tree/master/examples/android/cukeulator-test) example:

```
public class EspressoInstrumentation extends GoogleInstrumentationTestRunner {
    private CucumberInstrumentationHelper helper = new CucumberInstrumentationHelper(this);

    @Override
    public void onCreate(Bundle arguments) {
        helper.onCreate(arguments);
        super.onCreate(arguments);
    }

    @Override
    public void onStart() {
        helper.onStart();
    }
}

```

Fixes #662.

Notes on the what I found out about the current status of Maven and Espresso:
In [Quality-Tools-for-Android](https://github.com/stephanenicolas/Quality-Tools-for-Android) the Espresso jar is checked in as a local Maven [repo](https://github.com/stephanenicolas/Quality-Tools-for-Android/tree/master/android-sample-espresso-tests/repo/com/google/android/android-espresso).
A [Gradle port](https://github.com/JakeWharton/double-espresso/) of Espresso is available through [Maven Central](http://search.maven.org/#search|ga|1|espresso) 
