### PR TITLE
Add options to the JUnit module

### DIFF
--- a/core/src/main/java/cucumber/api/CucumberOptions.java
+++ b/core/src/main/java/cucumber/api/CucumberOptions.java
@@ -64,4 +64,10 @@ public @interface CucumberOptions {
      * @return what format should the snippets use. underscore, camelcase
      */
     SnippetType snippets() default SnippetType.UNDERSCORE;
+
+    /**
+     * @return the options for the JUnit runner
+     */
+    String[] junit() default {};
+
 }

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -39,6 +39,7 @@ public class RuntimeOptions {
     private final List<String> pluginFormatterNames = new ArrayList<String>();
     private final List<String> pluginStepDefinitionReporterNames = new ArrayList<String>();
     private final List<String> pluginSummaryPrinterNames = new ArrayList<String>();
+    private final List<String> junitOptions = new ArrayList<String>();
     private final PluginFactory pluginFactory;
     private final List<Object> plugins = new ArrayList<Object>();
     private boolean dryRun;
@@ -100,6 +101,7 @@ public class RuntimeOptions {
         List<Object> parsedFilters = new ArrayList<Object>();
         List<String> parsedFeaturePaths = new ArrayList<String>();
         List<String> parsedGlue = new ArrayList<String>();
+        List<String> parsedJunitOptions = new ArrayList<String>();
 
         while (!args.isEmpty()) {
             String arg = args.remove(0).trim();
@@ -136,6 +138,10 @@ public class RuntimeOptions {
                 String nextArg = args.remove(0);
                 Pattern patternFilter = Pattern.compile(nextArg);
                 parsedFilters.add(patternFilter);
+            } else if (arg.startsWith("--junit,")) {
+                for (String option : arg.substring("--junit,".length()).split(",")) {
+                    parsedJunitOptions.add(option);
+                }
             } else if (arg.startsWith("-")) {
                 printUsage();
                 throw new CucumberException("Unknown option: " + arg);
@@ -157,6 +163,10 @@ public class RuntimeOptions {
         if (!parsedGlue.isEmpty()) {
             glue.clear();
             glue.addAll(parsedGlue);
+        }
+        if (!parsedJunitOptions.isEmpty()) {
+            junitOptions.clear();
+            junitOptions.addAll(parsedJunitOptions);
         }
     }
 
@@ -346,5 +356,9 @@ public class RuntimeOptions {
 
     public SnippetType getSnippetType() {
         return snippetType;
+    }
+
+    public List<String> getJunitOptions() {
+        return junitOptions;
     }
 }

--- a/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
@@ -40,6 +40,7 @@ public class RuntimeOptionsFactory {
                 addSnippets(options, args);
                 addGlue(options, args);
                 addFeatures(options, args);
+                addJunitOptions(options, args);
             }
         }
         addDefaultFeaturePathIfNoFeaturePathIsSpecified(args, clazz);
@@ -131,6 +132,12 @@ public class RuntimeOptionsFactory {
     private void addStrict(CucumberOptions options, List<String> args) {
         if (options.strict()) {
             args.add("--strict");
+        }
+    }
+
+    private void addJunitOptions(CucumberOptions options, List<String> args) {
+        for (String junitOption : options.junit()) {
+            args.add("--junit," + junitOption);
         }
     }
 

--- a/core/src/main/resources/cucumber/api/cli/USAGE.txt
+++ b/core/src/main/resources/cucumber/api/cli/USAGE.txt
@@ -24,6 +24,9 @@ Options:
   -h, --help                             You're looking at it.
   --i18n LANG                            List keywords for in a particular language
                                          Run with "--i18n help" to see all languages
+  --junit,OPTION[,OPTION]*               Pass the OPTION(s) to the JUnit module.
+                                         Use --junit,-h or --junit,--help to print the
+                                         options of the JUnit module.
 
 Feature path examples:
   <path>                                 Load the files with the extension ".feature"

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
@@ -124,6 +124,14 @@ public class RuntimeOptionsFactoryTest {
         assertTrue(runtimeOptions.isMonochrome());
     }
 
+    @Test
+    public void create_with_junit_options() {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(ClassWithJunitOption.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+
+        assertEquals(asList("option1", "option2=value"), runtimeOptions.getJunitOptions());
+    }
+
     private void assertPluginExists(List<Object> plugins, String pluginName) {
         boolean found = false;
         for (Object plugin : plugins) {
@@ -194,6 +202,11 @@ public class RuntimeOptionsFactoryTest {
 
     @CucumberOptions(plugin = "pretty")
     static class ClassWithNoSummaryPrinterPlugin {
+        // empty
+    }
+
+    @CucumberOptions(junit = {"option1", "option2=value"})
+    static class ClassWithJunitOption {
         // empty
     }
 }

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -163,6 +163,26 @@ public class RuntimeOptionsTest {
     }
 
     @Test
+    public void assigns_single_junit_option() {
+        RuntimeOptions options = new RuntimeOptions(asList("--junit,option"));
+        assertEquals(asList("option"), options.getJunitOptions());
+    }
+
+    @Test
+    public void assigns_multiple_junit_options() {
+        RuntimeOptions options = new RuntimeOptions(asList("--junit,option1,option2=value"));
+        assertEquals(asList("option1", "option2=value"), options.getJunitOptions());
+    }
+
+    @Test
+    public void clobbers_junit_options_from_cli_if_junit_options_specified_in_cucumber_options_property() {
+        Properties properties = new Properties();
+        properties.setProperty("cucumber.options", "--junit,option_from_property");
+        RuntimeOptions runtimeOptions = new RuntimeOptions(new Env(properties), asList("--junit,option_to_be_clobbered"));
+        assertEquals(asList("option_from_property"), runtimeOptions.getJunitOptions());
+    }
+
+    @Test
     public void overrides_options_with_system_properties_without_clobbering_non_overridden_ones() {
         Properties properties = new Properties();
         properties.setProperty("cucumber.options", "--glue lookatme this_clobbers_feature_paths");

--- a/junit/src/main/java/cucumber/api/junit/Cucumber.java
+++ b/junit/src/main/java/cucumber/api/junit/Cucumber.java
@@ -10,6 +10,7 @@ import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.io.ResourceLoaderClassFinder;
 import cucumber.runtime.junit.Assertions;
 import cucumber.runtime.junit.FeatureRunner;
+import cucumber.runtime.junit.JUnitOptions;
 import cucumber.runtime.junit.JUnitReporter;
 import cucumber.runtime.model.CucumberFeature;
 import org.junit.runner.Description;
@@ -57,8 +58,9 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
         ResourceLoader resourceLoader = new MultiLoader(classLoader);
         runtime = createRuntime(resourceLoader, classLoader, runtimeOptions);
 
+        final JUnitOptions junitOptions = new JUnitOptions(runtimeOptions.getJunitOptions());
         final List<CucumberFeature> cucumberFeatures = runtimeOptions.cucumberFeatures(resourceLoader);
-        jUnitReporter = new JUnitReporter(runtimeOptions.reporter(classLoader), runtimeOptions.formatter(classLoader), runtimeOptions.isStrict());
+        jUnitReporter = new JUnitReporter(runtimeOptions.reporter(classLoader), runtimeOptions.formatter(classLoader), runtimeOptions.isStrict(), junitOptions);
         addChildren(cucumberFeatures);
     }
 

--- a/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
+++ b/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
@@ -42,7 +42,12 @@ public class ExecutionUnitRunner extends ParentRunner<Step> {
 
     @Override
     public String getName() {
-        return cucumberScenario.getVisualName();
+        String name = cucumberScenario.getVisualName();
+        if (jUnitReporter.useFilenameCompatibleNames()) {
+            return makeNameFilenameCompatible(name);
+        } else {
+            return name;
+        }
     }
 
     @Override
@@ -78,7 +83,13 @@ public class ExecutionUnitRunner extends ParentRunner<Step> {
     protected Description describeChild(Step step) {
         Description description = stepDescriptions.get(step);
         if (description == null) {
-            description = Description.createTestDescription(getName(), step.getKeyword() + step.getName(), step);
+            String testName;
+            if (jUnitReporter.useFilenameCompatibleNames()) {
+                testName = makeNameFilenameCompatible(step.getKeyword() + step.getName());
+            } else {
+                testName = step.getKeyword() + step.getName();
+            }
+            description = Description.createTestDescription(getName(), testName, step);
             stepDescriptions.put(step, description);
         }
         return description;
@@ -98,5 +109,9 @@ public class ExecutionUnitRunner extends ParentRunner<Step> {
         // Instead it happens via cucumberScenario.run(jUnitReporter, jUnitReporter, runtime);
         throw new UnsupportedOperationException();
         // cucumberScenario.runStep(step, jUnitReporter, runtime);
+    }
+
+    private String makeNameFilenameCompatible(String name) {
+        return name.replaceAll("[^A-Za-z0-9_]", "_");
     }
 }

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitOptions.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitOptions.java
@@ -1,0 +1,69 @@
+package cucumber.runtime.junit;
+
+import cucumber.runtime.CucumberException;
+import gherkin.util.FixJava;
+
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+
+public class JUnitOptions {
+    public static final String OPTIONS_RESOURCE = "/cucumber/api/junit/OPTIONS.txt";
+    private static String optionsText;
+
+    private boolean allowStartedIgnored = false;
+    private boolean filenameCompatibleNames = false;
+
+    /**
+     * Create a new instance from a list of options, for example:
+     * <p/>
+     * <pre<{@code Arrays.asList("--allow-started-ignored", "--filename-compatible-names");}</pre>
+     *
+     * @param argv the arguments
+     */
+    public JUnitOptions(List<String> argv) {
+        argv = new ArrayList<String>(argv); // in case the one passed in is unmodifiable.
+        parse(argv);
+    }
+
+    private void parse(List<String> args) {
+        while (!args.isEmpty()) {
+            String arg = args.remove(0).trim();
+
+            if (arg.equals("--help") || arg.equals("-h")) {
+                printOptions();
+                System.exit(0);
+            } else if (arg.equals("--no-allow-started-ignored") || arg.equals("--allow-started-ignored")) {
+                allowStartedIgnored = !arg.startsWith("--no-");
+            } else if (arg.equals("--filename-compatible-names") || arg.equals("--filename-compatible-names")) {
+                filenameCompatibleNames = !arg.startsWith("--no-");
+            } else {
+                throw new CucumberException("Unknown option: " + arg);
+            }
+        }
+    }
+
+    public boolean allowStartedIgnored() {
+        return allowStartedIgnored;
+    }
+    public boolean filenameCompatibleNames() {
+        return filenameCompatibleNames;
+    }
+
+    private void printOptions() {
+        loadUsageTextIfNeeded();
+        System.out.println(optionsText);
+    }
+
+    static void loadUsageTextIfNeeded() {
+        if (optionsText == null) {
+            try {
+                Reader reader = new InputStreamReader(FixJava.class.getResourceAsStream(OPTIONS_RESOURCE), "UTF-8");
+                optionsText = FixJava.readReader(reader);
+            } catch (Exception e) {
+                optionsText = "Could not load usage text: " + e.toString();
+            }
+        }
+    }
+}

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -66,6 +66,9 @@ public class JUnitReporter implements Reporter, Formatter {
         Description description = executionUnitRunner.describeChild(runnerStep);
         stepNotifier = new EachTestNotifier(runNotifier, description);
         reporter.match(match);
+        if (junitOptions.allowStartedIgnored()) {
+            stepNotifier.fireTestStarted();
+        }
     }
 
     private Step fetchAndCheckRunnerStep() {
@@ -96,7 +99,9 @@ public class JUnitReporter implements Reporter, Formatter {
         } else {
             if (stepNotifier != null) {
                 //Should only fireTestStarted if not ignored
-                stepNotifier.fireTestStarted();
+                if (!junitOptions.allowStartedIgnored()) {
+                    stepNotifier.fireTestStarted();
+                }
                 if (error != null) {
                     stepNotifier.addFailure(error);
                 }
@@ -123,7 +128,9 @@ public class JUnitReporter implements Reporter, Formatter {
 
     private void addFailureOrIgnoreStep(Result result) {
         if (strict) {
-            stepNotifier.fireTestStarted();
+            if (!junitOptions.allowStartedIgnored()) {
+                stepNotifier.fireTestStarted();
+            }
             addFailure(result);
             stepNotifier.fireTestFinished();
         } else {

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -121,6 +121,10 @@ public class JUnitReporter implements Reporter, Formatter {
         reporter.result(result);
     }
 
+    public boolean useFilenameCompatibleNames() {
+        return junitOptions.filenameCompatibleNames();
+    }
+
     private boolean isPendingOrUndefined(Result result) {
         Throwable error = result.getError();
         return Result.UNDEFINED == result || isPending(error);

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -26,6 +26,7 @@ public class JUnitReporter implements Reporter, Formatter {
     private final Reporter reporter;
     private final Formatter formatter;
     private final boolean strict;
+    private final JUnitOptions junitOptions;
 
     EachTestNotifier stepNotifier;
     private ExecutionUnitRunner executionUnitRunner;
@@ -35,10 +36,11 @@ public class JUnitReporter implements Reporter, Formatter {
     private boolean ignoredStep;
     private boolean inScenarioLifeCycle;
 
-    public JUnitReporter(Reporter reporter, Formatter formatter, boolean strict) {
+    public JUnitReporter(Reporter reporter, Formatter formatter, boolean strict, JUnitOptions junitOption) {
         this.reporter = reporter;
         this.formatter = formatter;
         this.strict = strict;
+        this.junitOptions = junitOption;
     }
 
     public void startExecutionUnit(ExecutionUnitRunner executionUnitRunner, RunNotifier runNotifier) {

--- a/junit/src/main/resources/cucumber/api/junit/OPTIONS.txt
+++ b/junit/src/main/resources/cucumber/api/junit/OPTIONS.txt
@@ -1,0 +1,4 @@
+JUnit Options:
+
+  -h, --help                             You're looking at it.
+

--- a/junit/src/main/resources/cucumber/api/junit/OPTIONS.txt
+++ b/junit/src/main/resources/cucumber/api/junit/OPTIONS.txt
@@ -1,4 +1,11 @@
 JUnit Options:
 
   -h, --help                             You're looking at it.
+  --[no-]allow-started-ignored           Fire test started before the execution of a
+                                         step. This makes it possible to use the
+                                         test started and test finished notification
+                                         to calculate the execution time of the step.
+                                         If the step is pending the test started will
+                                         be followed by a test ignored, which can
+                                         confuse some listeners.
 

--- a/junit/src/main/resources/cucumber/api/junit/OPTIONS.txt
+++ b/junit/src/main/resources/cucumber/api/junit/OPTIONS.txt
@@ -8,4 +8,9 @@ JUnit Options:
                                          If the step is pending the test started will
                                          be followed by a test ignored, which can
                                          confuse some listeners.
+  --[no-]filename-compatible-names       Make sure that the names of the test cases
+                                         only is made up of [A-Za-Z0-9_] so that the
+                                         names for certain can be used as file names.
+                                         For instance gradle will use these names in 
+                                         the file names of the JUnit xml report files.
 

--- a/junit/src/test/java/cucumber/runtime/junit/ExecutionUnitRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/ExecutionUnitRunnerTest.java
@@ -33,7 +33,7 @@ public class ExecutionUnitRunnerTest {
         ExecutionUnitRunner runner = new ExecutionUnitRunner(
                 null,
                 (CucumberScenario) features.get(0).getFeatureElements().get(0),
-                null
+                createStandardJUnitReporter()
         );
 
         // fish out the two occurrences of the same step and check whether we really got them
@@ -61,7 +61,7 @@ public class ExecutionUnitRunnerTest {
         ExecutionUnitRunner runner = new ExecutionUnitRunner(
                 null,
                 (CucumberScenario) features.get(0).getFeatureElements().get(0),
-                null
+                createStandardJUnitReporter()
         );
 
         // fish out the data from runner
@@ -85,7 +85,7 @@ public class ExecutionUnitRunnerTest {
         ExecutionUnitRunner runner = new ExecutionUnitRunner(
                 null,
                 (CucumberScenario) cucumberFeature.getFeatureElements().get(0),
-                null
+                createStandardJUnitReporter()
         );
 
         // fish out the data from runner
@@ -105,4 +105,7 @@ public class ExecutionUnitRunnerTest {
         assertEquals(stepDescription, Description.createTestDescription("", "", step));
     }
 
+    private JUnitReporter createStandardJUnitReporter() {
+        return new JUnitReporter(null, null, false, new JUnitOptions(Collections.<String>emptyList()));
+    }
 }

--- a/junit/src/test/java/cucumber/runtime/junit/ExecutionUnitRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/ExecutionUnitRunnerTest.java
@@ -1,19 +1,13 @@
 package cucumber.runtime.junit;
 
-import cucumber.runtime.FeatureBuilder;
 import cucumber.runtime.io.ClasspathResourceLoader;
-import cucumber.runtime.io.Resource;
 import cucumber.runtime.model.CucumberFeature;
 import cucumber.runtime.model.CucumberScenario;
 import gherkin.formatter.model.Step;
 import org.junit.Test;
 import org.junit.runner.Description;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -99,6 +93,55 @@ public class ExecutionUnitRunnerTest {
         assertDescriptionHasStepAsUniqueId(scenarioStepDescription, runnerScenarioStep);
     }
 
+    @Test
+    public void shouldUseScenarioNameForRunnerName() throws Exception {
+        CucumberFeature cucumberFeature = TestFeatureBuilder.feature("featurePath", "" +
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Then it works\n");
+
+        ExecutionUnitRunner runner = new ExecutionUnitRunner(
+                null,
+                (CucumberScenario) cucumberFeature.getFeatureElements().get(0),
+                createStandardJUnitReporter()
+        );
+
+        assertEquals("Scenario: scenario name", runner.getName());
+    }
+
+    @Test
+    public void shouldUseStepKeyworkAndNameForChildName() throws Exception {
+        CucumberFeature cucumberFeature = TestFeatureBuilder.feature("featurePath", "" +
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Then it works\n");
+
+        ExecutionUnitRunner runner = new ExecutionUnitRunner(
+                null,
+                (CucumberScenario) cucumberFeature.getFeatureElements().get(0),
+                createStandardJUnitReporter()
+        );
+
+        assertEquals("Then it works", runner.getDescription().getChildren().get(0).getMethodName());
+    }
+
+    @Test
+    public void shouldConvertTextFromFeatureFileForNamesWithFilenameCompatibleNameOption() throws Exception {
+        CucumberFeature cucumberFeature = TestFeatureBuilder.feature("featurePath", "" +
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Then it works\n");
+
+        ExecutionUnitRunner runner = new ExecutionUnitRunner(
+                null,
+                (CucumberScenario) cucumberFeature.getFeatureElements().get(0),
+                createJUnitReporterWithOption("--filename-compatible-names")
+        );
+
+        assertEquals("Scenario__scenario_name", runner.getName());
+        assertEquals("Then_it_works", runner.getDescription().getChildren().get(0).getMethodName());
+    }
+
     private void assertDescriptionHasStepAsUniqueId(Description stepDescription, Step step) {
         // Note, JUnit uses the the serializable parameter (in this case the step)
         // as the unique id when comparing Descriptions
@@ -107,5 +150,9 @@ public class ExecutionUnitRunnerTest {
 
     private JUnitReporter createStandardJUnitReporter() {
         return new JUnitReporter(null, null, false, new JUnitOptions(Collections.<String>emptyList()));
+    }
+
+    private JUnitReporter createJUnitReporterWithOption(String option) {
+        return new JUnitReporter(null, null, false, new JUnitOptions(Arrays.asList(option)));
     }
 }

--- a/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
 
+import java.util.Collections;
+
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -136,7 +138,7 @@ public class FeatureRunnerTest {
         final RuntimeGlue glue = mock(RuntimeGlue.class);
         final Runtime runtime = new Runtime(resourceLoader, classLoader, asList(mock(Backend.class)), runtimeOptions, new StopWatch.Stub(0l), glue);
         FormatterSpy formatterSpy = new FormatterSpy();
-        FeatureRunner runner = new FeatureRunner(cucumberFeature, runtime, new JUnitReporter(formatterSpy, formatterSpy, false));
+        FeatureRunner runner = new FeatureRunner(cucumberFeature, runtime, new JUnitReporter(formatterSpy, formatterSpy, false, new JUnitOptions(Collections.<String>emptyList())));
         runner.run(mock(RunNotifier.class));
         return formatterSpy.toString();
     }

--- a/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
@@ -21,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -232,7 +233,7 @@ public class JUnitReporterTest {
         Scenario scenario = mock(Scenario.class);
         Step step = mock(Step.class);
         Formatter formatter = mock(Formatter.class);
-        jUnitReporter = new JUnitReporter(mock(Reporter.class), formatter, false);
+        jUnitReporter = new JUnitReporter(mock(Reporter.class), formatter, false, new JUnitOptions(Collections.<String>emptyList()));
 
         jUnitReporter.uri(uri);
         jUnitReporter.feature(feature);
@@ -270,7 +271,7 @@ public class JUnitReporterTest {
         byte data[] = new byte[] {1};
         String text = "text";
         Reporter reporter = mock(Reporter.class);
-        jUnitReporter = new JUnitReporter(reporter, mock(Formatter.class), false);
+        jUnitReporter = new JUnitReporter(reporter, mock(Formatter.class), false, new JUnitOptions(Collections.<String>emptyList()));
 
         jUnitReporter.startExecutionUnit(executionUnitRunner, mock(RunNotifier.class));
         jUnitReporter.startOfScenarioLifeCycle(mock(Scenario.class));
@@ -297,7 +298,7 @@ public class JUnitReporterTest {
         ExecutionUnitRunner executionUnitRunner = mockExecutionUnitRunner(runnerSteps(runnerStep));
         when(executionUnitRunner.describeChild(runnerStep)).thenReturn(runnerStepDescription);
         RunNotifier notifier = mock(RunNotifier.class);
-        jUnitReporter = new JUnitReporter(mock(Reporter.class), mock(Formatter.class), false);
+        jUnitReporter = new JUnitReporter(mock(Reporter.class), mock(Formatter.class), false, new JUnitOptions(Collections.<String>emptyList()));
 
         jUnitReporter.startExecutionUnit(executionUnitRunner, notifier);
         jUnitReporter.startOfScenarioLifeCycle(mock(Scenario.class));
@@ -312,7 +313,7 @@ public class JUnitReporterTest {
     public void throws_exception_when_runner_step_name_do_no_match_scenario_step_name() throws Exception {
         Step runnerStep = mockStep("Runner Step Name");
         ExecutionUnitRunner executionUnitRunner = mockExecutionUnitRunner(runnerSteps(runnerStep));
-        jUnitReporter = new JUnitReporter(mock(Reporter.class), mock(Formatter.class), false);
+        jUnitReporter = new JUnitReporter(mock(Reporter.class), mock(Formatter.class), false, new JUnitOptions(Collections.<String>emptyList()));
 
         jUnitReporter.startExecutionUnit(executionUnitRunner, mock(RunNotifier.class));
         jUnitReporter.startOfScenarioLifeCycle(mock(Scenario.class));
@@ -389,7 +390,7 @@ public class JUnitReporterTest {
         Formatter formatter = mock(Formatter.class);
         Reporter reporter = mock(Reporter.class);
 
-        jUnitReporter = new JUnitReporter(reporter, formatter, strict);
+        jUnitReporter = new JUnitReporter(reporter, formatter, strict, new JUnitOptions(Collections.<String>emptyList()));
     }
 
 }

--- a/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -36,6 +37,24 @@ public class JUnitReporterTest {
 
     private JUnitReporter jUnitReporter;
     private RunNotifier runNotifier;
+
+    @Test
+    public void match_allow_stared_ignored() {
+        createAllowStartedIgnoredReporter();
+        Step runnerStep = mockStep();
+        Description runnerStepDescription = stepDescription(runnerStep);
+        ExecutionUnitRunner executionUnitRunner = mockExecutionUnitRunner(runnerSteps(runnerStep));
+        when(executionUnitRunner.describeChild(runnerStep)).thenReturn(runnerStepDescription);
+        runNotifier = mock(RunNotifier.class);
+
+        jUnitReporter.startExecutionUnit(executionUnitRunner, runNotifier);
+        jUnitReporter.startOfScenarioLifeCycle(mock(Scenario.class));
+        jUnitReporter.step(runnerStep);
+        jUnitReporter.match(mock(Match.class));
+
+        verify(runNotifier).fireTestStarted(executionUnitRunner.getDescription());
+        verify(runNotifier).fireTestStarted(runnerStepDescription);
+    }
 
     @Test
     public void resultWithError() {
@@ -161,6 +180,22 @@ public class JUnitReporterTest {
         jUnitReporter.result(result);
 
         verify(stepNotifier).fireTestStarted();
+        verify(stepNotifier).fireTestFinished();
+        verify(stepNotifier, times(0)).addFailure(Matchers.<Throwable>any(Throwable.class));
+        verify(stepNotifier, times(0)).fireTestIgnored();
+    }
+
+    @Test
+    public void result_without_error_allow_stared_ignored() {
+        createAllowStartedIgnoredReporter();
+        Result result = mock(Result.class);
+
+        EachTestNotifier stepNotifier = mock(EachTestNotifier.class);
+        jUnitReporter.stepNotifier = stepNotifier;
+
+        jUnitReporter.result(result);
+
+        verify(stepNotifier, times(0)).fireTestStarted();
         verify(stepNotifier).fireTestFinished();
         verify(stepNotifier, times(0)).addFailure(Matchers.<Throwable>any(Throwable.class));
         verify(stepNotifier, times(0)).fireTestIgnored();
@@ -379,18 +414,23 @@ public class JUnitReporterTest {
     }
 
     private void createStrictReporter() {
-        createReporter(true);
+        createReporter(true, false);
     }
 
     private void createNonStrictReporter() {
-        createReporter(false);
+        createReporter(false, false);
     }
 
-    private void createReporter(boolean strict) {
+    private void createAllowStartedIgnoredReporter() {
+        createReporter(false, true);
+    }
+
+    private void createReporter(boolean strict, boolean allowStartedIgnored) {
         Formatter formatter = mock(Formatter.class);
         Reporter reporter = mock(Reporter.class);
 
-        jUnitReporter = new JUnitReporter(reporter, formatter, strict, new JUnitOptions(Collections.<String>emptyList()));
+        String allowStartedIgnoredOption = allowStartedIgnored ? "--allow-started-ignored" : "--no-allow-started-ignored";
+        jUnitReporter = new JUnitReporter(reporter, formatter, strict, new JUnitOptions(asList(allowStartedIgnoredOption)));
     }
 
 }


### PR DESCRIPTION
The PR adds the mechanisms to have options for the JUnit module. To avoid that the Core module need to know about every option of the JUnit module, the JUnit options is passed through the Core module classes the same way that GCC passes option through to the pre-processor, linker etc. A JUnit option on the command line:
```
    --junit,<option>
```
and in `@CucumberOptions`:
```
@CucumberOptions(junit = { <option> })
``` 

Two JUnit options are added:
- `--allow-started-ignored`
- `--filename-compatible-names`


The `--allow-started-ignored` makes the JUnit module fire the test started notification before each test step is executed. The current behaviour is to wait to fire the test started notification until after the test step has executed. This is done to be able to not fire the test started notifications for pending steps, for which only the test ignored notification is fired. The rational for the current behaviour is that there are listeners that do not expect a test started to be followed by a test ignored. For instance Eclipse (v4.5 Mars) will report the wrong number of tests executed in that case - for instance "37 out of 36 tests executed". A consequence of the current behaviour is that a listener cannot calculate the execution time of a step from the elapsed time between the test started notification and the test finished notification, see #825.

The current behaviour will still be the default behaviour with the PR, but the `--allow-started-ignored` can be used when it is important that the elapsed time between the test started notification and the test finished notification reflects the execution time of the steps. Closes #825.


The `--filename-compatible-names` makes the JUnit module change the names used for "Execution units"/test cases and test steps in the notifications, so that they on all platforms can be used in file names (the names are actually constrained to [A-Za-z0-9_]). For instance Gradle will use the names of the test cases in report file names, and especially Windows cannot handle all characters in filenames, see #972. In some cases also names of the test steps are used for file names, see http://stackoverflow.com/questions/25174141/could-not-generate-test-report-in-gradle-due-to-cucumber-step-syntax. Fixes #972.
