### PR TITLE
SnippetGenerator recognises parameters from Scenario Outline (<param>)

### DIFF
--- a/core/src/main/java/cucumber/runtime/snippets/ArgumentPattern.java
+++ b/core/src/main/java/cucumber/runtime/snippets/ArgumentPattern.java
@@ -7,9 +7,15 @@ public class ArgumentPattern {
 
     private final Pattern pattern;
     private final Class<?> type;
+    private final String replacement;
 
     public ArgumentPattern(Pattern pattern, Class<?> type) {
+        this(pattern, pattern.pattern(), type);
+    }
+
+    public ArgumentPattern(Pattern pattern, String replacement, Class<?> type) {
         this.pattern = pattern;
+        this.replacement = replacement;
         this.type = type;
     }
 
@@ -22,7 +28,7 @@ public class ArgumentPattern {
     }
 
     public String replaceMatchesWithGroups(String name) {
-        return replaceMatchWith(name, pattern.pattern());
+        return replaceMatchWith(name, replacement);
     }
 
     public String replaceMatchesWithSpace(String name) {

--- a/core/src/main/java/cucumber/runtime/snippets/SnippetGenerator.java
+++ b/core/src/main/java/cucumber/runtime/snippets/SnippetGenerator.java
@@ -13,7 +13,8 @@ import java.util.regex.Pattern;
 public class SnippetGenerator {
     private static final ArgumentPattern[] DEFAULT_ARGUMENT_PATTERNS = new ArgumentPattern[]{
             new ArgumentPattern(Pattern.compile("\"([^\"]*)\""), String.class),
-            new ArgumentPattern(Pattern.compile("(\\d+)"), Integer.TYPE)
+            new ArgumentPattern(Pattern.compile("(\\d+)"), Integer.TYPE),
+            new ArgumentPattern(Pattern.compile("<([^>]*)>"), "(.*)", String.class)
     };
     private static final Pattern GROUP_PATTERN = Pattern.compile("\\(");
     private static final Pattern[] ESCAPE_PATTERNS = new Pattern[]{

--- a/java/src/test/java/cucumber/runtime/java/JavaSnippetTest.java
+++ b/java/src/test/java/cucumber/runtime/java/JavaSnippetTest.java
@@ -158,6 +158,18 @@ public class JavaSnippetTest {
         assertEquals(expected, snippetForDataTable("I have:", dataTable));
     }
 
+    @Test
+    public void generateSnippetWithOutlineParam() {
+        String expected = "" +
+                "@Given(\"^Then it responds (.*)$\")\n" +
+                "public void then_it_responds(String arg1) throws Throwable {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new PendingException();\n" +
+                "}\n";
+
+        assertEquals(expected, snippetFor("Then it responds <param>"));
+    }
+
     private String snippetFor(String name) {
         Step step = new Step(NO_COMMENTS, "Given ", name, 0, null, null);
         return new SnippetGenerator(new JavaSnippet()).getSnippet(step, functionNameGenerator);


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
SnippetGenerator recognises outline step parameters

## Details

<!--- Describe your changes in detail -->
SnippetGenerator - added pattern for \<param\>
ArgumentPattern - added possibility to provide custom replacement string
JavaSnippetTest - test

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
SnippetGenerator should suggest correct step definition for Scenario Outline Steps. At the moment cucumber-jvm creates step definition like this:

```
@Given("^Given a step with <param> from Scenario Outline$")
public void given_a_step() {
...
}
```

Fix makes the following step definition: 
```
@Given("^Given a step with (.*) from Scenario Outline$")
public void given_a_step(String arg0) {
...
}
```
We have related issue in tracker of IntelliJ IDEA: https://youtrack.jetbrains.com/issue/IDEA-160330

## How Has This Been Tested?
Fix tested like tested all other patterns for step parameters. See JavaSnippetTest

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

