### PR TITLE
Update Java8StepDefinition.java

### DIFF
--- a/java/src/main/java/cucumber/runtime/java/Java8StepDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/Java8StepDefinition.java
@@ -65,7 +65,7 @@ public class Java8StepDefinition implements StepDefinition {
 
     @Override
     public Integer getParameterCount() {
-        return pattern.matcher("").groupCount();
+        return parameterInfos.size();
     }
 
     @Override

--- a/java/src/test/java/cucumber/runtime/java/Java8StepDefinitionTest.java
+++ b/java/src/test/java/cucumber/runtime/java/Java8StepDefinitionTest.java
@@ -1,0 +1,37 @@
+package cucumber.runtime.java;
+
+import java.util.regex.Pattern;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import cucumber.api.java8.StepdefBody;
+
+public class Java8StepDefinitionTest {
+
+    private Java8StepDefinition java8StepDefinition;
+
+    @Test
+    public void should_calculate_parameters_count_by_using_only_step_method_parameters_definition() throws Exception {
+        java8StepDefinition = new Java8StepDefinition(Pattern.compile("^I have (\\d) some step (.*)$"), 0, oneParamStep(), null);
+        Assert.assertEquals(new Integer(1), java8StepDefinition.getParameterCount());
+
+        java8StepDefinition = new Java8StepDefinition(Pattern.compile("^I have some step $"), 0, twoParamStep(), null);
+        Assert.assertEquals(new Integer(2), java8StepDefinition.getParameterCount());
+    }
+
+    private StepdefBody oneParamStep() {
+        return new StepdefBody.A1<String>() {
+            public void accept(String p1) {
+            }
+        };
+    }
+
+    private StepdefBody twoParamStep() {
+        return new StepdefBody.A2<String, String>() {
+            public void accept(String p1, String p2) {
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
I have Arity mismatch error when using Java8 step definitions.
Looking at class Java8StepDefinition, I saw that could be solved by returning parameterCounter like JavaStepDefinition actually does. Simple:  return parameterInfos.size();