### PR TITLE
Show explicit error message when field name missed in table header

### DIFF
--- a/core/src/main/java/cucumber/runtime/table/CamelCaseStringConverter.java
+++ b/core/src/main/java/cucumber/runtime/table/CamelCaseStringConverter.java
@@ -1,5 +1,7 @@
 package cucumber.runtime.table;
 
+import cucumber.runtime.CucumberException;
+
 import java.util.regex.Pattern;
 
 public class CamelCaseStringConverter implements StringConverter {
@@ -34,6 +36,9 @@ public class CamelCaseStringConverter implements StringConverter {
     }
 
     private String uncapitalize(String string) {
+        if (string.isEmpty()) {
+            throw new CucumberException("Field name cannot be empty. Please check the table header.");
+        }
         return new StringBuilder(string.length()).append(Character.toLowerCase(string.charAt(0))).append(string.substring(1)).toString();
     }
 

--- a/core/src/test/java/cucumber/runtime/table/CamelCaseStringConverterTest.java
+++ b/core/src/test/java/cucumber/runtime/table/CamelCaseStringConverterTest.java
@@ -1,15 +1,25 @@
 package cucumber.runtime.table;
 
+import cucumber.runtime.CucumberException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class CamelCaseStringConverterTest {
+
+    private final CamelCaseStringConverter mapper = new CamelCaseStringConverter();
+
     @Test
     public void testTransformToJavaPropertyName() {
-        CamelCaseStringConverter mapper = new CamelCaseStringConverter();
+
         assertEquals("Transformed Name", "userName", mapper.map("User Name"));
         assertEquals("Transformed Name", "birthDate", mapper.map("  Birth   Date\t"));
         assertEquals("Transformed Name", "email", mapper.map("email"));
     }
+
+    @Test(expected = CucumberException.class)
+    public void testEmptyInputShouldBeRejected() {
+        assertEquals("", mapper.map(" "));
+    }
+
 }

--- a/core/src/test/java/cucumber/runtime/table/ToDataTableTest.java
+++ b/core/src/test/java/cucumber/runtime/table/ToDataTableTest.java
@@ -66,6 +66,21 @@ public class ToDataTableTest {
     }
 
     @Test
+    public void gives_explicit_error_message_on_field_name_missing_in_header() {
+        try {
+            tc.toList(TableParser.parse("" +
+                    "| name        |            |\n" +
+                    "| Sid Vicious | 10/05/1957 |\n" +
+                    "| Frank Zappa | 21/12/1940 |\n" +
+                    "", PARAMETER_INFO),
+                    UserPojo.class);
+            fail();
+        } catch (CucumberException e) {
+            assertEquals("Field name cannot be empty. Please check the table header.", e.getMessage());
+        }
+    }
+
+    @Test
     public void gives_a_nice_error_message_when_primitive_field_is_null() {
         try {
             tc.toList(TableParser.parse("" +


### PR DESCRIPTION
instead of a `StringIndexOutOfBoundsException`:

``` java
java.lang.StringIndexOutOfBoundsException: String index out of range: 0
at java.lang.String.charAt(String.java:658)
  at cucumber.runtime.table.CamelCaseStringConverter.uncapitalize(CamelCaseStringConverter.java:37)
  at cucumber.runtime.table.CamelCaseStringConverter.map(CamelCaseStringConverter.java:13)
  at cucumber.runtime.table.TableConverter$1.map(TableConverter.java:284)
  at cucumber.runtime.table.TableConverter$1.map(TableConverter.java:281)
  at gherkin.util.FixJava.map(FixJava.java:28)
  at cucumber.runtime.table.TableConverter.convertTopCellsToFieldNames(TableConverter.java:281)
  at cucumber.runtime.table.TableConverter.toListOfComplexType(TableConverter.java:101)
  at cucumber.runtime.table.TableConverter.convert(TableConverter.java:91)
  at cucumber.runtime.StepDefinitionMatch.tableArgument(StepDefinitionMatch.java:97)
```

Motivation: when doing a larger refactoring on somewhat oversized tables it was not instantly clear what went wrong.
