### PR TITLE
Handle whitespace in rerun file

### DIFF
--- a/core/src/main/java/cucumber/runtime/model/CucumberFeature.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberFeature.java
@@ -64,6 +64,10 @@ public class CucumberFeature {
             String source = builder.read(resource);
             if (!source.isEmpty()) {
                 for (String featurePath : source.split(" ")) {
+                    featurePath = featurePath.trim();
+                    if (featurePath.length() == 0) {
+                        continue;
+                    }
                     loadFromFileSystemOrClasspath(builder, resourceLoader, featurePath, filters);
                 }
             }

--- a/core/src/test/java/cucumber/runtime/model/CucumberFeatureTest.java
+++ b/core/src/test/java/cucumber/runtime/model/CucumberFeatureTest.java
@@ -226,6 +226,29 @@ public class CucumberFeatureTest {
         }
     }
 
+    @Test
+    public void ignores_whitespace_in_rerun_filepath() throws Exception {
+        String featurePath1 = "path/bar.feature";
+        String feature1 = "" +
+                "Feature: bar\n" +
+                "  Scenario: scenario bar\n" +
+                "    * step\n";
+        String rerunPath = "  path/rerun.txt    \n  ";
+        String rerunFile = featurePath1 + ":2";
+        ResourceLoader resourceLoader = mockFeatureFileResource(featurePath1, feature1);
+        mockFileResource(resourceLoader, rerunPath, null, rerunFile);
+
+        List<CucumberFeature> features = CucumberFeature.load(
+                resourceLoader,
+                singletonList("@" + rerunPath),
+                new ArrayList<Object>(),
+                new PrintStream(new ByteArrayOutputStream()));
+
+        assertEquals(1, features.size());
+        assertEquals(1, features.get(0).getFeatureElements().size());
+        assertEquals("Scenario: scenario bar", features.get(0).getFeatureElements().get(0).getVisualName());
+    }
+
     private ResourceLoader mockFeatureFileResource(String featurePath, String feature)
             throws IOException {
         ResourceLoader resourceLoader = mock(ResourceLoader.class);


### PR DESCRIPTION
If I write a rerun file manually using vi on a Mac and pass it to Cucumber as an option (`@rerun.txt`), it fails to run because it can't find the feature files. Even though the same text in a rerun file generated by Cucumber works.

The error is because there was a newline to the end of the rerun file. The rerun file generated by Cucumber does not have this.

It seems Cucumber shouldn't care whether or not lines have newlines or any other kind of whitespace.
