### PR TITLE
Make the Summary Printer into a plugin

### DIFF
--- a/core/src/main/java/cucumber/api/SummaryPrinter.java
+++ b/core/src/main/java/cucumber/api/SummaryPrinter.java
@@ -1,0 +1,5 @@
+package cucumber.api;
+
+public interface SummaryPrinter {
+    public void print(cucumber.runtime.Runtime runtime);
+}

--- a/core/src/main/java/cucumber/runtime/DefaultSummaryPrinter.java
+++ b/core/src/main/java/cucumber/runtime/DefaultSummaryPrinter.java
@@ -1,15 +1,18 @@
 package cucumber.runtime;
 
+import cucumber.api.SummaryPrinter;
+
 import java.io.PrintStream;
 import java.util.List;
 
-public class SummaryPrinter {
+public class DefaultSummaryPrinter implements SummaryPrinter {
     private final PrintStream out;
 
-    public SummaryPrinter(PrintStream out) {
-        this.out = out;
+    public DefaultSummaryPrinter() {
+        this.out = System.out;
     }
 
+    @Override
     public void print(cucumber.runtime.Runtime runtime) {
         out.println();
         printStats(runtime);

--- a/core/src/main/java/cucumber/runtime/NullSummaryPrinter.java
+++ b/core/src/main/java/cucumber/runtime/NullSummaryPrinter.java
@@ -1,0 +1,12 @@
+package cucumber.runtime;
+
+import cucumber.api.SummaryPrinter;
+
+public class NullSummaryPrinter implements SummaryPrinter {
+
+    @Override
+    public void print(Runtime runtime) {
+        // Do nothing
+    }
+
+}

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -132,7 +132,7 @@ public class Runtime implements UnreportedStepExecutor {
     }
 
     void printStats(PrintStream out) {
-        stats.printStats(out);
+        stats.printStats(out, runtimeOptions.isStrict());
     }
 
     public void buildBackendWorlds(Reporter reporter, Set<Tag> tags, Scenario gherkinScenario) {
@@ -145,8 +145,8 @@ public class Runtime implements UnreportedStepExecutor {
         scenarioResult = new ScenarioImpl(reporter, tags, gherkinScenario);
     }
 
-    public void disposeBackendWorlds() {
-        stats.addScenario(scenarioResult.getStatus());
+    public void disposeBackendWorlds(String scenarioDesignation) {
+        stats.addScenario(scenarioResult.getStatus(), scenarioDesignation);
         for (Backend backend : backends) {
             backend.disposeWorld();
         }

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -2,6 +2,7 @@ package cucumber.runtime;
 
 import cucumber.api.Pending;
 import cucumber.api.StepDefinitionReporter;
+import cucumber.api.SummaryPrinter;
 import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.model.CucumberFeature;
 import cucumber.runtime.xstream.LocalizedXStreams;
@@ -126,8 +127,8 @@ public class Runtime implements UnreportedStepExecutor {
     }
 
     public void printSummary() {
-        // TODO: inject a SummaryPrinter in the ctor
-        new SummaryPrinter(System.out).print(this);
+        SummaryPrinter summaryPrinter = runtimeOptions.summaryPrinter(classLoader);
+        summaryPrinter.print(this);
     }
 
     void printStats(PrintStream out) {

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -2,13 +2,14 @@ package cucumber.runtime;
 
 import cucumber.api.SnippetType;
 import cucumber.api.StepDefinitionReporter;
+import cucumber.api.SummaryPrinter;
 import cucumber.runtime.formatter.ColorAware;
 import cucumber.runtime.formatter.PluginFactory;
 import cucumber.runtime.formatter.StrictAware;
 import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.model.CucumberFeature;
-import gherkin.I18n;
 import cucumber.runtime.model.PathWithLines;
+import gherkin.I18n;
 import gherkin.formatter.Formatter;
 import gherkin.formatter.Reporter;
 import gherkin.util.FixJava;
@@ -33,6 +34,7 @@ public class RuntimeOptions {
     private final List<String> featurePaths = new ArrayList<String>();
     private final List<String> pluginFormatterNames = new ArrayList<String>();
     private final List<String> pluginStepDefinitionReporterNames = new ArrayList<String>();
+    private final List<String> pluginSummaryPrinterNames = new ArrayList<String>();
     private final PluginFactory pluginFactory;
     private final List<Object> plugins = new ArrayList<Object>();
     private boolean dryRun;
@@ -84,6 +86,9 @@ public class RuntimeOptions {
 
         if (pluginFormatterNames.isEmpty()) {
             pluginFormatterNames.add("progress");
+        }
+        if (pluginSummaryPrinterNames.isEmpty()) {
+            pluginSummaryPrinterNames.add("cucumber.runtime.DefaultSummaryPrinter");
         }
     }
 
@@ -152,10 +157,12 @@ public class RuntimeOptions {
     }
 
     private void addPluginName(String name) {
-        if (pluginFactory.isFormatterName(name)) {
+        if (PluginFactory.isFormatterName(name)) {
             pluginFormatterNames.add(name);
-        } else if (pluginFactory.isStepDefinitionResporterName(name)) {
+        } else if (PluginFactory.isStepDefinitionResporterName(name)) {
             pluginStepDefinitionReporterNames.add(name);
+        } else if (PluginFactory.isSummaryPrinterName(name)) {
+            pluginSummaryPrinterNames.add(name);
         } else {
             throw new CucumberException("Unrecognized plugin: " + name);
         }
@@ -224,6 +231,10 @@ public class RuntimeOptions {
                 Object plugin = pluginFactory.create(pluginName);
                 plugins.add(plugin);
             }
+            for (String pluginName : pluginSummaryPrinterNames) {
+                Object plugin = pluginFactory.create(pluginName);
+                plugins.add(plugin);
+            }
             pluginNamesInstantiated = true;
         }
         return plugins;
@@ -239,6 +250,10 @@ public class RuntimeOptions {
 
     public StepDefinitionReporter stepDefinitionReporter(ClassLoader classLoader) {
         return pluginProxy(classLoader, StepDefinitionReporter.class);
+    }
+
+    public SummaryPrinter summaryPrinter(ClassLoader classLoader) {
+        return pluginProxy(classLoader, SummaryPrinter.class);
     }
 
     /**

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -88,7 +88,7 @@ public class RuntimeOptions {
             pluginFormatterNames.add("progress");
         }
         if (pluginSummaryPrinterNames.isEmpty()) {
-            pluginSummaryPrinterNames.add("cucumber.runtime.DefaultSummaryPrinter");
+            pluginSummaryPrinterNames.add("default_summary");
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
@@ -1,6 +1,7 @@
 package cucumber.runtime;
 
 import cucumber.api.CucumberOptions;
+import cucumber.runtime.formatter.PluginFactory;
 import cucumber.runtime.io.MultiLoader;
 
 import java.util.ArrayList;
@@ -85,7 +86,9 @@ public class RuntimeOptionsFactory {
         for (String plugin : plugins) {
             args.add("--plugin");
             args.add(plugin);
-            pluginSpecified = true;
+            if (PluginFactory.isFormatterName(plugin)) {
+                pluginSpecified = true;
+            }
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/Stats.java
+++ b/core/src/main/java/cucumber/runtime/Stats.java
@@ -9,6 +9,8 @@ import gherkin.formatter.model.Result;
 import java.io.PrintStream;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 class Stats {
@@ -20,6 +22,10 @@ class Stats {
     private long totalDuration = 0;
     private Formats formats;
     private Locale locale;
+    private List<String> failedScenarios = new ArrayList<String>();
+    private List<String> pendingScenarios = new ArrayList<String>();
+    private List<String> undefinedScenarios = new ArrayList<String>();
+    private List<String> passedScenarios = new ArrayList<String>();
 
     public Stats(boolean monochrome) {
         this(monochrome, Locale.getDefault());
@@ -34,7 +40,8 @@ class Stats {
         }
     }
 
-    public void printStats(PrintStream out) {
+    public void printStats(PrintStream out, boolean isStrict) {
+        printNonZeroResultScenarios(out, isStrict);
         if (stepSubCounts.getTotal() == 0) {
             out.println("0 Scenarios");
             out.println("0 Steps");
@@ -86,6 +93,35 @@ class Stats {
         out.println(format.format(((double) (totalDuration % ONE_MINUTE)) / ONE_SECOND) + "s");
     }
 
+    private void printNonZeroResultScenarios(PrintStream out, boolean isStrict) {
+        printScenarios(out, failedScenarios, Result.FAILED);
+        if (isStrict) {
+            printScenarios(out, pendingScenarios, PENDING);
+            printScenarios(out, undefinedScenarios, Result.UNDEFINED.getStatus());
+        }
+    }
+
+    private void printScenarios(PrintStream out, List<String> scenarios, String type) {
+        Format format = formats.get(type);
+        if (!scenarios.isEmpty()) {
+            out.println(format.text(capitalizeFirstLetter(type) + " scenarios:"));
+        }
+        for (String scenario : scenarios) {
+            String[] parts = scenario.split("#");
+            out.print(format.text(parts[0]));
+            for (int i = 1; i < parts.length; ++i) {
+                out.println("#" + parts[i]);
+            }
+        }
+        if (!scenarios.isEmpty()) {
+            out.println();
+        }
+    }
+
+    private String capitalizeFirstLetter(String type) {
+        return type.substring(0, 1).toUpperCase(locale) + type.substring(1);
+    }
+
     public void addStep(Result result) {
         addResultToSubCount(stepSubCounts, result.getStatus());
         addTime(result.getDuration());
@@ -114,6 +150,19 @@ class Stats {
             subCounts.skipped++;
         } else if (resultStatus.equals(Result.PASSED)) {
             subCounts.passed++;
+        }
+    }
+
+    public void addScenario(String resultStatus, String scenarioDesignation) {
+        addResultToSubCount(scenarioSubCounts, resultStatus);
+        if (resultStatus.equals(Result.FAILED)) {
+            failedScenarios.add(scenarioDesignation);
+        } else if (resultStatus.equals(PENDING)) {
+            pendingScenarios.add(scenarioDesignation);
+        } else if (resultStatus.equals(Result.UNDEFINED.getStatus())) {
+            undefinedScenarios.add(scenarioDesignation);
+        } else if (resultStatus.equals(Result.PASSED)) {
+            passedScenarios.add(scenarioDesignation);
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
@@ -1,6 +1,7 @@
 package cucumber.runtime.formatter;
 
 import cucumber.api.StepDefinitionReporter;
+import cucumber.api.SummaryPrinter;
 import cucumber.runtime.CucumberException;
 import cucumber.runtime.io.URLOutputStream;
 import cucumber.runtime.io.UTF8OutputStreamWriter;
@@ -196,6 +197,14 @@ public class PluginFactory {
     public static boolean isStepDefinitionResporterName(String name) {
         Class pluginClass = getPluginClass(name);
         if (StepDefinitionReporter.class.isAssignableFrom(pluginClass)) {
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean isSummaryPrinterName(String name) {
+        Class pluginClass = getPluginClass(name);
+        if (SummaryPrinter.class.isAssignableFrom(pluginClass)) {
             return true;
         }
         return false;

--- a/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
@@ -1,8 +1,11 @@
 package cucumber.runtime.formatter;
 
+import cucumber.api.StepDefinitionReporter;
 import cucumber.runtime.CucumberException;
 import cucumber.runtime.io.URLOutputStream;
 import cucumber.runtime.io.UTF8OutputStreamWriter;
+import gherkin.formatter.Formatter;
+import gherkin.formatter.Reporter;
 
 import java.io.File;
 import java.io.IOException;
@@ -150,7 +153,7 @@ public class PluginFactory {
         }
     }
 
-    private <T> Class<T> pluginClass(String pluginName) {
+    private static <T> Class<T> pluginClass(String pluginName) {
         Class<T> pluginClass = (Class<T>) PLUGIN_CLASSES.get(pluginName);
         if (pluginClass == null) {
             pluginClass = loadClass(pluginName);
@@ -159,7 +162,7 @@ public class PluginFactory {
     }
 
     @SuppressWarnings("unchecked")
-    private <T> Class<T> loadClass(String className) {
+    private static <T> Class<T> loadClass(String className) {
         try {
             return (Class<T>) Thread.currentThread().getContextClassLoader().loadClass(className);
         } catch (ClassNotFoundException e) {
@@ -180,5 +183,32 @@ public class PluginFactory {
         } finally {
             defaultOut = null;
         }
+    }
+
+    public static boolean isFormatterName(String name) {
+        Class pluginClass = getPluginClass(name);
+        if (Formatter.class.isAssignableFrom(pluginClass) || Reporter.class.isAssignableFrom(pluginClass)) {
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean isStepDefinitionResporterName(String name) {
+        Class pluginClass = getPluginClass(name);
+        if (StepDefinitionReporter.class.isAssignableFrom(pluginClass)) {
+            return true;
+        }
+        return false;
+    }
+
+    private static Class getPluginClass(String name) {
+        Matcher pluginWithFile = PLUGIN_WITH_FILE_PATTERN.matcher(name);
+        String pluginName;
+        if (pluginWithFile.matches()) {
+            pluginName = pluginWithFile.group(1);
+        } else {
+            pluginName = name;
+        }
+        return pluginClass(pluginName);
     }
 }

--- a/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
@@ -3,6 +3,8 @@ package cucumber.runtime.formatter;
 import cucumber.api.StepDefinitionReporter;
 import cucumber.api.SummaryPrinter;
 import cucumber.runtime.CucumberException;
+import cucumber.runtime.DefaultSummaryPrinter;
+import cucumber.runtime.NullSummaryPrinter;
 import cucumber.runtime.io.URLOutputStream;
 import cucumber.runtime.io.UTF8OutputStreamWriter;
 import gherkin.formatter.Formatter;
@@ -56,6 +58,8 @@ public class PluginFactory {
         put("json", CucumberJSONFormatter.class);
         put("usage", UsageFormatter.class);
         put("rerun", RerunFormatter.class);
+        put("default_summary", DefaultSummaryPrinter.class);
+        put("null_summary", NullSummaryPrinter.class);
     }};
     private static final Pattern PLUGIN_WITH_FILE_PATTERN = Pattern.compile("([^:]+):(.*)");
     private String defaultOutFormatter = null;

--- a/core/src/main/java/cucumber/runtime/model/CucumberScenario.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberScenario.java
@@ -53,7 +53,12 @@ public class CucumberScenario extends CucumberTagStatement {
         } catch (Throwable ignore) {
             // IntelliJ has its own formatter which doesn't yet implement this.
         }
-        runtime.disposeBackendWorlds();
+        runtime.disposeBackendWorlds(createScenarioDesignation());
+    }
+
+    private String createScenarioDesignation() {
+        return cucumberFeature.getPath() + ":" + Integer.toString(scenario.getLine()) + " # " +
+                scenario.getKeyword() + ": " + scenario.getName();
     }
 
     private void runBackground(Formatter formatter, Reporter reporter, Runtime runtime) {

--- a/core/src/main/resources/cucumber/api/cli/USAGE.txt
+++ b/core/src/main/resources/cucumber/api/cli/USAGE.txt
@@ -4,8 +4,9 @@ Options:
 
     -g, --glue PATH                        Where glue code (step definitions and hooks) is loaded from.
     -p, --plugin PLUGIN[:PATH_OR_URL]      Register a plugin.
-                                           Built-in PLUGIN types: junit, html, pretty, progress, json, usage,
-                                           rerun. PLUGIN can also be a fully qualified class name, allowing
+                                           Built-in formatter PLUGIN types: junit, html, pretty, progress, 
+                                           json, usage, rerun. Built-in summary PLUGIN types: default_summary,
+                                           null_summary. PLUGIN can also be a fully qualified class name, allowing
                                            registration of 3rd party plugins.
     -f, --format FORMAT[:PATH_OR_URL]      Deprecated. Use --plugin instead.
     -t, --tags TAG_EXPRESSION              Only run scenarios tagged with tags matching TAG_EXPRESSION.

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
@@ -95,6 +95,21 @@ public class RuntimeOptionsFactoryTest {
     }
 
     @Test
+    public void create_null_formatter_when_no_formatter_plugin_is_defined() {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(ClassWithNoFormatterPlugin.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+
+        List<Object> plugins = runtimeOptions.getPlugins();
+        boolean found = false;
+        for (Object plugin : plugins) {
+            if ("cucumber.runtime.formatter.NullFormatter".equals(plugin.getClass().getName())) {
+                found = true;
+            }
+        }
+        assertTrue("NullFormatter not found among plugins", found);
+    }
+
+    @Test
     public void inherit_plugin_from_baseclass() {
         RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(SubClassWithFormatter.class);
         RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
@@ -163,6 +178,11 @@ public class RuntimeOptionsFactoryTest {
 
     @CucumberOptions(monochrome = false)
     static class BaseClassWithMonoChromeFalse {
+        // empty
+    }
+
+    @CucumberOptions(plugin = "cucumber.runtime.formatter.AnyStepDefinitionReporter")
+    static class ClassWithNoFormatterPlugin {
         // empty
     }
 }

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
@@ -39,8 +39,7 @@ public class RuntimeOptionsFactoryTest {
         assertFalse(runtimeOptions.isStrict());
         assertEquals(asList("classpath:cucumber/runtime"), runtimeOptions.getFeaturePaths());
         assertEquals(asList("classpath:cucumber/runtime"), runtimeOptions.getGlue());
-        assertEquals(1, runtimeOptions.getPlugins().size());
-        assertEquals("cucumber.runtime.formatter.NullFormatter", runtimeOptions.getPlugins().get(0).getClass().getName());
+        assertPluginExists(runtimeOptions.getPlugins(), "cucumber.runtime.formatter.NullFormatter");
     }
 
     @Test
@@ -49,8 +48,7 @@ public class RuntimeOptionsFactoryTest {
         RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
         assertEquals(asList("classpath:cucumber/runtime"), runtimeOptions.getFeaturePaths());
         assertEquals(asList("classpath:cucumber/runtime"), runtimeOptions.getGlue());
-        assertEquals(1, runtimeOptions.getPlugins().size());
-        assertEquals("cucumber.runtime.formatter.NullFormatter", runtimeOptions.getPlugins().get(0).getClass().getName());
+        assertPluginExists(runtimeOptions.getPlugins(), "cucumber.runtime.formatter.NullFormatter");
     }
 
     @Test
@@ -98,15 +96,14 @@ public class RuntimeOptionsFactoryTest {
     public void create_null_formatter_when_no_formatter_plugin_is_defined() {
         RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(ClassWithNoFormatterPlugin.class);
         RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+        assertPluginExists(runtimeOptions.getPlugins(), "cucumber.runtime.formatter.NullFormatter");
+    }
 
-        List<Object> plugins = runtimeOptions.getPlugins();
-        boolean found = false;
-        for (Object plugin : plugins) {
-            if ("cucumber.runtime.formatter.NullFormatter".equals(plugin.getClass().getName())) {
-                found = true;
-            }
-        }
-        assertTrue("NullFormatter not found among plugins", found);
+    @Test
+    public void create_default_summary_printer_when_no_summary_printer_plugin_is_defined() {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(ClassWithNoSummaryPrinterPlugin.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+        assertPluginExists(runtimeOptions.getPlugins(), "cucumber.runtime.DefaultSummaryPrinter");
     }
 
     @Test
@@ -115,9 +112,8 @@ public class RuntimeOptionsFactoryTest {
         RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
 
         List<Object> plugins = runtimeOptions.getPlugins();
-        assertEquals(2, plugins.size());
-        assertTrue(plugins.get(0) instanceof PrettyFormatter);
-        assertTrue(plugins.get(1) instanceof JSONFormatter);
+        assertPluginExists(plugins, "cucumber.runtime.formatter.CucumberJSONFormatter");
+        assertPluginExists(plugins, "cucumber.runtime.formatter.CucumberPrettyFormatter");
     }
 
     @Test
@@ -126,6 +122,16 @@ public class RuntimeOptionsFactoryTest {
         RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
 
         assertTrue(runtimeOptions.isMonochrome());
+    }
+
+    private void assertPluginExists(List<Object> plugins, String pluginName) {
+        boolean found = false;
+        for (Object plugin : plugins) {
+            if (plugin.getClass().getName() == pluginName) {
+                found = true;
+            }
+        }
+        assertTrue(pluginName + " not found among the plugins", found);
     }
 
 
@@ -183,6 +189,11 @@ public class RuntimeOptionsFactoryTest {
 
     @CucumberOptions(plugin = "cucumber.runtime.formatter.AnyStepDefinitionReporter")
     static class ClassWithNoFormatterPlugin {
+        // empty
+    }
+
+    @CucumberOptions(plugin = "pretty")
+    static class ClassWithNoSummaryPrinterPlugin {
         // empty
     }
 }

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -87,15 +87,22 @@ public class RuntimeOptionsTest {
     }
 
     @Test
-    public void creates_progress_formatter_when_non_formatter_plugin_is_specified() {
+    public void creates_progress_formatter_when_no_formatter_plugin_is_specified() {
         RuntimeOptions options = new RuntimeOptions(asList("--plugin", "cucumber.runtime.formatter.AnyStepDefinitionReporter", "--glue", "somewhere"));
-        boolean found = false;
-        for (Object plugin : options.getPlugins()) {
-            if (plugin.getClass().getName() == "cucumber.runtime.formatter.ProgressFormatter") {
-                found = true;
-            }
-        }
-        assertTrue("ProgressFormatter not found among the plugins", found);
+        assertPluginExists(options.getPlugins(), "cucumber.runtime.formatter.ProgressFormatter");
+    }
+
+    @Test
+    public void creates_default_summary_printer_when_no_summary_printer_plugin_is_specified() {
+        RuntimeOptions options = new RuntimeOptions(asList("--plugin", "pretty", "--glue", "somewhere"));
+        assertPluginExists(options.getPlugins(), "cucumber.runtime.DefaultSummaryPrinter");
+    }
+
+    @Test
+    public void creates_null_summary_printer() {
+        RuntimeOptions options = new RuntimeOptions(asList("--plugin", "cucumber.runtime.NullSummaryPrinter", "--glue", "somewhere"));
+        assertPluginExists(options.getPlugins(), "cucumber.runtime.NullSummaryPrinter");
+        assertPluginNotExists(options.getPlugins(), "cucumber.runtime.DefaultSummaryPrinter");
     }
 
     @Test
@@ -325,6 +332,24 @@ public class RuntimeOptionsTest {
         when(resource1.getPath()).thenReturn(featurePath);
         when(resource1.getInputStream()).thenReturn(new ByteArrayInputStream(feature.getBytes("UTF-8")));
         when(resourceLoader.resources(featurePath, ".feature")).thenReturn(asList(resource1));
+    }
+
+    private void assertPluginExists(List<Object> plugins, String pluginName) {
+        assertTrue(pluginName + " not found among the plugins", pluginExists(plugins, pluginName));
+    }
+
+    private void assertPluginNotExists(List<Object> plugins, String pluginName) {
+        assertFalse(pluginName + " found among the plugins", pluginExists(plugins, pluginName));
+    }
+
+    private boolean pluginExists(List<Object> plugins, String pluginName) {
+        boolean found = false;
+        for (Object plugin : plugins) {
+            if (plugin.getClass().getName() == pluginName) {
+                found = true;
+            }
+        }
+        return found;
     }
 }
 

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -81,6 +81,24 @@ public class RuntimeOptionsTest {
     }
 
     @Test
+    public void creates_progress_formatter_as_default() {
+        RuntimeOptions options = new RuntimeOptions(asList("--glue", "somewhere"));
+        assertEquals("cucumber.runtime.formatter.ProgressFormatter", options.getPlugins().get(0).getClass().getName());
+    }
+
+    @Test
+    public void creates_progress_formatter_when_non_formatter_plugin_is_specified() {
+        RuntimeOptions options = new RuntimeOptions(asList("--plugin", "cucumber.runtime.formatter.AnyStepDefinitionReporter", "--glue", "somewhere"));
+        boolean found = false;
+        for (Object plugin : options.getPlugins()) {
+            if (plugin.getClass().getName() == "cucumber.runtime.formatter.ProgressFormatter") {
+                found = true;
+            }
+        }
+        assertTrue("ProgressFormatter not found among the plugins", found);
+    }
+
+    @Test
     public void assigns_strict() {
         RuntimeOptions options = new RuntimeOptions(asList("--strict", "--glue", "somewhere"));
         assertTrue(options.isStrict());
@@ -309,3 +327,4 @@ public class RuntimeOptionsTest {
         when(resourceLoader.resources(featurePath, ".feature")).thenReturn(asList(resource1));
     }
 }
+

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -100,7 +100,7 @@ public class RuntimeOptionsTest {
 
     @Test
     public void creates_null_summary_printer() {
-        RuntimeOptions options = new RuntimeOptions(asList("--plugin", "cucumber.runtime.NullSummaryPrinter", "--glue", "somewhere"));
+        RuntimeOptions options = new RuntimeOptions(asList("--plugin", "null_summary", "--glue", "somewhere"));
         assertPluginExists(options.getPlugins(), "cucumber.runtime.NullSummaryPrinter");
         assertPluginNotExists(options.getPlugins(), "cucumber.runtime.DefaultSummaryPrinter");
     }

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 import static cucumber.runtime.TestHelper.feature;
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -262,9 +263,9 @@ public class RuntimeTest {
         runScenario(reporter, runtime, stepCount(1));
         runtime.printStats(new PrintStream(baos));
 
-        assertThat(baos.toString(), startsWith(String.format(
+        assertThat(baos.toString(), containsString(String.format("" +
                 "1 Scenarios (1 pending)%n" +
-                        "1 Steps (1 pending)%n")));
+                "1 Steps (1 pending)%n")));
     }
 
     @Test
@@ -277,9 +278,9 @@ public class RuntimeTest {
         runScenario(reporter, runtime, stepCount(1));
         runtime.printStats(new PrintStream(baos));
 
-        assertThat(baos.toString(), startsWith(String.format(
+        assertThat(baos.toString(), containsString(String.format("" +
                 "1 Scenarios (1 failed)%n" +
-                        "1 Steps (1 failed)%n")));
+                "1 Steps (1 failed)%n")));
     }
 
     @Test
@@ -291,9 +292,9 @@ public class RuntimeTest {
         runScenario(reporter, runtime, stepCount(1));
         runtime.printStats(new PrintStream(baos));
 
-        assertThat(baos.toString(), startsWith(String.format(
+        assertThat(baos.toString(), containsString(String.format(""+
                 "1 Scenarios (1 failed)%n" +
-                        "1 Steps (1 failed)%n")));
+                "1 Steps (1 failed)%n")));
     }
 
     @Test
@@ -306,9 +307,9 @@ public class RuntimeTest {
         runScenario(reporter, runtime, stepCount(2));
         runtime.printStats(new PrintStream(baos));
 
-        assertThat(baos.toString(), startsWith(String.format(
+        assertThat(baos.toString(), containsString(String.format("" +
                 "1 Scenarios (1 failed)%n" +
-                        "2 Steps (1 failed, 1 skipped)%n")));
+                "2 Steps (1 failed, 1 skipped)%n")));
     }
 
     @Test
@@ -320,9 +321,9 @@ public class RuntimeTest {
         runScenario(reporter, runtime, stepCount(1));
         runtime.printStats(new PrintStream(baos));
 
-        assertThat(baos.toString(), startsWith(String.format(
+        assertThat(baos.toString(), containsString(String.format("" +
                 "1 Scenarios (1 undefined)%n" +
-                        "1 Steps (1 undefined)%n")));
+                "1 Steps (1 undefined)%n")));
     }
 
     @Test
@@ -336,9 +337,9 @@ public class RuntimeTest {
         runScenario(reporter, runtime, stepCount(1));
         runtime.printStats(new PrintStream(baos));
 
-        assertThat(baos.toString(), startsWith(String.format(
+        assertThat(baos.toString(), containsString(String.format("" +
                 "1 Scenarios (1 failed)%n" +
-                        "1 Steps (1 skipped)%n")));
+                "1 Steps (1 skipped)%n")));
     }
 
     @Test
@@ -352,9 +353,9 @@ public class RuntimeTest {
         runScenario(reporter, runtime, stepCount(1));
         runtime.printStats(new PrintStream(baos));
 
-        assertThat(baos.toString(), startsWith(String.format(
+        assertThat(baos.toString(), containsString(String.format("" +
                 "1 Scenarios (1 failed)%n" +
-                        "1 Steps (1 passed)%n")));
+                "1 Steps (1 passed)%n")));
     }
 
     @Test
@@ -628,7 +629,7 @@ public class RuntimeTest {
             runStep(reporter, runtime);
         }
         runtime.runAfterHooks(reporter, Collections.<Tag>emptySet());
-        runtime.disposeBackendWorlds();
+        runtime.disposeBackendWorlds("scenario designation");
     }
 
     private int stepCount(int stepCount) {

--- a/core/src/test/java/cucumber/runtime/formatter/AnyStepDefinitionReporter.java
+++ b/core/src/test/java/cucumber/runtime/formatter/AnyStepDefinitionReporter.java
@@ -1,0 +1,17 @@
+package cucumber.runtime.formatter;
+
+import cucumber.api.StepDefinitionReporter;
+import cucumber.runtime.StepDefinition;
+
+public class AnyStepDefinitionReporter implements StepDefinitionReporter {
+
+    public AnyStepDefinitionReporter() {
+        // TODO Auto-generated constructor stub
+    }
+
+    @Override
+    public void stepDefinition(StepDefinition stepDefinition) {
+        // TODO Auto-generated method stub
+    }
+
+}

--- a/jython/bin/cucumber-jvm.py
+++ b/jython/bin/cucumber-jvm.py
@@ -5,10 +5,12 @@ cucumber_jython_shaded_path = os.path.dirname(inspect.getfile(inspect.currentfra
 sys.path.append(cucumber_jython_shaded_path)
 
 from java.io import File
+from java.lang import Thread
 from java.net import URLClassLoader
 from cucumber.api.cli import Main
 
 cl = URLClassLoader([File(cucumber_jython_shaded_path).toURL()], Main.getClassLoader())
+Thread.currentThread().contextClassLoader = cl
 
 exitstatus = Main.run(sys.argv[1:], cl)
 sys.exit(exitstatus)

--- a/jython/bin/cucumber-jvm.py
+++ b/jython/bin/cucumber-jvm.py
@@ -5,12 +5,10 @@ cucumber_jython_shaded_path = os.path.dirname(inspect.getfile(inspect.currentfra
 sys.path.append(cucumber_jython_shaded_path)
 
 from java.io import File
-from java.lang import Thread
 from java.net import URLClassLoader
 from cucumber.api.cli import Main
 
 cl = URLClassLoader([File(cucumber_jython_shaded_path).toURL()], Main.getClassLoader())
-Thread.currentThread().contextClassLoader = cl
 
 exitstatus = Main.run(sys.argv[1:], cl)
 sys.exit(exitstatus)


### PR DESCRIPTION
This PR turns the summary printing into a plugin, [as discussed on the mailing list](https://groups.google.com/forum/#!searchin/cukes/[JVM]$20Control$20over$20the$20error$20summary$20printing./cukes/BZaKvrmdH9c/CnMPzWHAnKQJ). Two built-in summary printer plugins are created,
 - `default_summary` which basically gives the same summary output as today, and 
 - `null_summary` which gives no output at al

Inspired by Cucumber-Ruby, the `default_summary` is extended (compared to the current behaviour), with the listing of failed scenarios. Or to be precise the listing of the scenarios that makes the exit code non-zero, that is in strict mode also undefined and pending scenarios are listed.

The different supported plugin types are separated into different categories internally, to be able to detect when to add default formatter. The [current code](https://github.com/cucumber/cucumber-jvm/blob/master/core/src/main/java/cucumber/runtime/RuntimeOptions.java#L84-L85) is not entirely correct, if a StepDefinitionsReporter is added when the runtime options first is parsed (and not Formatter/Reporter plugin is also added), no Formatter/Reporter will exist during the execution. 