### PR TITLE
Fix and re-enable Gosu

### DIFF
--- a/gosu/pom.xml
+++ b/gosu/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-gosu</artifactId>

--- a/gosu/pom.xml
+++ b/gosu/pom.xml
@@ -11,7 +11,19 @@
     <artifactId>cucumber-gosu</artifactId>
     <packaging>jar</packaging>
     <name>Cucumber-JVM: Gosu</name>
-
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>${gosu.skipTests}</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
     <dependencies>
         <dependency>
             <groupId>info.cukes</groupId>

--- a/gosu/src/main/java/cucumber/runtime/gosu/GlueSource.java
+++ b/gosu/src/main/java/cucumber/runtime/gosu/GlueSource.java
@@ -1,73 +1,34 @@
 package cucumber.runtime.gosu;
 
 import cucumber.runtime.io.Resource;
-import gw.lang.launch.IArgInfo;
-import gw.lang.launch.IBooleanArgKey;
-import gw.lang.launch.IProgramSource;
-import gw.lang.launch.IStringArgKey;
+import gw.lang.reflect.ReflectUtil;
+import gw.lang.reflect.gs.GosuClassPathThing;
+import gw.lang.reflect.gs.IProgramInstance;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
+class GlueSource {
 
-class GlueSource implements IProgramSource {
-    private final StringBuilder sourceBuilder = new StringBuilder();
-
-    @Override
-    public String getRawPath() {
-        // This file doesn't really exist, but we have to say something I guess!
-        return "cucumber.gsp";
+    /**
+     * Performs minimal initialization of the Gosu TypeSystem; this is required for later calls to ReflectUtil#getClass
+     */
+    public GlueSource() {
+        GosuClassPathThing.init();
     }
 
-    @Override
-    public File getFile() {
-        return null;
-    }
-
-    @Override
-    public InputStream openInputStream() throws IOException {
-        return new ByteArrayInputStream(sourceBuilder.toString().getBytes("UTF-8"));
-    }
-
+    /**
+     * Given a glue Resource, calculates the FQN of the Gosu Program as a class, 
+     * loads it via reflection and calls its evaluate method. 
+     * @param glueScript
+     */
     public void addGlueScript(Resource glueScript) {
-        // https://groups.google.com/d/msg/gosu-lang/yMJnzQwuFpo/msg81GNGlAYJ
         String className = glueScript.getClassName(".gsp");
-        sourceBuilder.append("(" + className + ".Type as java.lang.Class).getDeclaredMethod( \"evaluate\", {gw.lang.reflect.gs.IExternalSymbolMap} ).invoke( new " + className + "(), {null})\n");
+        Class clazz = ReflectUtil.getClass(className).getBackingClass();
+        try {
+            ((IProgramInstance)(clazz.newInstance())).evaluate(null);
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
     }
 
-    public IArgInfo toArgInfo() {
-        return new IArgInfo() {
-            @Override
-            public boolean consumeArg(IBooleanArgKey iBooleanArgKey) {
-                return false;
-            }
-
-            @Override
-            public String consumeArg(IStringArgKey iStringArgKey) {
-                return null;
-            }
-
-            @Override
-            public void processUnknownArgs() {
-
-            }
-
-            @Override
-            public String getErrorMessage() {
-                return null;
-            }
-
-            @Override
-            public IProgramSource getProgramSource() {
-                return GlueSource.this;
-            }
-
-            @Override
-            public List<String> getArgsList() {
-                return null;
-            }
-        };
-    }
 }

--- a/gosu/src/main/java/cucumber/runtime/gosu/GosuBackend.java
+++ b/gosu/src/main/java/cucumber/runtime/gosu/GosuBackend.java
@@ -8,7 +8,6 @@ import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.snippets.FunctionNameGenerator;
 import cucumber.runtime.snippets.SnippetGenerator;
 import gherkin.formatter.model.Step;
-import gw.lang.Gosu;
 import gw.lang.function.AbstractBlock;
 
 import java.util.List;
@@ -37,8 +36,6 @@ public class GosuBackend implements Backend {
             }
         }
 
-        Gosu gosu = new Gosu();
-        gosu.start(source.toArgInfo());
     }
 
     @Override
@@ -60,7 +57,8 @@ public class GosuBackend implements Backend {
     public String getSnippet(Step step, FunctionNameGenerator functionNameGenerator) {
         return snippetGenerator.getSnippet(step, null);    }
 
-    public void addStepDefinition(String regexp, Object body) {
+    @SuppressWarnings("unused") // this is indeed invoked by static methods on cucumber.api.gosu.en.Dsl
+    public void addStepDefinition( String regexp, Object body) {
         AbstractBlock block = (AbstractBlock) body;
         glue.addStepDefinition(new GosuStepDefinition(Pattern.compile(regexp), block, currentLocation()));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <clojure.version>1.8.0</clojure.version>
         <!-- This is only here for the example project to use, the 3 scala projects maintain their own versions -->
         <scala.latest.version>2.11.8</scala.latest.version>
-        <gosu.version>1.2</gosu.version>
+        <gosu.version>1.14.2</gosu.version>
         <rhino.version>1.7.7.1</rhino.version>
         <jsoup.version>1.9.2</jsoup.version>
         <testng.version>6.9.10</testng.version>
@@ -526,14 +526,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <repositories>
-        <!--<repository>-->
-        <!--<id>gosu-lang.org-releases</id>-->
-        <!--<name>Official Gosu website (releases)</name>-->
-        <!--<url>http://gosu-lang.org/repositories/m2/releases</url>-->
-        <!--</repository>-->
-    </repositories>
-
     <!--
      this adds a repository that the plugins will use for dependency resolution
      Any items that we use in a plugin's <dependency> phase can be resolved from here, as well as central
@@ -546,7 +538,7 @@
     </pluginRepositories>
 
     <modules>
-        <!--<module>gosu</module>-->
+        <module>gosu</module>
         <module>core</module>
         <module>java</module>
         <module>testng</module>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
         <!-- This is only here for the example project to use, the 3 scala projects maintain their own versions -->
         <scala.latest.version>2.11.8</scala.latest.version>
         <gosu.version>1.14.2</gosu.version>
+        <!-- used by Gosu to skip test execution on Java 7 -->
+        <gosu.skipTests>true</gosu.skipTests>
         <rhino.version>1.7.7.1</rhino.version>
         <jsoup.version>1.9.2</jsoup.version>
         <testng.version>6.9.10</testng.version>
@@ -568,6 +570,9 @@
             <modules>
                 <module>java8</module>
             </modules>
+            <properties>
+                <gosu.skipTests>false</gosu.skipTests>
+            </properties>
         </profile>
 
         <profile>


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
Re-enable Gosu! Thanks to @kausnz for supplying the clever reflection solution.

## Details
This PR updates Gosu support and re-enables the cucumber-gosu module.

I have one concern - that being, "modern" Gosu requires Java 8 at runtime. So I only expect the tests to pass when the Travis matrix runs with `oraclejdk8`. ~~Can I have some help disabling test execution on the `cucumter-gosu` module unless the `java8` profile is active?~~ My second commit skips Gosu test execution unless the `java8` profile is active.

## Motivation and Context
Gosu has been broken for a while now, see #874 

## How Has This Been Tested?
Existing tests are passing again.

## Screenshots (if appropriate):
n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

