### PR TITLE
Allow the ability to have failed scenarios retried immediately by passin...

### DIFF
--- a/core/src/main/java/cucumber/api/CucumberOptions.java
+++ b/core/src/main/java/cucumber/api/CucumberOptions.java
@@ -64,4 +64,9 @@ public @interface CucumberOptions {
      * @return what format should the snippets use. underscore, camelcase
      */
     SnippetType snippets() default SnippetType.UNDERSCORE;
+
+    /**
+     * @return the number of times a scenario should be retried
+     */
+    String[] retryScenario() default {};
 }

--- a/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
@@ -7,6 +7,7 @@ import cucumber.runtime.io.MultiLoader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.lang.Integer;
 
 import static java.util.Arrays.asList;
 
@@ -15,6 +16,8 @@ public class RuntimeOptionsFactory {
     private boolean featuresSpecified = false;
     private boolean glueSpecified = false;
     private boolean pluginSpecified = false;
+    private int retry;
+
 
     public RuntimeOptionsFactory(Class clazz) {
         this.clazz = clazz;
@@ -40,6 +43,7 @@ public class RuntimeOptionsFactory {
                 addSnippets(options, args);
                 addGlue(options, args);
                 addFeatures(options, args);
+                addRetryScenario(options);
             }
         }
         addDefaultFeaturePathIfNoFeaturePathIsSpecified(args, clazz);
@@ -127,13 +131,18 @@ public class RuntimeOptionsFactory {
         }
     }
 
-
     private void addStrict(CucumberOptions options, List<String> args) {
         if (options.strict()) {
             args.add("--strict");
         }
     }
-
+   
+    private void addRetryScenario(CucumberOptions options) {
+        for (String retry : options.retryScenario()) {
+            this.retry = Integer.parseInt(retry);
+        }
+    }
+ 
     static String packagePath(Class clazz) {
         return packagePath(packageName(clazz.getName()));
     }
@@ -158,5 +167,9 @@ public class RuntimeOptionsFactory {
 
     private CucumberOptions getOptions(Class<?> clazz) {
         return clazz.getAnnotation(CucumberOptions.class);
+    }
+  
+    public int getRetry() {
+        return retry;
     }
 }

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
@@ -134,6 +134,19 @@ public class RuntimeOptionsFactoryTest {
         assertTrue(pluginName + " not found among the plugins", found);
     }
 
+    @Test
+    public void create_with_retry_scenario() throws Exception {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(retryScenario.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+        assertTrue(runtimeOptions.getRetryScenario().equals("2"));
+    }
+
+    @Test
+    public void create_with_retry_scenario() throws Exception {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(emptyRetryScenario.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+        assertTrue(runtimeOptions.getRetryScenario().isEmpty());
+    }
 
     @CucumberOptions(snippets = SnippetType.CAMELCASE)
     static class Snippets {
@@ -196,4 +209,14 @@ public class RuntimeOptionsFactoryTest {
     static class ClassWithNoSummaryPrinterPlugin {
         // empty
     }
+
+    @CucumberOptions(retry = {"2"})
+    static class retryScenario {
+        // empty
+    }
+
+    static class emptyRetryScenario {
+        // empty
+    }
+
 }

--- a/testng/src/main/java/cucumber/api/testng/TestNGCucumberRunner.java
+++ b/testng/src/main/java/cucumber/api/testng/TestNGCucumberRunner.java
@@ -20,9 +20,11 @@ import java.util.List;
 public class TestNGCucumberRunner {
     private Runtime runtime;
     private RuntimeOptions runtimeOptions;
+    private RuntimeOptionsFactory runtimeOptionsFactory;
     private ResourceLoader resourceLoader;
     private FeatureResultListener resultListener;
     private ClassLoader classLoader;
+    private int retry;
 
     /**
      * Bootstrap the cucumber runtime
@@ -35,6 +37,7 @@ public class TestNGCucumberRunner {
 
         RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(clazz);
         runtimeOptions = runtimeOptionsFactory.create();
+        retry = runtimeOptionsFactory.getRetry();
 
         TestNgReporter reporter = new TestNgReporter(System.out);
         ClassFinder classFinder = new ResourceLoaderClassFinder(resourceLoader, classLoader);
@@ -60,10 +63,17 @@ public class TestNGCucumberRunner {
 
     public void runCucumber(CucumberFeature cucumberFeature) {
         resultListener.startFeature();
-        cucumberFeature.run(
-                runtimeOptions.formatter(classLoader),
-                resultListener,
-                runtime);
+        if (retry > 0) {
+            cucumberFeature.run(
+                    runtimeOptions.formatter(classLoader),
+                    resultListener,
+                    runtime, retry);
+        } else { 
+            cucumberFeature.run(
+                    runtimeOptions.formatter(classLoader),
+                    resultListener,
+                    runtime);
+        }
 
         if (!resultListener.isPassed()) {
             throw new CucumberException(resultListener.getFirstError());


### PR DESCRIPTION
...g in a value for the 'retryScenario' parameter via @CucumberOptions:

@CucumberOptions(
                format={"pretty", "html:target/cucumber"},
                features={"src/test/resources"},
                retryScenario={"2"}
        )

Failures are listened for at the scenario level by passing a FeatureResultListener and retry value to CucumberFeature.run