### PR TITLE
Allow invoking methods on an instance which is loaded by a different class loader

### DIFF
--- a/core/src/test/java/cucumber/runtime/UtilsTest.java
+++ b/core/src/test/java/cucumber/runtime/UtilsTest.java
@@ -2,12 +2,15 @@ package cucumber.runtime;
 
 import org.junit.Test;
 
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLClassLoader;
 
 import static cucumber.runtime.Utils.isInstantiable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class UtilsTest {
@@ -32,5 +35,70 @@ public class UtilsTest {
         URL dotCucumber = Utils.toURL("foo/bar/.cucumber");
         URL url = new URL(dotCucumber, "stepdefs.json");
         assertEquals(new URL("file:foo/bar/.cucumber/stepdefs.json"), url);
+    }
+
+    @Test
+    public void testInvokeDefaultClassLoader() throws Throwable {
+        // Sanity check to verify that MyClass was loaded by the default class loader/
+        assertEquals(ClassLoader.getSystemClassLoader(), MyClass.class.getClassLoader());
+        Object target = new MyClass();
+
+        Method publicInterfaceMethod = MyClass.class.getMethod("publicInterfaceMethod");
+        assertEquals(Boolean.TRUE, Utils.invoke(target, publicInterfaceMethod, 1000));
+
+        Method protectedAbstractMethod = MyClass.class.getDeclaredMethod("protectedAbstractMethod");
+        assertEquals(Boolean.TRUE, Utils.invoke(target, protectedAbstractMethod, 1000));
+
+        Method privateMethod = MyAbstractClass.class.getDeclaredMethod("privateMethod");
+        assertEquals(Boolean.TRUE, Utils.invoke(target, privateMethod, 1000));
+    }
+
+    @Test
+    public void testInvokeOtherClassLoader() throws Throwable {
+        // Create a new class loader using the same URLs as the system class loader
+        URL[] urls = ((URLClassLoader) ClassLoader.getSystemClassLoader()).getURLs();
+        ClassLoader myClassLoader = new URLClassLoader(urls, null);
+
+        // Load the test class MyClass using our newly create class loader and create an instance.
+        Class<?> myClass = myClassLoader.loadClass(MyClass.class.getName());
+        Object target = myClass.getConstructor().newInstance();
+
+        // Sanity check to verify that MyClass was loaded by the default class loader.
+        assertEquals(ClassLoader.getSystemClassLoader(), MyClass.class.getClassLoader());
+        // Verify that the class loader of our loaded class is different.
+        assertNotEquals(MyClass.class.getClassLoader(), myClass.getClassLoader());
+
+        Method publicInterfaceMethod = MyClass.class.getMethod("publicInterfaceMethod");
+        assertEquals(Boolean.TRUE, Utils.invoke(target, publicInterfaceMethod, 1000));
+
+        Method protectedAbstractMethod = MyClass.class.getDeclaredMethod("protectedAbstractMethod");
+        assertEquals(Boolean.TRUE, Utils.invoke(target, protectedAbstractMethod, 1000));
+
+        Method privateMethod = MyAbstractClass.class.getDeclaredMethod("privateMethod");
+        assertEquals(Boolean.TRUE, Utils.invoke(target, privateMethod, 1000));
+    }
+
+    public static interface MyInterface {
+        Boolean publicInterfaceMethod();
+    }
+
+    public static abstract class MyAbstractClass implements MyInterface {
+        protected abstract Boolean protectedAbstractMethod();
+
+        private Boolean privateMethod() {
+            return Boolean.TRUE;
+        }
+    }
+
+    public static class MyClass extends MyAbstractClass {
+        @Override
+        public Boolean publicInterfaceMethod() {
+            return Boolean.TRUE;
+        }
+
+        @Override
+        protected Boolean protectedAbstractMethod() {
+            return Boolean.TRUE;
+        }
     }
 }


### PR DESCRIPTION
Currently an IllegalArgumentException is thrown when an implementation of the ObjectFactory interface (from cucumber-java) creates an instance of a class that is loaded by another class loader:
java.lang.IllegalArgumentException: object is not an instance of declaring class
          	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
          	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
          	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
          	at java.lang.reflect.Method.invoke(Method.java:601)
          	at cucumber.runtime.Utils$1.call(Utils.java:34)
          	... 52 more

This happens in my case where I implemented an ObjectFactory that creates an instance in an OSGi context. The OSGi framework requires the class to be loaded by a bundle's class loader and as such the class loaded is different from the class loaded by the JavaBackend (which loads the class with the system classloader).

This issue can be solved by checking if the class loader of the target instance differs from the class loader of the method's declaring class. If so the method can be retrieved from the target instance's class instead and invoked in the same way. I also added 2 tests to validate the current behavior and new behavior.