### PR TITLE
downgrade cucumber-jvm-deps to 1.0.3 as per this issue https://github…

### DIFF
--- a/examples/android/android-studio/Cukeulator/app/build.gradle
+++ b/examples/android/android-studio/Cukeulator/app/build.gradle
@@ -36,6 +36,11 @@ android {
 dependencies {
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.0'
     androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
-    androidTestCompile 'info.cukes:cucumber-android:1.2.5'
-    androidTestCompile 'info.cukes:cucumber-picocontainer:1.2.5'
+    androidTestCompile('info.cukes:cucumber-android:1.2.5') {
+        exclude module: 'cucumber-jvm-deps'
+    }
+    androidTestCompile('info.cukes:cucumber-picocontainer:1.2.5') {
+        exclude module: 'cucumber-jvm-deps'
+    }
+    androidTestCompile 'info.cukes:cucumber-jvm-deps:1.0.3'
 }

--- a/examples/android/android-studio/Cukeulator/app/src/main/res/layout/activity_calculator.xml
+++ b/examples/android/android-studio/Cukeulator/app/src/main/res/layout/activity_calculator.xml
@@ -36,7 +36,7 @@
             android:layout_marginBottom="24dp"
             android:layout_centerHorizontal="true"
             android:layout_alignParentBottom="true"
-            android:useDefaultMargins="true"
+            android:layout_marginRight="4dp"
             android:columnCount="4">
 
         <!-- row 4 -->


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->
## Summary

The android studio example doesn't compile for newcomers because of dependencies compiled using java 8 that cannot be compiled for older sdk versions.
issue here:
https://github.com/cucumber/cucumber-jvm/issues/893 

There was also a minor layout issue that caused the buttons on the right side to get cut off on emulators with API 21 and above. 

The buttons getting cut off caused the default Espresso click visibility rule of 90% to fail, which in turn caused all of the tests to fail. 
## Details

in app/build.gradle, excluded cucumber-jvm-deps from cucumber-android and cucumber-picocontainer and downgraded it to version 1.0.3

Made a minor layout change because buttons were getting cut off on some emulators starting with API 21. This was causing the tests to fail because of Espresso. 
## Motivation and Context

The project does not compile for newcomers like myself. The compilation errors are due to Java 8 dependencies which do not work in Android. The errors are not very clear and it's difficult to track down the issue.  

The layout fix is to ensure that the test pass on any emulator using any API version. 
## How Has This Been Tested?

There are no code changes. just a change in build.gradle and a minor change in activity_calculator.xml to ensure that the buttons don't get cut off.  

<!--- Please describe in detail how you tested your changes. -->

build.gradle file allows the project to compile. yay!

For the layout changes I ran the tests on emulators with API 14, 16,18,21,23,24
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

….com/cucumber/cucumber-jvm/issues/893 so that it compiles on Android projects using java 7. Fix layout issue where buttons rendered off margin in API 21+ causing the Espresso 90% condition to fail and then causing all the tests to fail
