### PR TITLE
Make sure that example versions are updated during release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,8 @@ Then, make sure you have the proper keys set up - in your `~/.m2/settings.xml` -
 Replace version numbers in:
 
 * examples/java-gradle/build.gradle
+* examples/android/android-studio/Cukeulator/app/build.gradle
+* examples/clojure_cukes/project.clj
 * History.md
 
 Make sure you can generate Javadocs for all modules, or else the

--- a/pom.xml
+++ b/pom.xml
@@ -614,12 +614,24 @@
         <profile>
             <id>release-sign-artifacts</id>
             <modules>
-                <module>android</module>
+                <module>examples/java-wicket</module>
+                <module>examples/java-wicket/java-wicket-main</module>
+                <module>examples/java-wicket/java-wicket-test</module>
                 <module>examples/spring-txn</module>
+                <module>examples/clojure_cukes</module>
                 <module>examples/java-calculator</module>
+                <module>examples/java-calculator-testng</module>
                 <module>examples/groovy-calculator</module>
                 <module>examples/scala-calculator</module>
                 <module>examples/java-webbit-websockets-selenium</module>
+                <module>examples/pax-exam</module>
+                <module>examples/pax-exam/calculator-api</module>
+                <module>examples/pax-exam/calculator-service</module>
+                <module>examples/pax-exam/calculator-test</module>
+                <module>examples/android</module>
+                <module>examples/android/android-test</module>
+                <module>examples/android/cukeulator</module>
+                <module>examples/android/cukeulator-test</module>
             </modules>
             <activation>
                 <property>


### PR DESCRIPTION
Currently only some of the examples modules get their versions updated during a release. This will eventually make the openjdk7 job on Travis start to fail (when the snaphot versions for the latest release is no longer available from sonatype). To me it looks like it is the example modules that are in the release-sign-artifacts profile that get their versions updated during a release, therefore add all example modules are in the profile release-sign-artifacts.

The android module is removed from the profile release-sign-artifacts, I think that was only necessary when the android module was in a separate android profile.

Also add reminder in Contributing.md to update to the files in the example modules that specify the latest released version.