### PR TITLE
Fix broken link to scaladoc

### DIFF
--- a/scala/sources/src/main/scala/cucumber/api/scala/package.html
+++ b/scala/sources/src/main/scala/cucumber/api/scala/package.html
@@ -1,5 +1,5 @@
 <body>
 <p>
-    See <a href="http://cukes.info/api/cucumber/jvm/scala">the Scala API</a> for cucumber-scala.
+    See <a href="http://cukes.info/api/cucumber/jvm/scaladoc">the Scala API</a> for cucumber-scala.
 </p>
 </body>


### PR DESCRIPTION
## How Has This Been Tested?

Tested that http://cucumber.github.io/api/cucumber/jvm/scaladoc/ works
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
## Checklist:
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
