### PR TITLE
Always tear down TestNG cucumber tests.

### DIFF
--- a/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
+++ b/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
@@ -29,7 +29,7 @@ public abstract class AbstractTestNGCucumberTests {
         return testNGCucumberRunner.provideFeatures();
     }
 
-    @AfterClass
+    @AfterClass(alwaysRun = true)
     public void tearDownClass() throws Exception {
         testNGCucumberRunner.finish();
     }

--- a/testng/src/test/java/cucumber/api/testng/AbstractTestNGCucumberTestsTest.java
+++ b/testng/src/test/java/cucumber/api/testng/AbstractTestNGCucumberTestsTest.java
@@ -1,0 +1,35 @@
+package cucumber.api.testng;
+
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Test
+public final class AbstractTestNGCucumberTestsTest {
+
+    private Set<String> invokedConfigurationMethodNames;
+
+    @BeforeClass(alwaysRun = true)
+    public void setUp() {
+        InvokedConfigurationMethodListener icml = new InvokedConfigurationMethodListener();
+        TestNG testNG = new TestNG();
+        testNG.addListener(icml);
+        testNG.setGroups("cucumber");
+        testNG.setTestClasses(new Class[]{new AbstractTestNGCucumberTests() {}.getClass()});
+        testNG.run();
+        invokedConfigurationMethodNames = icml.getInvokedMethodNames();
+    }
+    
+    @Test
+    public void setUpClassIsInvoked() {
+        Assert.assertTrue(invokedConfigurationMethodNames.contains("setUpClass"), "setUpClass must be invoked");
+    }
+    
+    @Test
+    public void tearDownClassIsInvoked() {
+        Assert.assertTrue(invokedConfigurationMethodNames.contains("tearDownClass"), "tearDownClass must be invoked");
+    }
+}

--- a/testng/src/test/java/cucumber/api/testng/InvokedConfigurationMethodListener.java
+++ b/testng/src/test/java/cucumber/api/testng/InvokedConfigurationMethodListener.java
@@ -1,0 +1,30 @@
+package cucumber.api.testng;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+
+public final class InvokedConfigurationMethodListener implements IInvokedMethodListener {
+
+    private Set<String> invokedMethodNames = new HashSet<String>();
+    
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+        if (method.isConfigurationMethod()) {
+            invokedMethodNames.add(method.getTestMethod().getMethodName());
+        }
+    }
+
+    public Set<String> getInvokedMethodNames() {
+        return Collections.unmodifiableSet(invokedMethodNames);
+    }
+    
+}


### PR DESCRIPTION
This ensures that TestNGCucumberRunner.finish() will always be invoked.

Fixes cucumber/cucumber-jvm#955