### PR TITLE
Run the Android examples on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,13 @@ matrix:
         - platform-tools
         - extra-android-support
         - android-21
-        - sys-img-armeabi-v7a-android-21
+        - android-15
+        - sys-img-armeabi-v7a-android-15
     script: mvn install -P android-examples -pl examples/android,examples/android/android-test -am -amd -Dno.gem.deploy=true -Dandroid.device=test
     install: mvn install -P android-examples -pl examples/android,examples/android/android-test -am -amd -DskipTests=true -Dmaven.javadoc.skip=true -B -V
     # Emulator Management: Create, Start and Wait
-    before_script:
-      - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+    before_install:
+      - echo no | android create avd --force -n test -t android-15 --abi armeabi-v7a
       - emulator -avd test -no-skin -no-audio -no-window &
       - android-wait-for-emulator
   - jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ matrix:
     before_install:
       - echo no | android create avd --force -n test -t android-15 --abi armeabi-v7a
       - emulator -avd test -no-skin -no-audio -no-window &
-    # Download the maven plugins and project dependencies before the script runs
-    install: mvn verify -P android-examples -pl examples/android,examples/android/android-test -am -amd dependency:go-offline
+    # Build the Android example dependencies, without test, to install dependencies
+    install: mvn verify -pl android,picocontainer -am -DskipTests=true -Dmaven.javadoc.skip=true -B -V
     # Emulator Management: Wait until the emulator is ready
     before_script:
       - android-wait-for-emulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,18 @@ matrix:
         - android-21
         - android-15
         - sys-img-armeabi-v7a-android-15
-    script: mvn install -P android-examples -pl examples/android,examples/android/android-test -am -amd -Dno.gem.deploy=true -Dandroid.device=test
-    install: mvn install -P android-examples -pl examples/android,examples/android/android-test -am -amd -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-    # Emulator Management: Create, Start and Wait
+    # Emulator Management: Create and start up in parallel with the install
+    # An old emulator is used to use less resources
     before_install:
       - echo no | android create avd --force -n test -t android-15 --abi armeabi-v7a
       - emulator -avd test -no-skin -no-audio -no-window &
+    # Download the maven plugins and project dependencies before the script runs
+    install: mvn verify -P android-examples -pl examples/android,examples/android/android-test -am -amd dependency:go-offline
+    # Emulator Management: Wait until the emulator is ready
+    before_script:
       - android-wait-for-emulator
+    # Build and test the Android examples
+    script: mvn verify -P android-examples -pl examples/android,examples/android/android-test -am -amd -Dandroid.device=test
   - jdk: oraclejdk8
     script: mvn -q deploy -P java8 -pl java8 --settings .travis-settings.xml -Dno.gem.deploy=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
   include:
   - jdk: oraclejdk7
     script: mvn -q deploy --settings .travis-settings.xml -Dno.gem.deploy=true
+  - jdk: oraclejdk7
+    env: ANDROID_EXAMPLES=true
+    script: mvn install -pl android -am -Dno.gem.deploy=true -Dandroid.device=test
+    install: mvn install -pl android -am -DskipTests=true -Dmaven.javadoc.skip=true -B -V
   - jdk: oraclejdk8
     script: mvn -q deploy -P java8 -pl java8 --settings .travis-settings.xml -Dno.gem.deploy=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,15 @@ matrix:
     script: mvn -q deploy --settings .travis-settings.xml -Dno.gem.deploy=true
   - jdk: oraclejdk7
     env: ANDROID_EXAMPLES=true
-    script: mvn install -pl android -am -Dno.gem.deploy=true -Dandroid.device=test
-    install: mvn install -pl android -am -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+    language: android
+    android:
+      components:
+        - build-tools-21.1.1
+        - platform-tools
+        - extra-android-support
+        - android-21
+    script: mvn install -P android-examples -pl examples/android,examples/android/android-test -am -amd -DskipTests=true -Dno.gem.deploy=true -Dandroid.device=test
+    install: mvn install -P android-examples -pl examples/android,examples/android/android-test -am -amd -DskipTests=true -Dmaven.javadoc.skip=true -B -V
   - jdk: oraclejdk8
     script: mvn -q deploy -P java8 -pl java8 --settings .travis-settings.xml -Dno.gem.deploy=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,14 @@ matrix:
         - platform-tools
         - extra-android-support
         - android-21
-    script: mvn install -P android-examples -pl examples/android,examples/android/android-test -am -amd -DskipTests=true -Dno.gem.deploy=true -Dandroid.device=test
+        - sys-img-armeabi-v7a-android-21
+    script: mvn install -P android-examples -pl examples/android,examples/android/android-test -am -amd -Dno.gem.deploy=true -Dandroid.device=test
     install: mvn install -P android-examples -pl examples/android,examples/android/android-test -am -amd -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+    # Emulator Management: Create, Start and Wait
+    before_script:
+      - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+      - emulator -avd test -no-skin -no-audio -no-window &
+      - android-wait-for-emulator
   - jdk: oraclejdk8
     script: mvn -q deploy -P java8 -pl java8 --settings .travis-settings.xml -Dno.gem.deploy=true
 


### PR DESCRIPTION
Use the new Android [support](http://docs.travis-ci.com/user/languages/android/) (still in beta) to run the Android examples on Travis

[X] Create "walking skeleton" Travis job for the Android examples
[X] Update the job to build the Android examples
[X] Update the job to run the examples on emulator
[ ] Update the job to also run the Android Studio example

Closes #578.
