### PR TITLE
Lazy initialization of "static" fields should be "synchronized"

### DIFF
--- a/android/src/test/java/com/vladium/emma/rt/RT.java
+++ b/android/src/test/java/com/vladium/emma/rt/RT.java
@@ -7,7 +7,7 @@ import java.io.File;
  */
 public class RT {
 
-    private static File lastFile;
+    private static volatile File lastFile;
     private static Throwable throwable;
 
     public static void dumpCoverageData(final File file, final boolean merge, final boolean stopDataCollection) throws Throwable {
@@ -20,7 +20,7 @@ public class RT {
         lastFile = file;
     }
 
-    public static void throwOnNextInvocation(final Throwable throwable) {
+    public static synchronized void throwOnNextInvocation(final Throwable throwable) {
         RT.throwable = throwable;
     }
 

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -195,7 +195,7 @@ public class RuntimeOptions {
         System.out.println(usageText);
     }
 
-    static void loadUsageTextIfNeeded() {
+    static synchronized void loadUsageTextIfNeeded() {
         if (usageText == null) {
             try {
                 Reader reader = new InputStreamReader(FixJava.class.getResourceAsStream(USAGE_RESOURCE), "UTF-8");

--- a/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
@@ -264,7 +264,7 @@ class JUnitFormatter implements Formatter, Reporter, StrictAware {
             tc.setAttribute("name", calculateElementName(scenario));
         }
 
-        private String calculateElementName(Scenario scenario) {
+        private synchronized String calculateElementName(Scenario scenario) {
             String scenarioName = scenario.getName();
             if (scenario.getKeyword().equals("Scenario Outline") && scenarioName.equals(previousScenarioOutlineName)) {
                 return scenarioName + (includesBlank(scenarioName) ? " " : "_") + ++exampleNumber;

--- a/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
@@ -233,7 +233,7 @@ class TestNGFormatter implements Formatter, Reporter, StrictAware {
             element.setAttribute("started-at", DATE_FORMAT.format(new Date()));
         }
 
-        private String calculateElementName(Scenario scenario) {
+        private synchronized String calculateElementName(Scenario scenario) {
             String scenarioName = scenario.getName();
             if (scenario.getKeyword().equals("Scenario Outline") && scenarioName.equals(previousScenarioOutlineName)) {
                 return scenarioName + "_" + ++exampleNumber;

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -214,7 +214,7 @@ public class RuntimeTest {
     }
 
     public static class StepdefsPrinter implements StepDefinitionReporter {
-        public static StepdefsPrinter instance;
+        public static volatile StepdefsPrinter instance;
         public StepDefinition stepDefinition;
 
         public StepdefsPrinter() {

--- a/examples/java-wicket/java-wicket-main/src/main/java/cucumber/examples/java/wicket/model/dao/InMemoryCarDAO.java
+++ b/examples/java-wicket/java-wicket-main/src/main/java/cucumber/examples/java/wicket/model/dao/InMemoryCarDAO.java
@@ -6,7 +6,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class InMemoryCarDAO implements CarDAO {
-    private static List<Car> cars;
+    private static volatile List<Car> cars;
 
     public InMemoryCarDAO() {
         if (cars == null) {

--- a/gosu/src/main/java/cucumber/runtime/gosu/GosuBackend.java
+++ b/gosu/src/main/java/cucumber/runtime/gosu/GosuBackend.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 public class GosuBackend implements Backend {
-    public static GosuBackend instance;
+    public static volatile GosuBackend instance;
 
     private final ResourceLoader resourceLoader;
     private final SnippetGenerator snippetGenerator = new SnippetGenerator(new GosuSnippet());

--- a/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
+++ b/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
 public class LambdaStepdefs implements En {
-    private static LambdaStepdefs lastInstance;
+    private static volatile LambdaStepdefs lastInstance;
 
     public LambdaStepdefs() {
         Before((Scenario scenario) -> {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2444 - Lazy initialization of "static" fields should be "synchronized"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2444
Please let me know if you have any questions.
Kirill Vlasov