### PR TITLE
Fix to allow lein test to to run successfully

### DIFF
--- a/examples/clojure_cukes/project.clj
+++ b/examples/clojure_cukes/project.clj
@@ -2,4 +2,9 @@
   :description "A demo of Cucumber with Clojure and Leiningen"
   :dependencies [[org.clojure/clojure "1.6.0"]]
   :plugins [[lein-cucumber "1.0.2"]]
-  :cucumber-feature-paths ["test/features/"])
+  :cucumber-feature-paths ["test/features/"]
+  :profiles
+  {:dev
+   {:dependencies [[lein-cucumber "1.0.2"]
+                   [info.cukes/cucumber-core "1.1.1"]]}}
+)

--- a/examples/clojure_cukes/test/clojure_cukes/test/core.clj
+++ b/examples/clojure_cukes/test/clojure_cukes/test/core.clj
@@ -1,6 +1,8 @@
 (ns clojure-cukes.test.core
   (:use [clojure-cukes.core])
-  (:use [clojure.test]))
+  (:use [clojure.test])
+  (:use [leiningen.cucumber])
+  (:import [cucumber.api.cli Main]))
 
 (deftest run-cukes
-  (. cucumber.api.cli.Main (main (into-array ["--plugin" "pretty" "--glue" "test/features/step_definitions" "test/features"]))))
+  (. cucumber.api.cli.Main (main (into-array ["--format" "pretty" "--glue" "test" "test/features"]))))

--- a/examples/clojure_cukes/test/features/cukes.feature
+++ b/examples/clojure_cukes/test/features/cukes.feature
@@ -1,7 +1,6 @@
 Feature: Cukes
-  An example of testing Clojure with cucumber. The last 'Then' of
-  'eat 1 cuke' is failing. Change the "happy" to "meh" to make
-  it pass.
+  An example of testing Clojure with cucumber. To see a failure try changing
+  the last 'Then' of 'eat 1 cuke' "meh" to "happy".
 
   Scenario: in the belly
     Given I have 4 big "cukes" in my belly
@@ -13,4 +12,4 @@ Feature: Cukes
     When I eat 1 "cukes"
     Then I am "sad"
     When I eat 1 "cukes"
-    Then I am "happy"
+    Then I am "meh"

--- a/examples/clojure_cukes/test/features/cukes.feature
+++ b/examples/clojure_cukes/test/features/cukes.feature
@@ -13,4 +13,4 @@ Feature: Cukes
     When I eat 1 "cukes"
     Then I am "sad"
     When I eat 1 "cukes"
-    Then I am "meh"
+    Then I am "happy"


### PR DESCRIPTION
Fixed core.clj and associated deps in project to allow (run-cukes) to execute from repl and 'lein test' to succeed.