### PR TITLE
Scala 2.12 compatibility

### DIFF
--- a/examples/android/android-test/pom.xml
+++ b/examples/android/android-test/pom.xml
@@ -7,7 +7,7 @@
         <groupId>info.cukes.android-examples</groupId>
         <artifactId>android-examples</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-android-test</artifactId>

--- a/examples/android/cukeulator-test/pom.xml
+++ b/examples/android/cukeulator-test/pom.xml
@@ -7,7 +7,7 @@
         <groupId>info.cukes.android-examples</groupId>
         <artifactId>android-examples</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>cukelator-test</artifactId>

--- a/examples/android/cukeulator/pom.xml
+++ b/examples/android/cukeulator/pom.xml
@@ -7,7 +7,7 @@
         <groupId>info.cukes.android-examples</groupId>
         <artifactId>android-examples</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>cukelator</artifactId>

--- a/examples/android/pom.xml
+++ b/examples/android/pom.xml
@@ -7,7 +7,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <groupId>info.cukes.android-examples</groupId>

--- a/examples/pax-exam/calculator-api/pom.xml
+++ b/examples/pax-exam/calculator-api/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>pax-exam</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>pax-exam-calculator-api</artifactId>

--- a/examples/pax-exam/calculator-service/pom.xml
+++ b/examples/pax-exam/calculator-service/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>pax-exam</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>pax-exam-calculator-service</artifactId>

--- a/examples/pax-exam/calculator-test/pom.xml
+++ b/examples/pax-exam/calculator-test/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>pax-exam</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>pax-exam-calculator-test</artifactId>

--- a/examples/pax-exam/pom.xml
+++ b/examples/pax-exam/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>pax-exam</artifactId>

--- a/examples/scala-calculator/pom.xml
+++ b/examples/scala-calculator/pom.xml
@@ -12,6 +12,10 @@
     <packaging>jar</packaging>
     <name>Examples: Scala Calculator</name>
 
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>info.cukes</groupId>
@@ -20,7 +24,7 @@
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
-            <artifactId>cucumber-scala_2.11</artifactId>
+            <artifactId>cucumber-scala_${scala.latest.major}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/scala-calculator/pom.xml
+++ b/examples/scala-calculator/pom.xml
@@ -13,7 +13,9 @@
     <name>Examples: Scala Calculator</name>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Using 2.11 because it works with both Java 7 and 8 -->
+        <scala.major.version>2.11</scala.major.version>
+        <scala.version>${scala.2.11.version}</scala.version>
     </properties>
 
     <dependencies>
@@ -24,7 +26,8 @@
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
-            <artifactId>cucumber-scala_${scala.latest.major}</artifactId>
+            <artifactId>cucumber-scala_${scala.major.version}</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -40,13 +43,13 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.latest.version}</version>
+            <version>${scala.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>${scala.latest.version}</version>
+            <version>${scala.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -58,7 +61,6 @@
                 <artifactId>maven-scala-plugin</artifactId>
                 <version>2.15.2</version>
                 <configuration>
-                    <!--encoding>UTF-8</encoding-->
                     <excludes>
                         <exclude>**/*.java</exclude>
                     </excludes>

--- a/gosu/pom.xml
+++ b/gosu/pom.xml
@@ -5,7 +5,7 @@
         <groupId>info.cukes</groupId>
         <artifactId>cucumber-jvm</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-gosu</artifactId>

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -12,6 +12,10 @@
     <packaging>jar</packaging>
     <name>Cucumber-JVM: Java8</name>
 
+    <properties>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>info.cukes</groupId>
@@ -87,19 +91,6 @@ I18n.all.each { i18n ->
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <fork>true</fork>
-                    <encoding>UTF-8</encoding>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <compilerArgument>-XDignore.symbol.file=true</compilerArgument>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <clojure.version>1.8.0</clojure.version>
         <!-- These are only here for the example project to use, the 3 scala projects maintain their own versions -->
         <scala.latest.major>2.12</scala.latest.major>
-        <scala.latest.version>${scala.latest.major}.0-M1</scala.latest.version>
+        <scala.latest.version>${scala.latest.major}.1</scala.latest.version>
         <gosu.version>1.2</gosu.version>
         <rhino.version>1.7.7.1</rhino.version>
         <jsoup.version>1.9.2</jsoup.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <minimum.maven.version>3.1.1</minimum.maven.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
         <outputDirectory>${project.build.directory}</outputDirectory>
         <gherkin.version>2.12.2</gherkin.version>
         <groovy.version>2.4.7</groovy.version>
@@ -729,9 +731,11 @@
                     <version>3.5.1</version>
                     <configuration>
                         <encoding>UTF-8</encoding>
-                        <source>1.6</source>
-                        <target>1.6</target>
-                        <compilerArgument>-Werror</compilerArgument>
+                        <fork>true</fork>
+                        <compilerArgs>
+                          <arg>-XDignore.symbol.file=true</arg>
+                          <arg>-Werror</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,9 @@
         <guice.version>4.0</guice.version>
         <!-- Remember to bounce version in examples/clojure_cukes/project.clj as well -->
         <clojure.version>1.8.0</clojure.version>
-        <!-- This is only here for the example project to use, the 3 scala projects maintain their own versions -->
-        <scala.latest.version>2.11.8</scala.latest.version>
+        <!-- These are only here for the example project to use, the 3 scala projects maintain their own versions -->
+        <scala.latest.major>2.12</scala.latest.major>
+        <scala.latest.version>${scala.latest.major}.0-M1</scala.latest.version>
         <gosu.version>1.2</gosu.version>
         <rhino.version>1.7.7.1</rhino.version>
         <jsoup.version>1.9.2</jsoup.version>
@@ -160,7 +161,7 @@
             </dependency>
             <dependency>
                 <groupId>info.cukes</groupId>
-                <artifactId>cucumber-scala_2.11</artifactId>
+                <artifactId>cucumber-scala_${scala.latest.major}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
         <gherkin.version>2.12.2</gherkin.version>
         <groovy.version>2.4.7</groovy.version>
         <picocontainer.version>2.15</picocontainer.version>
-        <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
         <spring.version>4.3.2.RELEASE</spring.version>
         <spring.data.version>1.10.2.RELEASE</spring.data.version>
         <!-- 5.2.2.Final or above does not appear to work on Java 7 -->
@@ -36,9 +35,9 @@
         <guice.version>4.0</guice.version>
         <!-- Remember to bounce version in examples/clojure_cukes/project.clj as well -->
         <clojure.version>1.8.0</clojure.version>
-        <!-- These are only here for the example project to use, the 3 scala projects maintain their own versions -->
-        <scala.latest.major>2.12</scala.latest.major>
-        <scala.latest.version>${scala.latest.major}.1</scala.latest.version>
+        <scala.2.10.version>2.10.6</scala.2.10.version>
+        <scala.2.11.version>2.11.8</scala.2.11.version>
+        <scala.2.12.version>2.12.1</scala.2.12.version>
         <gosu.version>1.2</gosu.version>
         <rhino.version>1.7.7.1</rhino.version>
         <jsoup.version>1.9.2</jsoup.version>
@@ -157,11 +156,6 @@
             <dependency>
                 <groupId>info.cukes</groupId>
                 <artifactId>cucumber-picocontainer</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>info.cukes</groupId>
-                <artifactId>cucumber-scala_${scala.latest.major}</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -852,7 +846,7 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>${scala-maven-plugin.version}</version>
+                    <version>3.2.2</version>
                 </plugin>
 
                 <plugin>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -15,8 +15,19 @@
     <modules>
         <module>scala_2.11</module>
         <module>scala_2.10</module>
-        <module>scala_2.12</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <modules>
+                <module>scala_2.12</module>
+            </modules>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>
@@ -56,7 +67,6 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>${scala-maven-plugin.version}</version>
                     <configuration>
                         <args>
                             <arg>-feature</arg>

--- a/scala/scala_2.10/pom.xml
+++ b/scala/scala_2.10/pom.xml
@@ -12,22 +12,18 @@
     <packaging>jar</packaging>
     <name>Cucumber-JVM: Scala (2.10)</name>
 
-    <properties>
-        <scala.version>2.10.6</scala.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.10.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.10.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/scala/scala_2.11/pom.xml
+++ b/scala/scala_2.11/pom.xml
@@ -12,22 +12,18 @@
     <packaging>jar</packaging>
     <name>Cucumber-JVM: Scala (2.11)</name>
 
-    <properties>
-        <scala.version>2.11.8</scala.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.11.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.11.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/scala/scala_2.12/pom.xml
+++ b/scala/scala_2.12/pom.xml
@@ -13,12 +13,7 @@
     <name>Cucumber-JVM: Scala (2.12)</name>
 
     <properties>
-        <!--
-        Upgrading to 2.12.0-M2 or higher causes:
-
-        initializationError(cucumber.runtime.scala.test.RunCukesTest)  Time elapsed: 0.006 sec  <<< ERROR! java.util.NoSuchElementException: next on empty iterator [no stack trace]
-        -->
-        <scala.version>2.12.0-M1</scala.version>
+        <scala.version>2.12.1</scala.version>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 

--- a/scala/scala_2.12/pom.xml
+++ b/scala/scala_2.12/pom.xml
@@ -19,6 +19,7 @@
         initializationError(cucumber.runtime.scala.test.RunCukesTest)  Time elapsed: 0.006 sec  <<< ERROR! java.util.NoSuchElementException: next on empty iterator [no stack trace]
         -->
         <scala.version>2.12.0-M1</scala.version>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/scala/scala_2.12/pom.xml
+++ b/scala/scala_2.12/pom.xml
@@ -13,7 +13,6 @@
     <name>Cucumber-JVM: Scala (2.12)</name>
 
     <properties>
-        <scala.version>2.12.1</scala.version>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
@@ -21,14 +20,14 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.12.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.12.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/scala/sources/src/main/scala/cucumber/api/scala/ScalaDsl.scala
+++ b/scala/sources/src/main/scala/cucumber/api/scala/ScalaDsl.scala
@@ -1,10 +1,10 @@
 package cucumber.api.scala
 
-import _root_.cucumber.api.Scenario
-import _root_.cucumber.runtime.scala.ScalaHookDefinition
-import _root_.cucumber.runtime.scala.ScalaStepDefinition
-import _root_.cucumber.runtime.HookDefinition
-import _root_.cucumber.runtime.StepDefinition
+import cucumber.api.Scenario
+import cucumber.runtime.scala.ScalaHookDefinition
+import cucumber.runtime.scala.ScalaStepDefinition
+import cucumber.runtime.HookDefinition
+import cucumber.runtime.StepDefinition
 import collection.mutable.ArrayBuffer
 import java.lang.reflect.Type
 

--- a/scala/sources/src/main/scala/cucumber/api/scala/ScalaDsl.scala
+++ b/scala/sources/src/main/scala/cucumber/api/scala/ScalaDsl.scala
@@ -51,59 +51,23 @@ trait ScalaDsl { self =>
     def apply(regex: String): StepBody = new StepBody(name, regex)
   }
 
-  final class Fun0(val f: Function0[Any])
-
-  object Fun0 {
-    implicit def function02Fun0(f: Function0[Any]) = new Fun0(f)
-  }
-
   final class StepBody(name:String, regex:String) {
 
-    def apply(f: => Unit){ apply(f _) }
-
-    def apply(fun: Fun0) {
-      register(Array[Type]()) {case Nil => fun.f()}
+    def apply(f: => Any) {
+      register() {
+        case Nil => f
+      }
     }
 
-    /**
-     * Concerning the type handling in all apply methods below.
-     *
-     * Unfortunately the obvious approach (as follows) doesn't work as expected in all scenarios :
-     *
-     * {{{
-     *   def apply[T1](f: (T1) => Any)(implicit m1: Manifest[T1]) = {
-     *     register(List(m1)) {
-     *       case List(a1:T1) => f(a1)
-     *     }
-     *   }
-     * }}}
-     *
-     * This is due to the Scala 'Value Classes' being boxed when moving into the Java world,
-     * and then returned into the Scala layer as these boxed types, which causes the following use case.
-     *
-     * - Step definition is defined with expected argument of scala type 'Int'
-     * - Step is 'registered' passing the Scala Int type into the Java layer
-     * - Inside the Java layer this is boxed from a 'primitive' into a java.lang.Integer
-     * - The parsed value is returned into Scala layer, retaining it's boxed type
-     * - When we perform the pattern match in the partial function, a List[Int] is expected but List[java.lang.Integer]
-     *   is passed in and fails the match (causing a match exception)
-     *
-     * Therefore by casting we unbox the java.util.Integer (or other boxed type) back into the expected value working
-     * around this issue - anything else should be the expected object anyway, so it makes no difference in that case.
-     *
-     * There's likely a cleaner way of doing this - please refactor if so.
-     *
-     */
-
     def apply[T1](f: (T1) => Any)(implicit m1: Manifest[T1]) {
-      register(functionParams(m1)) {
+      register(m1) {
         case List(a1:AnyRef) =>
           f(a1.asInstanceOf[T1])
       }
     }
 
     def apply[T1, T2](f: (T1, T2) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2]) {
-      register(functionParams(m1, m2)) {
+      register(m1, m2) {
         case List(a1:AnyRef, a2:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2])
@@ -111,7 +75,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3](f: (T1, T2, T3) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3]) {
-      register(functionParams(m1, m2, m3)) {
+      register(m1, m2, m3) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -120,7 +84,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4](f: (T1, T2, T3, T4) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4]) {
-      register(functionParams(m1, m2, m3, m4)) {
+      register(m1, m2, m3, m4) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -130,7 +94,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5](f: (T1, T2, T3, T4, T5) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5]) {
-      register(functionParams(m1, m2, m3, m4, m5)) {
+      register(m1, m2, m3, m4, m5) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -141,7 +105,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6](f: (T1, T2, T3, T4, T5, T6) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6)) {
+      register(m1, m2, m3, m4, m5, m6) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -153,7 +117,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7](f: (T1, T2, T3, T4, T5, T6, T7) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7)) {
+      register(m1, m2, m3, m4, m5, m6, m7) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -166,7 +130,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8](f: (T1, T2, T3, T4, T5, T6, T7, T8) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -180,7 +144,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -195,7 +159,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -211,7 +175,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -228,7 +192,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -246,7 +210,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -265,7 +229,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -285,7 +249,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -306,7 +270,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -328,7 +292,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -351,7 +315,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -375,7 +339,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -400,7 +364,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19], m20: Manifest[T20]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef, a20:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -426,7 +390,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19], m20: Manifest[T20], m21: Manifest[T21]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef, a20:AnyRef, a21:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -453,7 +417,7 @@ trait ScalaDsl { self =>
     }
 
     def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19], m20: Manifest[T20], m21: Manifest[T21], m22: Manifest[T22]) {
-      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, m22)) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, m22) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef, a20:AnyRef, a21:AnyRef, a22:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -480,8 +444,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    private def register(types: Array[Type])(pf: PartialFunction[List[Any], Any]) = {
-      val frame: StackTraceElement = obtainFrame
+    private def register(ms: Manifest[_ <: Any]*)(pf: PartialFunction[List[Any], Any]) = {
+      val frame = obtainFrame
+      val types = ms.map(m => toJavaType(m)).toArray
       stepDefinitions += new ScalaStepDefinition(frame, name, regex, types, pf)
     }
 
@@ -493,10 +458,6 @@ trait ScalaDsl { self =>
       val frames = Thread.currentThread().getStackTrace
       val currentClass = self.getClass.getName
       frames.find(_.getClassName == currentClass).get
-    }
-
-    private def functionParams(ms: Manifest[_ <: Any]*): Array[Type] = {
-      ms.map(m => toJavaType(m)).toArray
     }
 
     private def toJavaType(m: Manifest[_]): Type = {

--- a/scala/sources/src/main/scala/cucumber/api/scala/ScalaDsl.scala
+++ b/scala/sources/src/main/scala/cucumber/api/scala/ScalaDsl.scala
@@ -5,8 +5,11 @@ import cucumber.runtime.scala.ScalaHookDefinition
 import cucumber.runtime.scala.ScalaStepDefinition
 import cucumber.runtime.HookDefinition
 import cucumber.runtime.StepDefinition
+
 import collection.mutable.ArrayBuffer
-import java.lang.reflect.Type
+import java.lang.reflect.{ParameterizedType, Type}
+
+import scala.reflect._
 
 /**
  * Base trait for a scala step definition implementation.
@@ -20,7 +23,7 @@ trait ScalaDsl { self =>
 
   private [cucumber] val afterHooks = new ArrayBuffer[HookDefinition]
 
-  def Before(f: Scenario => Unit){
+  def Before(f: Scenario => Unit) {
     Before()(f)
   }
 
@@ -28,11 +31,11 @@ trait ScalaDsl { self =>
     Before(Int.MaxValue, tags :_*)(f)
   }
 
-  def Before(order:Int, tags:String*)(f: Scenario => Unit){
+  def Before(order:Int, tags:String*)(f: Scenario => Unit) {
     beforeHooks += new ScalaHookDefinition(f, order, tags)
   }
 
-  def After(f: Scenario => Unit){
+  def After(f: Scenario => Unit) {
     After()(f)
   }
 
@@ -40,7 +43,7 @@ trait ScalaDsl { self =>
     After(Int.MaxValue, tags:_*)(f)
   }
 
-  def After(order:Int, tags: String*)(f: Scenario => Unit){
+  def After(order:Int, tags: String*)(f: Scenario => Unit) {
     afterHooks += new ScalaHookDefinition(f, order, tags)
   }
 
@@ -68,7 +71,7 @@ trait ScalaDsl { self =>
      * Unfortunately the obvious approach (as follows) doesn't work as expected in all scenarios :
      *
      * {{{
-     *   def apply[T1](f: (T1) => Any)(implicit m1:Manifest[T1]) = {
+     *   def apply[T1](f: (T1) => Any)(implicit m1: Manifest[T1]) = {
      *     register(List(m1)) {
      *       case List(a1:T1) => f(a1)
      *     }
@@ -92,23 +95,23 @@ trait ScalaDsl { self =>
      *
      */
 
-    def apply[T1](f: (T1) => Any)(implicit m1:Manifest[T1]) {
-      register(functionParams(f)) {
+    def apply[T1](f: (T1) => Any)(implicit m1: Manifest[T1]) {
+      register(functionParams(m1)) {
         case List(a1:AnyRef) =>
           f(a1.asInstanceOf[T1])
       }
     }
 
-    def apply[T1, T2](f: (T1, T2) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2]) {
-      register(functionParams(f)) {
+    def apply[T1, T2](f: (T1, T2) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2]) {
+      register(functionParams(m1, m2)) {
         case List(a1:AnyRef, a2:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2])
       }
     }
 
-    def apply[T1, T2, T3](f: (T1, T2, T3) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3](f: (T1, T2, T3) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3]) {
+      register(functionParams(m1, m2, m3)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -116,8 +119,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4](f: (T1, T2, T3, T4) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4](f: (T1, T2, T3, T4) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4]) {
+      register(functionParams(m1, m2, m3, m4)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -126,8 +129,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5](f: (T1, T2, T3, T4, T5) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5](f: (T1, T2, T3, T4, T5) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5]) {
+      register(functionParams(m1, m2, m3, m4, m5)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -137,8 +140,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6](f: (T1, T2, T3, T4, T5, T6) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6](f: (T1, T2, T3, T4, T5, T6) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -149,8 +152,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7](f: (T1, T2, T3, T4, T5, T6, T7) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7](f: (T1, T2, T3, T4, T5, T6, T7) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -162,8 +165,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8](f: (T1, T2, T3, T4, T5, T6, T7, T8) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8](f: (T1, T2, T3, T4, T5, T6, T7, T8) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -176,8 +179,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -191,8 +194,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -207,8 +210,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -224,8 +227,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -242,8 +245,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -261,8 +264,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -281,8 +284,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -302,8 +305,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -324,8 +327,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -347,8 +350,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17], m18:Manifest[T18]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -371,8 +374,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17], m18:Manifest[T18], m19:Manifest[T19]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -396,8 +399,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17], m18:Manifest[T18], m19:Manifest[T19], m20:Manifest[T20]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19], m20: Manifest[T20]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef, a20:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -422,8 +425,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17], m18:Manifest[T18], m19:Manifest[T19], m20:Manifest[T20], m21:Manifest[T21]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19], m20: Manifest[T20], m21: Manifest[T21]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef, a20:AnyRef, a21:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -449,8 +452,8 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17], m18:Manifest[T18], m19:Manifest[T19], m20:Manifest[T20], m21:Manifest[T21], m22:Manifest[T22]) {
-      register(functionParams(f)) {
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19], m20: Manifest[T20], m21: Manifest[T21], m22: Manifest[T22]) {
+      register(functionParams(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, m22)) {
         case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef, a20:AnyRef, a21:AnyRef, a22:AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
@@ -492,7 +495,21 @@ trait ScalaDsl { self =>
       frames.find(_.getClassName == currentClass).get
     }
 
-    private def functionParams(f: Any) =
-      f.getClass.getDeclaredMethods.filter(m => "apply".equals(m.getName) && !m.isBridge).head.getGenericParameterTypes
+    private def functionParams(ms: Manifest[_ <: Any]*): Array[Type] = {
+      ms.map(m => toJavaType(m)).toArray
+    }
+
+    private def toJavaType(m: Manifest[_]): Type = {
+      val typeArgs = m.typeArguments
+      if (typeArgs.isEmpty) {
+        m.runtimeClass
+      } else {
+        new ParameterizedType {
+          override def getActualTypeArguments: Array[Type] = typeArgs.map(toJavaType(_)).toArray
+          override def getRawType: Type = m.runtimeClass
+          override def getOwnerType: Type = ???
+        }
+      }
+    }
   }
 }

--- a/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaBackend.scala
+++ b/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaBackend.scala
@@ -1,18 +1,18 @@
 package cucumber.runtime.scala
 
-import _root_.java.util.{List => JList}
-import _root_.gherkin.formatter.model.Step
-import _root_.java.lang.reflect.Modifier
-import _root_.cucumber.runtime.snippets.SnippetGenerator
-import _root_.cucumber.runtime.snippets.FunctionNameGenerator
-import _root_.cucumber.api.scala.ScalaDsl
-import _root_.cucumber.runtime.ClassFinder
-import _root_.cucumber.runtime.io.ResourceLoaderClassFinder
-import _root_.cucumber.runtime.io.ResourceLoader
-import _root_.cucumber.runtime.io.MultiLoader
-import _root_.cucumber.runtime.Backend
-import _root_.cucumber.runtime.UnreportedStepExecutor
-import _root_.cucumber.runtime.Glue
+import java.util.{List => JList}
+import gherkin.formatter.model.Step
+import java.lang.reflect.Modifier
+import cucumber.runtime.snippets.SnippetGenerator
+import cucumber.runtime.snippets.FunctionNameGenerator
+import cucumber.api.scala.ScalaDsl
+import cucumber.runtime.ClassFinder
+import cucumber.runtime.io.ResourceLoaderClassFinder
+import cucumber.runtime.io.ResourceLoader
+import cucumber.runtime.io.MultiLoader
+import cucumber.runtime.Backend
+import cucumber.runtime.UnreportedStepExecutor
+import cucumber.runtime.Glue
 import collection.JavaConversions._
 
 class ScalaBackend(resourceLoader:ResourceLoader) extends Backend {

--- a/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaHookDefinition.scala
+++ b/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaHookDefinition.scala
@@ -1,10 +1,10 @@
 package cucumber.runtime.scala
 
-import _root_.gherkin.TagExpression
-import _root_.gherkin.formatter.model.Tag
-import _root_.java.util.Collection
-import _root_.cucumber.api.Scenario
-import _root_.cucumber.runtime.HookDefinition
+import gherkin.TagExpression
+import gherkin.formatter.model.Tag
+import java.util.Collection
+import cucumber.api.Scenario
+import cucumber.runtime.HookDefinition
 import collection.JavaConverters._
 
 class ScalaHookDefinition(f:Scenario => Unit,

--- a/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaSnippet.scala
+++ b/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaSnippet.scala
@@ -1,8 +1,8 @@
 package cucumber.runtime.scala
 
-import _root_.cucumber.runtime.snippets.Snippet
-import _root_.gherkin.formatter.model.Step
-import _root_.java.util.List
+import cucumber.runtime.snippets.Snippet
+import gherkin.formatter.model.Step
+import java.util.List
 import collection.JavaConverters._
 
 class ScalaSnippetGenerator extends Snippet {

--- a/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaStepDefinition.scala
+++ b/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaStepDefinition.scala
@@ -1,12 +1,12 @@
 package cucumber.runtime.scala
 
-import _root_.java.lang.reflect.Type
-import _root_.gherkin.formatter.model.Step
-import _root_.gherkin.I18n
-import _root_.java.util.regex.Pattern
-import _root_.cucumber.runtime.StepDefinition
-import _root_.cucumber.runtime.JdkPatternArgumentMatcher
-import _root_.cucumber.runtime.ParameterInfo
+import java.lang.reflect.Type
+import gherkin.formatter.model.Step
+import gherkin.I18n
+import java.util.regex.Pattern
+import cucumber.runtime.StepDefinition
+import cucumber.runtime.JdkPatternArgumentMatcher
+import cucumber.runtime.ParameterInfo
 import collection.JavaConversions._
 import cucumber.api.Transform
 

--- a/scala/sources/src/test/scala/cucumber/api/scala/ScalaDslTest.scala
+++ b/scala/sources/src/test/scala/cucumber/api/scala/ScalaDslTest.scala
@@ -1,9 +1,9 @@
 package cucumber.api.scala
 
-import _root_.org.junit.{Test, Assert}
+import org.junit.{Test, Assert}
 import Assert._
-import _root_.gherkin.I18n
-import _root_.gherkin.formatter.model.Tag
+import gherkin.I18n
+import gherkin.formatter.model.Tag
 import collection.JavaConverters._
 import cucumber.api.Scenario
 

--- a/scala/sources/src/test/scala/cucumber/runtime/scala/test/RunCukesTest.scala
+++ b/scala/sources/src/test/scala/cucumber/runtime/scala/test/RunCukesTest.scala
@@ -1,8 +1,8 @@
 package cucumber.runtime.scala.test
 
-import _root_.org.junit.runner.RunWith
-import _root_.cucumber.api.junit.Cucumber
-import _root_.cucumber.api.CucumberOptions
+import org.junit.runner.RunWith
+import cucumber.api.junit.Cucumber
+import cucumber.api.CucumberOptions
 
 @RunWith(classOf[Cucumber])
 @CucumberOptions(strict=true)

--- a/scala/sources/src/test/scala/cucumber/runtime/scala/test/StepDefs.scala
+++ b/scala/sources/src/test/scala/cucumber/runtime/scala/test/StepDefs.scala
@@ -1,6 +1,6 @@
 package cucumber.runtime.scala.test
 
-import _root_.cucumber.api.scala._
+import cucumber.api.scala._
 
 import cucumber.api.DataTable
 import junit.framework.Assert._


### PR DESCRIPTION
## Summary

Fix cucumber-scala compatibility with Scala 2.12.

## Details

* cucumber-scala_2.12 is compiled as Java 8 bytecode, along with scala-calculator (and cucumber-java8)
* Scala version has been upgraded to the latest 2.12.1, using `Manifest` instead of Java reflection
* @aslakhellesoy should probably verify the code, given that it's a variation on something that previously was found not to work (see his comment removed on `ScalaDsl`)

## Motivation and Context

Issue #1087.

## How Has This Been Tested?

Existing tests and Scala example passing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
