### PR TITLE
The package org.ops4j.pax.exam.util is optional for cucumber-osgi

### DIFF
--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -87,6 +87,7 @@
                     <instructions>
                         <Bundle-Description />
                         <Export-Package>cucumber.*</Export-Package>
+                        <Import-Package>org.ops4j.pax.exam.util;resolution:=optional,*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
cucumber-osgi can be used without pax-exam, just a small change to the manifest removes the necessity to need pax-exam bundles to be installed in the container running the tests.