### PR TITLE
Add notes about Step class lifecycles

### DIFF
--- a/picocontainer/README.md
+++ b/picocontainer/README.md
@@ -1,0 +1,11 @@
+# Step dependencies
+
+The picocontainer will create singleton instances of any Step class dependencies which are constructor parameters and inject them into the Step class instances when constructing them.
+
+# Step scope and lifecycle
+
+All step classes and their dependencies will be recreated fresh for each scenario, even if the scenario in question does not use any steps from that particular class.
+
+If any step classes or dependencies use expensive resources (such as database connections), you should create them lazily on-demand, rather than eagerly, to improve performance.
+
+The pico container created by `cucumber-jvm` uses a `NullLifecycleStrategy` (see http://picocontainer.com/lifecycle.html ) so the Startable or Disposeable interfaces will be ignored. You should use cucumber.api.java.After annotations to do any necessary cleanup.


### PR DESCRIPTION
See http://stackoverflow.com/a/33063300/8261 -- it is not at all obvious that Step classes (or their dependencies) are destroyed and re-created for each Scenario. This doc should hopefully make that clearer.

Since the Steps are destroyed & recreated for each Scenario, it is very important to clean up any resources allocated by them (e.g. database connections) otherwise projects with lots of Scenarios will grind to a halt with resource leaks. However, the Picocontainer lifecycle annotations for this are ignored by `cucumber-jvm` since it sets `NullLifecycleStrategy`. I have added documentation here about the simplest workaround (@After annotations, which do work).

HTH