### PR TITLE
Improve error message for multiple formatters using STDOUT

### DIFF
--- a/core/src/test/java/cucumber/runtime/formatter/FormatterFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/FormatterFactoryTest.java
@@ -108,7 +108,9 @@ public class FormatterFactoryTest {
             fc.create("cucumber.runtime.formatter.FormatterFactoryTest$WantsAppendable");
             fail();
         } catch (CucumberException expected) {
-            assertEquals("Only one formatter can use STDOUT. If you use more than one formatter you must specify output path with FORMAT:PATH_OR_URL", expected.getMessage());
+            assertEquals("Only one formatter can use STDOUT, now both cucumber.runtime.formatter.FormatterFactoryTest$WantsAppendable " +
+                         "and cucumber.runtime.formatter.FormatterFactoryTest$WantsAppendable use it. " +
+                         "If you use more than one formatter you must specify output path with FORMAT:PATH_OR_URL", expected.getMessage());
         }
     }
 


### PR DESCRIPTION
Since the formatters used can be added from several places, from `-Dcucumber.options` on the command line, from the runner class `@CucumberOptions`, from the base class `@CucumberOptions`, it can be possible to have two formatters using STDOUT without realising it (see [mailing list post](https://groups.google.com/d/msg/cukes/8bZd6dWnSwc/fSQgztzCjyUJ)).

It would be helpful if the error message lists the two formatter strings that are conflicting.

Relates to #643.
