### PR TITLE
729 Test fails : HTMLFormatterTest#writes_valid_report_js

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -94,6 +94,15 @@
                     </archive>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Duser.language=en</argLine>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
workaround to run local test.
Don't understand why configuration are not propagated to cucumber-core.
