### PR TITLE
Move the deployment to the after_success phase on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ jdk:
 matrix:
   include:
   - jdk: oraclejdk7
-    script: mvn -q install
-    after_success: mvn -q deploy --settings .travis-settings.xml -Dno.gem.deploy=true -DskipTests=true -Dmaven.javadoc.skip=true
+    script: mvn -q deploy --settings .travis-settings.xml -Dno.gem.deploy=true -DdeployAtEnd=true
   - jdk: oraclejdk8
     script: mvn -q install -P java8
     after_success: mvn -q deploy -P java8 -pl java8 --settings .travis-settings.xml -DskipTests=true -Dmaven.javadoc.skip=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 ---
 language: java
+# skip the default install (mvn install -DskipTests=true) to speed up the build
+install: true
 script: mvn -q install -P examples
 jdk:
 - openjdk7
 matrix:
   include:
   - jdk: oraclejdk7
-    script: mvn verify
-    after_success: mvn deploy --settings .travis-settings.xml -Dno.gem.deploy=true -DskipTests=true -Dmaven.javadoc.skip=true
+    script: mvn -q install
+    after_success: mvn -q deploy --settings .travis-settings.xml -Dno.gem.deploy=true -DskipTests=true -Dmaven.javadoc.skip=true
   - jdk: oraclejdk8
-    script: mvn verify -P java8
-    after_success: mvn deploy -P java8 -pl java8 --settings .travis-settings.xml -DskipTests=true -Dmaven.javadoc.skip=true
+    script: mvn -q install -P java8
+    after_success: mvn -q deploy -P java8 -pl java8 --settings .travis-settings.xml -DskipTests=true -Dmaven.javadoc.skip=true
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ jdk:
 matrix:
   include:
   - jdk: oraclejdk7
-    script: mvn -q deploy --settings .travis-settings.xml -Dno.gem.deploy=true
+    script: mvn verify
+    after_success: mvn deploy --settings .travis-settings.xml -Dno.gem.deploy=true -DskipTests=true -Dmaven.javadoc.skip=true
   - jdk: oraclejdk8
-    script: mvn -q deploy -P java8 -pl java8 --settings .travis-settings.xml -Dno.gem.deploy=true
+    script: mvn verify -P java8
+    after_success: mvn deploy -P java8 -pl java8 --settings .travis-settings.xml -DskipTests=true -Dmaven.javadoc.skip=true
 
 branches:
   only:


### PR DESCRIPTION
The benefits are that only if the test for all modules passes are the modules deployed, and that the tests for all modules are also executed on Java8. 