### PR TITLE
Groovy: Fixed NPE when using List as parameter type in step definitions

### DIFF
--- a/groovy/src/main/java/cucumber/runtime/groovy/GroovyStepDefinition.java
+++ b/groovy/src/main/java/cucumber/runtime/groovy/GroovyStepDefinition.java
@@ -56,11 +56,7 @@ public class GroovyStepDefinition implements StepDefinition {
 
     private List<ParameterInfo> getParameterInfos() {
         Class[] parameterTypes = body.getParameterTypes();
-        List<ParameterInfo> result = new ArrayList<ParameterInfo>(parameterTypes.length);
-        for (Class parameterType : parameterTypes) {
-            result.add(new ParameterInfo(parameterType, null, null, null));
-        }
-        return result;
+        return ParameterInfo.fromTypes(parameterTypes);
     }
 
     public void execute(I18n i18n, final Object[] args) throws Throwable {

--- a/groovy/src/test/groovy/cucumber/runtime/groovy/compiled_stepdefs.groovy
+++ b/groovy/src/test/groovy/cucumber/runtime/groovy/compiled_stepdefs.groovy
@@ -21,6 +21,12 @@ Given(~'^the following table:$') { table ->
     assertEquals("Cucumber-JVM", things[1].name)
 }
 
+Given(~'^this should be converted to a list:(.+)$') { List list ->
+    assertEquals(3, list.size())
+    assertEquals("Cucumber-JVM", list.get(0))
+    assertEquals("Cucumber", list.get(1))
+}
+
 class Thing {
     Integer year
     String name

--- a/groovy/src/test/resources/cucumber/runtime/groovy/a_feature.feature
+++ b/groovy/src/test/resources/cucumber/runtime/groovy/a_feature.feature
@@ -23,6 +23,9 @@ Feature: Cucumber Runner Rocks
       | 2008 | Cucumber     |
       | 2012 | Cucumber-JVM |
 
+    Scenario: Test list conversion
+      Given this should be converted to a list:Cucumber-JVM, Cucumber, Nice
+
   Scenario: A date
     Given today's date is "1971-10-03" and tomorrow is:
       """


### PR DESCRIPTION
To reproduce:

The following code caused a NullPointerException because ParameterInfo was initialized without default delimiter:
```
Given(~'^this should be converted to a list:(.+)$') { List list ->
    assertEquals(3, list.size())
    assertEquals("Cucumber-JVM", list.get(0))
    assertEquals("Cucumber", list.get(1))
}
```

The pull request contains the fix and the corresponding test.