### PR TITLE
Use an enum for result status.

### DIFF
--- a/core/src/main/java/cucumber/api/Result.java
+++ b/core/src/main/java/cucumber/api/Result.java
@@ -8,15 +8,32 @@ import java.util.List;
 public class Result {
     private static final long serialVersionUID = 1L;
 
-    private final String status;
+    private final Result.Type status;
     private final Long duration;
     private final Throwable error;
     private final List<String> snippets;
-    public static final Result SKIPPED = new Result("skipped", null, null);
-    public static final String UNDEFINED = "undefined";
-    public static final String PASSED = "passed";
-    public static final String PENDING = "pending";
-    public static final String FAILED = "failed";
+    public static final Result SKIPPED = new Result(Result.Type.SKIPPED, null, null);
+    public static enum Type {
+        PASSED,
+        SKIPPED,
+        PENDING,
+        UNDEFINED,
+        FAILED;
+
+        public static Type fromLowerCaseName(String lowerCaseName) {
+            return valueOf(lowerCaseName.toUpperCase());
+        }
+
+        public String lowerCaseName() {
+            return name().toLowerCase();
+        }
+
+        public String firstLetterCapitalizedName() {
+            return name().substring(0, 1) + name().substring(1).toLowerCase();
+        }
+
+
+    }
 
     /**
      * Used at runtime
@@ -25,7 +42,7 @@ public class Result {
      * @param duration
      * @param error
      */
-    public Result(String status, Long duration, Throwable error) {
+    public Result(Result.Type status, Long duration, Throwable error) {
         this(status, duration, error, Collections.<String>emptyList());
     }
 
@@ -37,14 +54,14 @@ public class Result {
      * @param error
      * @param snippets
      */
-    public Result(String status, Long duration, Throwable error, List<String> snippets) {
+    public Result(Result.Type status, Long duration, Throwable error, List<String> snippets) {
         this.status = status;
         this.duration = duration;
         this.error = error;
         this.snippets = snippets;
     }
 
-    public String getStatus() {
+    public Result.Type getStatus() {
         return status;
     }
 
@@ -64,16 +81,20 @@ public class Result {
         return snippets;
     }
 
+    public boolean is(Result.Type status) {
+        return this.status == status;
+    }
+
     public boolean isOk(boolean isStrict) {
         return hasAlwaysOkStatus() || !isStrict && hasOkWhenNotStrictStatus();
     }
 
     private boolean hasAlwaysOkStatus() {
-        return Result.PASSED.equals(status) || Result.SKIPPED.getStatus().equals(status);
+        return is(Result.Type.PASSED) || is(Result.Type.SKIPPED);
     }
 
     private boolean hasOkWhenNotStrictStatus() {
-        return Result.UNDEFINED.equals(status) || Result.PENDING.equals(status);
+        return is(Result.Type.UNDEFINED) || is(Result.Type.PENDING);
     }
 
     private String getErrorMessage(Throwable error) {

--- a/core/src/main/java/cucumber/api/Scenario.java
+++ b/core/src/main/java/cucumber/api/Scenario.java
@@ -13,9 +13,9 @@ public interface Scenario {
     Collection<String> getSourceTagNames();
 
     /**
-     * @return the <em>most severe</em> status of the Scenario's Steps. One of "passed", "undefined", "pending", "skipped", "failed"
+     * @return the <em>most severe</em> status of the Scenario's Steps.
      */
-    String getStatus();
+    Result.Type getStatus();
 
     /**
      * @return true if and only if {@link #getStatus()} returns "failed"

--- a/core/src/main/java/cucumber/api/TestCase.java
+++ b/core/src/main/java/cucumber/api/TestCase.java
@@ -26,7 +26,7 @@ public class TestCase {
         ScenarioImpl scenarioResult = new ScenarioImpl(bus, pickleEvent.pickle);
         for (TestStep step : testSteps) {
             Result stepResult = step.run(bus, pickleEvent.pickle.getLanguage(), scenarioResult, skipNextStep);
-            if (stepResult.getStatus() != Result.PASSED) {
+            if (!stepResult.is(Result.Type.PASSED)) {
                 skipNextStep = true;
             }
             scenarioResult.add(stepResult);

--- a/core/src/main/java/cucumber/runner/UnskipableStep.java
+++ b/core/src/main/java/cucumber/runner/UnskipableStep.java
@@ -18,9 +18,9 @@ public class UnskipableStep extends TestStep {
         this.hookType = hookType;
     }
 
-    protected String executeStep(String language, Scenario scenario, boolean skipSteps) throws Throwable {
+    protected Result.Type executeStep(String language, Scenario scenario, boolean skipSteps) throws Throwable {
         definitionMatch.runStep(language, scenario);
-        return Result.PASSED;
+        return Result.Type.PASSED;
     }
 
     @Override

--- a/core/src/main/java/cucumber/runtime/ScenarioImpl.java
+++ b/core/src/main/java/cucumber/runtime/ScenarioImpl.java
@@ -17,7 +17,7 @@ import java.util.Set;
 import static java.util.Arrays.asList;
 
 public class ScenarioImpl implements Scenario {
-    private static final List<String> SEVERITY = asList("passed", "skipped", "pending", "undefined", "failed");
+    private static final List<Result.Type> SEVERITY = asList(Result.Type.PASSED, Result.Type.SKIPPED, Result.Type.PENDING, Result.Type.UNDEFINED, Result.Type.FAILED);
     private final List<Result> stepResults = new ArrayList<Result>();
     private final List<PickleTag> tags;
     private final String scenarioName;
@@ -44,7 +44,7 @@ public class ScenarioImpl implements Scenario {
     }
 
     @Override
-    public String getStatus() {
+    public Result.Type getStatus() {
         int pos = 0;
         for (Result stepResult : stepResults) {
             pos = Math.max(pos, SEVERITY.indexOf(stepResult.getStatus()));

--- a/core/src/main/java/cucumber/runtime/UndefinedStepsTracker.java
+++ b/core/src/main/java/cucumber/runtime/UndefinedStepsTracker.java
@@ -75,7 +75,7 @@ public class UndefinedStepsTracker implements EventListener {
     }
 
     void handleTestStepFinished(TestStep step, Result result) {
-        if (Result.UNDEFINED.equals(result.getStatus())) {
+        if (result.is(Result.Type.UNDEFINED)) {
             hasUndefinedSteps = true;
             String keyword = givenWhenThenKeyword(step.getPickleStep());
             for (String rawSnippet : result.getSnippets()) {

--- a/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
@@ -425,7 +425,7 @@ class HTMLFormatter implements Formatter {
 
     private Map<String, Object> createMatchMap(TestStep testStep, Result result) {
         Map<String, Object> matchMap = new HashMap<String, Object>();
-        if (!result.getStatus().equals(Result.UNDEFINED)) {
+        if (!result.is(Result.Type.UNDEFINED)) {
             matchMap.put("location", testStep.getCodeLocation());
         }
         return matchMap;
@@ -433,7 +433,7 @@ class HTMLFormatter implements Formatter {
 
     private Map<String, Object> createResultMap(Result result) {
         Map<String, Object> resultMap = new HashMap<String, Object>();
-        resultMap.put("status", result.getStatus());
+        resultMap.put("status", result.getStatus().lowerCaseName());
         if (result.getErrorMessage() != null) {
             resultMap.put("error_message", result.getErrorMessage());
         }

--- a/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
@@ -317,7 +317,7 @@ public class JSONFormatter implements Formatter {
             }
             matchMap.put("arguments", argumentList);
         }
-        if (!result.getStatus().equals(Result.UNDEFINED)) {
+        if (!result.is(Result.Type.UNDEFINED)) {
             matchMap.put("location", testStep.getCodeLocation());
         }
         return matchMap;
@@ -325,7 +325,7 @@ public class JSONFormatter implements Formatter {
 
     private Map<String, Object> createResultMap(Result result) {
         Map<String, Object> resultMap = new HashMap<String, Object>();
-        resultMap.put("status", result.getStatus());
+        resultMap.put("status", result.getStatus().lowerCaseName());
         if (result.getErrorMessage() != null) {
             resultMap.put("error_message", result.getErrorMessage());
         }

--- a/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
@@ -254,12 +254,12 @@ class JUnitFormatter implements Formatter, StrictAware {
             addStepAndResultListing(sb);
             Result skipped = null, failed = null;
             for (Result result : results) {
-                if ("failed".equals(result.getStatus())) failed = result;
-                if ("undefined".equals(result.getStatus()) || "pending".equals(result.getStatus())) skipped = result;
+                if (result.is(Result.Type.FAILED)) failed = result;
+                if (result.is(Result.Type.UNDEFINED) || result.is(Result.Type.PENDING)) skipped = result;
             }
             for (Result result : hookResults) {
-                if (failed == null && "failed".equals(result.getStatus())) failed = result;
-                if (skipped == null && "pending".equals(result.getStatus())) skipped = result;
+                if (failed == null && result.is(Result.Type.FAILED)) failed = result;
+                if (skipped == null && result.is(Result.Type.PENDING)) skipped = result;
             }
             Element child;
             if (failed != null) {
@@ -310,7 +310,7 @@ class JUnitFormatter implements Formatter, StrictAware {
                 int length = sb.length();
                 String resultStatus = "not executed";
                 if (i < results.size()) {
-                    resultStatus = results.get(i).getStatus();
+                    resultStatus = results.get(i).getStatus().lowerCaseName();
                 }
                 sb.append(getKeywordFromSource(steps.get(i).getStepLine()) + steps.get(i).getStepText());
                 do {

--- a/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
@@ -203,7 +203,7 @@ public class PrettyFormatter implements Formatter, ColorAware {
         String keyword = getStepKeyword(testStep);
         String stepText = testStep.getStepText();
         String locationPadding = createPaddingToLocation(STEP_INDENT, keyword + stepText);
-        String formattedStepText = formatStepText(keyword, stepText, formats.get(result.getStatus()), formats.get(result.getStatus() + "_arg"), testStep.getDefinitionArgument());
+        String formattedStepText = formatStepText(keyword, stepText, formats.get(result.getStatus().lowerCaseName()), formats.get(result.getStatus().lowerCaseName() + "_arg"), testStep.getDefinitionArgument());
         out.println(STEP_INDENT + formattedStepText + locationPadding + getLocationText(testStep.getCodeLocation()));
     }
 
@@ -323,7 +323,7 @@ public class PrettyFormatter implements Formatter, ColorAware {
 
     private void printError(Result result) {
         if (result.getError() != null) {
-            out.println("      " + formats.get(result.getStatus()).text(result.getErrorMessage()));
+            out.println("      " + formats.get(result.getStatus().lowerCaseName()).text(result.getErrorMessage()));
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/formatter/ProgressFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/ProgressFormatter.java
@@ -15,19 +15,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 class ProgressFormatter implements Formatter, ColorAware {
-    private static final Map<String, Character> CHARS = new HashMap<String, Character>() {{
-        put("passed", '.');
-        put("undefined", 'U');
-        put("pending", 'P');
-        put("skipped", '-');
-        put("failed", 'F');
+    private static final Map<Result.Type, Character> CHARS = new HashMap<Result.Type, Character>() {{
+        put(Result.Type.PASSED, '.');
+        put(Result.Type.UNDEFINED, 'U');
+        put(Result.Type.PENDING, 'P');
+        put(Result.Type.SKIPPED, '-');
+        put(Result.Type.FAILED, 'F');
     }};
-    private static final Map<String, AnsiEscapes> ANSI_ESCAPES = new HashMap<String, AnsiEscapes>() {{
-        put("passed", AnsiEscapes.GREEN);
-        put("undefined", AnsiEscapes.YELLOW);
-        put("pending", AnsiEscapes.YELLOW);
-        put("skipped", AnsiEscapes.CYAN);
-        put("failed", AnsiEscapes.RED);
+    private static final Map<Result.Type, AnsiEscapes> ANSI_ESCAPES = new HashMap<Result.Type, AnsiEscapes>() {{
+        put(Result.Type.PASSED, AnsiEscapes.GREEN);
+        put(Result.Type.UNDEFINED, AnsiEscapes.YELLOW);
+        put(Result.Type.PENDING, AnsiEscapes.YELLOW);
+        put(Result.Type.SKIPPED, AnsiEscapes.CYAN);
+        put(Result.Type.FAILED, AnsiEscapes.RED);
     }};
 
     private final NiceAppendable out;
@@ -68,7 +68,7 @@ class ProgressFormatter implements Formatter, ColorAware {
     }
 
     private void handleTestStepFinished(TestStepFinished event) {
-        if (!event.testStep.isHook() || event.result.getStatus().equals(Result.FAILED)) {
+        if (!event.testStep.isHook() || event.result.is(Result.Type.FAILED)) {
             if (!monochrome) {
                 ANSI_ESCAPES.get(event.result.getStatus()).appendTo(out);
             }

--- a/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
@@ -226,15 +226,15 @@ class TestNGFormatter implements Formatter, StrictAware {
             Result skipped = null;
             Result failed = null;
             for (Result result : results) {
-                if ("failed".equals(result.getStatus())) {
+                if (result.is(Result.Type.FAILED)) {
                     failed = result;
                 }
-                if ("undefined".equals(result.getStatus()) || "pending".equals(result.getStatus())) {
+                if (result.is(Result.Type.UNDEFINED) || result.is(Result.Type.PENDING)) {
                     skipped = result;
                 }
             }
             for (Result result : hooks) {
-                if (failed == null && "failed".equals(result.getStatus())) {
+                if (failed == null && result.is(Result.Type.FAILED)) {
                     failed = result;
                 }
             }
@@ -273,7 +273,7 @@ class TestNGFormatter implements Formatter, StrictAware {
                 int length = sb.length();
                 String resultStatus = "not executed";
                 if (i < results.size()) {
-                    resultStatus = results.get(i).getStatus();
+                    resultStatus = results.get(i).getStatus().lowerCaseName();
                 }
                 sb.append(steps.get(i).getStepText());
                 do {

--- a/core/src/main/java/cucumber/runtime/formatter/UsageFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/UsageFormatter.java
@@ -60,7 +60,7 @@ class UsageFormatter implements Formatter {
     }
 
     void handleTestStepFinished(TestStepFinished event) {
-        if (!event.testStep.isHook() && event.result.getStatus().equals(Result.PASSED)) {
+        if (!event.testStep.isHook() && event.result.is(Result.Type.PASSED)) {
             addUsageEntry(event.result, event.testStep.getPattern(), event.testStep.getStepText(), event.testStep.getStepLocation());
         }
     }

--- a/core/src/test/java/cucumber/api/ResultTest.java
+++ b/core/src/test/java/cucumber/api/ResultTest.java
@@ -9,7 +9,7 @@ public class ResultTest {
 
     @Test
     public void passed_result_is_always_ok() {
-        Result passedResult = new Result(Result.PASSED, null, null);
+        Result passedResult = new Result(Result.Type.PASSED, null, null);
 
         assertTrue(passedResult.isOk(isStrict(false)));
         assertTrue(passedResult.isOk(isStrict(true)));
@@ -17,13 +17,15 @@ public class ResultTest {
 
     @Test
     public void skipped_result_is_always_ok() {
-        assertTrue(Result.SKIPPED.isOk(isStrict(false)));
-        assertTrue(Result.SKIPPED.isOk(isStrict(true)));
+        Result skippedResult = new Result(Result.Type.SKIPPED, null, null);
+
+        assertTrue(skippedResult.isOk(isStrict(false)));
+        assertTrue(skippedResult.isOk(isStrict(true)));
     }
 
     @Test
     public void failed_result_is_never_ok() {
-        Result failedResult = new Result(Result.FAILED, null, null);
+        Result failedResult = new Result(Result.Type.FAILED, null, null);
 
         assertFalse(failedResult.isOk(isStrict(false)));
         assertFalse(failedResult.isOk(isStrict(true)));
@@ -31,7 +33,7 @@ public class ResultTest {
 
     @Test
     public void undefined_result_is_only_ok_when_not_strict() {
-        Result undefinedResult = new Result(Result.UNDEFINED, null, null);
+        Result undefinedResult = new Result(Result.Type.UNDEFINED, null, null);
 
         assertTrue(undefinedResult.isOk(isStrict(false)));
         assertFalse(undefinedResult.isOk(isStrict(true)));
@@ -39,10 +41,37 @@ public class ResultTest {
 
     @Test
     public void pending_result_is_only_ok_when_not_strict() {
-        Result pendingResult = new Result(Result.PENDING, null, null);
+        Result pendingResult = new Result(Result.Type.PENDING, null, null);
 
         assertTrue(pendingResult.isOk(isStrict(false)));
         assertFalse(pendingResult.isOk(isStrict(true)));
+    }
+
+    @Test
+    public void is_query_returns_true_for_the_status_of_the_result_object() {
+        int checkCount = 0;
+        for (Result.Type status : Result.Type.values()) {
+            Result result = new Result(status, null, null);
+
+            assertTrue(result.is(result.getStatus()));
+            checkCount += 1;
+        }
+        assertTrue("No checks performed", checkCount > 0);
+    }
+
+    @Test
+    public void is_query_returns_false_for_statuses_different_from_the_status_of_the_result_object() {
+        int checkCount = 0;
+        for (Result.Type resultStatus : Result.Type.values()) {
+            Result result = new Result(resultStatus, null, null);
+            for (Result.Type status : Result.Type.values()) {
+                if (status != resultStatus) {
+                    assertFalse(result.is(status));
+                    checkCount += 1;
+                }
+            }
+        }
+        assertTrue("No checks performed", checkCount > 0);
     }
 
     private boolean isStrict(boolean value) {

--- a/core/src/test/java/cucumber/api/TestCaseTest.java
+++ b/core/src/test/java/cucumber/api/TestCaseTest.java
@@ -29,7 +29,7 @@ public class TestCaseTest {
         EventBus bus = mock(EventBus.class);
         String language = ENGLISH;
         TestStep testStep = mock(TestStep.class);
-        when(testStep.run(eq(bus), eq(language), isA(Scenario.class), anyBoolean())).thenReturn(resultWithStatus(Result.UNDEFINED));
+        when(testStep.run(eq(bus), eq(language), isA(Scenario.class), anyBoolean())).thenReturn(resultWithStatus(Result.Type.UNDEFINED));
 
         TestCase testCase = new TestCase(Arrays.asList(testStep), pickleEvent());
         testCase.run(bus);
@@ -45,9 +45,9 @@ public class TestCaseTest {
         EventBus bus = mock(EventBus.class);
         String language = ENGLISH;
         TestStep testStep1 = mock(TestStep.class);
-        when(testStep1.run(eq(bus), eq(language), isA(Scenario.class), anyBoolean())).thenReturn(resultWithStatus(Result.PASSED));
+        when(testStep1.run(eq(bus), eq(language), isA(Scenario.class), anyBoolean())).thenReturn(resultWithStatus(Result.Type.PASSED));
         TestStep testStep2 = mock(TestStep.class);
-        when(testStep2.run(eq(bus), eq(language), isA(Scenario.class), anyBoolean())).thenReturn(resultWithStatus(Result.PASSED));
+        when(testStep2.run(eq(bus), eq(language), isA(Scenario.class), anyBoolean())).thenReturn(resultWithStatus(Result.Type.PASSED));
 
         TestCase testCase = new TestCase(Arrays.asList(testStep1, testStep2), pickleEvent());
         testCase.run(bus);
@@ -62,9 +62,9 @@ public class TestCaseTest {
         EventBus bus = mock(EventBus.class);
         String language = ENGLISH;
         TestStep testStep1 = mock(TestStep.class);
-        when(testStep1.run(eq(bus), eq(language), isA(Scenario.class), anyBoolean())).thenReturn(resultWithStatus(Result.UNDEFINED));
+        when(testStep1.run(eq(bus), eq(language), isA(Scenario.class), anyBoolean())).thenReturn(resultWithStatus(Result.Type.UNDEFINED));
         TestStep testStep2 = mock(TestStep.class);
-        when(testStep2.run(eq(bus), eq(language), isA(Scenario.class), anyBoolean())).thenReturn(Result.SKIPPED);
+        when(testStep2.run(eq(bus), eq(language), isA(Scenario.class), anyBoolean())).thenReturn(resultWithStatus(Result.Type.SKIPPED));
 
         TestCase testCase = new TestCase(Arrays.asList(testStep1, testStep2), pickleEvent());
         testCase.run(bus);
@@ -80,7 +80,7 @@ public class TestCaseTest {
         return new PickleEvent("uri", pickle);
     }
 
-    private Result resultWithStatus(String status) {
+    private Result resultWithStatus(Result.Type status) {
         return new Result(status, null, null);
     }
 }

--- a/core/src/test/java/cucumber/api/TestStepTest.java
+++ b/core/src/test/java/cucumber/api/TestStepTest.java
@@ -49,14 +49,14 @@ public class TestStepTest {
     public void result_is_passed_when_step_definition_does_not_throw_exception() throws Throwable {
         Result result = step.run(bus, language, scenario, false);
 
-        assertEquals(Result.PASSED, result.getStatus());
+        assertEquals(Result.Type.PASSED, result.getStatus());
     }
 
     @Test
     public void result_is_skipped_when_skip_step_is_true() throws Throwable {
         Result result = step.run(bus, language, scenario, true);
 
-        assertEquals(Result.SKIPPED, result);
+        assertEquals(Result.Type.SKIPPED, result.getStatus());
     }
 
     @Test
@@ -65,7 +65,7 @@ public class TestStepTest {
 
         Result result = step.run(bus, language, scenario, false);
 
-        assertEquals(Result.FAILED, result.getStatus());
+        assertEquals(Result.Type.FAILED, result.getStatus());
     }
 
     @Test
@@ -74,7 +74,7 @@ public class TestStepTest {
 
         Result result = step.run(bus, language, scenario, false);
 
-        assertEquals(Result.PENDING, result.getStatus());
+        assertEquals(Result.Type.PENDING, result.getStatus());
     }
 
     @Test

--- a/core/src/test/java/cucumber/runner/UnskipableTestStepTest.java
+++ b/core/src/test/java/cucumber/runner/UnskipableTestStepTest.java
@@ -35,6 +35,6 @@ public class UnskipableTestStepTest {
     public void result_is_passed_when_step_definition_does_not_throw_exception_and_skip_steps_is_true() throws Throwable {
         Result result = step.run(bus, language, scenario, true);
 
-        assertEquals(Result.PASSED, result.getStatus());
+        assertEquals(Result.Type.PASSED, result.getStatus());
     }
 }

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -588,7 +588,7 @@ public class RuntimeTest {
 
     private Result mockResultWithSnippets() {
         Result result = mock(Result.class);
-        when(result.getStatus()).thenReturn(Result.UNDEFINED);
+        when(result.getStatus()).thenReturn(Result.Type.UNDEFINED);
         when(result.getSnippets()).thenReturn(asList(""));
         return result;
     }

--- a/core/src/test/java/cucumber/runtime/ScenarioResultTest.java
+++ b/core/src/test/java/cucumber/runtime/ScenarioResultTest.java
@@ -22,41 +22,41 @@ public class ScenarioResultTest {
 
     @Test
     public void no_steps_is_passed() throws Exception {
-        assertEquals("passed", s.getStatus());
+        assertEquals(Result.Type.PASSED, s.getStatus());
     }
 
     @Test
     public void passed_failed_pending_undefined_skipped_is_failed() throws Exception {
-        s.add(new Result("passed", 0L, null));
-        s.add(new Result("failed", 0L, null));
-        s.add(new Result("pending", 0L, null));
-        s.add(new Result("undefined", 0L, null));
-        s.add(new Result("skipped", 0L, null));
-        assertEquals("failed", s.getStatus());
+        s.add(new Result(Result.Type.PASSED, 0L, null));
+        s.add(new Result(Result.Type.FAILED, 0L, null));
+        s.add(new Result(Result.Type.PENDING, 0L, null));
+        s.add(new Result(Result.Type.UNDEFINED, 0L, null));
+        s.add(new Result(Result.Type.SKIPPED, 0L, null));
+        assertEquals(Result.Type.FAILED, s.getStatus());
     }
 
     @Test
     public void passed_and_skipped_is_skipped_although_we_cant_have_skipped_without_undefined_or_pending() throws Exception {
-        s.add(new Result("passed", 0L, null));
-        s.add(new Result("skipped", 0L, null));
-        assertEquals("skipped", s.getStatus());
+        s.add(new Result(Result.Type.PASSED, 0L, null));
+        s.add(new Result(Result.Type.SKIPPED, 0L, null));
+        assertEquals(Result.Type.SKIPPED, s.getStatus());
     }
 
     @Test
     public void passed_pending_undefined_skipped_is_pending() throws Exception {
-        s.add(new Result("passed", 0L, null));
-        s.add(new Result("undefined", 0L, null));
-        s.add(new Result("pending", 0L, null));
-        s.add(new Result("skipped", 0L, null));
-        assertEquals("undefined", s.getStatus());
+        s.add(new Result(Result.Type.PASSED, 0L, null));
+        s.add(new Result(Result.Type.UNDEFINED, 0L, null));
+        s.add(new Result(Result.Type.PENDING, 0L, null));
+        s.add(new Result(Result.Type.SKIPPED, 0L, null));
+        assertEquals(Result.Type.UNDEFINED, s.getStatus());
     }
 
     @Test
     public void passed_undefined_skipped_is_undefined() throws Exception {
-        s.add(new Result("passed", 0L, null));
-        s.add(new Result("undefined", 0L, null));
-        s.add(new Result("skipped", 0L, null));
-        assertEquals("undefined", s.getStatus());
+        s.add(new Result(Result.Type.PASSED, 0L, null));
+        s.add(new Result(Result.Type.UNDEFINED, 0L, null));
+        s.add(new Result(Result.Type.SKIPPED, 0L, null));
+        assertEquals(Result.Type.UNDEFINED, s.getStatus());
     }
 
     @Test
@@ -77,8 +77,8 @@ public class ScenarioResultTest {
         Throwable failedError = mock(Throwable.class);
         Throwable pendingError = mock(Throwable.class);
 
-        s.add(new Result("failed", 0L, failedError));
-        s.add(new Result("pending", 0L, pendingError));
+        s.add(new Result(Result.Type.FAILED, 0L, failedError));
+        s.add(new Result(Result.Type.PENDING, 0L, pendingError));
 
         assertThat(s.getError(), sameInstance(failedError));
     }
@@ -88,8 +88,8 @@ public class ScenarioResultTest {
         Throwable pendingError = mock(Throwable.class);
         Throwable failedError = mock(Throwable.class);
 
-        s.add(new Result("pending", 0L, pendingError));
-        s.add(new Result("failed", 0L, failedError));
+        s.add(new Result(Result.Type.PENDING, 0L, pendingError));
+        s.add(new Result(Result.Type.FAILED, 0L, failedError));
 
         assertThat(s.getError(), sameInstance(failedError));
     }

--- a/core/src/test/java/cucumber/runtime/StatsTest.java
+++ b/core/src/test/java/cucumber/runtime/StatsTest.java
@@ -33,13 +33,13 @@ public class StatsTest {
     @Test
     public void should_only_print_sub_counts_if_not_zero() {
         Stats counter = createMonochromeSummaryCounter();
-        Result passedResult = createResultWithStatus(Result.PASSED);
+        Result passedResult = createResultWithStatus(Result.Type.PASSED);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         counter.addStep(passedResult);
         counter.addStep(passedResult);
         counter.addStep(passedResult);
-        counter.addScenario(Result.PASSED);
+        counter.addScenario(Result.Type.PASSED);
         counter.printStats(new PrintStream(baos), isStrict(false));
 
         assertThat(baos.toString(), startsWith(String.format(
@@ -52,11 +52,11 @@ public class StatsTest {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        addOneStepScenario(counter, Result.PASSED);
-        addOneStepScenario(counter, Result.FAILED);
-        addOneStepScenario(counter, Stats.PENDING);
-        addOneStepScenario(counter, Result.UNDEFINED);
-        addOneStepScenario(counter, Result.SKIPPED.getStatus());
+        addOneStepScenario(counter, Result.Type.PASSED);
+        addOneStepScenario(counter, Result.Type.FAILED);
+        addOneStepScenario(counter, Result.Type.PENDING);
+        addOneStepScenario(counter, Result.Type.UNDEFINED);
+        addOneStepScenario(counter, Result.Type.SKIPPED);
         counter.printStats(new PrintStream(baos), isStrict(false));
 
         assertThat(baos.toString(), containsString(String.format("" +
@@ -69,11 +69,11 @@ public class StatsTest {
         Stats counter = createColorSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        addOneStepScenario(counter, Result.PASSED);
-        addOneStepScenario(counter, Result.FAILED);
-        addOneStepScenario(counter, Stats.PENDING);
-        addOneStepScenario(counter, Result.UNDEFINED);
-        addOneStepScenario(counter, Result.SKIPPED.getStatus());
+        addOneStepScenario(counter, Result.Type.PASSED);
+        addOneStepScenario(counter, Result.Type.FAILED);
+        addOneStepScenario(counter, Result.Type.PENDING);
+        addOneStepScenario(counter, Result.Type.UNDEFINED);
+        addOneStepScenario(counter, Result.Type.SKIPPED);
         counter.printStats(new PrintStream(baos), isStrict(false));
 
         String colorSubCounts =
@@ -104,8 +104,8 @@ public class StatsTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         counter.addHookTime(ONE_MILLI_SECOND);
-        counter.addStep(new Result(Result.PASSED, ONE_MILLI_SECOND, null));
-        counter.addStep(new Result(Result.PASSED, ONE_MILLI_SECOND, null));
+        counter.addStep(new Result(Result.Type.PASSED, ONE_MILLI_SECOND, null));
+        counter.addStep(new Result(Result.Type.PASSED, ONE_MILLI_SECOND, null));
         counter.addHookTime(ONE_MILLI_SECOND);
         counter.printStats(new PrintStream(baos), isStrict(false));
 
@@ -118,9 +118,9 @@ public class StatsTest {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        counter.addStep(new Result(Result.PASSED, Stats.ONE_MINUTE, null));
-        counter.addStep(new Result(Result.PASSED, Stats.ONE_SECOND, null));
-        counter.addStep(new Result(Result.PASSED, ONE_MILLI_SECOND, null));
+        counter.addStep(new Result(Result.Type.PASSED, Stats.ONE_MINUTE, null));
+        counter.addStep(new Result(Result.Type.PASSED, Stats.ONE_SECOND, null));
+        counter.addStep(new Result(Result.Type.PASSED, ONE_MILLI_SECOND, null));
         counter.printStats(new PrintStream(baos), isStrict(false));
 
         assertThat(baos.toString(), endsWith(String.format(
@@ -132,8 +132,8 @@ public class StatsTest {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        counter.addStep(new Result(Result.PASSED, ONE_HOUR, null));
-        counter.addStep(new Result(Result.PASSED, Stats.ONE_MINUTE, null));
+        counter.addStep(new Result(Result.Type.PASSED, ONE_HOUR, null));
+        counter.addStep(new Result(Result.Type.PASSED, Stats.ONE_MINUTE, null));
         counter.printStats(new PrintStream(baos), isStrict(false));
 
         assertThat(baos.toString(), endsWith(String.format(
@@ -145,9 +145,9 @@ public class StatsTest {
         Stats counter = new Stats(true, Locale.GERMANY);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        counter.addStep(new Result(Result.PASSED, Stats.ONE_MINUTE, null));
-        counter.addStep(new Result(Result.PASSED, Stats.ONE_SECOND, null));
-        counter.addStep(new Result(Result.PASSED, ONE_MILLI_SECOND, null));
+        counter.addStep(new Result(Result.Type.PASSED, Stats.ONE_MINUTE, null));
+        counter.addStep(new Result(Result.Type.PASSED, Stats.ONE_SECOND, null));
+        counter.addStep(new Result(Result.Type.PASSED, ONE_MILLI_SECOND, null));
         counter.printStats(new PrintStream(baos), isStrict(false));
 
         assertThat(baos.toString(), endsWith(String.format(
@@ -159,12 +159,12 @@ public class StatsTest {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        counter.addStep(createResultWithStatus(Result.FAILED));
-        counter.addScenario(Result.FAILED, "path/file.feature:3 # Scenario: scenario_name");
-        counter.addStep(createResultWithStatus(Result.UNDEFINED));
-        counter.addScenario(Result.UNDEFINED, "path/file.feature:3 # Scenario: scenario_name");
-        counter.addStep(createResultWithStatus(Stats.PENDING));
-        counter.addScenario(Stats.PENDING, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addStep(createResultWithStatus(Result.Type.FAILED));
+        counter.addScenario(Result.Type.FAILED, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addStep(createResultWithStatus(Result.Type.UNDEFINED));
+        counter.addScenario(Result.Type.UNDEFINED, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addStep(createResultWithStatus(Result.Type.PENDING));
+        counter.addScenario(Result.Type.PENDING, "path/file.feature:3 # Scenario: scenario_name");
         counter.printStats(new PrintStream(baos), isStrict(false));
 
         assertThat(baos.toString(), startsWith(String.format("" +
@@ -179,12 +179,12 @@ public class StatsTest {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        counter.addStep(createResultWithStatus(Result.FAILED));
-        counter.addScenario(Result.FAILED, "path/file.feature:3 # Scenario: scenario_name");
-        counter.addStep(createResultWithStatus(Result.UNDEFINED));
-        counter.addScenario(Result.UNDEFINED, "path/file.feature:3 # Scenario: scenario_name");
-        counter.addStep(createResultWithStatus(Stats.PENDING));
-        counter.addScenario(Stats.PENDING, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addStep(createResultWithStatus(Result.Type.FAILED));
+        counter.addScenario(Result.Type.FAILED, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addStep(createResultWithStatus(Result.Type.UNDEFINED));
+        counter.addScenario(Result.Type.UNDEFINED, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addStep(createResultWithStatus(Result.Type.PENDING));
+        counter.addScenario(Result.Type.PENDING, "path/file.feature:3 # Scenario: scenario_name");
         counter.printStats(new PrintStream(baos), isStrict(true));
 
         assertThat(baos.toString(), startsWith(String.format("" +
@@ -200,12 +200,12 @@ public class StatsTest {
                 "3 Scenarios")));
     }
 
-    private void addOneStepScenario(Stats counter, String status) {
+    private void addOneStepScenario(Stats counter, Result.Type status) {
         counter.addStep(createResultWithStatus(status));
         counter.addScenario(status, "scenario designation");
     }
 
-    private Result createResultWithStatus(String status) {
+    private Result createResultWithStatus(Result.Type status) {
         return new Result(status, 0l, null);
     }
 

--- a/core/src/test/java/cucumber/runtime/UndefinedStepsTrackerTest.java
+++ b/core/src/test/java/cucumber/runtime/UndefinedStepsTrackerTest.java
@@ -175,7 +175,7 @@ public class UndefinedStepsTrackerTest {
 
     private Result undefinedResultWithSnippets(List<String> snippets) {
         Result result = mock(Result.class);
-        when(result.getStatus()).thenReturn(Result.UNDEFINED);
+        when(result.is(Result.Type.UNDEFINED)).thenReturn(true);
         when(result.getSnippets()).thenReturn(snippets);
         return result;
     }

--- a/core/src/test/java/cucumber/runtime/formatter/PluginFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/PluginFactoryTest.java
@@ -96,7 +96,9 @@ public class PluginFactoryTest {
             ProgressFormatter plugin = (ProgressFormatter) fc.create("progress");
             EventBus bus = new EventBus(new TimeService.Stub(0));
             plugin.setEventPublisher(bus);
-            bus.send(new TestStepFinished(bus.getTime(), mock(TestStep.class), new Result("passed", null, null)));
+            Result result = new Result(Result.Type.PASSED, null, null);
+            TestStepFinished event = new TestStepFinished(bus.getTime(), mock(TestStep.class), result);
+            bus.send(event);
 
             assertThat(mockSystemOut.toString(), is(not("")));
         } finally {

--- a/core/src/test/java/cucumber/runtime/formatter/UsageFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/UsageFormatterTest.java
@@ -35,7 +35,7 @@ public class UsageFormatterTest {
         Appendable out = mock(Appendable.class);
         UsageFormatter usageFormatter = new UsageFormatter(out);
         Result result = mock(Result.class);
-        when(result.getStatus()).thenReturn(Result.SKIPPED.getStatus());
+        when(result.is(Result.Type.PASSED)).thenReturn(false);
 
         usageFormatter.handleTestStepFinished(new TestStepFinished(0l, mockTestStep(), result));
         verifyZeroInteractions(out);
@@ -49,7 +49,7 @@ public class UsageFormatterTest {
         TestStep testStep = mockTestStep();
         Result result = mock(Result.class);
         when(result.getDuration()).thenReturn(12345L);
-        when(result.getStatus()).thenReturn(Result.PASSED);
+        when(result.is(Result.Type.PASSED)).thenReturn(true);
 
         usageFormatter.handleTestStepFinished(new TestStepFinished(0l, testStep, result));
 
@@ -70,7 +70,7 @@ public class UsageFormatterTest {
         TestStep testStep = mockTestStep();
         Result result = mock(Result.class);
         when(result.getDuration()).thenReturn(0L);
-        when(result.getStatus()).thenReturn(Result.PASSED);
+        when(result.is(Result.Type.PASSED)).thenReturn(true);
 
         usageFormatter.handleTestStepFinished(new TestStepFinished(0l, testStep, result));
 
@@ -91,7 +91,7 @@ public class UsageFormatterTest {
         TestStep testStep = mockTestStep();
         Result result = mock(Result.class);
         when(result.getDuration()).thenReturn(null);
-        when(result.getStatus()).thenReturn(Result.PASSED);
+        when(result.is(Result.Type.PASSED)).thenReturn(true);
 
         usageFormatter.handleTestStepFinished(new TestStepFinished(0l, testStep, result));
 

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -82,7 +82,7 @@ public class JUnitReporter {
 
     void handleStepResult(Result result) {
         Throwable error = result.getError();
-        if (Result.SKIPPED == result) {
+        if (result.is(Result.Type.SKIPPED)) {
             stepNotifier.fireTestIgnored();
         } else if (isPendingOrUndefined(result)) {
             addFailureOrIgnoreStep(result);
@@ -105,7 +105,7 @@ public class JUnitReporter {
     }
 
     void handleHookResult(Result result) {
-        if (result.getStatus().equals(Result.FAILED) || (strict && isPending(result.getError()))) {
+        if (result.is(Result.Type.FAILED) || (strict && isPending(result.getError()))) {
             executionUnitNotifier.addFailure(result.getError());
         } else if (isPending(result.getError())) {
             ignoredStep = true;
@@ -118,7 +118,7 @@ public class JUnitReporter {
 
     private boolean isPendingOrUndefined(Result result) {
         Throwable error = result.getError();
-        return Result.UNDEFINED.equals(result.getStatus()) || isPending(error);
+        return result.is(Result.Type.UNDEFINED) || isPending(error);
     }
 
     private void addFailureOrIgnoreStep(Result result) {

--- a/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
@@ -71,7 +71,7 @@ public class JUnitReporterTest {
         EachTestNotifier stepNotifier = mock(EachTestNotifier.class);
         jUnitReporter.stepNotifier = stepNotifier;
 
-        jUnitReporter.handleStepResult(mockResult(Result.UNDEFINED));
+        jUnitReporter.handleStepResult(mockResult(Result.Type.UNDEFINED));
 
         verify(stepNotifier, times(0)).fireTestStarted();
         verify(stepNotifier, times(0)).fireTestFinished();
@@ -88,7 +88,7 @@ public class JUnitReporterTest {
         EachTestNotifier executionUnitNotifier = mock(EachTestNotifier.class);
         jUnitReporter.executionUnitNotifier = executionUnitNotifier;
 
-        jUnitReporter.handleStepResult(mockResult(Result.UNDEFINED));
+        jUnitReporter.handleStepResult(mockResult(Result.Type.UNDEFINED));
 
         verify(stepNotifier, times(1)).fireTestStarted();
         verify(stepNotifier, times(1)).fireTestFinished();
@@ -194,8 +194,7 @@ public class JUnitReporterTest {
     public void hook_with_pending_exception_strict() {
         createStrictReporter();
         createDefaultRunNotifier();
-        Result result = mock(Result.class);
-        when(result.getStatus()).thenReturn("Pending");
+        Result result = mockResult(Result.Type.PENDING);
         when(result.getError()).thenReturn(new PendingException());
 
         EachTestNotifier executionUnitNotifier = mock(EachTestNotifier.class);
@@ -210,8 +209,7 @@ public class JUnitReporterTest {
     public void hook_with_pending_exception_non_strict() {
         createNonStrictReporter();
         createDefaultRunNotifier();
-        Result result = mock(Result.class);
-        when(result.getStatus()).thenReturn("Pending");
+        Result result = mockResult(Result.Type.PENDING);
         when(result.getError()).thenReturn(new PendingException());
 
         EachTestNotifier executionUnitNotifier = mock(EachTestNotifier.class);
@@ -230,8 +228,7 @@ public class JUnitReporterTest {
         Result stepResult = mock(Result.class);
         Throwable exception = mock(Throwable.class);
         when(stepResult.getError()).thenReturn(exception);
-        Result hookResult = mock(Result.class);
-        when(hookResult.getStatus()).thenReturn("Pending");
+        Result hookResult = mockResult(Result.Type.PENDING);
         when(hookResult.getError()).thenReturn(new PendingException());
 
         EachTestNotifier executionUnitNotifier = mock(EachTestNotifier.class);
@@ -261,12 +258,14 @@ public class JUnitReporterTest {
     }
 
     private Result mockResult() {
-        return mockResult("passed");
+        return mockResult(Result.Type.PASSED);
     }
 
-    private Result mockResult(String status) {
+    private Result mockResult(Result.Type status) {
         Result result = mock(Result.class);
-        when(result.getStatus()).thenReturn(status);
+        for (Result.Type type : Result.Type.values()) {
+            when(result.is(type)).thenReturn(type == status);
+        }
         return result;
     }
 

--- a/testng/src/main/java/cucumber/api/testng/FeatureResultListener.java
+++ b/testng/src/main/java/cucumber/api/testng/FeatureResultListener.java
@@ -8,7 +8,6 @@ import cucumber.api.event.TestStepFinished;
 import cucumber.api.formatter.Formatter;
 
 public class FeatureResultListener implements Formatter {
-    static final String PENDING_STATUS = "pending";
     static final String UNDEFINED_MESSAGE = "There are undefined steps";
     static final String PENDING_MESSAGE = "There are pending steps";
     private boolean strict;
@@ -30,15 +29,15 @@ public class FeatureResultListener implements Formatter {
     }
 
     void collectError(Result result) {
-        if (result.getStatus().equals(Result.FAILED)) {
+        if (result.is(Result.Type.FAILED)) {
             if (error == null || isUndefinedError(error) || isPendingError(error)) {
                 error = result.getError();
             }
-        } else if (result.getStatus().equals(PENDING_STATUS) && strict) {
+        } else if (result.is(Result.Type.PENDING) && strict) {
             if (error == null || isUndefinedError(error)) {
                 error = new CucumberException(PENDING_MESSAGE);
             }
-        } else if (result.getStatus().equals(Result.UNDEFINED) && strict) {
+        } else if (result.is(Result.Type.UNDEFINED) && strict) {
             if (error == null) {
                 error = new CucumberException(UNDEFINED_MESSAGE);
             }

--- a/testng/src/main/java/cucumber/api/testng/TestNgReporter.java
+++ b/testng/src/main/java/cucumber/api/testng/TestNgReporter.java
@@ -52,15 +52,15 @@ public class TestNgReporter implements Formatter {
     private void result(String stepText, Result result) {
         logResult(stepText, result);
 
-        if (Result.FAILED.equals(result.getStatus())) {
+        if (result.is(Result.Type.FAILED)) {
             ITestResult tr = getCurrentTestResult();
             tr.setThrowable(result.getError());
             tr.setStatus(ITestResult.FAILURE);
-        } else if (Result.SKIPPED.equals(result)) {
+        } else if (result.is(Result.Type.SKIPPED)) {
             ITestResult tr = getCurrentTestResult();
             tr.setThrowable(result.getError());
             tr.setStatus(ITestResult.SKIP);
-        } else if (Result.UNDEFINED.equals(result)) {
+        } else if (result.is(Result.Type.UNDEFINED)) {
             ITestResult tr = getCurrentTestResult();
             tr.setThrowable(result.getError());
             tr.setStatus(ITestResult.FAILURE);

--- a/testng/src/test/java/cucumber/api/testng/FeatureResultListenerTest.java
+++ b/testng/src/test/java/cucumber/api/testng/FeatureResultListenerTest.java
@@ -133,27 +133,31 @@ public class FeatureResultListenerTest {
     }
 
     private Result mockPassedResult() {
-        Result result = mock(Result.class);
-        when(result.getStatus()).thenReturn(Result.PASSED);
+        Result result = mockResult(Result.Type.PASSED);
         return result;
     }
 
     private Result mockUndefinedResult() {
-        Result result = mock(Result.class);
-        when(result.getStatus()).thenReturn(Result.UNDEFINED);
+        Result result = mockResult(Result.Type.UNDEFINED);
         return result;
     }
 
     private Result mockFailedResult() {
-        Result result = mock(Result.class);
-        when(result.getStatus()).thenReturn(Result.FAILED);
+        Result result = mockResult(Result.Type.FAILED);
         when(result.getError()).thenReturn(mock(Throwable.class));
         return result;
     }
 
     private Result mockPendingResult() {
+        Result result = mockResult(Result.Type.PENDING);
+        return result;
+    }
+
+    private Result mockResult(Result.Type status) {
         Result result = mock(Result.class);
-        when(result.getStatus()).thenReturn(FeatureResultListener.PENDING_STATUS);
+        for (Result.Type type : Result.Type.values()) {
+            when(result.is(type)).thenReturn(type == status);
+        }
         return result;
     }
 }


### PR DESCRIPTION
## Summary

Instead of using string constants, use an enum for the result status
(passed, failed, ...).

## Motivation and Context

Based on a [review comment](https://github.com/cucumber/cucumber-jvm/pull/1035#pullrequestreview-38007345) on the upgrade to a newer Gherkin version, that pointed to the problem of using string constants for result status (the result class in Gherkin2 did not have a string constant for the pending status, making matter more complicated), I have introduced an enum in the Result class for the possible result statuses

## How Has This Been Tested?

The test suites has been updated and amended to, so it covers the change from strings to enum constants for result statuses.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
