### PR TITLE
Disregard order of HashMap entries in unit tests

### DIFF
--- a/core/src/test/java/cucumber/runtime/table/FromDataTableTest.java
+++ b/core/src/test/java/cucumber/runtime/table/FromDataTableTest.java
@@ -183,7 +183,9 @@ public class FromDataTableTest {
     public void transforms_to_map_of_double_to_double() throws Throwable {
         Method m = StepDefs.class.getMethod("mapOfDoubleToDouble", Map.class);
         StepDefs stepDefs = runStepDef(m, listOfDoublesWithoutHeader());
-        assertEquals("{1000.0=999.0, 0.5=-0.5, 100.5=99.5}", stepDefs.mapOfDoubleToDouble.toString());
+        assertEquals(Double.valueOf(999.0), stepDefs.mapOfDoubleToDouble.get(1000.0));
+        assertEquals(Double.valueOf(-0.5), stepDefs.mapOfDoubleToDouble.get(0.5));
+        assertEquals(Double.valueOf(99.5), stepDefs.mapOfDoubleToDouble.get(100.5));
     }
 
     @Test


### PR DESCRIPTION
FormDataTableTest _transforms_to_map_of_double_to_double_ should not rely on [Map#toString()](http://docs.oracle.com/javase/7/docs/api/java/util/AbstractMap.html#toString%28%29) to test values in a Map, which relies on the order of the Map's EntrySet iterator. In the case of HashMaps, used by cucumber, that order is unpredictable, and (can be) different in Java8 from previous versions, causing tests to fail.

This patch tests the mapping directly, and disregards iteration order.
