### PR TITLE
Disregard order of JSON properties in PrettyPrint unit tests

### DIFF
--- a/core/src/test/java/cucumber/runtime/formatter/JSONPrettyFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JSONPrettyFormatterTest.java
@@ -9,6 +9,8 @@ import cucumber.runtime.io.ClasspathResourceLoader;
 import cucumber.runtime.snippets.FunctionNameGenerator;
 import gherkin.formatter.model.Step;
 import gherkin.formatter.model.Tag;
+import gherkin.deps.com.google.gson.JsonParser;
+import gherkin.deps.com.google.gson.JsonElement;
 import org.junit.Test;
 
 import java.io.File;
@@ -18,6 +20,7 @@ import java.util.List;
 import java.util.Scanner;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.sort;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyListOf;
@@ -32,7 +35,28 @@ public class JSONPrettyFormatterTest {
         String expected = new Scanner(getClass().getResourceAsStream("JSONPrettyFormatterTest.json"), "UTF-8").useDelimiter("\\A").next();
         String actual = new Scanner(report, "UTF-8").useDelimiter("\\A").next();
 
-        assertEquals(expected, actual);
+        assertPrettyJsonEquals(expected, actual);
+    }
+
+    private void assertPrettyJsonEquals(final String expected, final String actual) {
+        assertJsonEquals(expected, actual);
+
+        List<String> expectedLines = sortedLinesWithWhitespace(expected);
+        List<String> actualLines = sortedLinesWithWhitespace(actual);
+        assertEquals(expectedLines, actualLines);
+    }
+
+    private List<String> sortedLinesWithWhitespace(final String string) {
+        List<String> lines = asList(string.split(",?(?:\r\n?|\n)")); // also remove trailing ','
+        sort(lines);
+        return lines;
+    }
+
+    private void assertJsonEquals(final String expected, final String actual) {
+        JsonParser parser = new JsonParser();
+        JsonElement o1 = parser.parse(expected);
+        JsonElement o2 = parser.parse(actual);
+        assertEquals(o1, o2);
     }
 
     private File runFeaturesWithJSONPrettyFormatter(final List<String> featurePaths) throws IOException {


### PR DESCRIPTION
JSONPrettyFormatterTest should not rely on the order of JSON fields. Changes were made in Java 8 which change the output order of the fields, though the JSON is still valid.

This allows cucumber-core to build in Java 8.

In this change, rather than expecting exact character matching, or writing a parser that considers white-space, I have:
1. Validate the output and equality with expected output using Gson, which correctly ignores property order.
2. Split expected/actual into lines, stripping trailing commas (to hide order within objects), sort, and compare.

While not 100% infallible (two properties at different depth with the same value _could_ have coincidentally swapped indentations, and still pass both comparisons), failure is extremely unlikely, and would still be valid JSON regardless.

Note this uses the Gson classes shadowed into the gherkin packages - I'm not sure how stable that is expected to be, but if it is an issue, Gson could be included as a test dependency of core without external visibility.
