### PR TITLE
Two branches in the same conditional structure should not have exactly the same implementation

### DIFF
--- a/android/src/main/java/cucumber/runtime/android/Arguments.java
+++ b/android/src/main/java/cucumber/runtime/android/Arguments.java
@@ -167,9 +167,8 @@ public class Arguments {
                 appendOption(sb, "--tags", bundle.getString(key));
             } else if ("name".equals(key)) {
                 appendOption(sb, "--name", bundle.getString(key));
-            } else if ("dryRun".equals(key) && getBooleanArgument(bundle, key)) {
-                appendOption(sb, "--dry-run", "");
-            } else if ("log".equals(key) && getBooleanArgument(bundle, key)) {
+            } else if (("dryRun".equals(key) && getBooleanArgument(bundle, key))
+                    || ("log".equals(key) && getBooleanArgument(bundle, key))) {
                 appendOption(sb, "--dry-run", "");
             } else if ("noDryRun".equals(key) && getBooleanArgument(bundle, key)) {
                 appendOption(sb, "--no-dry-run", "");

--- a/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
@@ -50,9 +50,7 @@ public class StepDefinitionMatch extends Match {
     private Object[] transformedArgs(Step step, LocalizedXStreams.LocalizedXStream xStream) {
         int argumentCount = getArguments().size();
 
-        if (step.getRows() != null) {
-            argumentCount++;
-        } else if (step.getDocString() != null) {
+        if (step.getRows() != null || step.getDocString() != null) {
             argumentCount++;
         }
         Integer parameterCount = stepDefinition.getParameterCount();

--- a/testng/src/main/java/cucumber/api/testng/TestNgReporter.java
+++ b/testng/src/main/java/cucumber/api/testng/TestNgReporter.java
@@ -99,7 +99,8 @@ public class TestNgReporter implements Formatter, Reporter {
     public void result(Result result) {
         logResult(result);
 
-        if (Result.FAILED.equals(result.getStatus())) {
+        if (Result.FAILED.equals(result.getStatus())
+                || Result.UNDEFINED.equals(result)) {
             ITestResult tr = getCurrentTestResult();
             tr.setThrowable(result.getError());
             tr.setStatus(ITestResult.FAILURE);
@@ -107,10 +108,6 @@ public class TestNgReporter implements Formatter, Reporter {
             ITestResult tr = getCurrentTestResult();
             tr.setThrowable(result.getError());
             tr.setStatus(ITestResult.SKIP);
-        } else if (Result.UNDEFINED.equals(result)) {
-            ITestResult tr = getCurrentTestResult();
-            tr.setThrowable(result.getError());
-            tr.setStatus(ITestResult.FAILURE);
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1871 - Two branches in the same conditional structure should not have exactly the same implementation
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1871
Please let me know if you have any questions.
Kirill Vlasov
