### PR TITLE
Set a description for Scenario Outline scenarios.

### DIFF
--- a/core/src/main/java/cucumber/runtime/model/CucumberExamples.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberExamples.java
@@ -25,7 +25,7 @@ public class CucumberExamples {
         List<ExamplesTableRow> rows = examples.getRows();
         List<Tag> tags = new ArrayList<Tag>(tagsAndInheritedTags());
         for (int i = 1; i < rows.size(); i++) {
-            exampleScenarios.add(cucumberScenarioOutline.createExampleScenario(rows.get(0), rows.get(i), tags));
+            exampleScenarios.add(cucumberScenarioOutline.createExampleScenario(rows.get(0), rows.get(i), tags, examples.getDescription()));
         }
         return exampleScenarios;
     }

--- a/core/src/main/java/cucumber/runtime/model/CucumberScenarioOutline.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberScenarioOutline.java
@@ -52,11 +52,12 @@ public class CucumberScenarioOutline extends CucumberTagStatement {
         format(formatter);
     }
 
-    CucumberScenario createExampleScenario(ExamplesTableRow header, ExamplesTableRow example, List<Tag> examplesTags) {
+    CucumberScenario createExampleScenario(ExamplesTableRow header, ExamplesTableRow example, List<Tag> examplesTags, String examplesDescription) {
         // Make sure we replace the tokens in the name of the scenario
         String exampleScenarioName = replaceTokens(new HashSet<Integer>(), header.getCells(), example.getCells(), getGherkinModel().getName());
+        String exampleScenarioDescription = createExampleScenarioDescription(getGherkinModel().getDescription(), examplesDescription);
 
-        Scenario exampleScenario = new Scenario(example.getComments(), examplesTags, getGherkinModel().getKeyword(), exampleScenarioName, "", example.getLine(), example.getId());
+        Scenario exampleScenario = new Scenario(example.getComments(), examplesTags, getGherkinModel().getKeyword(), exampleScenarioName, exampleScenarioDescription, example.getLine(), example.getId());
         CucumberScenario cucumberScenario = new CucumberScenario(cucumberFeature, cucumberBackground, exampleScenario, example);
         for (Step step : getSteps()) {
             cucumberScenario.step(createExampleStep(step, header, example));
@@ -122,5 +123,17 @@ public class CucumberScenarioOutline extends CucumberTagStatement {
             }
         }
         return text;
+    }
+
+    private String createExampleScenarioDescription(String scenarioOutlineDescription, String examplesDescription) {
+        if (!examplesDescription.isEmpty()) {
+            if (!scenarioOutlineDescription.isEmpty()) {
+                return scenarioOutlineDescription + ", " + examplesDescription;
+            } else {
+                return examplesDescription;
+            }
+        } else {
+            return scenarioOutlineDescription;
+        }
     }
 }

--- a/core/src/test/java/cucumber/runtime/model/CucumberExamplesTest.java
+++ b/core/src/test/java/cucumber/runtime/model/CucumberExamplesTest.java
@@ -1,5 +1,6 @@
 package cucumber.runtime.model;
 
+import cucumber.runtime.TestHelper;
 import gherkin.formatter.model.Comment;
 import gherkin.formatter.model.Examples;
 import gherkin.formatter.model.ExamplesTableRow;
@@ -9,6 +10,7 @@ import gherkin.formatter.model.Step;
 import gherkin.formatter.model.Tag;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -49,4 +51,58 @@ public class CucumberExamplesTest {
         assertEquals("I have 5 cukes in my belly", step.getName());
     }
 
+    @Test
+    public void should_concatenate_outline_description_and_examples_description() throws IOException {
+        CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
+                "Feature: feature name\n" +
+                "  Scenario Outline: outline name\n" +
+                "  outline description\n" +
+                "    Given first step\n" +
+                "    Examples: examples name\n "+
+                "    examples description\n" +
+                "      | dummy |\n" +
+                "      |   1   |\n");
+        CucumberScenarioOutline cso = (CucumberScenarioOutline) feature.getFeatureElements().get(0);
+        CucumberExamples cucumberExamples = cso.getCucumberExamplesList().get(0);
+
+        List<CucumberScenario> exampleScenarios = cucumberExamples.createExampleScenarios();
+
+        assertEquals("outline description, examples description", exampleScenarios.get(0).getGherkinModel().getDescription());
+    }
+
+    @Test
+    public void should_use_outline_description_when_examples_description_is_empty() throws IOException {
+        CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
+                "Feature: feature name\n" +
+                "  Scenario Outline: outline name\n" +
+                "  outline description\n" +
+                "    Given first step\n" +
+                "    Examples: examples name\n "+
+                "      | dummy |\n" +
+                "      |   1   |\n");
+        CucumberScenarioOutline cso = (CucumberScenarioOutline) feature.getFeatureElements().get(0);
+        CucumberExamples cucumberExamples = cso.getCucumberExamplesList().get(0);
+
+        List<CucumberScenario> exampleScenarios = cucumberExamples.createExampleScenarios();
+
+        assertEquals("outline description", exampleScenarios.get(0).getGherkinModel().getDescription());
+    }
+
+    @Test
+    public void should_use_examples_description_when_outline_description_is_empty() throws IOException {
+        CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
+                "Feature: feature name\n" +
+                "  Scenario Outline: outline name\n" +
+                "    Given first step\n" +
+                "    Examples: examples name\n "+
+                "    examples description\n" +
+                "      | dummy |\n" +
+                "      |   1   |\n");
+        CucumberScenarioOutline cso = (CucumberScenarioOutline) feature.getFeatureElements().get(0);
+        CucumberExamples cucumberExamples = cso.getCucumberExamplesList().get(0);
+
+        List<CucumberScenario> exampleScenarios = cucumberExamples.createExampleScenarios();
+
+        assertEquals("examples description", exampleScenarios.get(0).getGherkinModel().getDescription());
+    }
 }

--- a/core/src/test/java/cucumber/runtime/model/CucumberScenarioOutlineTest.java
+++ b/core/src/test/java/cucumber/runtime/model/CucumberScenarioOutlineTest.java
@@ -102,7 +102,7 @@ public class CucumberScenarioOutlineTest {
 
         // ... then the Cukes implementation
         CucumberScenarioOutline cukeOutline = new CucumberScenarioOutline(null, null, outline);
-        CucumberScenario exampleScenario = cukeOutline.createExampleScenario(new ExamplesTableRow(C, asList("LOCATION_NAME"), 1, ""), new ExamplesTableRow(C, asList("London"), 1, ""), T);
+        CucumberScenario exampleScenario = cukeOutline.createExampleScenario(new ExamplesTableRow(C, asList("LOCATION_NAME"), 1, ""), new ExamplesTableRow(C, asList("London"), 1, ""), T, "");
 
         assertEquals("Time offset check for London", exampleScenario.getGherkinModel().getName());
     }  


### PR DESCRIPTION
Currently the description of an example scenario created from a Scenario Outline is empty. Both Scenario Outlines and Examples tables can have a description. This PR sets the description for an example scenario created from a Scenario Outline to:
 * the concatenation of these description - if they both exists,
 * the one that to exist - if only one of them exists,
 * the empty string - if none of them exists.

Fixes #837.