### PR TITLE
Cucumber is ready to run in OSGi containers

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -86,6 +86,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                         <manifest>
                             <mainClass>cucumber.api.cli.Main</mainClass>
                         </manifest>
@@ -98,6 +99,23 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>-Duser.language=en</argLine>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-Description></Bundle-Description>
+                        <Export-Package>cucumber.*</Export-Package>
+                        <Import-Package>
+                            *,
+                            cucumber.deps.com.thoughtworks.xstream.converters.extended,
+                            cucumber.deps.com.thoughtworks.xstream.converters.enums,
+                            cucumber.deps.com.thoughtworks.xstream.converters.basic
+                        </Import-Package>
+                    </instructions>
                 </configuration>
             </plugin>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -109,12 +109,7 @@
                     <instructions>
                         <Bundle-Description></Bundle-Description>
                         <Export-Package>cucumber.*</Export-Package>
-                        <Import-Package>
-                            *,
-                            cucumber.deps.com.thoughtworks.xstream.converters.extended,
-                            cucumber.deps.com.thoughtworks.xstream.converters.enums,
-                            cucumber.deps.com.thoughtworks.xstream.converters.basic
-                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -14,6 +14,8 @@ import gherkin.formatter.Formatter;
 import gherkin.formatter.Reporter;
 import gherkin.util.FixJava;
 
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -27,7 +29,9 @@ import static cucumber.runtime.model.CucumberFeature.load;
 // IMPORTANT! Make sure USAGE.txt is always uptodate if this class changes.
 public class RuntimeOptions {
     public static final String VERSION = ResourceBundle.getBundle("cucumber.version").getString("cucumber-jvm.version");
-    public static final String USAGE = FixJava.readResource("/cucumber/api/cli/USAGE.txt");
+    public static final String USAGE_RESOURCE = "/cucumber/api/cli/USAGE.txt";
+
+    static String usageText;
 
     private final List<String> glue = new ArrayList<String>();
     private final List<Object> filters = new ArrayList<Object>();
@@ -187,7 +191,19 @@ public class RuntimeOptions {
     }
 
     private void printUsage() {
-        System.out.println(USAGE);
+        loadUsageTextIfNeeded();
+        System.out.println(usageText);
+    }
+
+    static void loadUsageTextIfNeeded() {
+        if (usageText == null) {
+            try {
+                Reader reader = new InputStreamReader(FixJava.class.getResourceAsStream(USAGE_RESOURCE), "UTF-8");
+                usageText = FixJava.readReader(reader);
+            } catch (Exception e) {
+                usageText = "Could not load usage text: " + e.toString();
+            }
+        }
     }
 
     private int printI18n(String language) {

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -47,7 +47,8 @@ public class RuntimeOptionsTest {
 
     @Test
     public void has_usage() {
-        assertTrue(RuntimeOptions.USAGE.startsWith("Usage"));
+        RuntimeOptions.loadUsageTextIfNeeded();
+        assertTrue(RuntimeOptions.usageText.startsWith("Usage"));
     }
 
     @Test

--- a/examples/pax-exam/calculator-api/pom.xml
+++ b/examples/pax-exam/calculator-api/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>info.cukes</groupId>
+        <artifactId>pax-exam</artifactId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.2.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pax-exam-calculator-api</artifactId>
+    <packaging>bundle</packaging>
+    <name>Examples: Pax Exam: Calculator API</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>cucumber.examples.java.paxexam</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/pax-exam/calculator-api/src/main/java/cucumber/examples/java/paxexam/CalculatorService.java
+++ b/examples/pax-exam/calculator-api/src/main/java/cucumber/examples/java/paxexam/CalculatorService.java
@@ -1,0 +1,7 @@
+package cucumber.examples.java.paxexam;
+
+public interface CalculatorService {
+
+    int add(int a, int b);
+
+}

--- a/examples/pax-exam/calculator-service/pom.xml
+++ b/examples/pax-exam/calculator-service/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>info.cukes</groupId>
+        <artifactId>pax-exam</artifactId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.2.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pax-exam-calculator-service</artifactId>
+    <packaging>bundle</packaging>
+    <name>Examples: Pax Exam: Calculator Service</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>pax-exam-calculator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Activator>cucumber.examples.java.paxexam.service.Activator</Bundle-Activator>
+                        <Private-Package>cucumber.examples.java.paxexam.service</Private-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/pax-exam/calculator-service/src/main/java/cucumber/examples/java/paxexam/service/Activator.java
+++ b/examples/pax-exam/calculator-service/src/main/java/cucumber/examples/java/paxexam/service/Activator.java
@@ -1,0 +1,25 @@
+package cucumber.examples.java.paxexam.service;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+import cucumber.examples.java.paxexam.CalculatorService;
+
+public class Activator implements BundleActivator {
+
+    private volatile ServiceRegistration<CalculatorService> serviceRegistration;
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        serviceRegistration = context.registerService(CalculatorService.class, new CalculatorServiceImpl(), null);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        if (serviceRegistration != null) {
+            serviceRegistration.unregister();
+            serviceRegistration = null;
+        }
+    }
+}

--- a/examples/pax-exam/calculator-service/src/main/java/cucumber/examples/java/paxexam/service/CalculatorServiceImpl.java
+++ b/examples/pax-exam/calculator-service/src/main/java/cucumber/examples/java/paxexam/service/CalculatorServiceImpl.java
@@ -1,0 +1,12 @@
+package cucumber.examples.java.paxexam.service;
+
+import cucumber.examples.java.paxexam.CalculatorService;
+
+public class CalculatorServiceImpl implements CalculatorService {
+
+    @Override
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+}

--- a/examples/pax-exam/calculator-test/features/calculator.feature
+++ b/examples/pax-exam/calculator-test/features/calculator.feature
@@ -1,0 +1,12 @@
+Feature: Calculate a result
+
+  Scenario Outline: Add two numbers
+    Given I set a to <num1>
+    Given I set b to <num2>
+    When I call the calculator service
+    Then the result is <result>
+
+    Examples:
+      | num1 | num2 | result |
+      | 9    | 8    | 17     |
+      | 5    | 4    | 9      |

--- a/examples/pax-exam/calculator-test/pom.xml
+++ b/examples/pax-exam/calculator-test/pom.xml
@@ -1,0 +1,75 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>info.cukes</groupId>
+        <artifactId>pax-exam</artifactId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.2.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pax-exam-calculator-test</artifactId>
+    <packaging>jar</packaging>
+    <name>Examples: Pax Exam: Calculator Test</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>pax-exam-calculator-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>pax-exam-calculator-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-osgi</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-container-native</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-link-mvn</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.url</groupId>
+            <artifactId>pax-url-aether</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.framework</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/examples/pax-exam/calculator-test/src/test/java/cucumber/examples/java/paxexam/test/CalculatorSteps.java
+++ b/examples/pax-exam/calculator-test/src/test/java/cucumber/examples/java/paxexam/test/CalculatorSteps.java
@@ -1,0 +1,44 @@
+package cucumber.examples.java.paxexam.test;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.inject.Inject;
+
+import cucumber.api.java.Before;
+import cucumber.api.java.en.When;
+import cucumber.examples.java.paxexam.CalculatorService;
+
+public class CalculatorSteps {
+
+    @Inject
+    private CalculatorService calculatorService;
+
+    private int a, b, result;
+
+    @Before
+    public void before() {
+        a = 0;
+        b = 0;
+        result = 0;
+    }
+
+    @When("^I set a to (\\d+)$")
+    public void i_set_a_to(int v) throws Throwable {
+        a = v;
+    }
+
+    @When("^I set b to (\\d+)$")
+    public void i_set_b_to(int v) throws Throwable {
+        b = v;
+    }
+
+    @When("^I call the calculator service$")
+    public void i_call_the_calculator_service() throws Throwable {
+        result = calculatorService.add(a, b);
+    }
+
+    @When("^the result is (\\d+)$")
+    public void the_result_is(int expected) throws Throwable {
+        assertEquals(expected, result);
+    }
+}

--- a/examples/pax-exam/calculator-test/src/test/java/cucumber/examples/java/paxexam/test/CalculatorTest.java
+++ b/examples/pax-exam/calculator-test/src/test/java/cucumber/examples/java/paxexam/test/CalculatorTest.java
@@ -1,0 +1,93 @@
+package cucumber.examples.java.paxexam.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+import java.util.Collections;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+import org.ops4j.pax.exam.util.Injector;
+import org.osgi.framework.BundleContext;
+
+import cucumber.api.CucumberOptions;
+import cucumber.java.runtime.osgi.OsgiClassFinder;
+import cucumber.java.runtime.osgi.PaxExamObjectFactory;
+import cucumber.runtime.Backend;
+import cucumber.runtime.ClassFinder;
+import cucumber.runtime.CucumberException;
+import cucumber.runtime.Runtime;
+import cucumber.runtime.RuntimeOptions;
+import cucumber.runtime.RuntimeOptionsFactory;
+import cucumber.runtime.io.FileResourceLoader;
+import cucumber.runtime.io.ResourceLoader;
+import cucumber.runtime.java.JavaBackend;
+import cucumber.runtime.java.ObjectFactory;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+@CucumberOptions(features = "features")
+public class CalculatorTest {
+
+    @Inject
+    private Injector injector;
+
+    @Inject
+    private BundleContext bundleContext;
+
+    @Configuration
+    public Option[] config() {
+
+        return options(
+            mavenBundle("info.cukes", "pax-exam-calculator-api"),
+            mavenBundle("info.cukes", "pax-exam-calculator-service"),
+
+            mavenBundle("info.cukes", "gherkin"),
+            mavenBundle("info.cukes", "cucumber-jvm-deps", "1.0.4-SNAPSHOT"),
+            mavenBundle("info.cukes", "cucumber-core"),
+            mavenBundle("info.cukes", "cucumber-java"),
+            mavenBundle("info.cukes", "cucumber-osgi"),
+
+            mavenBundle("org.slf4j", "slf4j-api"),
+            mavenBundle("ch.qos.logback", "logback-core"),
+            mavenBundle("ch.qos.logback", "logback-classic"),
+
+            junitBundles()
+        );
+    }
+
+    @Test
+    public void cucumber() throws Exception {
+        assertNotNull(injector);
+        assertNotNull(bundleContext);
+        final ResourceLoader resourceLoader = new FileResourceLoader();
+        final ClassLoader classLoader = Runtime.class.getClassLoader();
+        final ObjectFactory objectFactory = new PaxExamObjectFactory(injector);
+        final ClassFinder classFinder = new OsgiClassFinder(bundleContext);
+        final Backend backend = new JavaBackend(objectFactory, classFinder);
+
+        final RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(getClass());
+        final RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+
+        final Runtime runtime = new Runtime(resourceLoader, classLoader, Collections.singleton(backend), runtimeOptions);
+
+        runtime.run();
+
+        if (!runtime.getErrors().isEmpty()) {
+            throw new CucumberException(runtime.getErrors().get(0));
+        } else if (runtime.exitStatus() != 0x00) {
+            throw new CucumberException("There are pending or undefined steps.");
+        }
+        assertEquals(runtime.getErrors().size(), 0);
+    }
+}

--- a/examples/pax-exam/pom.xml
+++ b/examples/pax-exam/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>info.cukes</groupId>
+        <artifactId>cucumber-jvm</artifactId>
+        <relativePath>../../pom.xml</relativePath>
+        <version>1.2.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>pax-exam</artifactId>
+    <packaging>pom</packaging>
+    <name>Examples: Pax Exam</name>
+
+    <modules>
+        <module>calculator-api</module>
+        <module>calculator-service</module>
+        <module>calculator-test</module>
+    </modules>
+</project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -137,6 +137,26 @@ I18n.all.each { i18n ->
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Description></Bundle-Description>
+                        <Export-Package>cucumber.*</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -43,4 +43,28 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Description></Bundle-Description>
+                        <Export-Package>cucumber.*</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -1,0 +1,95 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>info.cukes</groupId>
+        <artifactId>cucumber-jvm</artifactId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.2.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cucumber-osgi</artifactId>
+    <packaging>jar</packaging>
+    <name>Cucumber-JVM: OSGi</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-jvm-deps</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>gherkin</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.cobertura</groupId>
+            <artifactId>cobertura</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Description></Bundle-Description>
+                        <Export-Package>cucumber.*</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/osgi/src/main/java/cucumber/api/osgi/Filter.java
+++ b/osgi/src/main/java/cucumber/api/osgi/Filter.java
@@ -1,0 +1,17 @@
+package cucumber.api.osgi;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = { ElementType.FIELD })
+@Retention(value = RetentionPolicy.RUNTIME)
+@Documented
+public @interface Filter {
+
+    String value() default "";
+
+    long timeout() default 0;
+}

--- a/osgi/src/main/java/cucumber/api/osgi/ServiceNotFoundException.java
+++ b/osgi/src/main/java/cucumber/api/osgi/ServiceNotFoundException.java
@@ -1,0 +1,20 @@
+package cucumber.api.osgi;
+
+public class ServiceNotFoundException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public ServiceNotFoundException() {
+    }
+
+    public ServiceNotFoundException(String message) {
+        super(message);
+    }
+
+    public ServiceNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public ServiceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/osgi/src/main/java/cucumber/api/osgi/TimeoutException.java
+++ b/osgi/src/main/java/cucumber/api/osgi/TimeoutException.java
@@ -1,0 +1,20 @@
+package cucumber.api.osgi;
+
+public class TimeoutException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public TimeoutException() {
+    }
+
+    public TimeoutException(String message) {
+        super(message);
+    }
+
+    public TimeoutException(Throwable cause) {
+        super(cause);
+    }
+
+    public TimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/osgi/src/main/java/cucumber/java/runtime/osgi/OsgiClassFinder.java
+++ b/osgi/src/main/java/cucumber/java/runtime/osgi/OsgiClassFinder.java
@@ -1,0 +1,74 @@
+package cucumber.java.runtime.osgi;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cucumber.runtime.ClassFinder;
+
+public class OsgiClassFinder implements ClassFinder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OsgiClassFinder.class);
+
+    private final BundleContext bundleContext;
+
+    public OsgiClassFinder(BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+
+    @Override
+    public <T> Collection<Class<? extends T>> getDescendants(Class<T> parentType, String packageName) {
+        if (LOGGER.isDebugEnabled())
+            LOGGER.debug("Looking for sub classes of " + parentType.getName() + " in '" + packageName + "' package");
+
+        final String searchPath = packageName.replace('.', '/');
+
+        final ArrayList<Class<? extends T>> result = new ArrayList<Class<? extends T>>();;
+        for (Bundle bundle : bundleContext.getBundles()) {
+            try {
+                result.addAll(findClassesInBundle(bundle, searchPath, parentType));
+            } catch (Exception e) {
+                LOGGER.error("Failed to inspect bundle " + bundle.getSymbolicName() + ": " + e.getMessage(), e);
+            }
+        }
+        result.trimToSize();
+        return result;
+    }
+
+    private <T> Collection<Class<? extends T>> findClassesInBundle(Bundle bundle, String searchPath, Class<T> parentType) {
+        final Collection<Class<? extends T>> result = new ArrayList<Class<? extends T>>();
+        final Enumeration<URL> resources = bundle.findEntries(searchPath, "*.class", true);
+        if (resources == null)
+            return Collections.emptyList();
+        for (URL url : Collections.list(resources)) {
+            final String className = pathToClassName(url.getPath());
+            try {
+                final Class<? extends T> castClass = loadClassFromBundle(parentType, bundle, className);
+                if (castClass != null)
+                    result.add(castClass);
+            } catch (Exception e) {
+                LOGGER.error("Failed to load class " + className, e);
+            }
+        }
+        return result;
+    }
+
+    private <T> Class<? extends T> loadClassFromBundle(Class<T> parentType, Bundle bundle, String className) throws ClassNotFoundException {
+        final Class<?> clazz = bundle.loadClass(className);
+        if (clazz != null && !parentType.equals(clazz) && parentType.isAssignableFrom(clazz)) {
+            return clazz.asSubclass(parentType);
+        }
+        return null;
+    }
+
+    private static String pathToClassName(final String path) {
+        return path.substring(1, path.length() - 6).replace('/', '.');
+    }
+}

--- a/osgi/src/main/java/cucumber/java/runtime/osgi/OsgiObjectFactory.java
+++ b/osgi/src/main/java/cucumber/java/runtime/osgi/OsgiObjectFactory.java
@@ -1,0 +1,112 @@
+package cucumber.java.runtime.osgi;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+
+import javax.inject.Inject;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+
+import cucumber.api.osgi.Filter;
+import cucumber.api.osgi.ServiceNotFoundException;
+import cucumber.api.osgi.TimeoutException;
+
+public class OsgiObjectFactory extends OsgiObjectFactoryBase {
+
+    private BundleContext bundleContext;
+
+    public OsgiObjectFactory(BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+    }
+
+    @Override
+    protected void prepareGlueInstance(Object instance) {
+        injectFields(instance);
+    }
+
+    public void injectFields(Object target) {
+        for (   Class<?> targetClass = target.getClass();
+                targetClass != Object.class;
+                targetClass = targetClass.getSuperclass()) {
+
+            injectDeclaredFields(target, targetClass);
+        }
+    }
+
+    private void injectDeclaredFields(Object target, Class<?> targetClass) {
+        for (Field field : targetClass.getDeclaredFields()) {
+            if (field.getAnnotation(Inject.class) != null) {
+                injectField(target, targetClass, field);
+            }
+        }
+    }
+
+    private void injectField(Object target, Class<?> targetClass, Field field) {
+        Class<?> type = field.getType();
+        long timeout = 500;
+        String filterString = "";
+
+        final Filter filter = field.getAnnotation(Filter.class);
+        if (filter != null) {
+            filterString = filter.value();
+            if (filter.timeout() != 0)
+                timeout = filter.timeout();
+        }
+
+        // Retrieve bundle Context just before calling getService to avoid that the bundle restarts
+        // in between
+        final Object service = (BundleContext.class == type) ?
+                bundleContext : getService(type, timeout, filterString);
+        setField(target, field, service);
+    }
+
+    private void setField(Object target, Field field, Object service) {
+        try {
+            final boolean accessible = field.isAccessible();
+
+            if (!accessible) field.setAccessible(true);
+
+            try {
+                field.set(target, service);
+            }
+            finally {
+                if (!accessible) field.setAccessible(false);
+            }
+        }
+        catch (IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Object getService(Class<?> type, long timeout, String filter) {
+        final String serviceName = type.getName() + " " + filter;
+
+        try {
+            final long tryUntil = System.currentTimeMillis() + timeout;
+            Object service = null;
+            search : while (service == null) {
+                final Collection<?> serviceReferences = bundleContext.getServiceReferences(type, filter.isEmpty() ? null : filter);
+
+                for (Object serviceReference : serviceReferences) {
+                    service = bundleContext.getService((ServiceReference<?>) serviceReference);
+                    break search;
+                }
+
+                if (tryUntil < System.currentTimeMillis())
+                    break;
+
+                Thread.sleep(20);
+            }
+
+            if (service == null)
+                throw new ServiceNotFoundException(serviceName);
+            return service;
+        } catch (InvalidSyntaxException e) {
+            throw new IllegalArgumentException(e);
+        } catch (InterruptedException e) {
+            throw new TimeoutException(serviceName);
+        }
+    }
+}

--- a/osgi/src/main/java/cucumber/java/runtime/osgi/OsgiObjectFactoryBase.java
+++ b/osgi/src/main/java/cucumber/java/runtime/osgi/OsgiObjectFactoryBase.java
@@ -1,0 +1,51 @@
+package cucumber.java.runtime.osgi;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Map;
+
+import cucumber.runtime.CucumberException;
+import cucumber.runtime.java.ObjectFactory;
+
+public abstract class OsgiObjectFactoryBase implements ObjectFactory {
+    private final Map<Class<?>, Object> instances = new HashMap<Class<?>, Object>();
+
+    @Override
+    public void start() {
+        // No-op
+    }
+
+    @Override
+    public void stop() {
+        instances.clear();
+    }
+
+    @Override
+    public void addClass(Class<?> glueClass) {
+    }
+
+    @Override
+    public <T> T getInstance(Class<T> glueClass) {
+        T instance = glueClass.cast(instances.get(glueClass));
+        if (instance == null) {
+            instance = cacheNewInstance(glueClass);
+            prepareGlueInstance(instance);
+        }
+        return instance;
+    }
+
+    protected abstract void prepareGlueInstance(Object instance);
+
+    private <T> T cacheNewInstance(Class<T> type) {
+        try {
+            Constructor<T> constructor = type.getConstructor();
+            T instance = constructor.newInstance();
+            instances.put(type, instance);
+            return instance;
+        } catch (NoSuchMethodException e) {
+            throw new CucumberException(String.format("%s doesn't have an empty constructor. If you need DI, put cucumber-picocontainer on the classpath", type), e);
+        } catch (Exception e) {
+            throw new CucumberException(String.format("Failed to instantiate %s", type), e);
+        }
+    }
+}

--- a/osgi/src/main/java/cucumber/java/runtime/osgi/PaxExamObjectFactory.java
+++ b/osgi/src/main/java/cucumber/java/runtime/osgi/PaxExamObjectFactory.java
@@ -1,0 +1,17 @@
+package cucumber.java.runtime.osgi;
+
+import org.ops4j.pax.exam.util.Injector;
+
+public class PaxExamObjectFactory extends OsgiObjectFactoryBase {
+
+    private Injector injector;
+
+    public PaxExamObjectFactory(Injector injector) {
+        this.injector = injector;
+    }
+
+    @Override
+    protected void prepareGlueInstance(Object instance) {
+        injector.injectFields(instance);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -828,6 +828,21 @@
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>1.3.1.2</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>2.3.7</version>
+                    <extensions>true</extensions>
+                    <executions>
+                        <execution>
+                          <id>bundle-manifest</id>
+                          <phase>process-classes</phase>
+                          <goals>
+                            <goal>manifest</goal>
+                          </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,10 @@
         <jetty.version>8.1.12.v20130726</jetty.version>
         <xmlunit.version>1.6</xmlunit.version>
         <joda-time.version>2.7</joda-time.version>
+        <osgi.version>4.3.1</osgi.version>
+        <pax-exam.version>4.3.0</pax-exam.version>
+        <pax-url.version>2.2.0</pax-url.version>
+        <felix.version>4.0.3</felix.version>
     </properties>
     <licenses>
         <license>
@@ -90,7 +94,7 @@
             <dependency>
                 <groupId>info.cukes</groupId>
                 <artifactId>cucumber-jvm-deps</artifactId>
-                <version>1.0.3</version>
+                <version>1.0.4-SNAPSHOT</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.thoughtworks.xstream</groupId>
@@ -120,6 +124,11 @@
             <dependency>
                 <groupId>info.cukes</groupId>
                 <artifactId>cucumber-spring</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cukes</groupId>
+                <artifactId>cucumber-osgi</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -273,12 +282,22 @@
 
             <dependency>
                 <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
                 <version>${logback.version}</version>
             </dependency>
             <dependency>
@@ -468,6 +487,42 @@
                 <artifactId>joda-time</artifactId>
                 <version>${joda-time.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.core</artifactId>
+                <version>${osgi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam-container-native</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam-junit4</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ops4j.pax.exam</groupId>
+                <artifactId>pax-exam-link-mvn</artifactId>
+                <version>${pax-exam.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ops4j.pax.url</groupId>
+                <artifactId>pax-url-aether</artifactId>
+                <version>${pax-url.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.framework</artifactId>
+                <version>${felix.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -506,6 +561,7 @@
         <module>jruby</module>
         <module>jython</module>
         <module>spring</module>
+        <module>osgi</module>
         <module>guice</module>
         <module>weld</module>
         <module>groovy</module>
@@ -552,6 +608,7 @@
                 <module>examples/groovy-calculator</module>
                 <module>examples/scala-calculator</module>
                 <module>examples/java-webbit-websockets-selenium</module>
+                <module>examples/pax-exam</module>
             </modules>
         </profile>
 


### PR DESCRIPTION
This is an upgraded version of pull request of #799 

My changes include:

* Adds OSGi headers to core, java and JUnit bundles.
* Changed loading of the USAGE.txt in RuntimeOptions, because due to OSGi class loading cause problems. I wrote more details in the commit message.
* Pax Exam example is included.

*NOTE*: Please release cucumber-jvm-deps with my other pull request (see https://github.com/cucumber/cucumber-jvm-deps/pull/3), because this changes make only sense when the jvm-deps bundle has also OSGi headers.

Thank you!
