### PR TITLE
Allow construction of GuiceFactory from Injector

### DIFF
--- a/guice/src/main/java/cucumber/runtime/java/guice/impl/GuiceFactory.java
+++ b/guice/src/main/java/cucumber/runtime/java/guice/impl/GuiceFactory.java
@@ -16,13 +16,11 @@ public class GuiceFactory implements ObjectFactory {
         this(new InjectorSourceFactory(Env.INSTANCE).create().getInjector());
     }
 
-    /**
-     * Package private constructor that is called by the public constructor at runtime and is also called directly by
-     * tests.
+    /** Construct a GuiceFactory from an existing Injector.
      *
      * @param injector an injector configured with a binding for <code>cucumber.runtime.java.guice.ScenarioScope</code>.
      */
-    GuiceFactory(Injector injector) {
+    public GuiceFactory(Injector injector) {
         this.injector = injector;
     }
 


### PR DESCRIPTION
While convenient, `InjectorSourceFactory` requires the `InjectorSource` to be default constructible. In my case, it can't really, since I'd like to bind an instance as an eager singleton, and the `InjectorSource` cannot know beforehand which instance it will be. Opening up the `GuiceFactory`constructor that takes an Injector instance should solve this.
