### PR TITLE
Tear down test in case TestNG groups a set

### DIFF
--- a/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
+++ b/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
@@ -29,7 +29,7 @@ public abstract class AbstractTestNGCucumberTests {
         return testNGCucumberRunner.provideFeatures();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDownClass() throws Exception {
         testNGCucumberRunner.finish();
     }


### PR DESCRIPTION
AbstractTestNGCucumberTests did not call tearDownClass in case TestNG groups are present.
Fixed by setting alwaysRun property on AfterClass annotation to true. This conforms to BeforeClass behaviour.