### PR TITLE
Let the TestNG runner handle strict mode correctly

### DIFF
--- a/testng/src/main/java/cucumber/api/testng/TestNGCucumberRunner.java
+++ b/testng/src/main/java/cucumber/api/testng/TestNGCucumberRunner.java
@@ -53,9 +53,10 @@ public class TestNGCucumberRunner {
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
-        runtime.printSummary();
         if (!runtime.getErrors().isEmpty()) {
             throw new CucumberException(runtime.getErrors().get(0));
+        } else if (runtime.exitStatus() != 0x00) {
+            throw new CucumberException("There are pending or undefined steps.");
         }
     }
 

--- a/testng/src/test/java/cucumber/api/testng/TestNGCucumberRunnerTest.java
+++ b/testng/src/test/java/cucumber/api/testng/TestNGCucumberRunnerTest.java
@@ -1,0 +1,15 @@
+package cucumber.api.testng;
+
+import cucumber.runtime.CucumberException;
+import cucumber.runtime.testng.RunCukesStrict;
+import org.testng.annotations.Test;
+
+public class TestNGCucumberRunnerTest {
+
+    @Test(expectedExceptions = CucumberException.class)
+    public void runCukesStrict() throws Exception {
+        TestNGCucumberRunner testNGCucumberRunner = new TestNGCucumberRunner(RunCukesStrict.class);
+        testNGCucumberRunner.runCukes();
+    }
+
+}

--- a/testng/src/test/java/cucumber/runtime/testng/RunCukesStrict.java
+++ b/testng/src/test/java/cucumber/runtime/testng/RunCukesStrict.java
@@ -1,0 +1,8 @@
+package cucumber.runtime.testng;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.testng.AbstractTestNGCucumberTests;
+
+@CucumberOptions(strict = true)
+public class RunCukesStrict extends AbstractTestNGCucumberTests {
+}


### PR DESCRIPTION
In strict mode pending or undefined steps should make the TestNG runner fail. 
Fixes #665

Actually is #665 fixed (as a small part of it) by #653, so this RP the small, dedicated fix (which would make it easier to merge in).

This PR does also remove the duplicate printing of the summary.
