### PR TITLE
Add --add-plugin option and clobber when --plugin is used

### DIFF
--- a/core/src/main/resources/cucumber/api/cli/USAGE.txt
+++ b/core/src/main/resources/cucumber/api/cli/USAGE.txt
@@ -4,13 +4,16 @@ Options:
 
   -g, --glue PATH                        Where glue code (step definitions, hooks
                                          and plugins) are loaded from.
-  -p, --plugin PLUGIN[:PATH_OR_URL]      Register a plugin.
+  -p, --[add-]plugin PLUGIN[:PATH_OR_URL]
+                                         Register a plugin.
                                          Built-in formatter PLUGIN types: junit,
                                          html, pretty, progress, json, usage, rerun,
                                          testng. Built-in summary PLUGIN types:
                                          default_summary, null_summary. PLUGIN can
                                          also be a fully qualified class name, allowing
                                          registration of 3rd party plugins.
+                                         --add-plugin does not clobber plugins of that 
+                                         type defined from a different source.
   -f, --format FORMAT[:PATH_OR_URL]      Deprecated. Use --plugin instead.
   -t, --tags TAG_EXPRESSION              Only run scenarios tagged with tags matching
                                          TAG_EXPRESSION.

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -245,6 +245,51 @@ public class RuntimeOptionsTest {
     }
 
     @Test
+    public void clobbers_formatter_plugins_from_cli_if_formatters_specified_in_cucumber_options_property() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--plugin pretty");
+        RuntimeOptions options = new RuntimeOptions(new Env(properties), asList("--plugin", "html:some/dir", "--glue", "somewhere"));
+        assertPluginExists(options.getPlugins(), "cucumber.runtime.formatter.CucumberPrettyFormatter");
+        assertPluginNotExists(options.getPlugins(), "cucumber.runtime.formatter.HTMLFormatter");
+    }
+
+    @Test
+    public void adds_to_formatter_plugins_with_add_plugin_option() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--add-plugin pretty");
+        RuntimeOptions options = new RuntimeOptions(new Env(properties), asList("--plugin", "html:some/dir", "--glue", "somewhere"));
+        assertPluginExists(options.getPlugins(), "cucumber.runtime.formatter.HTMLFormatter");
+        assertPluginExists(options.getPlugins(), "cucumber.runtime.formatter.CucumberPrettyFormatter");
+    }
+
+    @Test
+    public void clobbers_summary_plugins_from_cli_if_summary_printer_specified_in_cucumber_options_property() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--plugin default_summary");
+        RuntimeOptions options = new RuntimeOptions(new Env(properties), asList("--plugin", "null_summary", "--glue", "somewhere"));
+        assertPluginExists(options.getPlugins(), "cucumber.runtime.DefaultSummaryPrinter");
+        assertPluginNotExists(options.getPlugins(), "cucumber.runtime.NullSummaryPrinter");
+    }
+
+    @Test
+    public void adds_to_summary_plugins_with_add_plugin_option() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--add-plugin default_summary");
+        RuntimeOptions options = new RuntimeOptions(new Env(properties), asList("--plugin", "null_summary", "--glue", "somewhere"));
+        assertPluginExists(options.getPlugins(), "cucumber.runtime.NullSummaryPrinter");
+        assertPluginExists(options.getPlugins(), "cucumber.runtime.DefaultSummaryPrinter");
+    }
+
+    @Test
+    public void does_not_clobber_plugins_of_different_type_when_specifying_plugins_in_cucumber_options_property() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--plugin default_summary");
+        RuntimeOptions options = new RuntimeOptions(new Env(properties), asList("--plugin", "pretty", "--glue", "somewhere"));
+        assertPluginExists(options.getPlugins(), "cucumber.runtime.formatter.CucumberPrettyFormatter");
+        assertPluginExists(options.getPlugins(), "cucumber.runtime.DefaultSummaryPrinter");
+    }
+
+    @Test
     public void allows_removal_of_strict_in_cucumber_options_property() {
         Properties properties = new Properties();
         properties.setProperty("cucumber.options", "--no-strict");


### PR DESCRIPTION
When using --plugin the plugins of that type defined from a different source is clobbered. Using -Dcucumber.options="--plugin pretty" would clobber the formatter/reporter plugins defined in `@CucumberOptions`. --add-plugin does not clobber any plugins defined from a different
source.

The rational for this PR is both consistency, other list type options do clobber, and it enables some use cases not possible today:
* forcing one specific formatter to write to stdout on the CI system even when the users have specified another formatter to write to stdout in the `@CucumberOptions` ([mailing list post](https://groups.google.com/d/msg/cukes/8bZd6dWnSwc/9nF0st9bkmYJ))