### PR TITLE
Fix issue in ComplexTypeWriter

### DIFF
--- a/core/src/main/java/cucumber/runtime/table/PascalCaseStringConverter.java
+++ b/core/src/main/java/cucumber/runtime/table/PascalCaseStringConverter.java
@@ -1,0 +1,35 @@
+package cucumber.runtime.table;
+
+import java.util.regex.Pattern;
+
+public class PascalCaseStringConverter implements StringConverter {
+
+    private static final String WHITESPACE = " ";
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
+
+    @Override
+    public String map(String string) {
+        String[] splitted = normalizeSpace(string).split(WHITESPACE);
+        for (int i = 0; i < splitted.length; i++) {
+            splitted[i] = capitalize(splitted[i]);
+        }
+        return join(splitted);
+    }
+
+    private String join(String[] splitted) {
+        StringBuilder sb = new StringBuilder();
+        for (String s : splitted) {
+            sb.append(s);
+        }
+        return sb.toString();
+    }
+
+    private String normalizeSpace(String originalHeaderName) {
+        return WHITESPACE_PATTERN.matcher(originalHeaderName.trim()).replaceAll(WHITESPACE);
+    }
+
+    private String capitalize(String string) {
+        return new StringBuilder(string.length()).append(Character.toTitleCase(string.charAt(0))).append(string.substring(1)).toString();
+    }
+
+}

--- a/core/src/main/java/cucumber/runtime/xstream/ComplexTypeWriter.java
+++ b/core/src/main/java/cucumber/runtime/xstream/ComplexTypeWriter.java
@@ -1,20 +1,25 @@
 package cucumber.runtime.xstream;
 
-import cucumber.runtime.table.CamelCaseStringConverter;
 
+import cucumber.deps.com.thoughtworks.xstream.annotations.XStreamConverter;
+import cucumber.runtime.CucumberException;
+import cucumber.runtime.table.CamelCaseStringConverter;
+import cucumber.runtime.table.PascalCaseStringConverter;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 
 import static java.util.Arrays.asList;
 
 public class ComplexTypeWriter extends CellWriter {
     private final List<String> columnNames;
-    private Map<String, String> fields = new LinkedHashMap<String, String>();
-    private String currentKey;
-
-    private int nodeDepth = 0;
+    private final Map<String, String> fields = new LinkedHashMap<String, String>();
+    private final Stack<String> currentKey = new Stack<String>();
 
     public ComplexTypeWriter(List<String> columnNames) {
         this.columnNames = columnNames;
@@ -48,10 +53,10 @@ public class ComplexTypeWriter extends CellWriter {
 
     @Override
     public void startNode(String name) {
-        if (nodeDepth == 1) {
-            currentKey = name;
+        currentKey.push(name);
+        if (currentKey.size() == 2) {
+            fields.put(name, "");
         }
-        nodeDepth++;
     }
 
     @Override
@@ -60,13 +65,26 @@ public class ComplexTypeWriter extends CellWriter {
 
     @Override
     public void setValue(String value) {
-        fields.put(currentKey, value == null ? "" : value);
+        // Add all simple types at level 2. nodeDepth 1 is the root node.
+        if(currentKey.size() < 2){
+            return;
+        }
+
+        if (currentKey.size() == 2) {
+            fields.put(currentKey.peek(), value == null ? "" : value);
+            return;
+        }
+
+        final String clazz = currentKey.get(0);
+        final String field = currentKey.get(1);
+        if ((columnNames.isEmpty() || columnNames.contains(field))) {
+            throw createMissingConverterException(clazz, field);
+        }
     }
 
     @Override
     public void endNode() {
-        nodeDepth--;
-        currentKey = null;
+        currentKey.pop();
     }
 
     @Override
@@ -77,5 +95,40 @@ public class ComplexTypeWriter extends CellWriter {
     @Override
     public void close() {
         throw new UnsupportedOperationException();
+    }
+
+    private static CucumberException createMissingConverterException(String clazz, String field) {
+        PascalCaseStringConverter converter = new PascalCaseStringConverter();
+        return new CucumberException(String.format(
+            "Don't know how to convert \"%s.%s\" into a table entry.\n" +
+                "Either exclude %s from the table by selecting the fields to include:\n" +
+                "\n" +
+                "DataTable.create(entries, \"Field\", \"Other Field\")\n" +
+                "\n" +
+                "Or try writing your own converter:\n" +
+                "\n" +
+                "@%s(%sConverter.class)\n" +
+                "%s %s;\n",
+            clazz,
+            field,
+            field,
+            XStreamConverter.class.getName(),
+            converter.map(field),
+            modifierAndTypeOfField(clazz, field),
+            field
+        ));
+    }
+
+    private static String modifierAndTypeOfField(String clazz, String fieldName) {
+        try {
+            Field field = Class.forName(clazz).getDeclaredField(fieldName);
+            String simpleTypeName = field.getType().getSimpleName();
+            String modifiers = Modifier.toString(field.getModifiers());
+            return modifiers + " " + simpleTypeName;
+        } catch (NoSuchFieldException e) {
+            return "private Object";
+        } catch (ClassNotFoundException e) {
+            return "private Object";
+        }
     }
 }

--- a/core/src/test/java/cucumber/runtime/table/ToDataTableTest.java
+++ b/core/src/test/java/cucumber/runtime/table/ToDataTableTest.java
@@ -7,13 +7,19 @@ import cucumber.runtime.xstream.LocalizedXStreams;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -38,6 +44,54 @@ public class ToDataTableTest {
                 "      | 3,000   | Frank Zappa | 21/12/1940 |\n" +
                 "", table.toString());
     }
+
+    @Test
+    public void converts_only_selected_fields_of_object_to_table() throws ParseException {
+        RelationPojo relation = new RelationPojo();
+        relation.id = 12;
+        relation.user = new UserPojo(0);
+        relation.user.credits = 1000;
+        relation.user.name = "Tom Scott";
+        relation.user.birthDate = new SimpleDateFormat("yyyy-MM-dd").parse("1984-01-01");
+        relation.created = new SimpleDateFormat("yyyy-MM-dd").parse("2000-01-01");
+        relation.tags = new HashSet<String>(Arrays.asList("A","B", "C"));
+
+        DataTable table = tc.toTable(singletonList(relation), "id", "created");
+        assertEquals("" +
+            "      | id | created    |\n" +
+            "      | 12 | 01/01/2000 |\n" +
+            "", table.toString());
+    }
+
+    @Test
+    public void throws_exception_when_converting_complex_selected_field_to_table() throws ParseException {
+        RelationPojo relation = new RelationPojo();
+        relation.id = 12;
+        relation.user = new UserPojo(0);
+        relation.user.credits = 1000;
+        relation.user.name = "Tom Scott";
+        relation.user.birthDate = new SimpleDateFormat("yyyy-MM-dd").parse("1984-01-01");
+        relation.created = new SimpleDateFormat("yyyy-MM-dd").parse("2000-01-01");
+        relation.tags = new HashSet<String>(Arrays.asList("A","B", "C"));
+
+        try {
+            tc.toTable(singletonList(relation), "id", "created", "tags");
+            fail();
+        } catch (CucumberException expected){
+            assertEquals("" +
+                    "Don't know how to convert \"cucumber.runtime.table.ToDataTableTest$RelationPojo.tags\" into a table entry.\n" +
+                    "Either exclude tags from the table by selecting the fields to include:\n" +
+                    "\n" +
+                    "DataTable.create(entries, \"Field\", \"Other Field\")\n" +
+                    "\n" +
+                    "Or try writing your own converter:\n" +
+                    "\n" +
+                    "@cucumber.deps.com.thoughtworks.xstream.annotations.XStreamConverter(TagsConverter.class)\n" +
+                    "public Set tags;\n",
+                expected.getMessage());
+        }
+    }
+
 
     @Test
     public void converts_list_of_beans_with_null_to_table() {
@@ -213,6 +267,17 @@ public class ToDataTableTest {
                 AnEnum.class
         );
         assertEquals("[yes, null]", actual.toString());
+    }
+
+    // No setters
+    public static class RelationPojo {
+        public Integer id;
+        public UserPojo user;
+        public Date created;
+        public Set<String> tags = new HashSet<String>();
+
+        public RelationPojo() {
+        }
     }
 
     // No setters


### PR DESCRIPTION
It can happen that in ComplexTypeWriter "startNode" is called more often than "setValue". In our case this happened when one of the fields was an empty Set, but perhaps there are other cases too.

In this case, startNode is called, but setValue is not. This causes the fieldNames and fieldValues lists to go out of alignment which causes all sorts of havoc when creating the DataTable.

This fix simply replaces the two separate lists with a Map, so that they are always aligned. One caveat of this approach is that if the same field name is serialized more than once, the previous value would be overwritten. However, seeing how the Writer is used, this does not seem like something that the current DataTables can handle anyway.

All existing tests pass.
