### PR TITLE
ISSUE-1104: Fixed PluginFactory to consider the no arg constructor the least option

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
@@ -47,7 +47,7 @@ import static java.util.Arrays.asList;
  * </ul>
  */
 public class PluginFactory {
-    private final Class[] CTOR_ARGS = new Class[]{null, Appendable.class, URI.class, URL.class, File.class};
+    private final Class[] CTOR_ARGS = new Class[]{Appendable.class, URI.class, URL.class, File.class};
 
     private static final Map<String, Class> PLUGIN_CLASSES = new HashMap<String, Class>() {{
         put("null", NullFormatter.class);
@@ -93,19 +93,29 @@ public class PluginFactory {
     }
 
     private <T> T instantiate(String pluginString, Class<T> pluginClass, String pathOrUrl) throws IOException, URISyntaxException {
+        if (pathOrUrl == null) {
+            Constructor<T> constructor = findConstructor(pluginClass, null);
+            if (constructor != null) {
+                try {
+                    return constructor.newInstance();
+                } catch (InstantiationException e) {
+                    throw new CucumberException(e);
+                } catch (IllegalAccessException e) {
+                    throw new CucumberException(e);
+                } catch (InvocationTargetException e) {
+                    throw new CucumberException(e.getTargetException());
+                }
+            }
+        }
         for (Class ctorArgClass : CTOR_ARGS) {
             Constructor<T> constructor = findConstructor(pluginClass, ctorArgClass);
             if (constructor != null) {
                 Object ctorArg = convertOrNull(pathOrUrl, ctorArgClass, pluginString);
                 try {
-                    if (ctorArgClass == null) {
-                        return constructor.newInstance();
-                    } else {
-                        if (ctorArg == null) {
-                            throw new CucumberException(String.format("You must supply an output argument to %s. Like so: %s:output", pluginString, pluginString));
-                        }
-                        return constructor.newInstance(ctorArg);
+                    if (ctorArg == null) {
+                        throw new CucumberException(String.format("You must supply an output argument to %s. Like so: %s:output", pluginString, pluginString));
                     }
+                    return constructor.newInstance(ctorArg);
                 } catch (InstantiationException e) {
                     throw new CucumberException(e);
                 } catch (IllegalAccessException e) {


### PR DESCRIPTION
This fixes #1104 

## Summary

If a plugin formatter contains a no-arg constructor and a constructor with one of the valid argument: Appendable, URI, URL or File, always the no-arg constructor is being triggered, even when the valid argument is passed.

## Motivation and Context

The expectation was that the constructor with File argument is called. But, the no-arg constructor is called. The motivation is to when the argument is given, report will be generated at the given location. If not, the no-arg constructor will generate the output at the default location defined by the framework.

## How Has This Been Tested?

My own formatter look like this:

```java
public class TestFormatter implements Formatter  {

    public TestListener() {
        System.err.println("Null constructor");
    }

    public TestListener(File file) {
        System.err.println("File Constructor");
    }
}
```

The runner look like as follows:

```java
@RunWith(Cucumber.class)
@CucumberOptions(
    features = {"src/test/resources/features/MyFeature.feature"},
    glue = {"com.cucumber.stepdefinitions"},
        plugin = {"com.cucumber.listener.TestListener:output/report.html"}
)
public class RunCukesTest {
}
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

The existing tests covers this change.