### PR TITLE
Integrates JMockit with cucumber-weld

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <junit.version>4.12</junit.version>
         <jython.version>2.7.0</jython.version>
         <mockito.version>1.10.19</mockito.version>
+		<jmockit.version>1.19</jmockit.version>
         <selenium.version>2.45.0</selenium.version>
         <webbit.version>0.4.15</webbit.version>
         <webbit-rest.version>0.3.0</webbit-rest.version>
@@ -156,6 +157,11 @@
             <dependency>
                 <groupId>info.cukes</groupId>
                 <artifactId>cucumber-scala_2.11</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>info.cukes</groupId>
+                <artifactId>cucumber-weld</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -342,6 +348,11 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
+            </dependency>
+			<dependency>
+                <groupId>org.jmockit</groupId>
+                <artifactId>jmockit</artifactId>
+                <version>${jmockit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>
@@ -561,6 +572,7 @@
         <module>osgi</module>
         <module>guice</module>
         <module>weld</module>
+		<module>weld-jmockit</module>
         <module>groovy</module>
         <module>rhino</module>
         <module>openejb</module>

--- a/weld-jmockit/README.md
+++ b/weld-jmockit/README.md
@@ -1,0 +1,30 @@
+# cucumber-weld-jmockit
+cucumber-weld-jmockit provides integration of [JMockit](https://github.com/jmockit/jmockit1) with [Cucumber-Weld](https://github.com/cucumber/cucumber-jvm/tree/master/weld).
+
+To integrate JMockit with cucumber-weld you have two options: either use a CDI extension or an interceptor.
+
+## CDI extension
+To use the CDI extension you can register the extension as a service provider by creating a file named _META-INF/services/javax.enterprise.inject.spi.Extension_, which contains the name of the extension class:
+
+```
+cucumber.runtime.java.weld.jmockit.WeldJMockitExtension
+```
+
+The extension will register an interceptor _(cucumber.runtime.java.weld.jmockit.JMockitInterceptor)_ to all step definitions (glue code) which provides the integration between JMockit, Cucumber and Weld.
+
+## Interceptor
+Alternatively, e.g. in case you do not want to use the CDI extension, you may want to use the interceptor directly. Therefore, simply annotate step definitions (glue code) with _@cucumber.runtime.java.weld.jmockit.WithJMockit_ annotation like so:
+
+```java
+import cucumber.api.java.en.Given;
+import cucumber.runtime.java.weld.jmockit.WithJMockit;
+
+@WithJMockit
+public class Stepdefs {
+
+    @Given("^I have (\\d+) cukes in my belly$")
+    public void I_have_cukes_in_my_belly(int cukes) throws Throwable {
+    }
+
+}
+```

--- a/weld-jmockit/pom.xml
+++ b/weld-jmockit/pom.xml
@@ -1,0 +1,67 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>info.cukes</groupId>
+        <artifactId>cucumber-jvm</artifactId>
+        <relativePath>../pom.xml</relativePath>
+        <version>1.2.5-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cucumber-weld-jmockit</artifactId>
+    <packaging>jar</packaging>
+    <name>Cucumber-JVM: Weld - JMockt Integration</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-weld</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>gherkin</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-jvm-deps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.cobertura</groupId>
+            <artifactId>cobertura</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/weld-jmockit/src/main/java/cucumber/runtime/java/weld/jmockit/AnnotatedTypeProcessor.java
+++ b/weld-jmockit/src/main/java/cucumber/runtime/java/weld/jmockit/AnnotatedTypeProcessor.java
@@ -1,0 +1,37 @@
+package cucumber.runtime.java.weld.jmockit;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+
+import org.jboss.weld.util.annotated.AnnotatedTypeWrapper;
+
+final class AnnotatedTypeProcessor {
+
+	public <T> void process(final ProcessAnnotatedType<T> processAnnotatedType) {
+
+		final AnnotatedType<T> annotatedType = processAnnotatedType.getAnnotatedType();
+
+		if (!Modifier.isFinal(annotatedType.getJavaClass().getModifiers())
+				&& !annotatedType.getJavaClass().equals(JMockitInterceptor.class)) {
+			
+			final Set<Annotation> annotations = new HashSet<Annotation>(annotatedType.getAnnotations());
+			annotations.add(new Annotation() {
+				@Override
+				public Class<? extends Annotation> annotationType() {
+					return WithJMockit.class;
+				}
+			});
+
+			final AnnotatedTypeWrapper<T> wrapper = new AnnotatedTypeWrapper<T>(
+					annotatedType, annotations.toArray(new Annotation[annotations.size()]));
+
+			processAnnotatedType.setAnnotatedType(wrapper);
+		}
+	}
+	
+}

--- a/weld-jmockit/src/main/java/cucumber/runtime/java/weld/jmockit/JMockitInterceptor.java
+++ b/weld-jmockit/src/main/java/cucumber/runtime/java/weld/jmockit/JMockitInterceptor.java
@@ -1,0 +1,69 @@
+package cucumber.runtime.java.weld.jmockit;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import mockit.integration.internal.TestRunnerDecorator;
+import mockit.internal.state.SavePoint;
+import mockit.internal.state.TestRun;
+
+@Interceptor
+@Priority(Interceptor.Priority.LIBRARY_BEFORE)
+@WithJMockit
+public final class JMockitInterceptor extends TestRunnerDecorator {
+
+	private final ThreadLocal<SavePoint> savePoint = new ThreadLocal<SavePoint>();
+	
+	@AroundInvoke
+	public Object intercept(final InvocationContext ctx) throws Exception {
+		final Object result;
+		this.beforeMethod(ctx);
+		try {
+			result = ctx.proceed();
+		} finally {
+			this.afterMethod(ctx);
+		}
+		return result;
+	}
+
+	private void afterMethod(final InvocationContext ctx) {
+
+	      final SavePoint testMethodSavePoint = savePoint.get();
+
+	      if (testMethodSavePoint == null) {
+	         return;
+	      }
+
+	      TestRun.enterNoMockingZone();
+	      
+	      shouldPrepareForNextTest = true;
+	      savePoint.set(null);
+
+	      TestRun.finishCurrentTestExecution();
+	}
+
+	private void beforeMethod(final InvocationContext ctx) {
+		
+		TestRun.clearNoMockingZone();
+
+		TestRun.enterNoMockingZone();
+
+		try {
+			updateTestClassState(ctx.getTarget(), ctx.getTarget().getClass());
+			TestRun.setRunningIndividualTest(ctx.getTarget());
+			final SavePoint testMethodSavePoint = new SavePoint();
+			savePoint.set(testMethodSavePoint);
+			if (shouldPrepareForNextTest) {
+				TestRun.prepareForNextTest();
+				shouldPrepareForNextTest = false;
+			}
+			createInstancesForTestedFields(ctx.getTarget(), false);
+		} finally {
+			TestRun.exitNoMockingZone();
+		}
+
+	}
+
+}

--- a/weld-jmockit/src/main/java/cucumber/runtime/java/weld/jmockit/WeldJMockitExtension.java
+++ b/weld-jmockit/src/main/java/cucumber/runtime/java/weld/jmockit/WeldJMockitExtension.java
@@ -1,0 +1,89 @@
+package cucumber.runtime.java.weld.jmockit;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.WithAnnotations;
+
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.runtime.ClassFinder;
+import cucumber.runtime.io.MultiLoader;
+import cucumber.runtime.io.ResourceLoader;
+import cucumber.runtime.io.ResourceLoaderClassFinder;
+import cucumber.runtime.java.StepDefAnnotation;
+
+public final class WeldJMockitExtension implements Extension {
+
+	private static final String CUCUMBER_API_PACKAGE = "cucumber.api";
+
+	private final Collection<Class<? extends Annotation>> stepDefAnnotationClasses = 
+			new HashSet<Class<? extends Annotation>>();
+	
+	private final AnnotatedTypeProcessor processor = new AnnotatedTypeProcessor();
+		
+	public WeldJMockitExtension() {
+		this.findStepDefAnnotations();
+	}
+	
+	public <T> void processAnnotatedTypeForHooks(
+			@Observes
+			@WithAnnotations( { After.class, Before.class } )
+			final ProcessAnnotatedType<T> processAnnotatedType) {
+		this.processor.process(processAnnotatedType);
+	}
+	
+	public <T> void processAnnotatedTypeGeneric(@Observes final ProcessAnnotatedType<T> processAnnotatedType) {
+		final Iterator<AnnotatedMethod<? super T>> methodsIterator = 
+				processAnnotatedType.getAnnotatedType().getMethods().iterator();
+		
+		while(methodsIterator.hasNext()) {
+			final AnnotatedMethod<? super T> method = methodsIterator.next();
+			if (this.processIfMethodHasStepDefAnnotation(processAnnotatedType, method)) {
+				break;
+			}
+		}
+	}
+	
+	private <T> boolean processIfMethodHasStepDefAnnotation(
+			final ProcessAnnotatedType<T> processAnnotatedType, final AnnotatedMethod<? super T> method) {
+		
+		if (this.isStepDefAnnotationPresent(processAnnotatedType, method)) {
+			this.processor.process(processAnnotatedType);
+			return true;
+		}
+		return false;
+	}
+
+	private <T> boolean isStepDefAnnotationPresent(
+			final ProcessAnnotatedType<T> processAnnotatedType, final AnnotatedMethod<? super T> method) {
+		
+		final Iterator<Class<? extends Annotation>> annotationIterator = this.stepDefAnnotationClasses.iterator();
+		while (annotationIterator.hasNext()) {
+			final Class<? extends Annotation> annotationClass = annotationIterator.next();
+			if (method.isAnnotationPresent(annotationClass)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private void findStepDefAnnotations() {
+		final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		final ResourceLoader resourceLoader = new MultiLoader(classLoader);
+        final ClassFinder classFinder = new ResourceLoaderClassFinder(resourceLoader, classLoader);
+        final Collection<Class<? extends Annotation>> annotations = 
+        		classFinder.getDescendants(Annotation.class, CUCUMBER_API_PACKAGE);
+        for (Class<? extends Annotation> annotationClass : annotations) {
+        	if (annotationClass.isAnnotationPresent(StepDefAnnotation.class)) {
+        		this.stepDefAnnotationClasses.add(annotationClass);
+        	}
+        }
+	}
+}

--- a/weld-jmockit/src/main/java/cucumber/runtime/java/weld/jmockit/WithJMockit.java
+++ b/weld-jmockit/src/main/java/cucumber/runtime/java/weld/jmockit/WithJMockit.java
@@ -1,0 +1,14 @@
+package cucumber.runtime.java.weld.jmockit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithJMockit {
+}

--- a/weld-jmockit/src/main/resources/META-INF/beans.xml
+++ b/weld-jmockit/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+    bean-discovery-mode="all">
+</beans>

--- a/weld-jmockit/src/test/java/cucumber/runtime/java/weld/jmockit/Belly.java
+++ b/weld-jmockit/src/test/java/cucumber/runtime/java/weld/jmockit/Belly.java
@@ -1,0 +1,13 @@
+package cucumber.runtime.java.weld.jmockit;
+
+public class Belly {
+    private int cukes;
+
+    public void setCukes(int cukes) {
+        this.cukes = cukes;
+    }
+
+    public int getCukes() {
+        return cukes;
+    }
+}

--- a/weld-jmockit/src/test/java/cucumber/runtime/java/weld/jmockit/JMockitStepdefs.java
+++ b/weld-jmockit/src/test/java/cucumber/runtime/java/weld/jmockit/JMockitStepdefs.java
@@ -1,0 +1,46 @@
+package cucumber.runtime.java.weld.jmockit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+
+import javax.inject.Singleton;
+
+import mockit.Mocked;
+import mockit.StrictExpectations;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Singleton
+public class JMockitStepdefs {
+
+	final List<Integer> capturedCukes = new ArrayList<Integer>();
+	
+    @Mocked
+    private Belly belly;
+
+    private boolean inTheBelly = false;
+
+    @Given("^I have (\\d+) mocks in my belly")
+    public void haveCukes(int n) {
+    	new StrictExpectations() {{
+    		belly.setCukes(withCapture(capturedCukes));
+    		times = 1;
+    	}};
+        belly.setCukes(n);
+        inTheBelly = true;
+    }
+
+    @Then("^there are (\\d+) mocks in my belly")
+    public void checkCukes(int n) {
+    	new StrictExpectations() {{
+    		belly.getCukes();
+    		times = 1;
+    		result = capturedCukes.get(0);
+    	}};
+        assertEquals(n, belly.getCukes());
+        assertTrue(inTheBelly);
+    }
+}

--- a/weld-jmockit/src/test/java/cucumber/runtime/java/weld/jmockit/RunCukesTest.java
+++ b/weld-jmockit/src/test/java/cucumber/runtime/java/weld/jmockit/RunCukesTest.java
@@ -1,0 +1,9 @@
+package cucumber.runtime.java.weld.jmockit;
+
+import cucumber.api.junit.Cucumber;
+
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+public class RunCukesTest {
+}

--- a/weld-jmockit/src/test/resources/META-INF/beans.xml
+++ b/weld-jmockit/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+	bean-discovery-mode="all">
+</beans>

--- a/weld-jmockit/src/test/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/weld-jmockit/src/test/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+cucumber.runtime.java.weld.jmockit.WeldJMockitExtension

--- a/weld-jmockit/src/test/resources/cucumber/runtime/java/weld/jmockit/jmockit.feature
+++ b/weld-jmockit/src/test/resources/cucumber/runtime/java/weld/jmockit/jmockit.feature
@@ -1,0 +1,5 @@
+Feature: Cukes with JMockit
+
+  Scenario: Eat some mocks
+    Given I have 5 mocks in my belly
+    Then there are 5 mocks in my belly

--- a/weld-jmockit/src/test/resources/org.jboss.weld.executor.properties
+++ b/weld-jmockit/src/test/resources/org.jboss.weld.executor.properties
@@ -1,0 +1,8 @@
+# Workaround for single core machines
+# See:
+# https://groups.google.com/d/topic/cukes/Jw8tKKEts1U/discussion
+# http://in.relation.to/Bloggers/Weld200Alpha2Released
+# https://issues.jboss.org/browse/WELD-1119
+
+# Set this to false if you are on a single-core machine.
+enabled=true


### PR DESCRIPTION
This PR provides a feature to support integration of [JMockit](https://github.com/jmockit/jmockit1) with [Cucumber-Weld](https://github.com/cucumber/cucumber-jvm/tree/master/weld).

To integrate JMockit with cucumber-weld this feature allows to either use a CDI extension or an interceptor.

## CDI extension
To use the CDI extension you can register the extension as a service provider by creating a file named _META-INF/services/javax.enterprise.inject.spi.Extension_, which contains the name of the extension class:

```
cucumber.runtime.java.weld.jmockit.WeldJMockitExtension
```

The extension will register an interceptor _(cucumber.runtime.java.weld.jmockit.JMockitInterceptor)_ to all step definitions (glue code) which provides the integration between JMockit, Cucumber and Weld.

## Interceptor
Alternatively, e.g. in case you do not want to use the CDI extension, you may want to use the interceptor directly. Therefore, simply annotate step definitions (glue code) with _@cucumber.runtime.java.weld.jmockit.WithJMockit_ annotation like so:

```java
import cucumber.api.java.en.Given;
import cucumber.runtime.java.weld.jmockit.WithJMockit;

@WithJMockit
public class Stepdefs {

    @Given("^I have (\\d+) cukes in my belly$")
    public void I_have_cukes_in_my_belly(int cukes) throws Throwable {
    }

}
```