### PR TITLE
Fix spelling of "isolated"

### DIFF
--- a/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
+++ b/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
@@ -2,6 +2,6 @@ Feature: Java8
   Scenario: use the API with Java8 style
     Given I have 42 cukes in my belly
 
-  Scenario: another scenario which should have isloated state
+  Scenario: another scenario which should have isolated state
     Given I have 42 cukes in my belly
     And something that isn't defined


### PR DESCRIPTION
Tiny, but annoying bug in the Java 8 test feature