### PR TITLE
Fix directory creation race condition

### DIFF
--- a/core/src/main/java/cucumber/runtime/io/URLOutputStream.java
+++ b/core/src/main/java/cucumber/runtime/io/URLOutputStream.java
@@ -49,7 +49,9 @@ public class URLOutputStream extends OutputStream {
     private void ensureParentDirExists(File file) throws IOException {
         if (file.getParentFile() != null && !file.getParentFile().isDirectory()) {
             boolean ok = file.getParentFile().mkdirs();
-            if (!ok) {
+            // (Re-check existence here, as "mkdirs()" may return false if another thread
+            // created the dir between our first check and the mkdirs call.)
+            if (!ok && !file.getParentFile().isDirectory()) {
                 throw new IOException("Failed to create directory " + file.getParentFile().getAbsolutePath());
             }
         }


### PR DESCRIPTION
I'm running my Cucumber tests in parallel, to speed up my build, using the mvn failsafe plugin.

The following code throws a lot of errors at test startup. I think there's a race between the "exists" check at line 50 and the mkdirs call at line 51.