### PR TITLE
[Weld] Document the need for a beans.xml per source root

### DIFF
--- a/weld/src/test/java/cucumber/runtime/java/weld/BellyStepdefs.java
+++ b/weld/src/test/java/cucumber/runtime/java/weld/BellyStepdefs.java
@@ -12,6 +12,10 @@ import static org.junit.Assert.assertTrue;
 @Singleton
 public class BellyStepdefs {
 
+    // For injecting classes from src/test/java, your beans.xml has to be
+    // located in src/test/resources.
+    // If you want to inject classes from src/main/java, you will need an
+    // additional beans.xml in src/main/resources.
     @Inject
     private Belly belly;
 


### PR DESCRIPTION
For injecting classes from `src/main/java` into glue code in `src/test/java`, two `beans.xml` files are required.
This is not trivial and should be documented in order to avoid confusion.

This PR adds documentation about where to place the `beans.xml` for selected injection scenarios.
