### PR TITLE
Double-check for directory exists in the ensureParentDirExists(File)

### DIFF
--- a/core/src/main/java/cucumber/runtime/io/URLOutputStream.java
+++ b/core/src/main/java/cucumber/runtime/io/URLOutputStream.java
@@ -48,7 +48,7 @@ public class URLOutputStream extends OutputStream {
 
     private void ensureParentDirExists(File file) throws IOException {
         if (file.getParentFile() != null && !file.getParentFile().isDirectory()) {
-            boolean ok = file.getParentFile().mkdirs();
+            boolean ok = file.getParentFile().mkdirs() || file.getParentFile().isDirectory();
             if (!ok) {
                 throw new IOException("Failed to create directory " + file.getParentFile().getAbsolutePath());
             }

--- a/core/src/test/java/cucumber/runtime/io/URLOutputStreamTest.java
+++ b/core/src/test/java/cucumber/runtime/io/URLOutputStreamTest.java
@@ -32,10 +32,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;

--- a/core/src/test/java/cucumber/runtime/io/URLOutputStreamTest.java
+++ b/core/src/test/java/cucumber/runtime/io/URLOutputStreamTest.java
@@ -29,8 +29,8 @@ public class URLOutputStreamTest {
     private WebServer webbit;
     private final int threadsCount = 100;
     private final long waitTimeoutMillis = 30000L;
-    private final List<File> tmpFiles = new ArrayList<>();
-    private final List<String> threadErrors = new ArrayList<>();
+    private final List<File> tmpFiles = new ArrayList<File>();
+    private final List<String> threadErrors = new ArrayList<String>();
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -139,7 +139,7 @@ public class URLOutputStreamTest {
     }
 
     private List<Thread> getThreadsWithLatchForFile(final CountDownLatch countDownLatch, int threadsCount) {
-        List<Thread> result = new ArrayList<>();
+        List<Thread> result = new ArrayList<Thread>();
         String ballast = "" + System.currentTimeMillis();
         for (int i = 0; i < threadsCount; i++) {
             final int curThreadNo = i;

--- a/core/src/test/java/cucumber/runtime/io/URLOutputStreamTest.java
+++ b/core/src/test/java/cucumber/runtime/io/URLOutputStreamTest.java
@@ -7,11 +7,21 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.webbitserver.*;
+import org.webbitserver.HttpControl;
+import org.webbitserver.HttpHandler;
+import org.webbitserver.HttpRequest;
+import org.webbitserver.HttpResponse;
+import org.webbitserver.WebServer;
 import org.webbitserver.netty.NettyWebServer;
 import org.webbitserver.rest.Rest;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.Writer;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -21,9 +31,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class URLOutputStreamTest {
     private WebServer webbit;


### PR DESCRIPTION
Hi.

I have several JUnit runners which runs cucumber tests in parallel at the same time. Each runner generate JSON file with test results to the one directory, e.g. ./target/json-files/
```
@CucumberOptions(
        plugin = {"json:target/json-files/Test1.json"}, ...)
```
Sometimes I have an issue when one of runner is unable to create reports directory because another runner already done this. And it fails with error "Failed to create directory".
I think there is a make sense to double-check if reports directory is already exists (method cucumber.runtime.io.URLOutputStream#ensureParentDirExists).