### PR TITLE
Allow empty doc string and data table entries after token replacement from scenario outlines

### DIFF
--- a/core/src/main/java/cucumber/runtime/model/CucumberScenarioOutline.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberScenarioOutline.java
@@ -67,6 +67,9 @@ public class CucumberScenarioOutline extends CucumberTagStatement {
 
         // Create a step with replaced tokens
         String name = replaceTokens(matchedColumns, headerCells, exampleCells, step.getName());
+        if (name.isEmpty()) {
+            throw new CucumberException("Step generated from scenario outline '" + step.getName() + "' is empty");
+        }
 
         return new ExampleStep(
                 step.getComments(),
@@ -111,9 +114,6 @@ public class CucumberScenarioOutline extends CucumberTagStatement {
 
             if (text.contains(token)) {
                 text = text.replace(token, value);
-                if (text.isEmpty()) {
-                    throw new CucumberException("Step generated from scenario outline '" + token + "' is empty");
-                }
                 matchedColumns.add(col);
             }
         }

--- a/core/src/test/java/cucumber/runtime/model/CucumberScenarioOutlineTest.java
+++ b/core/src/test/java/cucumber/runtime/model/CucumberScenarioOutlineTest.java
@@ -1,5 +1,6 @@
 package cucumber.runtime.model;
 
+import cucumber.runtime.CucumberException;
 import gherkin.formatter.model.Comment;
 import gherkin.formatter.model.DataTableRow;
 import gherkin.formatter.model.DocString;
@@ -43,6 +44,32 @@ public class CucumberScenarioOutlineTest {
         Step exampleStep = CucumberScenarioOutline.createExampleStep(outlineStep, new ExamplesTableRow(C, asList("n"), 1, ""), new ExamplesTableRow(C, asList("10"), 1, ""));
         assertEquals(asList("I", "have 10 cukes"), exampleStep.getRows().get(0).getCells());
     }  
+
+    @Test(expected=CucumberException.class)
+    public void does_not_allow_the_step_to_be_empty_after_replacement() {
+        Step outlineStep = new Step(C, null, "<step>", 0, null, null);
+
+        CucumberScenarioOutline.createExampleStep(outlineStep, new ExamplesTableRow(C, asList("step"), 1, ""), new ExamplesTableRow(C, asList(""), 1, ""));
+    }
+
+    @Test
+    public void allows_doc_strings_to_be_empty_after_replacement() {
+        Step outlineStep = new Step(C, null, "Some step", 0, null, new DocString(null, "<doc string>", 1));
+
+        Step exampleStep = CucumberScenarioOutline.createExampleStep(outlineStep, new ExamplesTableRow(C, asList("doc string"), 1, ""), new ExamplesTableRow(C, asList(""), 1, ""));
+
+        assertEquals("", exampleStep.getDocString().getValue());
+    }
+
+    @Test
+    public void allows_data_table_entries_to_be_empty_after_replacement() {
+        List<DataTableRow> rows = asList(new DataTableRow(C, asList("<entry>"), 1));
+        Step outlineStep = new Step(C, null, "Some step", 0, rows, null);
+
+        Step exampleStep = CucumberScenarioOutline.createExampleStep(outlineStep, new ExamplesTableRow(C, asList("entry"), 1, ""), new ExamplesTableRow(C, asList(""), 1, ""));
+
+        assertEquals(asList(""), exampleStep.getRows().get(0).getCells());
+    }
 
     /***
      * From a scenario outline, we create one or more "Example Scenario"s. This is composed


### PR DESCRIPTION
After token replacement for instantiated scenarios from scenario outlines, the doc string and data table entries are allowed to be empty. The step itself on the other hand, must be non-empty.

Fixes #712.
