### PR TITLE
Mod ConstantPoolTypeIntrospector to disregard closed variables

### DIFF
--- a/java/src/main/java/cucumber/runtime/java/Java8StepDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/Java8StepDefinition.java
@@ -40,11 +40,12 @@ public class Java8StepDefinition implements StepDefinition {
         Class<? extends StepdefBody> bodyClass = body.getClass();
 
         Type genericInterface = bodyClass.getGenericInterfaces()[0];
+        Class<? extends StepdefBody> interfac3 = (Class<? extends StepdefBody>) bodyClass.getInterfaces()[0];
         Type[] argumentTypes;
         if (genericInterface instanceof ParameterizedType) {
             argumentTypes = ((ParameterizedType) genericInterface).getActualTypeArguments();
         } else {
-            argumentTypes = typeIntrospector.getGenericTypes(bodyClass);
+            argumentTypes = typeIntrospector.getGenericTypes(bodyClass, interfac3);
         }
         verifyNotListOrMap(argumentTypes);
         this.parameterInfos = ParameterInfo.fromTypes(argumentTypes);

--- a/java/src/main/java/cucumber/runtime/java/TypeIntrospector.java
+++ b/java/src/main/java/cucumber/runtime/java/TypeIntrospector.java
@@ -1,7 +1,9 @@
 package cucumber.runtime.java;
 
+import cucumber.api.java8.StepdefBody;
+
 import java.lang.reflect.Type;
 
 public interface TypeIntrospector {
-    Type[] getGenericTypes(Class<?> clazz) throws Exception;
+    Type[] getGenericTypes(Class<? extends StepdefBody> clazz, Class<? extends StepdefBody> interfac3) throws Exception;
 }

--- a/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
+++ b/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
@@ -30,7 +30,7 @@ public class ConstantPoolTypeIntrospector implements TypeIntrospector {
         int typeParameterCount = interfac3.getTypeParameters().length;
         jdk.internal.org.objectweb.asm.Type[] argumentTypes = jdk.internal.org.objectweb.asm.Type.getArgumentTypes(typeString);
         // Only look at the N last arguments to the lambda static method, since the first ones might be variables
-        // who only pass in the stated of closed variables
+        // who only pass in the states of closed variables
         List<jdk.internal.org.objectweb.asm.Type> interestingArgumentTypes = Arrays.asList(argumentTypes)
                 .subList(argumentTypes.length - typeParameterCount, argumentTypes.length);
 

--- a/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
+++ b/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
@@ -1,11 +1,12 @@
 package cucumber.runtime.java8;
 
-import cucumber.runtime.CucumberException;
+import cucumber.api.java8.StepdefBody;
 import cucumber.runtime.java.TypeIntrospector;
 import sun.reflect.ConstantPool;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.List;
 
 public class ConstantPoolTypeIntrospector implements TypeIntrospector {
@@ -23,20 +24,38 @@ public class ConstantPoolTypeIntrospector implements TypeIntrospector {
     public static final TypeIntrospector INSTANCE = new ConstantPoolTypeIntrospector();
 
     @Override
-    public Type[] getGenericTypes(Class<?> clazz) throws Exception {
-        Type[] typeArguments;
+    public Type[] getGenericTypes(Class<? extends StepdefBody> clazz, Class<? extends StepdefBody> interfac3) throws Exception {
         ConstantPool constantPool = (ConstantPool) Class_getConstantPool.invoke(clazz);
-        String typeString = getTypeString(constantPool);
+        String typeString = getLambdaTypeString(constantPool);
+        int typeParameterCount = interfac3.getTypeParameters().length;
         jdk.internal.org.objectweb.asm.Type[] argumentTypes = jdk.internal.org.objectweb.asm.Type.getArgumentTypes(typeString);
-        typeArguments = new Type[argumentTypes.length];
-        for (int i = 0; i < argumentTypes.length; i++) {
-            typeArguments[i] = Class.forName(argumentTypes[i].getClassName());
+        // Only look at the N last arguments to the lambda static method, since the first ones might be variables
+        // who only pass in the stated of closed variables
+        List<jdk.internal.org.objectweb.asm.Type> interestingArgumentTypes = Arrays.asList(argumentTypes)
+                .subList(argumentTypes.length - typeParameterCount, argumentTypes.length);
+
+        Type[] typeArguments = new Type[typeParameterCount];
+        for (int i = 0; i < typeParameterCount; i++) {
+            typeArguments[i] = Class.forName(interestingArgumentTypes.get(i).getClassName());
         }
         return typeArguments;
     }
 
-    private String getTypeString(ConstantPool constantPool) {
-        String[] memberRef = constantPool.getMemberRefInfoAt(constantPool.getSize() - 2);
+    private String getLambdaTypeString(ConstantPool constantPool) {
+        int size = constantPool.getSize();
+        String[] memberRef = null;
+
+        // find last element in constantPool with valid memberRef
+        // - previously always at size-2 index but changed with JDK 1.8.0_60
+        for (int i = size - 1; i > -1; i--) {
+            try {
+                memberRef = constantPool.getMemberRefInfoAt(i);
+                break;
+            } catch (IllegalArgumentException e) {
+                // eat error; null entry at ConstantPool index?
+            }
+        }
+
         return memberRef[2];
     }
 

--- a/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
+++ b/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
@@ -31,6 +31,14 @@ public class LambdaStepdefs implements En {
         Given("^A statement with a simple match$", () -> {
             assertEquals(2, localInt+1);
         });
+        Given("^I will give you (\\d+) and ([\\d\\.]+) and (\\w+) and (\\d+)$", (Integer a, Float b, String c,
+                                                                                 Integer d)
+                -> {
+            assertEquals((Integer) 1, a);
+            assertEquals((Float) 2.2f, b);
+            assertEquals("threed", c);
+            assertEquals((Integer) 4, d);
+        });
     }
 
     public static class Person {

--- a/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
+++ b/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
@@ -22,6 +22,15 @@ public class LambdaStepdefs implements En {
             List<Person> people = peopleTable.asList(Person.class);
             assertEquals("Hellesøy", people.get(0).last);
         });
+        String localState = "hello";
+        Given("^I have (\\d+) cukes in my belly", (Integer i) -> {
+            assertEquals((Integer) 42, i);
+            assertEquals("hello", localState);
+        });
+        int localInt = 1;
+        Given("^A statement with a simple match$", () -> {
+            assertEquals(2, localInt+1);
+        });
     }
 
     public static class Person {

--- a/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
+++ b/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
@@ -10,6 +10,10 @@ Feature: Java8
   Scenario: Parameterless lambdas
     Given: A statement with a simple match
 
+  Scenario: Multi-param lambdas
+    Given: I will give you 1 and 2.2 and three and 4
+    And: Do I need this to not match
+
   Scenario: use a table
     Given this data table:
       | first  | last     |

--- a/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
+++ b/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
@@ -7,6 +7,9 @@ Feature: Java8
     Given I have 42 cukes in my belly
     And something that isn't defined
 
+  Scenario: Parameterless lambdas
+    Given: A statement with a simple match
+
   Scenario: use a table
     Given this data table:
       | first  | last     |


### PR DESCRIPTION
This is a new attempt at closing over local variables. 

When the ConstantPoolTypeIntrospector looks at the static method which the lambda refers to, it disregards leading arguments which are used for passing in local state. By using the actual argument count in the AN (A1, A2 etc) interface, it can figure out how many argument types to look for.

This branch also contains dcowboys changes copy-pasted, since they were needed to make everything work on the latest JDK. Tell me how you would like to handle the merge of that if you would like to merge this request. Otherwise feel free to just take inspiration from my code and rewrite it as you wish.