### PR TITLE
Implement enhancement: allow Java8 lambda steps to throw checked Exce…

### DIFF
--- a/java/src/main/java/cucumber/api/java8/StepdefBody.java
+++ b/java/src/main/java/cucumber/api/java8/StepdefBody.java
@@ -2,42 +2,42 @@ package cucumber.api.java8;
 
 public interface StepdefBody {
     public static interface A0 extends StepdefBody {
-        void accept();
+        void accept() throws Exception;
     }
 
     public static interface A1<T1> extends StepdefBody {
-        void accept(T1 p1);
+        void accept(T1 p1) throws Exception;
     }
 
     public static interface A2<T1, T2> extends StepdefBody {
-        void accept(T1 p1, T2 p2);
+        void accept(T1 p1, T2 p2) throws Exception;
     }
 
     public static interface A3<T1, T2, T3> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3);
+        void accept(T1 p1, T2 p2, T3 p3) throws Exception;
     }
 
     public static interface A4<T1, T2, T3, T4> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4) throws Exception;
     }
 
     public static interface A5<T1, T2, T3, T4, T5> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5) throws Exception;
     }
 
     public static interface A6<T1, T2, T3, T4, T5, T6> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6) throws Exception;
     }
 
     public static interface A7<T1, T2, T3, T4, T5, T6, T7> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7) throws Exception;
     }
 
     public static interface A8<T1, T2, T3, T4, T5, T6, T7, T8> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7, T8 p8);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7, T8 p8) throws Exception;
     }
 
     public static interface A9<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7, T8 p8, T9 p9);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7, T8 p8, T9 p9) throws Exception;
     }
 }

--- a/java/src/test/java/cucumber/runtime/java/java8test/AnonInnerClassStepdefs.java
+++ b/java/src/test/java/cucumber/runtime/java/java8test/AnonInnerClassStepdefs.java
@@ -11,7 +11,7 @@ public class AnonInnerClassStepdefs implements GlueBase {
     public AnonInnerClassStepdefs() {
         JavaBackend.INSTANCE.get().addStepDefinition("^I have (\\d+) cukes in my (.*)", 0, new StepdefBody.A2<Integer, String>() {
             @Override
-            public void accept(Integer cukes, String what) {
+            public void accept(Integer cukes, String what) throws Exception {
                 assertEquals(42, cukes.intValue());
                 assertEquals("belly", what);
             }

--- a/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
+++ b/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
@@ -49,6 +49,11 @@ public class LambdaStepdefs implements En {
             assertEquals("three", c);
             assertEquals((Integer) 4, d);
         });
+
+        Given("^A lambda that declares an exception$", this::methodThatDeclaresException);
+    }
+
+    private void methodThatDeclaresException() throws Exception {
     }
 
     public static class Person {

--- a/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
+++ b/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
@@ -19,3 +19,6 @@ Feature: Java8
       | first  | last     |
       | Aslak  | Hellesøy |
       | Donald | Duck     |
+
+  Scenario: using lambdas with exceptions
+    Given A lambda that declares an exception


### PR DESCRIPTION
…ptions #1001

## Summary

Implements enhancement: allow Java8 lambda steps to throw checked Exceptions #1001

## Details

* Add tests which use `throws Exception` in their `accept()` methods.
* Change the `accept()` methods in the nested interfaces in `StepdefBody` to declare `throws Exception`.

## Motivation and Context

This change solves the problem that `accept()` methods for cucumber-java8 had to wrap their code with boiler plate in case of checked exceptions. This is described in #1001

## How Has This Been Tested?

* I changed the `accept()` method in `AnonInnerClassStepdefs` to declare `throws Exception`.
* I added a new scenario to `java8.feature` along with the corresponding step definition, which uses a method reference that declares `throws Exception`.

I ran `mvn clean install` on the top-level of `cucumber-jvm` and everything still passes.

## Screenshots (if appropriate):

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

The ticket speaks of a feature. However, since `cucumber-java` supported steps with `throws Exception`, I think that `cucumber-java8` didn't is actually not a missing feature but a bug.
I can't judge whether the change counts as breaking change. Adding `throws Exception` to the `accept()` methods in `StepdefBody` is potentially breaking. However, I think that code which uses cucumber should actually never call these methods but implement these methods, they are callbacks.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

No change to the documentation required. An optional change could be made to show an example in https://cucumber.io/docs/reference/jvm#lambda-expressions-java-8 where the lambda calls a method that declares a checked exception.