### PR TITLE
Allows to configure TestNG to fail on unparseable feature files

### DIFF
--- a/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
+++ b/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
@@ -5,11 +5,25 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import cucumber.api.CucumberOptions;
+
 /**
  * Runs cucumber every detected feature as separated test
  */
 public abstract class AbstractTestNGCucumberTests {
     private TestNGCucumberRunner testNGCucumberRunner;
+    private boolean failOnUnparseableFeatures = false;
+
+    public AbstractTestNGCucumberTests() {
+        CucumberOptions options = this.getClass().getAnnotation(CucumberOptions.class);
+        if (options != null) {
+            setFailOnUnparseableFeatures(options.strict());
+        }
+    }
+
+    protected final void setFailOnUnparseableFeatures(boolean failOnUnparseableFeatures) {
+        this.failOnUnparseableFeatures = failOnUnparseableFeatures;
+    }
 
     @BeforeClass(alwaysRun = true)
     public void setUpClass() throws Exception {
@@ -19,6 +33,13 @@ public abstract class AbstractTestNGCucumberTests {
     @Test(groups = "cucumber", description = "Runs Cucumber Feature", dataProvider = "features")
     public void feature(CucumberFeatureWrapper cucumberFeature) {
         testNGCucumberRunner.runCucumber(cucumberFeature.getCucumberFeature());
+    }
+
+    @Test(groups = "cucumber", description = "Check if features files are parseable")
+    public void featuresParseable() {
+        if (failOnUnparseableFeatures) {
+            this.features();
+        }
     }
 
     /**

--- a/testng/src/test/java/cucumber/api/testng/AbstractTestNGCucumberTestsTest.java
+++ b/testng/src/test/java/cucumber/api/testng/AbstractTestNGCucumberTestsTest.java
@@ -1,0 +1,60 @@
+package cucumber.api.testng;
+
+import org.testng.Assert;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+
+import cucumber.api.CucumberOptions;
+
+public final class AbstractTestNGCucumberTestsTest {
+
+    @Test
+    public void failOnParsingError() throws Exception {
+        TestListenerAdapter tla = runTestNG(FailOnUnparseableFeaturesTest.class);
+        Assert.assertEquals(tla.getFailedTests().size(), 1, "Dataprovider must fail.");
+        Assert.assertEquals(tla.getPassedTests().size(), 0, "No test has passed.");
+        Assert.assertEquals(tla.getSkippedTests().size(), 1, "Actual test has been skipped.");
+    }
+
+    @Test
+    public void failOnParsingErrorIfStrictMode() throws Exception {
+        TestListenerAdapter tla = runTestNG(FailOnUnparseableFeaturesIfStrictModeTest.class);
+        Assert.assertEquals(tla.getFailedTests().size(), 1, "Dataprovider must fail.");
+        Assert.assertEquals(tla.getPassedTests().size(), 0, "No test has passed.");
+        Assert.assertEquals(tla.getSkippedTests().size(), 1, "Actual test has been skipped.");
+    }
+
+    @Test
+    public void succeedThoughParsingError() throws Exception {
+        TestListenerAdapter tla = runTestNG(SucceedOnUnparseableFeaturesTest.class);
+        Assert.assertEquals(tla.getFailedTests().size(), 0, "Dataprovider must not fail.");
+        Assert.assertEquals(tla.getPassedTests().size(), 1, "Dataprovider test must pass.");
+        Assert.assertEquals(tla.getSkippedTests().size(), 1, "Actual test has been skipped.");
+    }
+
+    private TestListenerAdapter runTestNG(final Class<? extends AbstractTestNGCucumberTests> testClass) {
+        TestNG testng = new TestNG();
+        testng.setGroups("cucumber");
+        TestListenerAdapter tla = new TestListenerAdapter();
+        testng.setTestClasses(new Class[] { testClass });
+        testng.addListener(tla);
+        testng.run();
+        return tla;
+    }
+
+    @CucumberOptions(features = { "cucumber/api/testng/unparseable.feature" })
+    private static final class FailOnUnparseableFeaturesTest extends AbstractTestNGCucumberTests {
+        public FailOnUnparseableFeaturesTest() {
+            setFailOnUnparseableFeatures(true);
+        }
+    }
+
+    @CucumberOptions(features = { "cucumber/api/testng/unparseable.feature" }, strict = true)
+    private static final class FailOnUnparseableFeaturesIfStrictModeTest extends AbstractTestNGCucumberTests {
+    }
+
+    @CucumberOptions(features = { "cucumber/api/testng/unparseable.feature" })
+    private static final class SucceedOnUnparseableFeaturesTest extends AbstractTestNGCucumberTests {
+    }
+}

--- a/testng/src/test/resources/cucumber/api/testng/unparseable.feature
+++ b/testng/src/test/resources/cucumber/api/testng/unparseable.feature
@@ -1,0 +1,6 @@
+Feature: Unparseable Feature
+  # This feature has syntax errors
+  Scenario: Unparseable scenario
+    Givven given step 
+    WWhen when step
+    Thenn then step


### PR DESCRIPTION
TestNG DataProvider did not fail if a feature file was not parseable.
This commit allows to configure whether a test fails if at least one
feature file is not parseable.
In addition, test always fails if at least one feature file is not
parseable and strict mode is enabled.

Fixes cucumber/cucumber-jvm#953