### PR TITLE
Add unit tests for ConstantPoolTypeIntrospector class.

### DIFF
--- a/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
+++ b/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
@@ -44,7 +44,7 @@ public class ConstantPoolTypeIntrospector implements TypeIntrospector {
 
     String getLambdaTypeString(ConstantPool constantPool) {
         int index = constantPool.getSize();
-        while (--index > 0) {
+        while (index-- > 0) {
             try {
                 return constantPool.getMemberRefInfoAt(index)[2];
             } catch (IllegalArgumentException | IndexOutOfBoundsException e) {

--- a/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
+++ b/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
@@ -1,7 +1,7 @@
 package cucumber.runtime.java8;
 
-import cucumber.runtime.CucumberException;
 import cucumber.api.java8.StepdefBody;
+import cucumber.runtime.CucumberException;
 import cucumber.runtime.java.TypeIntrospector;
 import sun.reflect.ConstantPool;
 
@@ -42,21 +42,16 @@ public class ConstantPoolTypeIntrospector implements TypeIntrospector {
         return typeArguments;
     }
 
-    private String getLambdaTypeString(ConstantPool constantPool) {
-        int size = constantPool.getSize();
-        String[] memberRef = null;
-
-        // find last element in constantPool with valid memberRef
-        // - previously always at size-2 index but changed with JDK 1.8.0_60
-        for (int i = size - 1; i > -1; i--) {
+    String getLambdaTypeString(ConstantPool constantPool) {
+        int index = constantPool.getSize();
+        while (--index > 0){
             try {
-                memberRef = constantPool.getMemberRefInfoAt(i);
-		return memberRef[2];
-            } catch (IllegalArgumentException e) {
-                // eat error; null entry at ConstantPool index?
+                return constantPool.getMemberRefInfoAt(index)[2];
+            } catch (IllegalArgumentException | IndexOutOfBoundsException e) {
+                // eat error; null entry at ConstantPool index? less than 3 elements?
             }
         }
-	throw new CucumberException("Couldn't find memberRef.");
+        throw new CucumberException("Couldn't find memberRef.");
     }
 
 }

--- a/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
+++ b/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
@@ -44,7 +44,7 @@ public class ConstantPoolTypeIntrospector implements TypeIntrospector {
 
     String getLambdaTypeString(ConstantPool constantPool) {
         int index = constantPool.getSize();
-        while (--index > 0){
+        while (--index > 0) {
             try {
                 return constantPool.getMemberRefInfoAt(index)[2];
             } catch (IllegalArgumentException | IndexOutOfBoundsException e) {

--- a/java8/src/test/java/cucumber/runtime/java8/ConstantPoolTypeIntrospectorTest.java
+++ b/java8/src/test/java/cucumber/runtime/java8/ConstantPoolTypeIntrospectorTest.java
@@ -1,0 +1,70 @@
+package cucumber.runtime.java8;
+
+import cucumber.runtime.CucumberException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import sun.reflect.ConstantPool;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConstantPoolTypeIntrospectorTest {
+    private final ConstantPoolTypeIntrospector constantPoolTypeIntrospector = new ConstantPoolTypeIntrospector();
+    @Mock
+    private ConstantPool constantPool;
+
+    @Test(expected = CucumberException.class)
+    public void should_throw_CucumberException_when_constant_pool_is_empty() {
+        //given
+        given(constantPool.getSize()).willReturn(0);
+
+        //when
+        constantPoolTypeIntrospector.getLambdaTypeString(constantPool);
+    }
+
+    @Test(expected = CucumberException.class)
+    public void should_throw_CucumberException_when_all_elements_throw_IllegalArgumentException() {
+        //given
+        given(constantPool.getSize()).willReturn(3);
+        givenThrowIllegalArgumentExceptionAt(0, 1, 2);
+
+        //when
+        constantPoolTypeIntrospector.getLambdaTypeString(constantPool);
+    }
+
+    private void givenThrowIllegalArgumentExceptionAt(int... indexes) {
+        for (int i : indexes) {
+            given(constantPool.getMemberRefInfoAt(i)).willThrow(new IllegalArgumentException());
+        }
+    }
+
+    @Test(expected = CucumberException.class)
+    public void should_throw_CucumberException_when_members_ref_has_less_than_3_elements() {
+        //given
+        given(constantPool.getSize()).willReturn(1);
+        given(constantPool.getMemberRefInfoAt(0)).willReturn(new String[]{"a", "b"});
+
+        //when
+        String memberRef = constantPoolTypeIntrospector.getLambdaTypeString(constantPool);
+
+        //then
+        assertEquals("memberRef", memberRef);
+    }
+
+    @Test
+    public void should_return_member_ref_when_some_element_returns_member_ref() {
+        //given
+        given(constantPool.getSize()).willReturn(3);
+        givenThrowIllegalArgumentExceptionAt(0, 2);
+        given(constantPool.getMemberRefInfoAt(1)).willReturn(new String[]{"a", "b", "memberRef"});
+
+        //when
+        String memberRef = constantPoolTypeIntrospector.getLambdaTypeString(constantPool);
+
+        //then
+        assertEquals("memberRef", memberRef);
+    }
+}

--- a/java8/src/test/java/cucumber/runtime/java8/ConstantPoolTypeIntrospectorTest.java
+++ b/java8/src/test/java/cucumber/runtime/java8/ConstantPoolTypeIntrospectorTest.java
@@ -67,4 +67,32 @@ public class ConstantPoolTypeIntrospectorTest {
         //then
         assertEquals("memberRef", memberRef);
     }
+
+    @Test
+    public void should_return_member_ref_when_first_element_returns_member_ref() {
+        //given
+        given(constantPool.getSize()).willReturn(3);
+        given(constantPool.getMemberRefInfoAt(0)).willReturn(new String[]{"a", "b", "memberRef"});
+        givenThrowIllegalArgumentExceptionAt(1, 2);
+
+        //when
+        String memberRef = constantPoolTypeIntrospector.getLambdaTypeString(constantPool);
+
+        //then
+        assertEquals("memberRef", memberRef);
+    }
+
+    @Test
+    public void should_return_member_ref_when_last_element_returns_member_ref() {
+        //given
+        given(constantPool.getSize()).willReturn(3);
+        given(constantPool.getMemberRefInfoAt(2)).willReturn(new String[]{"a", "b", "memberRef"});
+        givenThrowIllegalArgumentExceptionAt(0, 1);
+
+        //when
+        String memberRef = constantPoolTypeIntrospector.getLambdaTypeString(constantPool);
+
+        //then
+        assertEquals("memberRef", memberRef);
+    }
 }


### PR DESCRIPTION
This is related to changes made in PR #914.
I thought that it could be a good idea to add **unit tests** for those changes.
This allowed me to do a little refactor to method  **getLambdaTypeString()**.

I hope you can take a look at the changes.

Thanks.
