### PR TITLE
Added Spring meta-annotation support

### DIFF
--- a/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
+++ b/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
@@ -184,6 +184,17 @@ public class SpringFactory implements ObjectFactory {
     }
 
     private boolean dependsOnSpringContext(Class<?> type) {
+        boolean hasStandardAnnotations = annotatedWithSupportedSpringRootTestAnnotations(type);
+
+        if(hasStandardAnnotations) {
+            return true;
+        }
+
+        final Annotation[] annotations = type.getDeclaredAnnotations();
+        return (annotations.length == 1) && annotatedWithSupportedSpringRootTestAnnotations(annotations[0].annotationType());
+    }
+
+    private boolean annotatedWithSupportedSpringRootTestAnnotations(Class<?> type) {
         return type.isAnnotationPresent(ContextConfiguration.class)
             || type.isAnnotationPresent(ContextHierarchy.class);
     }

--- a/spring/src/test/java/cucumber/runtime/java/spring/SpringFactoryTest.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/SpringFactoryTest.java
@@ -7,11 +7,13 @@ import cucumber.runtime.java.spring.commonglue.AutowiresPlatformTransactionManag
 import cucumber.runtime.java.spring.commonglue.AutowiresThirdStepDef;
 import cucumber.runtime.java.spring.commonglue.OneStepDef;
 import cucumber.runtime.java.spring.commonglue.ThirdStepDef;
+import cucumber.runtime.java.spring.metaconfig.BellyMetaStepdefs;
 import cucumber.runtime.java.spring.contextconfig.BellyStepdefs;
 import cucumber.runtime.java.spring.contextconfig.WithSpringAnnotations;
 import cucumber.runtime.java.spring.contexthierarchyconfig.WithContextHierarchyAnnotation;
 import cucumber.runtime.java.spring.contexthierarchyconfig.WithDifferentContextHierarchyAnnotation;
 import cucumber.runtime.java.spring.dirtiescontextconfig.DirtiesContextBellyStepDefs;
+import cucumber.runtime.java.spring.metaconfig.dirties.DirtiesContextBellyMetaStepDefs;
 import org.junit.Test;
 import org.springframework.transaction.PlatformTransactionManager;
 
@@ -80,6 +82,27 @@ public class SpringFactoryTest {
         factory2.addClass(BellyStepdefs.class);
         factory2.start();
         final BellyBean o2 = factory2.getInstance(BellyStepdefs.class).getBellyBean();
+        factory2.stop();
+
+        assertNotNull(o1);
+        assertNotNull(o2);
+        assertSame(o1, o2);
+    }
+
+    @Test
+    public void shouldNeverCreateNewApplicationBeanInstancesUsingMetaConfiguration() {
+        // Feature 1
+        final ObjectFactory factory1 = new SpringFactory();
+        factory1.addClass(BellyMetaStepdefs.class);
+        factory1.start();
+        final BellyBean o1 = factory1.getInstance(BellyMetaStepdefs.class).getBellyBean();
+        factory1.stop();
+
+        // Feature 2
+        final ObjectFactory factory2 = new SpringFactory();
+        factory2.addClass(BellyMetaStepdefs.class);
+        factory2.start();
+        final BellyBean o2 = factory2.getInstance(BellyMetaStepdefs.class).getBellyBean();
         factory2.stop();
 
         assertNotNull(o1);
@@ -159,6 +182,27 @@ public class SpringFactoryTest {
         // Scenario 2
         factory.start();
         final BellyBean o2 = factory.getInstance(DirtiesContextBellyStepDefs.class).getBellyBean();
+        factory.stop();
+
+        assertNotNull(o1);
+        assertNotNull(o2);
+        assertNotSame(o1, o2);
+    }
+
+    @Test
+    public void shouldRespectDirtiesContextAnnotationsInStepDefsUsingMetaConfiguration() {
+        final ObjectFactory factory = new SpringFactory();
+        factory.addClass(DirtiesContextBellyMetaStepDefs.class);
+
+        // Scenario 1
+        factory.start();
+        final BellyBean o1 = factory.getInstance(DirtiesContextBellyMetaStepDefs.class).getBellyBean();
+
+        factory.stop();
+
+        // Scenario 2
+        factory.start();
+        final BellyBean o2 = factory.getInstance(DirtiesContextBellyMetaStepDefs.class).getBellyBean();
         factory.stop();
 
         assertNotNull(o1);

--- a/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/BellyMetaStepdefs.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/BellyMetaStepdefs.java
@@ -1,0 +1,32 @@
+package cucumber.runtime.java.spring.metaconfig;
+
+import cucumber.api.java.en.Then;
+import cucumber.runtime.java.spring.beans.Belly;
+import cucumber.runtime.java.spring.beans.BellyBean;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.Assert.assertNotNull;
+
+@MetaConfiguration
+public class BellyMetaStepdefs {
+
+    @Autowired
+    private Belly belly;
+
+    @Autowired
+    private BellyBean bellyBean;
+
+    public BellyBean getBellyBean() {
+        return bellyBean;
+    }
+
+    @Then("^I have a meta belly$")
+    public void I_have_belly() throws Throwable {
+        assertNotNull(belly);
+    }
+
+    @Then("^I have a meta belly bean$")
+    public void I_have_belly_bean() throws Throwable {
+        assertNotNull(bellyBean);
+    }
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/MetaConfiguration.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/MetaConfiguration.java
@@ -1,0 +1,16 @@
+package cucumber.runtime.java.spring.metaconfig;
+
+import org.springframework.test.context.ContextConfiguration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+
+@ContextConfiguration("classpath:cucumber.xml")
+public @interface MetaConfiguration {
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/RunCukesTest.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/RunCukesTest.java
@@ -1,0 +1,13 @@
+package cucumber.runtime.java.spring.metaconfig;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(glue = {"cucumber.runtime.java.spring.contextconfig",
+                "cucumber.runtime.java.spring.commonglue",
+                "cucumber.api.spring"},
+        features = {"classpath:cucumber/runtime/java/spring/springBeanInjectionWithMetaConfiguration.feature"})
+public class RunCukesTest {
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/dirties/DirtiesContextBellyMetaStepDefs.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/dirties/DirtiesContextBellyMetaStepDefs.java
@@ -1,0 +1,46 @@
+package cucumber.runtime.java.spring.metaconfig.dirties;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.runtime.java.spring.beans.Belly;
+import cucumber.runtime.java.spring.beans.BellyBean;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.Assert.assertEquals;
+
+@DirtiesMetaConfiguration
+public class DirtiesContextBellyMetaStepDefs {
+
+    @Autowired
+    private Belly belly;
+
+    @Autowired
+    private BellyBean bellyBean;
+
+    @Then("^there are (\\d+) dirty meta cukes in my belly")
+    public void checkCukes(final int n) {
+        assertEquals(n, belly.getCukes());
+    }
+
+    @Given("^I have (\\d+) dirty meta cukes in my belly")
+    public void haveCukes(final int n) {
+        assertEquals(0, belly.getCukes());
+        belly.setCukes(n);
+    }
+
+    @Given("^I have (\\d+) dirty meta beans in my belly$")
+    public void I_have_beans_in_my_belly(int n) {
+        assertEquals(0, bellyBean.getCukes());
+        bellyBean.setCukes(n);
+    }
+
+    @Then("^there are (\\d+) dirty meta beans in my belly$")
+    public void there_are_beans_in_my_belly(int n) {
+        assertEquals(n, bellyBean.getCukes());
+    }
+
+    public BellyBean getBellyBean() {
+        return bellyBean;
+    }
+
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/dirties/DirtiesMetaConfiguration.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/dirties/DirtiesMetaConfiguration.java
@@ -1,0 +1,18 @@
+package cucumber.runtime.java.spring.metaconfig.dirties;
+
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+
+@ContextConfiguration("classpath:cucumber.xml")
+@DirtiesContext
+public @interface DirtiesMetaConfiguration {
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/dirties/RunCukesTest.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/metaconfig/dirties/RunCukesTest.java
@@ -1,0 +1,11 @@
+package cucumber.runtime.java.spring.metaconfig.dirties;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(glue = {"cucumber.runtime.java.spring.metaconfig.dirties"},
+        features = {"classpath:cucumber/runtime/java/spring/dirtyCukesWithMetaConfiguration.feature"})
+public class RunCukesTest {
+}

--- a/spring/src/test/resources/cucumber/runtime/java/spring/dirtyCukesWithMetaConfiguration.feature
+++ b/spring/src/test/resources/cucumber/runtime/java/spring/dirtyCukesWithMetaConfiguration.feature
@@ -1,0 +1,24 @@
+Feature: Spring Dirty Cukes Meta
+  In order to have a completely clean system for each scenario
+  As a purity activist
+  I want each dirty scenario to have its own application context
+
+  Scenario Outline: Eat some annotated dirty cukes
+    Given there are 0 dirty meta cukes in my belly
+    When I have <numberOfBeans> dirty meta cukes in my belly
+    Then there are <numberOfBeans> dirty meta cukes in my belly
+
+    Examples:
+    | numberOfBeans |
+    | 4             |
+    | 2             |
+
+  Scenario Outline: Eat some XML dirty beans
+      Given there are 0 dirty meta beans in my belly
+      When I have <numberOfBeans> dirty meta beans in my belly
+      Then there are <numberOfBeans> dirty meta beans in my belly
+
+    Examples:
+      | numberOfBeans |
+      | 4             |
+      | 2             |

--- a/spring/src/test/resources/cucumber/runtime/java/spring/springBeanInjectionWithMetaConfiguration.feature
+++ b/spring/src/test/resources/cucumber/runtime/java/spring/springBeanInjectionWithMetaConfiguration.feature
@@ -1,0 +1,7 @@
+Feature: Cukes injection with meta annotation
+
+  Scenario: annotated bean with meta injected
+    Then I have a meta belly
+
+  Scenario: xml bean with meta injected
+    Then I have a meta belly bean


### PR DESCRIPTION
Added Spring meta-annotation support for test configuration (Spring provides this support built in since Spring 4.0.RC1 - https://jira.spring.io/browse/SPR-7827)
