### PR TITLE
remove reference to decommissioned repository.codehaus.org repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,11 +524,6 @@
     </dependencyManagement>
 
     <repositories>
-        <repository>
-            <id>codehaus</id>
-            <url>http://repository.codehaus.org</url>
-        </repository>
-
         <!--<repository>-->
             <!--<id>gosu-lang.org-releases</id>-->
             <!--<name>Official Gosu website (releases)</name>-->


### PR DESCRIPTION
"All Codehaus services will be terminated progressively until May 31st 2015" and repository.codehaus.org is no longer a usable maven repository.