### PR TITLE
Use EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+
+[*.{java,xml}]
+indent_style = space
+indent_size = 4
+
+[*.feature]
+indent_style = space
+indent_size = 2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,15 +41,17 @@ Just load the root `pom.xml`
 
 To hack on Cucumber-JVM you need a JDK, Maven and Git to get the code. You also need to set your IDE/text editor to use:
 
-* UTF-8 file encoding
-* LF (UNIX) line endings
+* UTF-8 file encoding <sup>+</sup>
+* LF (UNIX) line endings <sup>+</sup>
 * No wildcard imports
 * Curly brace on same line as block
-* 4 Space indent (no tabs)
+* 4 Space indent (no tabs) <sup>+</sup>
   * Java
   * XML
-* 2 Space indent (no tabs)
+* 2 Space indent (no tabs) <sup>+</sup>
   * Gherkin
+
+`+` These are set automatically if you use an editor/IDE that supports [EditorConfig](http://editorconfig.org/#download).
 
 Please do *not* add @author tags - this project embraces collective code ownership. If you want to know who wrote some
 code, look in git. When you are done, send a [pull request](http://help.github.com/send-pull-requests/).


### PR DESCRIPTION
## Summary

Use EditorConfig for some editor styles

[EditorConfig](http://editorconfig.org/) is a simple config file that sets various editor settings like line-feed and encoding automatically. It's supported by several editors and IDEs.

## Motivation and Context

EditorConfig makes some of the more general style guides automatically enforceable and it's wide adoption and support make it highly likely it's configuration will take hold for many users. It simplifies setup since users don't have to update their editor settings. There's a chance that a user either overrides the settings or doesn't use an editor that supports it, but that was an existing problem anyway.

## How Has This Been Tested?

Opened code in IntelliJ & Atom and verified changes to the `.editorconfig` file caused expected changes when adding/modifying lines in files.

## Checklist:

- [x] I have updated the documentation accordingly.
