### PR TITLE
Make the Rerun Formatter consistent with the exit code

### DIFF
--- a/core/src/test/java/cucumber/runtime/formatter/RerunFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/RerunFormatterTest.java
@@ -19,21 +19,43 @@ import static org.junit.Assert.assertEquals;
 public class RerunFormatterTest {
 
     @Test
-    public void should_leave_report_empty_when_no_scenario_fails() throws Throwable {
+    public void should_leave_report_empty_when_exit_code_is_zero() throws Throwable {
         CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
                 "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    Given first step\n" +
-                "    When second step\n" +
-                "    Then third step\n");
+                "  Scenario: passed scenario\n" +
+                "    Given passed step\n" +
+                "  Scenario: pending scenario\n" +
+                "    Given pending step\n" +
+                "  Scenario: undefined scenario\n" +
+                "    Given undefined step\n");
         Map<String, Result> stepsToResult = new HashMap<String, Result>();
-        stepsToResult.put("first step", result("passed"));
-        stepsToResult.put("second step", result("passed"));
-        stepsToResult.put("third step", result("passed"));
+        stepsToResult.put("passed step", result("passed"));
+        stepsToResult.put("pending step", result("pending"));
+        stepsToResult.put("undefined step", result("undefined"));
 
         String formatterOutput = runFeatureWithRerunFormatter(feature, stepsToResult);
 
         assertEquals("", formatterOutput);
+    }
+
+    @Test
+    public void should_put_data_in_report_when_exit_code_is_non_zero() throws Throwable {
+        CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
+                "Feature: feature name\n" +
+                "  Scenario: failed scenario\n" +
+                "    Given failed step\n" +
+                "  Scenario: pending scenario\n" +
+                "    Given pending step\n" +
+                "  Scenario: undefined scenario\n" +
+                "    Given undefined step\n");
+        Map<String, Result> stepsToResult = new HashMap<String, Result>();
+        stepsToResult.put("failed step", result("failed"));
+        stepsToResult.put("pending step", result("pending"));
+        stepsToResult.put("undefined step", result("undefined"));
+
+        String formatterOutput = runFeatureWithRerunFormatter(feature, stepsToResult, strict(true));
+
+        assertEquals("path/test.feature:2:4:6", formatterOutput);
     }
 
     @Test
@@ -180,26 +202,42 @@ public class RerunFormatterTest {
 
     private String runFeatureWithRerunFormatter(final CucumberFeature feature, final Map<String, Result> stepsToResult)
             throws Throwable {
-        return runFeatureWithRerunFormatter(feature, stepsToResult, Collections.<SimpleEntry<String, Result>>emptyList());
+        return runFeatureWithRerunFormatter(feature, stepsToResult, Collections.<SimpleEntry<String, Result>>emptyList(), false);
+    }
+
+    private String runFeatureWithRerunFormatter(final CucumberFeature feature, final Map<String, Result> stepsToResult, boolean isStrict)
+            throws Throwable {
+        return runFeatureWithRerunFormatter(feature, stepsToResult, Collections.<SimpleEntry<String, Result>>emptyList(), isStrict);
     }
 
     private String runFeatureWithRerunFormatter(final CucumberFeature feature, final Map<String, Result> stepsToResult,
                                                 final List<SimpleEntry<String, Result>> hooks) throws Throwable {
-        return runFeaturesWithRerunFormatter(Arrays.asList(feature), stepsToResult, hooks);
+        return runFeaturesWithRerunFormatter(Arrays.asList(feature), stepsToResult, hooks, strict(false));
+    }
+
+    private String runFeatureWithRerunFormatter(final CucumberFeature feature, final Map<String, Result> stepsToResult,
+                                                final List<SimpleEntry<String, Result>> hooks, boolean isStrict) throws Throwable {
+        return runFeaturesWithRerunFormatter(Arrays.asList(feature), stepsToResult, hooks, isStrict);
     }
 
     private String runFeaturesWithRerunFormatter(final List<CucumberFeature> features, final Map<String, Result> stepsToResult)
             throws Throwable {
-        return runFeaturesWithRerunFormatter(features, stepsToResult, Collections.<SimpleEntry<String, Result>>emptyList());
+        return runFeaturesWithRerunFormatter(features, stepsToResult, Collections.<SimpleEntry<String, Result>>emptyList(), strict(false));
     }
 
     private String runFeaturesWithRerunFormatter(final List<CucumberFeature> features, final Map<String, Result> stepsToResult,
-            final List<SimpleEntry<String, Result>> hooks) throws Throwable {
+            final List<SimpleEntry<String, Result>> hooks, boolean isStrict) throws Throwable {
         final StringBuffer buffer = new StringBuffer();
         final RerunFormatter rerunFormatter = new RerunFormatter(buffer);
+        if (isStrict) {
+            rerunFormatter.setStrict(isStrict);
+        }
         final long stepHookDuration = 0;
         TestHelper.runFeaturesWithFormatter(features, stepsToResult, hooks, stepHookDuration, rerunFormatter, rerunFormatter);
         return buffer.toString();
     }
 
+    private boolean strict(boolean value) {
+        return value;
+    }
 }


### PR DESCRIPTION
I think the invariant for the behaviour of the Rerun Formatter should be:
When the exit code is zero => the Rerun formatter output is empty
When the exit code is non-zero => the Rerun formatter output is not empty

This PR changes the behaviour the Rerun Formatter to fulfil this invariant.