### PR TITLE
Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/core/src/main/java/cucumber/runtime/Reflections.java
+++ b/core/src/main/java/cucumber/runtime/Reflections.java
@@ -16,7 +16,7 @@ public class Reflections {
         Collection<? extends T> instances = instantiateSubclasses(parentType, packageName, constructorParams, constructorArgs);
         if (instances.size() == 1) {
             return instances.iterator().next();
-        } else if (instances.size() == 0) {
+        } else if (instances.isEmpty()) {
             throw new NoInstancesException(parentType);
         } else {
             throw new TooManyInstancesException(instances);

--- a/core/src/main/java/cucumber/runtime/RuntimeGlue.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeGlue.java
@@ -61,7 +61,7 @@ public class RuntimeGlue implements Glue {
     public StepDefinitionMatch stepDefinitionMatch(String featurePath, Step step, I18n i18n) {
         List<StepDefinitionMatch> matches = stepDefinitionMatches(featurePath, step);
         try {
-            if (matches.size() == 0) {
+            if (matches.isEmpty()) {
                 tracker.addUndefinedStep(step, i18n);
                 return null;
             }

--- a/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
@@ -82,7 +82,7 @@ class RerunFormatter implements Formatter, Reporter, StrictAware {
         Set<Map.Entry<String, ArrayList<Integer>>> entries = featureAndFailedLinesMapping.entrySet();
         boolean firstFeature = true;
         for (Map.Entry<String, ArrayList<Integer>> entry : entries) {
-            if (entry.getValue().size() > 0) {
+            if (!entry.getValue().isEmpty()) {
                 if (!firstFeature) {
                     out.append(" ");
                 }

--- a/core/src/main/java/cucumber/runtime/table/TableConverter.java
+++ b/core/src/main/java/cucumber/runtime/table/TableConverter.java
@@ -289,7 +289,7 @@ public class TableConverter {
     private boolean isListOfSingleValue(Object object) {
         if (object instanceof List) {
             List list = (List) object;
-            return list.size() > 0 && xStream.getSingleValueConverter(list.get(0).getClass()) != null;
+            return !list.isEmpty() && xStream.getSingleValueConverter(list.get(0).getClass()) != null;
         }
         return false;
     }

--- a/core/src/main/java/cucumber/runtime/table/TableDiffer.java
+++ b/core/src/main/java/cucumber/runtime/table/TableDiffer.java
@@ -25,7 +25,7 @@ public class TableDiffer {
     }
 
     private void checkColumns(DataTable a, DataTable b) {
-        if (a.topCells().size() != b.topCells().size() && b.topCells().size() != 0) {
+        if (a.topCells().size() != b.topCells().size() && !b.topCells().isEmpty()) {
             throw new IllegalArgumentException("Tables must have equal number of columns:\n" + a + "\n" + b);
         }
     }

--- a/core/src/main/java/cucumber/runtime/xstream/ConverterWithFormat.java
+++ b/core/src/main/java/cucumber/runtime/xstream/ConverterWithFormat.java
@@ -18,7 +18,7 @@ abstract class ConverterWithFormat<T> extends Transformer<T> {
     }
 
     public T transform(String string) {
-        if (string == null || string.length() == 0) {
+        if (string == null || string.isEmpty()) {
             return null;
         }
         for (Format format : getFormats()) {

--- a/core/src/test/java/cucumber/runtime/TestHelper.java
+++ b/core/src/test/java/cucumber/runtime/TestHelper.java
@@ -147,10 +147,10 @@ public class TestHelper {
         for (SimpleEntry<String, Result> hookEntry : hooks) {
             TestHelper.mockHook(hookEntry, beforeHooks, afterHooks);
         }
-        if (beforeHooks.size() != 0) {
+        if (!beforeHooks.isEmpty()) {
             when(glue.getBeforeHooks()).thenReturn(beforeHooks);
         }
-        if (afterHooks.size() != 0) {
+        if (!afterHooks.isEmpty()) {
             when(glue.getAfterHooks()).thenReturn(afterHooks);
         }
     }

--- a/guice/src/test/java/cucumber/runtime/java/guice/collection/CollectionUtil.java
+++ b/guice/src/test/java/cucumber/runtime/java/guice/collection/CollectionUtil.java
@@ -14,7 +14,7 @@ public class CollectionUtil {
         if (list == null) {
             throw new NullPointerException("List must not be null.");
         }
-        if (list.size() < 1) {
+        if (list.isEmpty()) {
             throw new IllegalArgumentException("List must contain at least one element.");
         }
         while (list.size() > 1) {

--- a/testng/src/test/java/cucumber/api/testng/TestNGCucumberRunnerTest.java
+++ b/testng/src/test/java/cucumber/api/testng/TestNGCucumberRunnerTest.java
@@ -35,7 +35,7 @@ public class TestNGCucumberRunnerTest {
 
         Assert.assertEquals(features.size(), numberOfFeatures,
                 "Not all features associated with " + RunCukesTest.class.getSimpleName() + " were loaded. ");
-        Assert.assertTrue(features.size() > 0, "Feature files need to exist in the cucumber/runtime/testng/ folder for this test");
+        Assert.assertTrue(!features.isEmpty(), "Feature files need to exist in the cucumber/runtime/testng/ folder for this test");
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155
Please let me know if you have any questions.
Kirill Vlasov