### PR TITLE
Cucumber is ready to run in OSGi containers

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,6 +86,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                         <manifest>
                             <mainClass>cucumber.api.cli.Main</mainClass>
                         </manifest>
@@ -98,6 +99,23 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>-Duser.language=en</argLine>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-Description></Bundle-Description>
+                        <Export-Package>cucumber.*</Export-Package>
+                        <Import-Package>
+                            *,
+                            cucumber.deps.com.thoughtworks.xstream.converters.extended,
+                            cucumber.deps.com.thoughtworks.xstream.converters.enums,
+                            cucumber.deps.com.thoughtworks.xstream.converters.basic
+                        </Import-Package>
+                    </instructions>
                 </configuration>
             </plugin>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -109,12 +109,7 @@
                     <instructions>
                         <Bundle-Description></Bundle-Description>
                         <Export-Package>cucumber.*</Export-Package>
-                        <Import-Package>
-                            *,
-                            cucumber.deps.com.thoughtworks.xstream.converters.extended,
-                            cucumber.deps.com.thoughtworks.xstream.converters.enums,
-                            cucumber.deps.com.thoughtworks.xstream.converters.basic
-                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -13,6 +13,8 @@ import gherkin.formatter.Formatter;
 import gherkin.formatter.Reporter;
 import gherkin.util.FixJava;
 
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -26,7 +28,9 @@ import static cucumber.runtime.model.CucumberFeature.load;
 // IMPORTANT! Make sure USAGE.txt is always uptodate if this class changes.
 public class RuntimeOptions {
     public static final String VERSION = ResourceBundle.getBundle("cucumber.version").getString("cucumber-jvm.version");
-    public static final String USAGE = FixJava.readResource("/cucumber/api/cli/USAGE.txt");
+    public static final String USAGE_RESOURCE = "/cucumber/api/cli/USAGE.txt";
+
+    static String usageText;
 
     private final List<String> glue = new ArrayList<String>();
     private final List<Object> filters = new ArrayList<Object>();
@@ -169,7 +173,19 @@ public class RuntimeOptions {
     }
 
     private void printUsage() {
-        System.out.println(USAGE);
+        loadUsageTextIfNeeded();
+        System.out.println(usageText);
+    }
+
+    static void loadUsageTextIfNeeded() {
+        if (usageText == null) {
+            try {
+                Reader reader = new InputStreamReader(FixJava.class.getResourceAsStream(USAGE_RESOURCE), "UTF-8");
+                usageText = FixJava.readReader(reader);
+            } catch (Exception e) {
+                usageText = "Could not load usage text: " + e.toString();
+            }
+        }
     }
 
     private int printI18n(String language) {

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -13,8 +13,6 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -39,7 +37,8 @@ public class RuntimeOptionsTest {
 
     @Test
     public void has_usage() {
-        assertTrue(RuntimeOptions.USAGE.startsWith("Usage"));
+        RuntimeOptions.loadUsageTextIfNeeded();
+        assertTrue(RuntimeOptions.usageText.startsWith("Usage"));
     }
 
     @Test

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -137,6 +137,26 @@ I18n.all.each { i18n ->
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Description></Bundle-Description>
+                        <Export-Package>cucumber.*</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -43,4 +43,28 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Description></Bundle-Description>
+                        <Export-Package>cucumber.*</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -822,6 +822,21 @@
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>1.3.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>2.3.7</version>
+                    <extensions>true</extensions>
+                    <executions>
+                        <execution>
+                          <id>bundle-manifest</id>
+                          <phase>process-classes</phase>
+                          <goals>
+                            <goal>manifest</goal>
+                          </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
I have produced 2 commits that allow to run cucumber in OSGi containers.

* The first one adds OSGi headers to core, java and JUnit bundles.
* The second changes the loading of the USAGE.txt in RuntimeOptions, because due to OSGi class loading cause problems. I wrote more details in the commit message.

*NOTE*: Please release cucumber-jvm-deps with my other pull request (see https://github.com/cucumber/cucumber-jvm-deps/pull/3), because this changes make only sense when the jvm-deps bundle has also OSGi headers.

Thank you!
