### PR TITLE
Allow global registration of custom XStream converters.

### DIFF
--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -85,7 +85,7 @@ public class Runtime implements UnreportedStepExecutor {
         this.backends = backends;
         this.runtimeOptions = runtimeOptions;
         this.stopWatch = stopWatch;
-        this.glue = optionalGlue != null ? optionalGlue : new RuntimeGlue(undefinedStepsTracker, new LocalizedXStreams(classLoader));
+        this.glue = optionalGlue != null ? optionalGlue : new RuntimeGlue(undefinedStepsTracker, new LocalizedXStreams(classLoader, runtimeOptions.getConverters()));
         this.stats = new Stats(runtimeOptions.isMonochrome());
 
         for (Backend backend : backends) {

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -3,6 +3,7 @@ package cucumber.runtime;
 import cucumber.api.SnippetType;
 import cucumber.api.StepDefinitionReporter;
 import cucumber.api.SummaryPrinter;
+import cucumber.deps.com.thoughtworks.xstream.annotations.XStreamConverter;
 import cucumber.runtime.formatter.ColorAware;
 import cucumber.runtime.formatter.PluginFactory;
 import cucumber.runtime.formatter.StrictAware;
@@ -25,6 +26,7 @@ import java.util.ResourceBundle;
 import java.util.regex.Pattern;
 
 import static cucumber.runtime.model.CucumberFeature.load;
+import static java.util.Collections.unmodifiableList;
 
 // IMPORTANT! Make sure USAGE.txt is always uptodate if this class changes.
 public class RuntimeOptions {
@@ -42,6 +44,7 @@ public class RuntimeOptions {
     private final List<String> junitOptions = new ArrayList<String>();
     private final PluginFactory pluginFactory;
     private final List<Object> plugins = new ArrayList<Object>();
+    private final List<XStreamConverter> converters = new ArrayList<XStreamConverter>();
     private boolean dryRun;
     private boolean strict = false;
     private boolean monochrome = false;
@@ -176,6 +179,11 @@ public class RuntimeOptions {
         parsedPluginData.updatePluginSummaryPrinterNames(pluginSummaryPrinterNames);
     }
 
+    RuntimeOptions withConverters(List<XStreamConverter> converters) {
+        this.converters.addAll(converters);
+        return this;
+    }
+
     private boolean haveLineFilters(List<String> parsedFeaturePaths) {
         for (String pathName : parsedFeaturePaths) {
             if (pathName.startsWith("@") || PathWithLines.hasLineFilters(pathName)) {
@@ -258,6 +266,10 @@ public class RuntimeOptions {
             pluginNamesInstantiated = true;
         }
         return plugins;
+    }
+
+    List<XStreamConverter> getConverters() {
+        return unmodifiableList(converters);
     }
 
     public Formatter formatter(ClassLoader classLoader) {

--- a/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
@@ -1,6 +1,8 @@
 package cucumber.runtime;
 
 import cucumber.api.CucumberOptions;
+import cucumber.deps.com.thoughtworks.xstream.annotations.XStreamConverter;
+import cucumber.deps.com.thoughtworks.xstream.annotations.XStreamConverters;
 import cucumber.runtime.formatter.PluginFactory;
 import cucumber.runtime.io.MultiLoader;
 
@@ -22,7 +24,9 @@ public class RuntimeOptionsFactory {
 
     public RuntimeOptions create() {
         List<String> args = buildArgsFromOptions();
-        return new RuntimeOptions(args);
+        List<XStreamConverter> converters = buildConverters();
+        return new RuntimeOptions(args)
+            .withConverters(converters);
     }
 
     private List<String> buildArgsFromOptions() {
@@ -139,6 +143,27 @@ public class RuntimeOptionsFactory {
         for (String junitOption : options.junit()) {
             args.add("--junit," + junitOption);
         }
+    }
+
+    private List<XStreamConverter> buildConverters() {
+        List<XStreamConverter> converters = new ArrayList<XStreamConverter>();
+
+        for (Class<?> classWithConverters = clazz;
+            hasSuperClass(classWithConverters);
+            classWithConverters = classWithConverters.getSuperclass()
+        ) {
+            XStreamConverters xstreamConverters = classWithConverters.getAnnotation(XStreamConverters.class);
+            if (xstreamConverters != null) {
+                Collections.addAll(converters, xstreamConverters.value());
+            }
+
+            XStreamConverter xstreamConverter = classWithConverters.getAnnotation(XStreamConverter.class);
+            if (xstreamConverter != null) {
+                converters.add(xstreamConverter);
+            }
+        }
+
+        return converters;
     }
 
     static String packagePath(Class clazz) {

--- a/core/src/test/java/cucumber/runtime/DummyConverter.java
+++ b/core/src/test/java/cucumber/runtime/DummyConverter.java
@@ -1,0 +1,26 @@
+package cucumber.runtime;
+
+import cucumber.deps.com.thoughtworks.xstream.converters.Converter;
+import cucumber.deps.com.thoughtworks.xstream.converters.MarshallingContext;
+import cucumber.deps.com.thoughtworks.xstream.converters.UnmarshallingContext;
+import cucumber.deps.com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import cucumber.deps.com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+
+public class DummyConverter implements Converter {
+
+    @Override
+    public void marshal(Object o, HierarchicalStreamWriter writer, MarshallingContext ctx) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext ctx) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public boolean canConvert(Class type) {
+        return false;
+    }
+
+}

--- a/core/src/test/java/cucumber/runtime/xstream/ExternalConverterTest.java
+++ b/core/src/test/java/cucumber/runtime/xstream/ExternalConverterTest.java
@@ -1,0 +1,69 @@
+package cucumber.runtime.xstream;
+
+import cucumber.deps.com.thoughtworks.xstream.annotations.XStreamConverter;
+import cucumber.deps.com.thoughtworks.xstream.converters.Converter;
+import cucumber.deps.com.thoughtworks.xstream.converters.ConverterLookup;
+import cucumber.deps.com.thoughtworks.xstream.converters.MarshallingContext;
+import cucumber.deps.com.thoughtworks.xstream.converters.UnmarshallingContext;
+import cucumber.deps.com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import cucumber.deps.com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExternalConverterTest {
+
+    private List<XStreamConverter> extraConverters;
+    private ClassLoader classLoader;
+
+    @Before
+    public void setUp() throws Exception {
+        extraConverters = new ArrayList<XStreamConverter>();
+        classLoader = Thread.currentThread().getContextClassLoader();
+    }
+
+    @Test
+    public void shouldUseExtraConverter() {
+        extraConverters.add(Registration.class.getAnnotation(XStreamConverter.class));
+        LocalizedXStreams transformers = new LocalizedXStreams(classLoader, extraConverters);
+
+        ConverterLookup lookup = transformers.get(Locale.US).getConverterLookup();
+        Converter c = lookup.lookupConverterForType(MyClass.class);
+        assertTrue(c instanceof AlwaysConverter);
+    }
+
+    @XStreamConverter(AlwaysConverter.class)
+    public static class Registration {
+    }
+
+    public static class AlwaysConverter implements Converter {
+
+        @Override
+        public void marshal(Object o, HierarchicalStreamWriter writer, MarshallingContext ctx) {
+            throw new UnsupportedOperationException("DUMMY MARSHAL");
+        }
+
+        @Override
+        public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext ctx) {
+            throw new UnsupportedOperationException("DUMMY UNMARSHAL");
+        }
+
+        @Override
+        public boolean canConvert(Class type) {
+            return true;
+        }
+
+    }
+
+    public static class MyClass {
+        public final String s;
+
+        public MyClass(String s) {
+            this.s = s;
+        }
+    }
+
+}


### PR DESCRIPTION
This lets us provide converters for any classes that we cannot annotate directly with `@XStreamConverter`. For example,

```
@XStreamConverters(
    @XStreamConverter(MyConverter.class),
    @XStreamConverter(MyOtherConverter.class)
)
@CucumberOptions(...)
@RunWith(Cucumber.class)
public class RunCukesTest {
}
```

The existing `@XStreamConverter` annotations are being reused for consistency. The `RuntimeOptionsFactory` will check for these annotations on the same class that has the `@CucumberOptions` annotation, which keeps this change nicely internal to `cucumber-core`.
