### PR TITLE
Expose CucumberBackground and CucumberFeature from scenarios

### DIFF
--- a/core/src/main/java/cucumber/runtime/model/CucumberScenario.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberScenario.java
@@ -10,23 +10,16 @@ import gherkin.formatter.model.Tag;
 import java.util.Set;
 
 public class CucumberScenario extends CucumberTagStatement {
-    private final CucumberBackground cucumberBackground;
     private final Scenario scenario;
 
     public CucumberScenario(CucumberFeature cucumberFeature, CucumberBackground cucumberBackground, Scenario scenario) {
-        super(cucumberFeature, scenario);
-        this.cucumberBackground = cucumberBackground;
+        super(cucumberBackground, cucumberFeature, scenario);
         this.scenario = scenario;
     }
 
     public CucumberScenario(CucumberFeature cucumberFeature, CucumberBackground cucumberBackground, Scenario exampleScenario, Row example) {
-        super(cucumberFeature, exampleScenario, example);
-        this.cucumberBackground = cucumberBackground;
+        super(cucumberBackground, cucumberFeature, exampleScenario, example);
         this.scenario = exampleScenario;
-    }
-
-    public CucumberBackground getCucumberBackground() {
-        return cucumberBackground;
     }
 
     /**
@@ -57,6 +50,7 @@ public class CucumberScenario extends CucumberTagStatement {
     }
 
     private void runBackground(Formatter formatter, Reporter reporter, Runtime runtime) {
+        final CucumberBackground cucumberBackground = getCucumberBackground();
         if (cucumberBackground != null) {
             cucumberBackground.format(formatter);
             cucumberBackground.runSteps(reporter, runtime);

--- a/core/src/main/java/cucumber/runtime/model/CucumberScenarioOutline.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberScenarioOutline.java
@@ -21,11 +21,9 @@ import java.util.Set;
 
 public class CucumberScenarioOutline extends CucumberTagStatement {
     private final List<CucumberExamples> cucumberExamplesList = new ArrayList<CucumberExamples>();
-    private final CucumberBackground cucumberBackground;
 
     public CucumberScenarioOutline(CucumberFeature cucumberFeature, CucumberBackground cucumberBackground, ScenarioOutline scenarioOutline) {
-        super(cucumberFeature, scenarioOutline);
-        this.cucumberBackground = cucumberBackground;
+        super(cucumberBackground, cucumberFeature, scenarioOutline);
     }
 
     public void examples(Examples examples) {
@@ -53,7 +51,7 @@ public class CucumberScenarioOutline extends CucumberTagStatement {
         String exampleScenarioName = replaceTokens(new HashSet<Integer>(), header.getCells(), example.getCells(), getGherkinModel().getName());
 
         Scenario exampleScenario = new Scenario(example.getComments(), examplesTags, getGherkinModel().getKeyword(), exampleScenarioName, "", example.getLine(), example.getId());
-        CucumberScenario cucumberScenario = new CucumberScenario(cucumberFeature, cucumberBackground, exampleScenario, example);
+        CucumberScenario cucumberScenario = new CucumberScenario(getCucumberFeature(), getCucumberBackground(), exampleScenario, example);
         for (Step step : getSteps()) {
             cucumberScenario.step(createExampleStep(step, header, example));
         }

--- a/core/src/main/java/cucumber/runtime/model/CucumberTagStatement.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberTagStatement.java
@@ -13,26 +13,33 @@ import java.util.Set;
 import static gherkin.util.FixJava.join;
 
 public abstract class CucumberTagStatement extends StepContainer {
+    private final CucumberBackground cucumberBackground;
     private final TagStatement gherkinModel;
     private final String visualName;
 
-    CucumberTagStatement(CucumberFeature cucumberFeature, TagStatement gherkinModel) {
+    CucumberTagStatement(CucumberBackground cucumberBackground, CucumberFeature cucumberFeature, TagStatement gherkinModel) {
         super(cucumberFeature, gherkinModel);
+        this.cucumberBackground = cucumberBackground;
         this.gherkinModel = gherkinModel;
         this.visualName = gherkinModel.getKeyword() + ": " + gherkinModel.getName();
     }
 
-    CucumberTagStatement(CucumberFeature cucumberFeature, TagStatement gherkinModel, Row example) {
+    CucumberTagStatement(CucumberBackground cucumberBackground, CucumberFeature cucumberFeature, TagStatement gherkinModel, Row example) {
         super(cucumberFeature, gherkinModel);
+        this.cucumberBackground = cucumberBackground;
         this.gherkinModel = gherkinModel;
         this.visualName = "| " + join(example.getCells(), " | ") + " |";
     }
 
     protected Set<Tag> tagsAndInheritedTags() {
         Set<Tag> tags = new HashSet<Tag>();
-        tags.addAll(cucumberFeature.getGherkinFeature().getTags());
+        tags.addAll(getCucumberFeature().getGherkinFeature().getTags());
         tags.addAll(gherkinModel.getTags());
         return tags;
+    }
+
+    public CucumberBackground getCucumberBackground() {
+        return cucumberBackground;
     }
 
     public String getVisualName() {

--- a/core/src/main/java/cucumber/runtime/model/StepContainer.java
+++ b/core/src/main/java/cucumber/runtime/model/StepContainer.java
@@ -11,12 +11,16 @@ import java.util.List;
 
 public class StepContainer {
     private final List<Step> steps = new ArrayList<Step>();
-    final CucumberFeature cucumberFeature;
+    private final CucumberFeature cucumberFeature;
     private final BasicStatement statement;
 
     StepContainer(CucumberFeature cucumberFeature, BasicStatement statement) {
         this.cucumberFeature = cucumberFeature;
         this.statement = statement;
+    }
+
+    public CucumberFeature getCucumberFeature() {
+        return cucumberFeature;
     }
 
     public List<Step> getSteps() {


### PR DESCRIPTION
For a custom reporting output I need to access the background steps of scenarios. The background was previously available from `CucumberScenario`, but not from `CucumberScenarioOutline`, but it really belongs to a feature. It would also be nice to expose the feature a scenario belongs to, in our report we currently need to either use reflection hacks or pass pairs of feature/scenario objects.
- Add method to retrieve the CucumberFeature from a CucumberScenario
- Move CucumberBackground from CucumberScenario to its parent CucumberTagStatement, so its also available for scenario outlines
