### PR TITLE
Dominic: expose current (gherkin) scenario to step definition code via T...

### DIFF
--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -3,18 +3,13 @@ package cucumber.runtime;
 import cucumber.api.Pending;
 import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.model.CucumberFeature;
+import cucumber.runtime.model.CurrentScenario;
 import cucumber.runtime.xstream.LocalizedXStreams;
 import gherkin.I18n;
 import gherkin.formatter.Argument;
 import gherkin.formatter.Formatter;
 import gherkin.formatter.Reporter;
-import gherkin.formatter.model.Comment;
-import gherkin.formatter.model.DataTableRow;
-import gherkin.formatter.model.DocString;
-import gherkin.formatter.model.Match;
-import gherkin.formatter.model.Result;
-import gherkin.formatter.model.Step;
-import gherkin.formatter.model.Tag;
+import gherkin.formatter.model.*;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -324,5 +319,13 @@ public class Runtime implements UnreportedStepExecutor {
     private void addHookToCounterAndResult(Result result) {
         scenarioResult.add(result);
         stats.addHookTime(result.getDuration());
+    }
+
+    public void setScenario(Scenario scenario) {
+        CurrentScenario.set(scenario);
+    }
+
+    public void clearScenario() {
+        CurrentScenario.set(null);
     }
 }

--- a/core/src/main/java/cucumber/runtime/model/CucumberScenario.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberScenario.java
@@ -11,15 +11,17 @@ import java.util.Set;
 
 public class CucumberScenario extends CucumberTagStatement {
     private final CucumberBackground cucumberBackground;
-
+    private final Scenario scenario;
     public CucumberScenario(CucumberFeature cucumberFeature, CucumberBackground cucumberBackground, Scenario scenario) {
         super(cucumberFeature, scenario);
         this.cucumberBackground = cucumberBackground;
+        this.scenario = scenario;
     }
 
     public CucumberScenario(CucumberFeature cucumberFeature, CucumberBackground cucumberBackground, Scenario exampleScenario, Row example) {
         super(cucumberFeature, exampleScenario, example);
         this.cucumberBackground = cucumberBackground;
+        this.scenario = exampleScenario;
     }
 
     public CucumberBackground getCucumberBackground() {
@@ -38,6 +40,8 @@ public class CucumberScenario extends CucumberTagStatement {
         } catch (Throwable ignore) {
             // IntelliJ has its own formatter which doesn't yet implement this.
         }
+
+        runtime.setScenario(scenario);
         runtime.runBeforeHooks(reporter, tags);
 
         runBackground(formatter, reporter, runtime);
@@ -50,6 +54,7 @@ public class CucumberScenario extends CucumberTagStatement {
         } catch (Throwable ignore) {
             // IntelliJ has its own formatter which doesn't yet implement this.
         }
+        runtime.clearScenario();
         runtime.disposeBackendWorlds();
     }
 

--- a/core/src/main/java/cucumber/runtime/model/CurrentScenario.java
+++ b/core/src/main/java/cucumber/runtime/model/CurrentScenario.java
@@ -1,0 +1,16 @@
+package cucumber.runtime.model;
+
+import gherkin.formatter.model.Scenario;
+
+public class CurrentScenario {
+
+    private static final ThreadLocal<Scenario> threadLocal = new ThreadLocal<Scenario>();
+
+    public static Scenario get() {
+        return threadLocal.get();
+    }
+
+    public static void set(Scenario scenario) {
+        threadLocal.set(scenario);
+    }
+}

--- a/java/src/test/java/cucumber/runtime/java/stepdefs/Stepdefs.java
+++ b/java/src/test/java/cucumber/runtime/java/stepdefs/Stepdefs.java
@@ -3,6 +3,7 @@ package cucumber.runtime.java.stepdefs;
 import cucumber.api.java.en.Given;
 
 public class Stepdefs {
+
     @Given("test")
     public void test() {
 

--- a/java/src/test/java/cucumber/runtime/java/test/ScenarioStepDefs.java
+++ b/java/src/test/java/cucumber/runtime/java/test/ScenarioStepDefs.java
@@ -1,0 +1,28 @@
+package cucumber.runtime.java.test;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.model.CurrentScenario;
+
+import static junit.framework.Assert.assertEquals;
+
+public class ScenarioStepDefs {
+
+    private String scenarioName = "";
+
+    @Given("^I am running a scenario$")
+    public void i_am_running_a_scenario() {
+
+    }
+
+    @When("^I try to get the scenario name$")
+    public void i_try_to_get_the_scenario_name() {
+        scenarioName = CurrentScenario.get().getName();
+    }
+
+    @Then("^The scenario name is \"([^\"]*)\"$")
+    public void the_scenario_name_is(String scenarioName) {
+        assertEquals(this.scenarioName, scenarioName);
+    }
+}

--- a/java/src/test/resources/cucumber/runtime/java/test/scenario.feature
+++ b/java/src/test/resources/cucumber/runtime/java/test/scenario.feature
@@ -1,0 +1,11 @@
+Feature: Scenario information is available during step execution
+
+  Scenario: My first scenario
+    Given I am running a scenario
+    When I try to get the scenario name
+    Then The scenario name is "My first scenario"
+
+  Scenario: My second scenario
+    Given I am running a scenario
+    When I try to get the scenario name
+    Then The scenario name is "My second scenario"


### PR DESCRIPTION
I am using Cucumber to define tests for a system which calls out to a stub server that services HTTP requests:

Cucumber -[executes]-> step definition -[calls]-> system under test -[calls]-> stub server

The stub server works by recording and replaying a transcript of requests and responses, identified as belonging to a named scenario. Each Cucumber scenario corresponds to a scenario on the stub server, which is configured at execution-time with the expected sequence of requests and responses. In order to facilitate tracing and debugging between Cucumber, the system under test and the stub server, it is useful if the stub server's scenario can be matched by name to the Cucumber scenario which drives the behaviour that results in the stubbed HTTP calls.

As things stand, Cucumber-JVM does not provide access to a scenario's name or other details for code running within a step definition. This is by design, to prevent unwanted coupling (step definitions should be re-usable across scenarios, and indifferent to the particular scenario they are running in). However, in the use case described above, the step definition does not _behave_ differently based on the scenario name; it merely passes the scenario name on to the stub server when recording its transcript of requests and responses. This does not result in any unwanted coupling, but makes it easier to trace calls across the system.

The change in this pull request exposes the currently-executing scenario's Gherkin Scenario object, via a ThreadLocal, so that a step definition can call CurrentScenario.get().getName() to discover the name of the currently-executing scenario.
