### PR TITLE
Support assume feature with JUnit 4.12.

### DIFF
--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -33,7 +33,8 @@ import java.util.Set;
  */
 public class Runtime implements UnreportedStepExecutor {
 
-    private static final String[] PENDING_EXCEPTIONS = new String[]{
+    private static final String[] PENDING_EXCEPTIONS = {
+            "org.junit.AssumptionViolatedException",
             "org.junit.internal.AssumptionViolatedException"
     };
 

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -169,9 +169,17 @@ public class RuntimeTest {
     }
 
     @Test
-    public void non_strict_with_failed_junit_assumption() {
+    public void non_strict_with_failed_junit_assumption_prior_to_junit_412() {
         Runtime runtime = createNonStrictRuntime();
         runtime.addError(new AssumptionViolatedException("should be treated like pending"));
+
+        assertEquals(0x0, runtime.exitStatus());
+    }
+
+    @Test
+    public void non_strict_with_failed_junit_assumption_from_junit_412_on() {
+        Runtime runtime = createNonStrictRuntime();
+        runtime.addError(new org.junit.AssumptionViolatedException("should be treated like pending"));
 
         assertEquals(0x0, runtime.exitStatus());
     }


### PR DESCRIPTION
JUnit 4.12 uses a different class for the `AssumptionViolatedException` than older versions.