### PR TITLE
Java8 standard function interfaces

### DIFF
--- a/java/src/main/java/cucumber/api/java8/HookBody.java
+++ b/java/src/main/java/cucumber/api/java8/HookBody.java
@@ -1,7 +1,0 @@
-package cucumber.api.java8;
-
-import cucumber.api.Scenario;
-
-public interface HookBody {
-    void accept(Scenario scenario);
-}

--- a/java/src/main/java/cucumber/api/java8/HookNoArgsBody.java
+++ b/java/src/main/java/cucumber/api/java8/HookNoArgsBody.java
@@ -1,5 +1,0 @@
-package cucumber.api.java8;
-
-public interface HookNoArgsBody {
-    void accept();
-}

--- a/java/src/main/java/cucumber/runtime/java/Java8HookDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/Java8HookDefinition.java
@@ -1,14 +1,13 @@
 package cucumber.runtime.java;
 
 import cucumber.api.Scenario;
-import cucumber.api.java8.HookBody;
-import cucumber.api.java8.HookNoArgsBody;
 import cucumber.runtime.HookDefinition;
 import cucumber.runtime.Timeout;
 import gherkin.TagExpression;
 import gherkin.formatter.model.Tag;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 
 import static java.util.Arrays.asList;
 
@@ -16,11 +15,11 @@ public class Java8HookDefinition implements HookDefinition {
     private final TagExpression tagExpression;
     private final int order;
     private final long timeoutMillis;
-    private final HookNoArgsBody hookNoArgsBody;
-    private final HookBody hookBody;
+    private final Runnable hookNoArgsBody;
+    private final Consumer<Scenario> hookBody;
     private final StackTraceElement location;
 
-    private Java8HookDefinition(String[] tagExpressions, int order, long timeoutMillis, HookBody hookBody, HookNoArgsBody hookNoArgsBody) {
+    private Java8HookDefinition(String[] tagExpressions, int order, long timeoutMillis, Consumer<Scenario> hookBody, Runnable hookNoArgsBody) {
         this.order = order;
         this.timeoutMillis = timeoutMillis;
         this.tagExpression = new TagExpression(asList(tagExpressions));
@@ -29,11 +28,11 @@ public class Java8HookDefinition implements HookDefinition {
         this.location = new Exception().getStackTrace()[3];
     }
 
-    public Java8HookDefinition(String[] tagExpressions, int order, long timeoutMillis, HookBody hookBody) {
+    public Java8HookDefinition(String[] tagExpressions, int order, long timeoutMillis, Consumer<Scenario> hookBody) {
         this(tagExpressions, order, timeoutMillis, hookBody, null);
     }
 
-    public Java8HookDefinition(String[] tagExpressions, int order, long timeoutMillis, HookNoArgsBody hookNoArgsBody) {
+    public Java8HookDefinition(String[] tagExpressions, int order, long timeoutMillis, Runnable hookNoArgsBody) {
         this(tagExpressions, order, timeoutMillis, null, hookNoArgsBody);
     }
 
@@ -50,7 +49,7 @@ public class Java8HookDefinition implements HookDefinition {
                 if (hookBody != null) {
                     hookBody.accept(scenario);
                 } else {
-                    hookNoArgsBody.accept();
+                    hookNoArgsBody.run();
                 }
                 return null;
 

--- a/java/src/main/java/cucumber/runtime/java/JavaBackend.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaBackend.java
@@ -1,11 +1,10 @@
 package cucumber.runtime.java;
 
+import cucumber.api.Scenario;
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
 import cucumber.api.java.ObjectFactory;
 import cucumber.api.java8.GlueBase;
-import cucumber.api.java8.HookBody;
-import cucumber.api.java8.HookNoArgsBody;
 import cucumber.api.java8.StepdefBody;
 import cucumber.runtime.Backend;
 import cucumber.runtime.ClassFinder;
@@ -28,6 +27,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import static cucumber.runtime.io.MultiLoader.packageName;
@@ -181,19 +181,19 @@ public class JavaBackend implements Backend {
         }
     }
 
-    public void addBeforeHookDefinition(String[] tagExpressions, long timeoutMillis, int order, HookBody body) {
+    public void addBeforeHookDefinition(String[] tagExpressions, long timeoutMillis, int order, Consumer<Scenario> body) {
         glue.addBeforeHook(new Java8HookDefinition(tagExpressions, order, timeoutMillis, body));
     }
 
-    public void addAfterHookDefinition(String[] tagExpressions, long timeoutMillis, int order, HookBody body) {
+    public void addAfterHookDefinition(String[] tagExpressions, long timeoutMillis, int order, Consumer<Scenario> body) {
         glue.addAfterHook(new Java8HookDefinition(tagExpressions, order, timeoutMillis, body));
     }
 
-    public void addBeforeHookDefinition(String[] tagExpressions, long timeoutMillis, int order, HookNoArgsBody body) {
+    public void addBeforeHookDefinition(String[] tagExpressions, long timeoutMillis, int order, Runnable body) {
         glue.addBeforeHook(new Java8HookDefinition(tagExpressions, order, timeoutMillis, body));
     }
 
-    public void addAfterHookDefinition(String[] tagExpressions, long timeoutMillis, int order, HookNoArgsBody body) {
+    public void addAfterHookDefinition(String[] tagExpressions, long timeoutMillis, int order, Runnable body) {
         glue.addAfterHook(new Java8HookDefinition(tagExpressions, order, timeoutMillis, body));
     }
 

--- a/java8/src/main/java/cucumber/runtime/java8/LambdaGlueBase.java
+++ b/java8/src/main/java/cucumber/runtime/java8/LambdaGlueBase.java
@@ -1,9 +1,10 @@
 package cucumber.runtime.java8;
 
+import cucumber.api.Scenario;
 import cucumber.api.java8.GlueBase;
-import cucumber.api.java8.HookBody;
-import cucumber.api.java8.HookNoArgsBody;
 import cucumber.runtime.java.JavaBackend;
+
+import java.util.function.Consumer;
 
 public interface LambdaGlueBase extends GlueBase {
 
@@ -12,83 +13,83 @@ public interface LambdaGlueBase extends GlueBase {
     int DEFAULT_BEFORE_ORDER = 0;
     int DEFAULT_AFTER_ORDER = 1000;
 
-    default void Before(final HookBody body) {
+    default void Before(final Consumer<Scenario> body) {
         JavaBackend.INSTANCE.get().addBeforeHookDefinition(EMPTY_TAG_EXPRESSIONS, NO_TIMEOUT, DEFAULT_BEFORE_ORDER, body);
     }
 
-    default void Before(String[] tagExpressions, final HookBody body) {
+    default void Before(String[] tagExpressions, final Consumer<Scenario> body) {
         JavaBackend.INSTANCE.get().addBeforeHookDefinition(tagExpressions, NO_TIMEOUT, DEFAULT_BEFORE_ORDER, body);
     }
 
-    default void Before(long timeoutMillis, final HookBody body) {
+    default void Before(long timeoutMillis, final Consumer<Scenario> body) {
         JavaBackend.INSTANCE.get().addBeforeHookDefinition(EMPTY_TAG_EXPRESSIONS, timeoutMillis, DEFAULT_BEFORE_ORDER, body);
     }
 
-    default void Before(int order, final HookBody body) {
+    default void Before(int order, final Consumer<Scenario> body) {
         JavaBackend.INSTANCE.get().addBeforeHookDefinition(EMPTY_TAG_EXPRESSIONS, NO_TIMEOUT, order, body);
     }
 
-    default void Before(String[] tagExpressions, long timeoutMillis, int order, final HookBody body) {
+    default void Before(String[] tagExpressions, long timeoutMillis, int order, final Consumer<Scenario> body) {
         JavaBackend.INSTANCE.get().addBeforeHookDefinition(tagExpressions, timeoutMillis, order, body);
     }
 
-    default void Before(final HookNoArgsBody body) {
+    default void Before(final Runnable body) {
         JavaBackend.INSTANCE.get().addBeforeHookDefinition(EMPTY_TAG_EXPRESSIONS, NO_TIMEOUT, DEFAULT_BEFORE_ORDER, body);
     }
 
-    default void Before(String[] tagExpressions, final HookNoArgsBody body) {
+    default void Before(String[] tagExpressions, final Runnable body) {
         JavaBackend.INSTANCE.get().addBeforeHookDefinition(tagExpressions, NO_TIMEOUT, DEFAULT_BEFORE_ORDER, body);
     }
 
-    default void Before(long timeoutMillis, final HookNoArgsBody body) {
+    default void Before(long timeoutMillis, final Runnable body) {
         JavaBackend.INSTANCE.get().addBeforeHookDefinition(EMPTY_TAG_EXPRESSIONS, timeoutMillis, DEFAULT_BEFORE_ORDER, body);
     }
 
-    default void Before(int order, final HookNoArgsBody body) {
+    default void Before(int order, final Runnable body) {
         JavaBackend.INSTANCE.get().addBeforeHookDefinition(EMPTY_TAG_EXPRESSIONS, NO_TIMEOUT, order, body);
     }
 
-    default void Before(String[] tagExpressions, long timeoutMillis, int order, final HookNoArgsBody body) {
+    default void Before(String[] tagExpressions, long timeoutMillis, int order, final Runnable body) {
         JavaBackend.INSTANCE.get().addBeforeHookDefinition(tagExpressions, timeoutMillis, order, body);
     }
 
-    default void After(final HookBody body) {
+    default void After(final Consumer<Scenario> body) {
         JavaBackend.INSTANCE.get().addAfterHookDefinition(EMPTY_TAG_EXPRESSIONS, NO_TIMEOUT, DEFAULT_AFTER_ORDER, body);
     }
 
-    default void After(String[] tagExpressions, final HookBody body) {
+    default void After(String[] tagExpressions, final Consumer<Scenario> body) {
         JavaBackend.INSTANCE.get().addAfterHookDefinition(tagExpressions, NO_TIMEOUT, DEFAULT_AFTER_ORDER, body);
     }
 
-    default void After(long timeoutMillis, final HookBody body) {
+    default void After(long timeoutMillis, final Consumer<Scenario> body) {
         JavaBackend.INSTANCE.get().addAfterHookDefinition(EMPTY_TAG_EXPRESSIONS, timeoutMillis, DEFAULT_AFTER_ORDER, body);
     }
 
-    default void After(int order, final HookBody body) {
+    default void After(int order, final Consumer<Scenario> body) {
         JavaBackend.INSTANCE.get().addAfterHookDefinition(EMPTY_TAG_EXPRESSIONS, NO_TIMEOUT, order, body);
     }
 
-    default void After(String[] tagExpressions, long timeoutMillis, int order, final HookBody body) {
+    default void After(String[] tagExpressions, long timeoutMillis, int order, final Consumer<Scenario> body) {
         JavaBackend.INSTANCE.get().addAfterHookDefinition(tagExpressions, timeoutMillis, order, body);
     }
 
-    default void After(final HookNoArgsBody body) {
+    default void After(final Runnable body) {
         JavaBackend.INSTANCE.get().addAfterHookDefinition(EMPTY_TAG_EXPRESSIONS, NO_TIMEOUT, DEFAULT_AFTER_ORDER, body);
     }
 
-    default void After(String[] tagExpressions, final HookNoArgsBody body) {
+    default void After(String[] tagExpressions, final Runnable body) {
         JavaBackend.INSTANCE.get().addAfterHookDefinition(tagExpressions, NO_TIMEOUT, DEFAULT_AFTER_ORDER, body);
     }
 
-    default void After(long timeoutMillis, final HookNoArgsBody body) {
+    default void After(long timeoutMillis, final Runnable body) {
         JavaBackend.INSTANCE.get().addAfterHookDefinition(EMPTY_TAG_EXPRESSIONS, timeoutMillis, DEFAULT_AFTER_ORDER, body);
     }
 
-    default void After(int order, final HookNoArgsBody body) {
+    default void After(int order, final Runnable body) {
         JavaBackend.INSTANCE.get().addAfterHookDefinition(EMPTY_TAG_EXPRESSIONS, NO_TIMEOUT, order, body);
     }
 
-    default void After(String[] tagExpressions, long timeoutMillis, int order, final HookNoArgsBody body) {
+    default void After(String[] tagExpressions, long timeoutMillis, int order, final Runnable body) {
         JavaBackend.INSTANCE.get().addAfterHookDefinition(tagExpressions, timeoutMillis, order, body);
     }
 }

--- a/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
+++ b/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
@@ -18,10 +18,97 @@ public class LambdaStepdefs implements En {
             lastInstance = this;
         });
 
+        // No-arg lambda is also OK.
+        Before(() -> {});
+
         Given("^this data table:$", (DataTable peopleTable) -> {
             List<Person> people = peopleTable.asList(Person.class);
             assertEquals("Hellesøy", people.get(0).last);
         });
+
+        // Arity steps
+        Given("0 args",
+              () -> {});
+
+        Given("1 arg: (.)",
+              (String arg1) -> {
+                  assertEquals("a", arg1);
+              });
+
+        Given("2 args: (.) (.)",
+              (String arg1, String arg2) -> {
+                  assertEquals("a", arg1);
+                  assertEquals("b", arg2);
+              });
+
+        Given("3 args: (.) (.) (.)",
+              (String arg1, String arg2, String arg3) -> {
+                  assertEquals("a", arg1);
+                  assertEquals("b", arg2);
+                  assertEquals("c", arg3);
+              });
+
+        Given("4 args: (.) (.) (.) (.)",
+              (String arg1, String arg2, String arg3, String arg4) -> {
+                  assertEquals("a", arg1);
+                  assertEquals("b", arg2);
+                  assertEquals("c", arg3);
+                  assertEquals("d", arg4);
+              });
+
+        Given("5 args: (.) (.) (.) (.) (.)",
+              (String arg1, String arg2, String arg3, String arg4, String arg5) -> {
+                  assertEquals("a", arg1);
+                  assertEquals("b", arg2);
+                  assertEquals("c", arg3);
+                  assertEquals("d", arg4);
+                  assertEquals("e", arg5);
+              });
+
+        Given("6 args: (.) (.) (.) (.) (.) (.)",
+              (String arg1, String arg2, String arg3, String arg4, String arg5, String arg6) -> {
+                  assertEquals("a", arg1);
+                  assertEquals("b", arg2);
+                  assertEquals("c", arg3);
+                  assertEquals("d", arg4);
+                  assertEquals("e", arg5);
+                  assertEquals("f", arg6);
+              });
+
+        Given("7 args: (.) (.) (.) (.) (.) (.) (.)",
+              (String arg1, String arg2, String arg3, String arg4, String arg5, String arg6, String arg7) -> {
+                  assertEquals("a", arg1);
+                  assertEquals("b", arg2);
+                  assertEquals("c", arg3);
+                  assertEquals("d", arg4);
+                  assertEquals("e", arg5);
+                  assertEquals("f", arg6);
+              });
+
+        Given("8 args: (.) (.) (.) (.) (.) (.) (.) (.)",
+              (String arg1, String arg2, String arg3, String arg4, String arg5, String arg6, String arg7,
+               String arg8) -> {
+                  assertEquals("a", arg1);
+                  assertEquals("b", arg2);
+                  assertEquals("c", arg3);
+                  assertEquals("d", arg4);
+                  assertEquals("e", arg5);
+                  assertEquals("f", arg6);
+                  assertEquals("g", arg7);
+              });
+
+        Given("9 args: (.) (.) (.) (.) (.) (.) (.) (.) (.)",
+              (String arg1, String arg2, String arg3, String arg4, String arg5, String arg6, String arg7,
+               String arg8, String arg9) -> {
+                  assertEquals("a", arg1);
+                  assertEquals("b", arg2);
+                  assertEquals("c", arg3);
+                  assertEquals("d", arg4);
+                  assertEquals("e", arg5);
+                  assertEquals("f", arg6);
+                  assertEquals("g", arg7);
+                  assertEquals("h", arg8);
+              });
     }
 
     public static class Person {

--- a/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
+++ b/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
@@ -12,3 +12,15 @@ Feature: Java8
       | first  | last     |
       | Aslak  | Hellesøy |
       | Donald | Duck     |
+
+  Scenario: permute arity
+    Given 0 args
+    And 1 arg: a
+    And 2 args: a b
+    And 3 args: a b c
+    And 4 args: a b c d
+    And 5 args: a b c d e
+    And 6 args: a b c d e f
+    And 7 args: a b c d e f g
+    And 8 args: a b c d e f g h
+    And 9 args: a b c d e f g h i


### PR DESCRIPTION
This PR falls short of the goal of #918 because of the difficulty of preserving the introspection of lambda step definitions.  I believe the goal of supporting functional programming API's like Durian Errors is probably jeopardized by this introspection technique, so the changes would be moot.

This PR does improve Before/After by allowing standard Java8 function types instead of proprietary interfaces.
