### PR TITLE
Don't build on openjdk, only oraclejdk 7/8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,10 @@ cache:
   directories:
     - $HOME/.m2
 
-script: mvn -q install -P examples
-
-jdk:
-- openjdk7
-
 matrix:
   include:
   - jdk: oraclejdk7
-    script: mvn -q install
+    script: mvn -q install -P examples
     after_success: mvn -q deploy --settings .travis-settings.xml -Dno.gem.deploy=true -DskipTests=true -Dmaven.javadoc.skip=true
   - jdk: oraclejdk8
     script: mvn -q install -P java8


### PR DESCRIPTION
Wicket has been failing on Openjdk7. We can add Openjdk back later if we can fix that, or maybe remove the Wicket module
