### PR TITLE
Moved the check for empty step name to take place at step generation...

### DIFF
--- a/core/src/main/java/cucumber/runtime/model/CucumberScenarioOutline.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberScenarioOutline.java
@@ -67,6 +67,9 @@ public class CucumberScenarioOutline extends CucumberTagStatement {
 
         // Create a step with replaced tokens
         String name = replaceTokens(matchedColumns, headerCells, exampleCells, step.getName());
+        if (name.isEmpty()) {
+            throw new CucumberException("Step generated from scenario outline is empty: " + step.getName());
+        }
 
         return new ExampleStep(
                 step.getComments(),
@@ -111,9 +114,6 @@ public class CucumberScenarioOutline extends CucumberTagStatement {
 
             if (text.contains(token)) {
                 text = text.replace(token, value);
-                if (text.isEmpty()) {
-                    throw new CucumberException("Step generated from scenario outline '" + token + "' is empty");
-                }
                 matchedColumns.add(col);
             }
         }


### PR DESCRIPTION
...instead of during example table value substitution.

As a result of https://github.com/cucumber/cucumber-jvm/commit/a280f2f9aa6a1ae004526985a62a93fa67f00e9e, blank table cells after substitution result in exception when they are totally valid.

This patch moves the check to the step generation part of the class, instead of at string substitution which is also used to substitute values in scenario name, table cell and docstring.
