### PR TITLE
Correct lookup environment variable - system property - resource bundle

### DIFF
--- a/core/src/main/java/cucumber/runtime/Env.java
+++ b/core/src/main/java/cucumber/runtime/Env.java
@@ -34,25 +34,42 @@ public class Env {
     }
 
     public String get(String key) {
-        String result = get0(asEnvKey(key));
+        String result = getFromEnvironment(key);
         if (result == null) {
-            result = get0(asPropertyKey(key));
+            result = getFromProperty(key);
+            if (result == null && bundleName != null) {
+                result = getFromBundle(key);
+            }
         }
         return result;
     }
 
-    private String get0(String key) {
-        String value = System.getenv(key);
+    private String getFromEnvironment(String key) {
+        String value = System.getenv(asEnvKey(key));
         if (value == null) {
-            value = properties.getProperty(key);
-            if (value == null && bundleName != null) {
-                try {
-                    value = ResourceBundle.getBundle(bundleName).getString(key);
-                } catch (MissingResourceException ignore) {
-                }
-            }
+            value = System.getenv(asPropertyKey(key));
         }
         return value;
+    }
+
+    private String getFromProperty(String key) {
+        String value = properties.getProperty(asEnvKey(key));
+        if (value == null) {
+            value = properties.getProperty(asPropertyKey(key));
+        }
+        return value;
+    }
+
+    private String getFromBundle(String key) {
+        try {
+            String value = ResourceBundle.getBundle(bundleName).getString(asEnvKey(key));
+            if (value == null) {
+                value = ResourceBundle.getBundle(bundleName).getString(asPropertyKey(key));
+            }
+            return value;
+        } catch (MissingResourceException ignore) {
+        }
+        return null;
     }
 
     public String get(String key, String defaultValue) {

--- a/core/src/test/resources/env-test.properties
+++ b/core/src/test/resources/env-test.properties
@@ -1,1 +1,1 @@
-env.test=from-bundle
+ENV_TEST=from-bundle


### PR DESCRIPTION
The intention is that values should be looked up in the order:
- from environment variable
- from system property
- from resource bundle

When aliases were introduced in https://github.com/cucumber/cucumber-jvm/commit/26938a84a983439809f4f57c76712926dc0db9ec, the detailed order of lookup became:
- alias from environment variable
- alias from system property
- alias from resource bundle
- key from environment variable
- key from system property
- key from resource bundle

The cucumber-java-skeleton project has a `cucumber.properties` file containing `CUCUMBER_OPTIONS="..."`, so currently using`mvn -Dcucumber.options="..."` has no effect, only `mvn -DCUCUMBER_OPTIONS="..."` work.

Change the lookup both include both the alias (HELLO_THERE) and the key (hello.there) from each source, before moving to the next source.
