### PR TITLE
Only include executed scenarios and steps from outlines in the JSON output

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/CucumberJSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/CucumberJSONFormatter.java
@@ -1,0 +1,38 @@
+package cucumber.runtime.formatter;
+
+import gherkin.formatter.JSONFormatter;
+import gherkin.formatter.model.Examples;
+import gherkin.formatter.model.Scenario;
+import gherkin.formatter.model.ScenarioOutline;
+import gherkin.formatter.model.Step;
+
+public class CucumberJSONFormatter extends JSONFormatter {
+    private boolean inScenarioOutline = false;
+
+    public CucumberJSONFormatter(Appendable out) {
+        super(out);
+    }
+
+    @Override
+    public void scenarioOutline(ScenarioOutline scenarioOutline) {
+        inScenarioOutline = true;
+    }
+
+    @Override
+    public void examples(Examples examples) {
+        // NoOp
+    }
+
+    @Override
+    public void startOfScenarioLifeCycle(Scenario scenario) {
+        inScenarioOutline = false;
+        super.startOfScenarioLifeCycle(scenario);
+    }
+
+    @Override
+    public void step(Step step) {
+        if (!inScenarioOutline) {
+            super.step(step);
+        }
+    }
+}

--- a/core/src/main/java/cucumber/runtime/formatter/FormatterFactory.java
+++ b/core/src/main/java/cucumber/runtime/formatter/FormatterFactory.java
@@ -4,7 +4,6 @@ import cucumber.runtime.CucumberException;
 import cucumber.runtime.io.URLOutputStream;
 import cucumber.runtime.io.UTF8OutputStreamWriter;
 import gherkin.formatter.Formatter;
-import gherkin.formatter.JSONFormatter;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,7 +36,7 @@ public class FormatterFactory {
         put("html", HTMLFormatter.class);
         put("pretty", CucumberPrettyFormatter.class);
         put("progress", ProgressFormatter.class);
-        put("json", JSONFormatter.class);
+        put("json", CucumberJSONFormatter.class);
         put("usage", UsageFormatter.class);
         put("rerun", RerunFormatter.class);
     }};

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -2,6 +2,7 @@ package cucumber.runtime;
 
 import cucumber.api.PendingException;
 import cucumber.api.Scenario;
+import cucumber.runtime.formatter.CucumberJSONFormatter;
 import cucumber.runtime.io.ClasspathResourceLoader;
 import cucumber.runtime.io.Resource;
 import cucumber.runtime.io.ResourceLoader;
@@ -51,7 +52,7 @@ public class RuntimeTest {
                 "  Scenario: scenario name\n" +
                 "    When s\n");
         StringBuilder out = new StringBuilder();
-        JSONFormatter jsonFormatter = new JSONFormatter(out);
+        JSONFormatter jsonFormatter = new CucumberJSONFormatter(out);
         List<Backend> backends = asList(mock(Backend.class));
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         RuntimeOptions runtimeOptions = new RuntimeOptions("");

--- a/core/src/test/resources/cucumber/runtime/formatter/JSONPrettyFormatterTest.json
+++ b/core/src/test/resources/cucumber/runtime/formatter/JSONPrettyFormatterTest.json
@@ -98,69 +98,6 @@
         "type": "scenario"
       },
       {
-        "id": "feature-3;scenariooutline-1",
-        "description": "",
-        "name": "ScenarioOutline_1",
-        "keyword": "Scenario Outline",
-        "line": 14,
-        "steps": [
-          {
-            "name": "so_1 \u003ca\u003e",
-            "keyword": "Given ",
-            "line": 15
-          },
-          {
-            "name": "so_2 \u003cc\u003e cucumbers",
-            "keyword": "When ",
-            "line": 16
-          },
-          {
-            "name": "\u003cb\u003e so_3",
-            "keyword": "Then ",
-            "line": 17
-          }
-        ],
-        "examples": [
-          {
-            "id": "feature-3;scenariooutline-1;",
-            "description": "",
-            "name": "",
-            "keyword": "Examples",
-            "line": 19,
-            "rows": [
-              {
-                "id": "feature-3;scenariooutline-1;;1",
-                "cells": [
-                  "a",
-                  "b",
-                  "c"
-                ],
-                "line": 20
-              },
-              {
-                "id": "feature-3;scenariooutline-1;;2",
-                "cells": [
-                  "12",
-                  "5",
-                  "7"
-                ],
-                "line": 21
-              },
-              {
-                "id": "feature-3;scenariooutline-1;;3",
-                "cells": [
-                  "20",
-                  "5",
-                  "15"
-                ],
-                "line": 22
-              }
-            ]
-          }
-        ],
-        "type": "scenario_outline"
-      },
-      {
         "description": "",
         "name": "",
         "keyword": "Background",


### PR DESCRIPTION
Do not include the Scenario Outline and Examples given as information before the execution of the instantiated scenarios from the outline. This unified the JSON output from Cucumber-JVM regardless of the feature is executed by the command line runner, the JUnit runner of the TestNG runner. The JUnit runner differs from the other by not sending the Scenario Outline and Examples as information to the formatters before executing the instantiated scenarios from the outline, so this PR only affects the output from the command line runner and the TestNG runner.

That the JSON output currently differs depending on which runner was used is confusing both for users (see for instance [this mailing list post](https://groups.google.com/d/msg/cukes/zM7QfHrBnlI/_fSLDmAowhsJ)), and tool developer (for instance the Jenkins Cucumber Report plugin, see [this discussion on a plugin issue starting here](https://github.com/masterthought/jenkins-cucumber-jvm-reports-plugin-java/issues/51#issuecomment-37534412) or [this discussion on a gherkin issue starting here](https://github.com/cucumber/gherkin/issues/165#issuecomment-35559497)).

Fixes #681 and fixes cucumber/gherkin#299, it most likely fix also any remaining Cucumber-JVM part of cucumber/gherkin#165.
