### PR TITLE
Using JUnit categories to control Cucumber tests

### DIFF
--- a/junit/src/main/java/cucumber/api/junit/Cucumber.java
+++ b/junit/src/main/java/cucumber/api/junit/Cucumber.java
@@ -14,6 +14,8 @@ import cucumber.runtime.junit.JUnitOptions;
 import cucumber.runtime.junit.JUnitReporter;
 import cucumber.runtime.model.CucumberFeature;
 import org.junit.runner.Description;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.NoTestsRemainException;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.ParentRunner;
 import org.junit.runners.model.InitializationError;
@@ -88,6 +90,14 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
     @Override
     protected Description describeChild(FeatureRunner child) {
         return child.getDescription();
+    }
+
+    @Override
+    public void filter(Filter filter) throws NoTestsRemainException {
+        // dont pass filter to children as ParentRunner does by default
+        if (!filter.shouldRun(getDescription())) {
+            children.clear();
+        }
     }
 
     @Override

--- a/junit/src/test/java/cucumber/runtime/junit/categories/CategoryFilterFactory.java
+++ b/junit/src/test/java/cucumber/runtime/junit/categories/CategoryFilterFactory.java
@@ -1,0 +1,15 @@
+package cucumber.runtime.junit.categories;
+
+import org.junit.experimental.categories.IncludeCategories;
+import org.junit.runner.Description;
+import org.junit.runner.FilterFactory;
+import org.junit.runner.FilterFactoryParams;
+import org.junit.runner.manipulation.Filter;
+
+public class CategoryFilterFactory {
+
+    public static Filter includeCategory(Class category) throws FilterFactory.FilterNotCreatedException {
+        Description description = Description.createTestDescription(CategoryFilterFactory.class, "CategoryFilterFactory");
+        return new IncludeCategories().createFilter(new FilterFactoryParams(description, category.getName()));
+    }
+}

--- a/junit/src/test/java/cucumber/runtime/junit/categories/UsedCategory.java
+++ b/junit/src/test/java/cucumber/runtime/junit/categories/UsedCategory.java
@@ -1,0 +1,4 @@
+package cucumber.runtime.junit.categories;
+
+public interface UsedCategory {
+}


### PR DESCRIPTION
I'm trying to address issue from here https://groups.google.com/forum/#!topic/cukes/jVqbTdwoAPo
At the moment Cucumber JUnit runner does not work with categories as it pass filter to children like FeatureRunner, that are unaware of categories (annotation of parent)

My solution is to just filter based on Cucumber entry point runner and add or none of children tests.
