### PR TITLE
Cannot close over local variable

### DIFF
--- a/java/src/main/java/cucumber/runtime/java/Java8StepDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/Java8StepDefinition.java
@@ -1,7 +1,11 @@
 package cucumber.runtime.java;
 
 import cucumber.api.java8.StepdefBody;
-import cucumber.runtime.*;
+import cucumber.runtime.CucumberException;
+import cucumber.runtime.JdkPatternArgumentMatcher;
+import cucumber.runtime.ParameterInfo;
+import cucumber.runtime.StepDefinition;
+import cucumber.runtime.Utils;
 import gherkin.I18n;
 import gherkin.formatter.Argument;
 import gherkin.formatter.model.Step;

--- a/java/src/main/java/cucumber/runtime/java/Java8StepDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/Java8StepDefinition.java
@@ -1,26 +1,17 @@
 package cucumber.runtime.java;
 
 import cucumber.api.java8.StepdefBody;
-import cucumber.runtime.CucumberException;
-import cucumber.runtime.JdkPatternArgumentMatcher;
-import cucumber.runtime.ParameterInfo;
-import cucumber.runtime.StepDefinition;
-import cucumber.runtime.Utils;
+import cucumber.runtime.*;
 import gherkin.I18n;
 import gherkin.formatter.Argument;
 import gherkin.formatter.model.Step;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.toList;
 
 public class Java8StepDefinition implements StepDefinition {
 

--- a/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
+++ b/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
@@ -1,8 +1,10 @@
 package cucumber.runtime.java8.test;
 
 import cucumber.api.DataTable;
+import cucumber.api.PendingException;
 import cucumber.api.Scenario;
 import cucumber.api.java8.En;
+import cucumber.api.java8.StepdefBody;
 
 import java.util.List;
 
@@ -17,10 +19,13 @@ public class LambdaStepdefs implements En {
             assertNotSame(this, lastInstance);
             lastInstance = this;
         });
-
         Given("^this data table:$", (DataTable peopleTable) -> {
             List<Person> people = peopleTable.asList(Person.class);
             assertEquals("Hellesøy", people.get(0).last);
+        });
+        Integer alreadyHadThisManyCukes = 1;
+        Given("^I have 42 cukes in my belly$", () -> {
+            assertEquals((Integer) 1, alreadyHadThisManyCukes);
         });
     }
 


### PR DESCRIPTION
This is a reproducing test and suggested fix for issue #916. The problem turned out to be that the information read out of the ConstantPool didn't actually represent the type signature of the lambda class when we had closed over local variables.

I also saw issue #912 which is related to that the constant pool interface isn't uniform or stable, so I decided to try to avoid it altogether.

So instead of trying to deduce the type signature of the body class, I look at the concrete types of the "accept" method parameters. I'm not sure if this is equivalent to the old method and if there are some cases which it doesn't cover, but at least all tests are passing in the project.

This fix also leads to the TypeIntrospector being unused, but I didn't remove it in the pull request to avoid cluttering.