### PR TITLE
added support for execution order for "Before" and "After" hook. closes #807

### DIFF
--- a/groovy/src/main/java/cucumber/api/groovy/Hooks.java
+++ b/groovy/src/main/java/cucumber/api/groovy/Hooks.java
@@ -8,28 +8,56 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Hooks {
+    private static final int DEFAULT_ORDER = 10000;
+    private static final long DEFAULT_TIMEOUT = 0;
+
     public static void World(Closure body) throws Throwable {
         GroovyBackend.getInstance().registerWorld(body);
     }
 
-    public static void Before(Object... args) throws Throwable {
+    /**
+     * Registers a before hook, which is executed before specific, or all, scenarios.
+     * <p/>
+     * Following values are expected as hook parameters.
+     * - Long timeoutMillis: max amount of milliseconds this is allowed to run for. The default is 0 which means no restriction.
+     * - Integer order: the order in which this hook should run. Lower numbers are run first. The default is 10000.
+     * - String(s) tags: one or more tag expression to filter the certain scenarios. The default is empty.
+     * - Closure body: hook body which is executed before scenario. Not null.
+     *
+     * @param args the hook parameters
+     */
+    public static void Before(Object... args) {
         addHook(args, true);
     }
 
-    public static void After(Object... args) throws Throwable {
+    /**
+     * Registers an after hook, which is executed after specific, or all, scenarios.
+     * <p/>
+     * Following values are expected as hook parameters.
+     * - Long timeoutMillis: max amount of milliseconds this is allowed to run for. The default is 0 which means no restriction.
+     * - Integer order: the order in which this hook should run. Higher numbers are run first. The default is 10000.
+     * - String(s) tags: one or more tag expression to filter the certain scenarios. The default is empty.
+     * - Closure body: hook body which is executed after scenario. Not null.
+     *
+     * @param args the hook parameters
+     */
+    public static void After(Object... args) {
         addHook(args, false);
     }
 
     private static void addHook(Object[] tagsExpressionsAndBody, boolean before) {
-        List<String> tagExpressions = new ArrayList<String>();
-        int timeoutMillis = 0;
+        long timeoutMillis = DEFAULT_TIMEOUT;
+        int order = DEFAULT_ORDER;
         Closure body = null;
+        List<String> tagExpressions = new ArrayList<String>();
 
         for (Object o : tagsExpressionsAndBody) {
             if (o instanceof String) {
                 tagExpressions.add((String) o);
+            } else if (o instanceof Long) {
+                timeoutMillis = (Long) o;
             } else if (o instanceof Integer) {
-                timeoutMillis = (Integer) o;
+                order = (Integer) o;
             } else if (o instanceof Closure) {
                 body = (Closure) o;
             }
@@ -37,9 +65,9 @@ public class Hooks {
 
         TagExpression tagExpression = new TagExpression(tagExpressions);
         if (before) {
-            GroovyBackend.getInstance().addBeforeHook(tagExpression, timeoutMillis, body);
+            GroovyBackend.getInstance().addBeforeHook(tagExpression, timeoutMillis, order, body);
         } else {
-            GroovyBackend.getInstance().addAfterHook(tagExpression, timeoutMillis, body);
+            GroovyBackend.getInstance().addAfterHook(tagExpression, timeoutMillis, order, body);
         }
     }
 }

--- a/groovy/src/main/java/cucumber/runtime/groovy/GroovyBackend.java
+++ b/groovy/src/main/java/cucumber/runtime/groovy/GroovyBackend.java
@@ -140,12 +140,12 @@ public class GroovyBackend implements Backend {
         worldClosures.add(closure);
     }
 
-    public void addBeforeHook(TagExpression tagExpression, long timeoutMillis, Closure body) {
-        glue.addBeforeHook(new GroovyHookDefinition(tagExpression, timeoutMillis, body, currentLocation(), this));
+    public void addBeforeHook(TagExpression tagExpression, long timeoutMillis, int order, Closure body) {
+        glue.addBeforeHook(new GroovyHookDefinition(tagExpression, timeoutMillis, order, body, currentLocation(), this));
     }
 
-    public void addAfterHook(TagExpression tagExpression, long timeoutMillis, Closure body) {
-        glue.addAfterHook(new GroovyHookDefinition(tagExpression, timeoutMillis, body, currentLocation(), this));
+    public void addAfterHook(TagExpression tagExpression, long timeoutMillis, int order, Closure body) {
+        glue.addAfterHook(new GroovyHookDefinition(tagExpression, timeoutMillis, order, body, currentLocation(), this));
     }
 
     public void invoke(Closure body, Object[] args) throws Throwable {

--- a/groovy/src/main/java/cucumber/runtime/groovy/GroovyHookDefinition.java
+++ b/groovy/src/main/java/cucumber/runtime/groovy/GroovyHookDefinition.java
@@ -12,13 +12,22 @@ import java.util.Collection;
 public class GroovyHookDefinition implements HookDefinition {
     private final TagExpression tagExpression;
     private final long timeoutMillis;
+    private final int order;
     private final Closure body;
     private final GroovyBackend backend;
     private final StackTraceElement location;
 
-    public GroovyHookDefinition(TagExpression tagExpression, long timeoutMillis, Closure body, StackTraceElement location, GroovyBackend backend) {
+    public GroovyHookDefinition(
+            TagExpression tagExpression,
+            long timeoutMillis,
+            int order,
+            Closure body,
+            StackTraceElement location,
+            GroovyBackend backend) {
+
         this.tagExpression = tagExpression;
         this.timeoutMillis = timeoutMillis;
+        this.order = order;
         this.body = body;
         this.location = location;
         this.backend = backend;
@@ -47,7 +56,7 @@ public class GroovyHookDefinition implements HookDefinition {
 
     @Override
     public int getOrder() {
-        return location.getFileName() == "env.groovy" ? -1 : 0;
+        return order;
     }
 }
 


### PR DESCRIPTION
Since the original method was accepting varargs (```Object... args```) as parameter, there was almost no way to add new method with proper parameters, without breaking backward compatibility. 

