### PR TITLE
Add unit tests to reproduce issue #1044 as well as proposed solution.

### DIFF
--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/ConstructorParameters.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/ConstructorParameters.java
@@ -1,0 +1,39 @@
+package cucumber.runtime.java.picocontainer;
+
+import org.picocontainer.Parameter;
+import org.picocontainer.parameters.ConstantParameter;
+import org.picocontainer.parameters.DefaultConstructorParameter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConstructorParameters
+{
+    private final static Map<Class<?>, Parameter[]> CONSTRUCTORS = new HashMap<Class<?>, Parameter[]>();
+    static
+    {
+        CONSTRUCTORS.put(String.class, constructor());
+        CONSTRUCTORS.put(Integer.class, constructor(0));
+        CONSTRUCTORS.put(Long.class, constructor((long) 0));
+        CONSTRUCTORS.put(Double.class, constructor(0.0d));
+        CONSTRUCTORS.put(Float.class, constructor(0.0f));
+        CONSTRUCTORS.put(Character.class, constructor('\u0000'));
+        CONSTRUCTORS.put(Short.class, constructor((short) 0));
+        CONSTRUCTORS.put(Byte.class, constructor((byte) 0));
+    }
+
+    private static Parameter[] constructor(Object value)
+    {
+        return new Parameter[] { new ConstantParameter(value) };
+    }
+
+    private static Parameter[] constructor()
+    {
+        return new Parameter[] { DefaultConstructorParameter.INSTANCE };
+    }
+
+    static Parameter[] getConstructorFor(Class<?> clazz)
+    {
+        return CONSTRUCTORS.get(clazz);
+    }
+}

--- a/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/PicoFactory.java
+++ b/picocontainer/src/main/java/cucumber/runtime/java/picocontainer/PicoFactory.java
@@ -9,6 +9,8 @@ import java.lang.reflect.Constructor;
 import java.util.HashSet;
 import java.util.Set;
 
+import static cucumber.runtime.java.picocontainer.ConstructorParameters.getConstructorFor;
+
 public class PicoFactory implements ObjectFactory {
     private MutablePicoContainer pico;
     private final Set<Class<?>> classes = new HashSet<Class<?>>();
@@ -19,7 +21,7 @@ public class PicoFactory implements ObjectFactory {
             .withLifecycle()
             .build();
         for (Class<?> clazz : classes) {
-            pico.addComponent(clazz);
+            pico.addComponent(clazz, clazz, getConstructorFor(clazz));
         }
         pico.start();
     }

--- a/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/PicoFactoryTest.java
+++ b/picocontainer/src/test/java/cucumber/runtime/java/picocontainer/PicoFactoryTest.java
@@ -9,9 +9,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class PicoFactoryTest {
+
+    private final ObjectFactory factory = new PicoFactory();
+
     @Test
     public void shouldGiveUsNewInstancesForEachScenario() {
-        ObjectFactory factory = new PicoFactory();
         factory.addClass(StepDefs.class);
 
         // Scenario 1
@@ -31,7 +33,6 @@ public class PicoFactoryTest {
     @Test
     public void shouldDisposeOnStop() {
         // Given
-        ObjectFactory factory = new PicoFactory();
         factory.addClass(StepDefs.class);
 
         // When
@@ -46,5 +47,122 @@ public class PicoFactoryTest {
 
         // Then
         assertTrue(steps.getBelly().isDisposed());
+    }
+
+    @Test
+    public void shouldGetStringInstance() {
+        // Given
+        factory.addClass(String.class);
+
+        // When
+        factory.start();
+        String str = factory.getInstance(String.class);
+
+        // Then
+        assertNotNull(str);
+    }
+
+    @Test
+    public void shouldGetDoubleInstance() {
+        // Given
+        factory.addClass(Double.class);
+
+        // When
+        factory.start();
+        Double aDouble = factory.getInstance(Double.class);
+
+        // Then
+        assertNotNull(aDouble);
+    }
+
+    @Test
+    public void shouldGetIntegerInstance() {
+        // Given
+        factory.addClass(Integer.class);
+
+        // When
+        factory.start();
+        Integer integer = factory.getInstance(Integer.class);
+
+        // Then
+        assertNotNull(integer);
+    }
+
+    @Test
+    public void shouldGetLongInstance() {
+        // Given
+        factory.addClass(Long.class);
+
+        // When
+        factory.start();
+        Long aLong = factory.getInstance(Long.class);
+
+        // Then
+        assertNotNull(aLong);
+    }
+
+    @Test
+    public void shouldGetBooleanInstance() {
+        // Given
+        factory.addClass(Boolean.class);
+
+        // When
+        factory.start();
+        Boolean aBoolean = factory.getInstance(Boolean.class);
+
+        // Then
+        assertNotNull(aBoolean);
+    }
+
+    @Test
+    public void shouldGetCharacterInstance() {
+        // Given
+        factory.addClass(Character.class);
+
+        // When
+        factory.start();
+        Character character = factory.getInstance(Character.class);
+
+        // Then
+        assertNotNull(character);
+    }
+
+    @Test
+    public void shouldGetShortInstance() {
+        // Given
+        factory.addClass(Short.class);
+
+        // When
+        factory.start();
+        Short aShort = factory.getInstance(Short.class);
+
+        // Then
+        assertNotNull(aShort);
+    }
+
+    @Test
+    public void shouldGetByteInstance() {
+        // Given
+        factory.addClass(Byte.class);
+
+        // When
+        factory.start();
+        Byte aByte = factory.getInstance(Byte.class);
+
+        // Then
+        assertNotNull(aByte);
+    }
+
+    @Test
+    public void shouldGetFloatInstance() {
+        // Given
+        factory.addClass(Float.class);
+
+        // When
+        factory.start();
+        Float aFloat = factory.getInstance(Float.class);
+
+        // Then
+        assertNotNull(aFloat);
     }
 }


### PR DESCRIPTION
This unit tests try to use picocontainer to resolve constructors for **String** and java primitive type wrapper classes (Integer, Double, Float, etc).

I propose to create a class called **ConstructorParameters** which can return a constructor parameters for these type of classes which can help picocontainer to identify the constructor that will be used.

This class can be used in the method **PicoFactory.start** to send those constructor parameters to the method **pico.addComponent()**.