### PR TITLE
Change filePath test to be platform independent

### DIFF
--- a/core/src/test/java/cucumber/runtime/io/HelpersTest.java
+++ b/core/src/test/java/cucumber/runtime/io/HelpersTest.java
@@ -25,7 +25,9 @@ public class HelpersTest {
     @Test
     public void computes_file_path_for_file_url() throws UnsupportedEncodingException, MalformedURLException {
         URL url = new URL("file:/Users/First%20Last/.m2/repository/info/cukes/cucumber-java/1.2.2/cucumber-java-1.2.2.jar");
-        assertEquals(new File("/Users/First Last/.m2/repository/info/cukes/cucumber-java/1.2.2/cucumber-java-1.2.2.jar").getAbsolutePath(), filePath(url));
+        File fileFromFilePath = new File(filePath(url));
+        File expectedFile = new File("/Users/First Last/.m2/repository/info/cukes/cucumber-java/1.2.2/cucumber-java-1.2.2.jar");
+        assertEquals(expectedFile, fileFromFilePath);
     }
 
     @Test


### PR DESCRIPTION
* File#getAbsolutePath produced different result in each platform,
which caused failed test case, particularly in Windows
* File#equals does test the path for equality with the given object