### PR TITLE
Handle "" properly in ListConverter.

### DIFF
--- a/core/src/main/java/cucumber/runtime/xstream/ListConverter.java
+++ b/core/src/main/java/cucumber/runtime/xstream/ListConverter.java
@@ -34,6 +34,10 @@ class ListConverter implements SingleValueConverter {
 
     @Override
     public Object fromString(String s) {
+        if (s.isEmpty()) {
+            return new ArrayList<String>(0);
+        }
+
         final String[] strings = s.split(delimiter);
         List<Object> list = new ArrayList<Object>(strings.length);
         for (String elem : strings) {


### PR DESCRIPTION
When an empty string is passed it should return an empty list rather than a list of one empty string.

I believe that the proposed behaviour is more useful than the current. The converter can be used to easily specify a variable number of arguments in a column. Users most likely want to be able to specify no elements at all.

Does this change sound reasonable ? 

PS: I decided to return a new ArralyList rather than an empty collection from Collections because I expect that some users mutate the list in their Step def. 
