### PR TITLE
Clobber all filter types when override one filter type in the environment options

### DIFF
--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -133,6 +133,9 @@ public class RuntimeOptions {
         if (!parsedFilters.isEmpty() || haveLineFilters(parsedFeaturePaths)) {
             filters.clear();
             filters.addAll(parsedFilters);
+            if (parsedFeaturePaths.isEmpty() && !featurePaths.isEmpty()) {
+                stripLinesFromFeaturePaths(featurePaths);
+            }
         }
         if (!parsedFeaturePaths.isEmpty()) {
             featurePaths.clear();
@@ -151,6 +154,15 @@ public class RuntimeOptions {
             }
         }
         return false;
+    }
+
+    private void stripLinesFromFeaturePaths(List<String> featurePaths) {
+       List<String> newPaths = new ArrayList<String>();
+       for (String pathName : featurePaths) {
+           newPaths.add(PathWithLines.stripLineFilters(pathName));
+       }
+       featurePaths.clear();
+       featurePaths.addAll(newPaths);
     }
 
     private void printUsage() {

--- a/core/src/main/java/cucumber/runtime/model/PathWithLines.java
+++ b/core/src/main/java/cucumber/runtime/model/PathWithLines.java
@@ -15,6 +15,15 @@ public class PathWithLines {
         return FILE_COLON_LINE_PATTERN.matcher(pathName).matches();
     }
 
+    public static String stripLineFilters(String pathName) {
+        Matcher matcher = FILE_COLON_LINE_PATTERN.matcher(pathName);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        } else {
+            return pathName;
+        }
+    }
+
     public PathWithLines(String pathName) {
         Matcher matcher = FILE_COLON_LINE_PATTERN.matcher(pathName);
         if (matcher.matches()) {

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -201,6 +201,14 @@ public class RuntimeOptionsTest {
     }
 
     @Test
+    public void strips_lines_from_features_from_cli_if_filters_are_specified_in_cucumber_options_property() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--tags @Tag");
+        RuntimeOptions runtimeOptions = new RuntimeOptions(new Env(properties), asList("path/file.feature:3"));
+        assertEquals(asList("path/file.feature"), runtimeOptions.getFeaturePaths());
+    }
+
+    @Test
     public void preserves_features_from_cli_if_features_not_specified_in_cucumber_options_property() {
         Properties properties = new Properties();
         properties.setProperty("cucumber.options", "--format pretty");


### PR DESCRIPTION
If using `-Dcucumber.options="path/file.feature --name scenario_name"`, to run a specific scenario, then any tag filters (or name filters) specified in `@CucumberOptions` will be clobbered. However if instead using `-Dcucumber.options="path/file.feature:line"`, to run a specific scenario, then the tag or name filters specified in `@CucumberOptions` will not be clobbered, and and "inconsistent filters" exception will occur. The same happens when using `-Dcucumber.options="@rerun.txt"`, since the `@rerun.txt` will contain feature paths with line filters.

The explanation from an implementation viewpoint is that this is because, tag- and name-filters are put in the same filter list, whereas the line filters need to be kept together the their feature paths (each line filter is only applied to its one feature path), so the stored in the feature path list.

This PR makes the specification of feature paths will line filters, or specification using the `@rerun.txt` syntax, clobber the list with tag and name filters from the `@CucumberOptions`. And also that the specification of tag of name filters, strips the line filters from feature paths from `@CucumberOptions`.

Should a file with feature paths and line filters be specified in the `@CucumberOptions`, those line filters will not be stripped if specifying a tag or name filter in `-Dcucumber.options`. In part because while it is possible, the `@rerun.txt` was not primarily intended for this, and in part because it would more complicated to implement.
