### PR TITLE
Handles zip and wsjar protocols properly (fixes #808)

### DIFF
--- a/core/src/main/java/cucumber/runtime/io/ZipResourceIteratorFactory.java
+++ b/core/src/main/java/cucumber/runtime/io/ZipResourceIteratorFactory.java
@@ -1,14 +1,11 @@
 package cucumber.runtime.io;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLDecoder;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Set;
 
 import cucumber.runtime.CucumberException;
 
@@ -18,28 +15,21 @@ import cucumber.runtime.CucumberException;
  */
 public class ZipResourceIteratorFactory implements ResourceIteratorFactory {
 
-    // weblogic uses zip as protocol for classpath resources inside jars,and webshpere uses wsjar, so
-    // those protocols must be handled too
-    private static final Set<String> SUPPORTED_PROTOCOLS
-        = new HashSet<String>(Arrays.asList("jar", "zip", "wsjar"));
-
     static String filePath(URL jarUrl) throws UnsupportedEncodingException, MalformedURLException {
         String urlFile = jarUrl.getFile();
-        if (urlFile.startsWith("file:")) {
-            urlFile = urlFile.substring("file:".length());
-        }
 
         int separatorIndex = urlFile.indexOf("!/");
         if (separatorIndex != -1) {
             urlFile = urlFile.substring(0, separatorIndex);
         }
 
-        return URLDecoder.decode(urlFile, "UTF-8");
+        URL url = new URL(urlFile);
+        return new File(url.getFile()).getPath();
     }
 
     @Override
     public boolean isFactoryFor(URL url) {
-        return SUPPORTED_PROTOCOLS.contains(url.getProtocol().toLowerCase());
+        return url.getFile().indexOf("!/") != -1;
     }
 
     @Override

--- a/core/src/main/java/cucumber/runtime/io/ZipResourceIteratorFactory.java
+++ b/core/src/main/java/cucumber/runtime/io/ZipResourceIteratorFactory.java
@@ -1,29 +1,45 @@
 package cucumber.runtime.io;
 
-import cucumber.runtime.CucumberException;
-
-import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
+
+import cucumber.runtime.CucumberException;
 
 /**
- * Factory which creates {@link ZipResourceIterator}s for URL's with the "jar"
- * protocol.
+ * Factory which creates {@link ZipResourceIterator}s for URL's with "jar", "zip" and "wsjar"
+ * protocols.
  */
 public class ZipResourceIteratorFactory implements ResourceIteratorFactory {
+
+    // weblogic uses zip as protocol for classpath resources inside jars,and webshpere uses wsjar, so
+    // those protocols must be handled too
+    private static final Set<String> SUPPORTED_PROTOCOLS
+        = new HashSet<String>(Arrays.asList("jar", "zip", "wsjar"));
+
     static String filePath(URL jarUrl) throws UnsupportedEncodingException, MalformedURLException {
-        String path = new File(new URL(jarUrl.getFile()).getFile()).getAbsolutePath();
-        String pathToJar = path.substring(0, path.lastIndexOf("!"));
-        return URLDecoder.decode(pathToJar, "UTF-8");
+        String urlFile = jarUrl.getFile();
+        if (urlFile.startsWith("file:")) {
+            urlFile = urlFile.substring("file:".length());
+        }
+
+        int separatorIndex = urlFile.indexOf("!/");
+        if (separatorIndex != -1) {
+            urlFile = urlFile.substring(0, separatorIndex);
+        }
+
+        return URLDecoder.decode(urlFile, "UTF-8");
     }
 
     @Override
     public boolean isFactoryFor(URL url) {
-        return "jar".equals(url.getProtocol());
+        return SUPPORTED_PROTOCOLS.contains(url.getProtocol().toLowerCase());
     }
 
     @Override

--- a/core/src/test/java/cucumber/runtime/io/ZipResourceIteratorFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/io/ZipResourceIteratorFactoryTest.java
@@ -41,6 +41,5 @@ public class ZipResourceIteratorFactoryTest {
         assertEquals("cucumber-core.jar", filePath(new URL("jar:file:cucumber-core.jar!/")));
         assertEquals("cucumber-core.jar", filePath(new URL(null, "zip:file:cucumber-core.jar!/", NULL_URL_STREAM_HANDLER)));
         assertEquals("cucumber-core.jar", filePath(new URL(null, "wsjar:file:cucumber-core.jar!/", NULL_URL_STREAM_HANDLER)));
-        assertEquals("cucumber-core.jar", filePath(new URL("file:cucumber-core.jar")));
     }
 }

--- a/core/src/test/java/cucumber/runtime/io/ZipResourceIteratorFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/io/ZipResourceIteratorFactoryTest.java
@@ -1,0 +1,46 @@
+package cucumber.runtime.io;
+
+import static cucumber.runtime.io.ZipResourceIteratorFactory.filePath;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+import org.junit.Test;
+
+// https://github.com/cucumber/cucumber-jvm/issues/808
+public class ZipResourceIteratorFactoryTest {
+
+    private static final URLStreamHandler NULL_URL_STREAM_HANDLER = new URLStreamHandler() {
+        @Override
+        protected URLConnection openConnection(URL u) throws IOException {
+            return null;
+        }
+    };
+
+    @Test
+    public void is_factory_for_jar_protocols() throws IOException {
+        ZipResourceIteratorFactory factory = new ZipResourceIteratorFactory();
+
+        assertTrue(factory.isFactoryFor(new URL("jar:file:cucumber-core.jar!/cucumber/runtime/io")));
+        assertTrue(factory.isFactoryFor(new URL(null, "zip:file:cucumber-core.jar!/cucumber/runtime/io", NULL_URL_STREAM_HANDLER)));
+        assertTrue(factory.isFactoryFor(new URL(null, "wsjar:file:cucumber-core.jar!/cucumber/runtime/io", NULL_URL_STREAM_HANDLER)));
+        assertFalse(factory.isFactoryFor(new URL("file:cucumber-core")));
+        assertFalse(factory.isFactoryFor(new URL("http://http://cukes.info/cucumber-core.jar")));
+    }
+
+    @Test
+    public void computes_file_path_for_jar_protocols() throws Exception {
+        assertEquals("cucumber-core.jar", filePath(new URL("jar:file:cucumber-core.jar!/cucumber/runtime/io")));
+        assertEquals("cucumber-core.jar", filePath(new URL(null, "zip:file:cucumber-core.jar!/cucumber/runtime/io", NULL_URL_STREAM_HANDLER)));
+        assertEquals("cucumber-core.jar", filePath(new URL(null, "wsjar:file:cucumber-core.jar!/cucumber/runtime/io", NULL_URL_STREAM_HANDLER)));
+        assertEquals("cucumber-core.jar", filePath(new URL("jar:file:cucumber-core.jar!/")));
+        assertEquals("cucumber-core.jar", filePath(new URL(null, "zip:file:cucumber-core.jar!/", NULL_URL_STREAM_HANDLER)));
+        assertEquals("cucumber-core.jar", filePath(new URL(null, "wsjar:file:cucumber-core.jar!/", NULL_URL_STREAM_HANDLER)));
+        assertEquals("cucumber-core.jar", filePath(new URL("file:cucumber-core.jar")));
+    }
+}


### PR DESCRIPTION
Here is a patch for #808. Unit tests included to ensure it works properly with zip and wsjar protocols (for weblogic and websphere support, respectively)