### PR TITLE
Changed reference to lein-plugin to an updated fork that works with n…

### DIFF
--- a/clojure/README.md
+++ b/clojure/README.md
@@ -59,11 +59,12 @@ There are several ways to run scenarios with Cucumber-Clojure:
   (:use [clojure.test]))
 
 (deftest run-cukes
-  (. cucumber.api.cli.Main (main (into-array ["--plugin" "pretty" "--glue" "test/features/step_definitions" "test/features"]))))
+  (. cucumber.api.cli.Main (main (into-array ["--plugin
+" "pretty" "--glue" "test/features/step_definitions" "test/features"]))))
 
 ```
 
-You then need to add `[lein-cucumber "1.0.2"]` to `:plugins` in your project.clj. This allows you to run all Cucumber features with `lein cucumber`
+You then need to add `[com.siili/lein-cucumber "1.0.7"]` to `:plugins` in your project.clj. This allows you to run all Cucumber features with `lein cucumber`
 
 ### JUnitRunner
 


### PR DESCRIPTION
…ewer versions of cucumber-jvm.

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

<!--- Provide a general summary description of your changes -->

The existing documented leiningen plugin was based on a very old version of the cucumber-jvm project and did not work.

<!--- Describe your changes in detail -->

Updated the README.md to reference a lein-plugin fork that works with newer version of cucumber-jvm

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This has been tested by changing the clojure project.clj file to reference the newer lein-cucumber plugin.

Step 1, run lein cucumber with the documented plugin.

$ git diff project.clj
diff --git a/project.clj b/project.clj
index 5187b21..5872b51 100644
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
   :main ^:skip-aot api-test.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}}
**-  :plugins [[com.siili/lein-cucumber "1.0.7"]]
+  :plugins [[lein-cucumber "1.0.2"]]**
   :resource-paths ["resources/com.ibm.mqjms.jar"
                    "resources/com.ibm.mq.jar"
                    "resources/dhbcore.jar"

Produces a missing class exception...

$ lein cucumber
Exception in thread "main" java.lang.ClassNotFoundException: cucumber.runtime.formatter.FormatterFactory, compiling:(leiningen/cucumber/util.clj:1:1)
	at clojure.lang.Compiler.load(Compiler.java:7391)
	at clojure.lang.RT.loadResourceScript(RT.java:372)
	at clojure.lang.RT.loadResourceScript(RT.java:363)
	at clojure.lang.RT.load(RT.java:453)
	at clojure.lang.RT.load(RT.java:419)
	at clojure.core$load$fn__5677.invoke

Step 2, use the updated lein-plugin...

$ git diff project.clj
$ lein cucumber
WARNING: update already refers to: #'clojure.core/update in namespace: useful.map, being replaced by: #'useful.map/update
WARNING: update already refers to: #'clojure.core/update in namespace: leiningen.core.project, being replaced by: #'useful.map/update
Running cucumber...
Looking for features in:  [features]
Looking for glue in:  [features/step_definitions]
No features found at [features]


0 Scenarios
0 Steps
0m0.000s


- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
