### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/android/src/test/java/com/vladium/emma/rt/RT.java
+++ b/android/src/test/java/com/vladium/emma/rt/RT.java
@@ -10,6 +10,9 @@ public class RT {
     private static File lastFile;
     private static Throwable throwable;
 
+    private RT() {
+    }
+
     public static void dumpCoverageData(final File file, final boolean merge, final boolean stopDataCollection) throws Throwable {
 
         if (throwable != null) {

--- a/core/src/main/java/cucumber/runtime/Shellwords.java
+++ b/core/src/main/java/cucumber/runtime/Shellwords.java
@@ -8,6 +8,9 @@ import java.util.regex.Pattern;
 public class Shellwords {
     private static final Pattern SHELLWORDS_PATTERN = Pattern.compile("[^\\s']+|'([^']*)'");
 
+    private Shellwords() {
+    }
+
     public static List<String> parse(String cmdline) {
         List<String> matchList = new ArrayList<String>();
         Matcher shellwordsMatcher = SHELLWORDS_PATTERN.matcher(cmdline);

--- a/core/src/main/java/cucumber/runtime/Timeout.java
+++ b/core/src/main/java/cucumber/runtime/Timeout.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class Timeout {
+    private Timeout() {
+    }
+
     public static <T> T timeout(Callback<T> callback, long timeoutMillis) throws Throwable {
         if (timeoutMillis == 0) {
             return callback.call();

--- a/core/src/main/java/cucumber/runtime/Utils.java
+++ b/core/src/main/java/cucumber/runtime/Utils.java
@@ -13,6 +13,9 @@ import java.util.List;
 import java.util.Map;
 
 public class Utils {
+    private Utils() {
+    }
+
     public static <T> List<T> listOf(int size, T obj) {
         List<T> list = new ArrayList<T>();
         for (int i = 0; i < size; i++) {

--- a/core/src/main/java/cucumber/runtime/io/Helpers.java
+++ b/core/src/main/java/cucumber/runtime/io/Helpers.java
@@ -7,6 +7,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 public class Helpers {
+    private Helpers() {
+    }
+
     static boolean hasSuffix(String suffix, String name) {
         return suffix == null || name.endsWith(suffix);
     }

--- a/core/src/test/java/cucumber/runtime/TestHelper.java
+++ b/core/src/test/java/cucumber/runtime/TestHelper.java
@@ -30,6 +30,9 @@ import static org.mockito.Mockito.*;
 
 @Ignore
 public class TestHelper {
+    private TestHelper() {
+    }
+
     public static CucumberFeature feature(final String path, final String source) throws IOException {
         ArrayList<CucumberFeature> cucumberFeatures = new ArrayList<CucumberFeature>();
         FeatureBuilder featureBuilder = new FeatureBuilder(cucumberFeatures);

--- a/core/src/test/java/cucumber/runtime/formatter/TempDir.java
+++ b/core/src/test/java/cucumber/runtime/formatter/TempDir.java
@@ -4,6 +4,9 @@ import java.io.File;
 import java.io.IOException;
 
 public class TempDir {
+    private TempDir() {
+    }
+
     public static File createTempDirectory() throws IOException {
         File temp = createTempFile();
 

--- a/core/src/test/java/cucumber/runtime/table/TableParser.java
+++ b/core/src/test/java/cucumber/runtime/table/TableParser.java
@@ -17,6 +17,9 @@ import java.util.Locale;
 public class TableParser {
     private static final List<Comment> NO_COMMENTS = Collections.emptyList();
 
+    private TableParser() {
+    }
+
     public static DataTable parse(String source, ParameterInfo parameterInfo) {
         final List<DataTableRow> rows = new ArrayList<DataTableRow>();
         Lexer l = new En(new Listener() {

--- a/guice/src/test/java/cucumber/runtime/java/guice/collection/CollectionUtil.java
+++ b/guice/src/test/java/cucumber/runtime/java/guice/collection/CollectionUtil.java
@@ -4,6 +4,9 @@ import java.util.List;
 
 public class CollectionUtil {
 
+    private CollectionUtil() {
+    }
+
     /**
      * Removes all elements in the supplied list except the first element.
      * @param list the list to be modified

--- a/java/src/main/java/cucumber/runtime/java/ObjectFactoryLoader.java
+++ b/java/src/main/java/cucumber/runtime/java/ObjectFactoryLoader.java
@@ -8,6 +8,9 @@ import cucumber.runtime.Reflections;
 import cucumber.runtime.TooManyInstancesException;
 
 public class ObjectFactoryLoader {
+    private ObjectFactoryLoader() {
+    }
+
     /**
      * Loads an instance of {@link ObjectFactory}. The class name can be explicit, or it can be null.
      * When it's null, the implementation is searched for in the <pre>cucumber.runtime</pre> packahe.

--- a/junit/src/main/java/cucumber/runtime/junit/Assertions.java
+++ b/junit/src/main/java/cucumber/runtime/junit/Assertions.java
@@ -6,6 +6,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 public class Assertions {
+    private Assertions() {
+    }
+
     public static void assertNoCucumberAnnotatedMethods(Class clazz) {
         for (Method method : clazz.getDeclaredMethods()) {
             for (Annotation annotation : method.getAnnotations()) {

--- a/junit/src/test/java/cucumber/runtime/junit/TestFeatureBuilder.java
+++ b/junit/src/test/java/cucumber/runtime/junit/TestFeatureBuilder.java
@@ -12,6 +12,9 @@ import java.util.ArrayList;
 
 public class TestFeatureBuilder {
 
+    private TestFeatureBuilder() {
+    }
+
     static CucumberFeature feature(final String path, final String source) throws IOException {
         ArrayList<CucumberFeature> cucumberFeatures = new ArrayList<CucumberFeature>();
         FeatureBuilder featureBuilder = new FeatureBuilder(cucumberFeatures);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
Please let me know if you have any questions.
Kirill Vlasov