### PR TITLE
Fixing randomly failing tests in the Scala module

### DIFF
--- a/scala/src/main/scala/cucumber/api/scala/ScalaDsl.scala
+++ b/scala/src/main/scala/cucumber/api/scala/ScalaDsl.scala
@@ -492,6 +492,6 @@ trait ScalaDsl { self =>
     }
 
     private def functionParams(f: Any) =
-      f.getClass.getDeclaredMethods.filterNot(_.isBridge).head.getGenericParameterTypes
+      f.getClass.getDeclaredMethods.filter(m => "apply".equals(m.getName) && !m.isBridge).head.getGenericParameterTypes
   }
 }


### PR DESCRIPTION
As described in #761, there are more than one non-bridge method generated and returned by the `getDeclaredMethods` call. In order to ensure that we retrieve the correct one, we match on the exact name, i.e. on the `apply` function.

Fixes #761.
