### PR TITLE
Run each Scenario as a TestNG @Test.

### DIFF
--- a/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
+++ b/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
@@ -1,5 +1,6 @@
 package cucumber.api.testng;
 
+import cucumber.runtime.model.CucumberTagStatement;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -21,12 +22,26 @@ public abstract class AbstractTestNGCucumberTests {
         testNGCucumberRunner.runCucumber(cucumberFeature.getCucumberFeature());
     }
 
+    @Test(groups = "cucumber-scenarios", description = "Runs Cucumber Scenarios", dataProvider = "scenarios")
+    public void scenario(CucumberTagStatementWrapper cucumberTagStatement) throws Throwable {
+        testNGCucumberRunner.runCucumberScenario(cucumberTagStatement.getCucumberScenario());
+    }
+
     /**
      * @return returns two dimensional array of {@link CucumberFeatureWrapper} objects.
      */
     @DataProvider
     public Object[][] features() {
         return testNGCucumberRunner.provideFeatures();
+    }
+
+    /**
+     * @return returns two dimensional array of {@link CucumberTagStatement} objects with the
+     * scenario name.
+     */
+    @DataProvider
+    public Object[][] scenarios() {
+        return testNGCucumberRunner.provideScenarios();
     }
 
     @AfterClass(alwaysRun = true)

--- a/testng/src/main/java/cucumber/api/testng/CucumberTagStatementWrapper.java
+++ b/testng/src/main/java/cucumber/api/testng/CucumberTagStatementWrapper.java
@@ -1,0 +1,13 @@
+package cucumber.api.testng;
+
+import cucumber.runtime.model.CucumberTagStatement;
+
+/**
+ * The only purpose of this interface is to be able to provide a custom
+ * <pre>toString()</pre>, making TestNG reports look more descriptive.
+ *
+ * @see CucumberFeatureWrapperImpl
+ */
+public interface CucumberTagStatementWrapper {
+    CucumberTagStatement getCucumberScenario();
+}

--- a/testng/src/main/java/cucumber/api/testng/CucumberTagStatementWrapperImpl.java
+++ b/testng/src/main/java/cucumber/api/testng/CucumberTagStatementWrapperImpl.java
@@ -1,0 +1,33 @@
+package cucumber.api.testng;
+
+import cucumber.runtime.model.CucumberTagStatement;
+
+/**
+ * The only purpose of this class is to provide custom {@linkplain #toString()},
+ * making TestNG reports look more descriptive.
+ *
+ * @see AbstractTestNGCucumberTests#feature(CucumberFeatureWrapper)
+ */
+public class CucumberTagStatementWrapperImpl implements CucumberTagStatementWrapper {
+    private final CucumberTagStatement cucumberScenario;
+
+    public CucumberTagStatementWrapperImpl(CucumberTagStatement cucumberScenario) {
+        this.cucumberScenario = cucumberScenario;
+    }
+
+    @Override
+    public CucumberTagStatement getCucumberScenario() {
+        return cucumberScenario;
+    }
+
+    @Override
+    public String toString() {
+
+        String returnVal = cucumberScenario.getVisualName();
+
+        if (!cucumberScenario.getVisualName().startsWith("Scenario"))
+            returnVal = String.format("Scenario Outline: %s{%s)", cucumberScenario.getGherkinModel().getName(), cucumberScenario.getVisualName());
+
+        return returnVal;
+    }
+}

--- a/testng/src/test/java/cucumber/api/testng/AbstractTestNGCucumberScenariosTest.java
+++ b/testng/src/test/java/cucumber/api/testng/AbstractTestNGCucumberScenariosTest.java
@@ -1,0 +1,35 @@
+package cucumber.api.testng;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+@Test
+public final class AbstractTestNGCucumberScenariosTest {
+
+    private Set<String> invokedConfigurationMethodNames;
+
+    @BeforeClass(alwaysRun = true)
+    public void setUp() {
+        InvokedConfigurationMethodListener icml = new InvokedConfigurationMethodListener();
+        TestNG testNG = new TestNG();
+        testNG.addListener(icml);
+        testNG.setGroups("cucumber-scenarios");
+        testNG.setTestClasses(new Class[]{new AbstractTestNGCucumberTests() {}.getClass()});
+        testNG.run();
+        invokedConfigurationMethodNames = icml.getInvokedMethodNames();
+    }
+
+    @Test
+    public void setUpClassScenarioIsInvoked() {
+        Assert.assertTrue(invokedConfigurationMethodNames.contains("setUpClass"), "setUpClass must be invoked");
+    }
+
+    @Test
+    public void tearDownClassScenarioIsInvoked() {
+        Assert.assertTrue(invokedConfigurationMethodNames.contains("tearDownClass"), "tearDownClass must be invoked");
+    }
+}

--- a/testng/src/test/java/cucumber/api/testng/TestNGCucumberRunnerTest.java
+++ b/testng/src/test/java/cucumber/api/testng/TestNGCucumberRunnerTest.java
@@ -2,6 +2,7 @@ package cucumber.api.testng;
 
 import cucumber.runtime.CucumberException;
 import cucumber.runtime.model.CucumberFeature;
+import cucumber.runtime.model.CucumberTagStatement;
 import cucumber.runtime.testng.RunCukesStrict;
 import cucumber.runtime.testng.RunCukesTest;
 import org.testng.Assert;
@@ -48,6 +49,17 @@ public class TestNGCucumberRunnerTest {
         Assert.assertEquals(features.size(), numberOfFeatures,
                 "Not all features associated with " + RunCukesTest.class.getSimpleName() + " were loaded. ");
         Assert.assertTrue(!features.isEmpty(), "Feature files need to exist in the cucumber/runtime/testng/ folder for this test");
+    }
+
+    @Test
+    public void getScenarios() throws Exception {
+        List<CucumberTagStatement> scenarios = testNGCucumberRunner.getScenarios();
+
+        int numberOfFeatures = getNumberOfFeatures();
+
+        Assert.assertTrue(scenarios.size() >= numberOfFeatures,
+                "Not all features associated with " + RunCukesTest.class.getSimpleName() + " were loaded. ");
+        Assert.assertTrue(!scenarios.isEmpty(), "Feature files need to exist in the cucumber/runtime/testng/ folder for this test");
     }
 
     /**

--- a/testng/src/test/resources/cucumber/runtime/testng/test_scenarios.feature
+++ b/testng/src/test/resources/cucumber/runtime/testng/test_scenarios.feature
@@ -1,0 +1,15 @@
+Feature: Test NG Scenarios
+
+  Scenario: Regular Scenario
+    Given Step1
+    When Step2
+    Then Step3
+
+  Scenario Outline: Test Outline
+    Given Step1 <text>
+    When Step2
+    Then Step3
+    Examples:
+      | text  |
+      | text1 |
+      | text2 |


### PR DESCRIPTION
## Summary

Currently, cucumber-testng provides the ability to execute each cucumber feature file as one TestNG Test.  This fix allows you to run each Scenario as a Test.

## Details

AbstractTestNGCucumberTests.class contains a Test method with groups="cucumber-scenarios".  The DataProvider for this Test pulls all Scenarios and Scenario Outlines in order to execute each one as its own TestNG test.

A sample implementation of cucumber-scenarios is:
```java
TestNG testNG = new TestNG();
testNG.setGroups("cucumber-scenarios");
testNG.setTestClasses(new Class[]{new AbstractTestNGCucumberTests() {}.getClass()});
testNG.run();
```
## Motivation and Context

#1113 

## How Has This Been Tested?

Tests added to the existing cucumber.api.testng tests.  Additional testing done from a separate java project utilizing the updated library.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
