### PR TITLE
Answer y several times to update the android sdk on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       # Install base Android SDK
       - sudo apt-get update -qq
       - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch > /dev/null; fi
+      - sudo apt-get install -qq --force-yes expect > /dev/null
       - wget http://dl.google.com/android/android-sdk_r22.6.2-linux.tgz
       - tar xzf android-sdk_r22.6.2-linux.tgz
       - export ANDROID_HOME=$PWD/android-sdk-linux
@@ -24,7 +25,7 @@ matrix:
       # Note that sysimg-16 downloads the ARM, x86 and MIPS images (we should optimize this).
       # Other relevant APIs:
       #  addon-google_apis-google-16
-      - echo y | android update sdk --filter build-tools-19.0.1,platform-tools,extra-android-support,android-8 --no-ui --force --all > /dev/null
+      - ./.travis_android_update > /dev/null
 
       # Create and start emulator
       - echo no | android create avd --force -n test -t android-8 --abi armeabi

--- a/.travis_android_update
+++ b/.travis_android_update
@@ -1,0 +1,11 @@
+#!/usr/bin/env expect
+
+set timeout 120 
+spawn android update sdk --filter build-tools-19.0.1,platform-tools,extra-android-support,android-8 --no-ui --force --all
+while {1} {
+  expect {
+    eof               {break}
+    "Do you accept"   {send "y\r"}
+  }
+}
+wait


### PR DESCRIPTION
Now you have to answer 'y' two times to accept license agreements to update the android sdk.

Since "yes | android ..." construct did not work, "expect" is used to answer 'y' to the two "Do you accept" questions during the updating of the android sdk.
