### PR TITLE
Use deterministic unique ids in Descriptions

### DIFF
--- a/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
+++ b/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
@@ -131,10 +131,10 @@ class ExecutionUnitRunner extends ParentRunner<PickleStep> {
         private final int pickleLine;
         private final int pickleStepLine;
 
-        PickleStepId(PickleEvent pickleEvent, PickleStep pickleStepLine) {
+        PickleStepId(PickleEvent pickleEvent, PickleStep pickleStep) {
             this.uri = pickleEvent.uri;
             this.pickleLine = pickleEvent.pickle.getLocations().get(0).getLine();
-            this.pickleStepLine = pickleStepLine.getLocations().get(0).getLine();
+            this.pickleStepLine = pickleStep.getLocations().get(0).getLine();
         }
 
         @Override

--- a/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
+++ b/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
@@ -49,7 +49,7 @@ class ExecutionUnitRunner extends ParentRunner<PickleStep> {
     public Description getDescription() {
         if (description == null) {
             String nameForDescription = getName().isEmpty() ? "EMPTY_NAME" : getName();
-            description = Description.createSuiteDescription(nameForDescription, new PickleWrapper(pickleEvent));
+            description = Description.createSuiteDescription(nameForDescription, new PickleId(pickleEvent));
 
             for (PickleStep step : getChildren()) {
                 description.addChild(describeChild(step));
@@ -68,7 +68,7 @@ class ExecutionUnitRunner extends ParentRunner<PickleStep> {
             } else {
                 testName = step.getText();
             }
-            description = Description.createTestDescription(getName(), testName, new PickleStepWrapper(step));
+            description = Description.createTestDescription(getName(), testName, new PickleStepId(pickleEvent, step));
             stepDescriptions.put(step, description);
         }
         return description;
@@ -93,22 +93,69 @@ class ExecutionUnitRunner extends ParentRunner<PickleStep> {
     private String makeNameFilenameCompatible(String name) {
         return name.replaceAll("[^A-Za-z0-9_]", "_");
     }
-}
 
-class PickleWrapper implements Serializable {
-    private static final long serialVersionUID = 1L;
-    private PickleEvent pickleEvent;
+    private static final class PickleId implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private final String uri;
+        private int pickleLine;
 
-    PickleWrapper(PickleEvent pickleEvent) {
-        this.pickleEvent = pickleEvent;
+        PickleId(PickleEvent pickleEvent) {
+            this.uri = pickleEvent.uri;
+            this.pickleLine = pickleEvent.pickle.getLocations().get(0).getLine();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            PickleId that = (PickleId) o;
+            return pickleLine == that.pickleLine && uri.equals(that.uri);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = uri.hashCode();
+            result = 31 * result + pickleLine;
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return uri + ":" + pickleLine;
+        }
     }
-}
 
-class PickleStepWrapper implements Serializable {
-    private static final long serialVersionUID = 1L;
-    private PickleStep step;
+    private static final class PickleStepId implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private final String uri;
+        private final int pickleLine;
+        private final int pickleStepLine;
 
-    PickleStepWrapper(PickleStep step) {
-        this.step = step;
+        PickleStepId(PickleEvent pickleEvent, PickleStep pickleStepLine) {
+            this.uri = pickleEvent.uri;
+            this.pickleLine = pickleEvent.pickle.getLocations().get(0).getLine();
+            this.pickleStepLine = pickleStepLine.getLocations().get(0).getLine();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            PickleStepId that = (PickleStepId) o;
+            return pickleLine == that.pickleLine && pickleStepLine == that.pickleStepLine && uri.equals(that.uri);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = pickleLine;
+            result = 31 * result + uri.hashCode();
+            result = 31 * result + pickleStepLine;
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return uri + ":" + pickleLine + ":" + pickleStepLine;
+        }
     }
 }

--- a/junit/src/main/java/cucumber/runtime/junit/FeatureRunner.java
+++ b/junit/src/main/java/cucumber/runtime/junit/FeatureRunner.java
@@ -12,6 +12,7 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.ParentRunner;
 import org.junit.runners.model.InitializationError;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,7 +37,7 @@ public class FeatureRunner extends ParentRunner<ParentRunner> {
     @Override
     public Description getDescription() {
         if (description == null) {
-            description = Description.createSuiteDescription(getName(), cucumberFeature);
+            description = Description.createSuiteDescription(getName(), new FeatureId(cucumberFeature));
             for (ParentRunner child : getChildren()) {
                 description.addChild(describeChild(child));
             }
@@ -84,6 +85,34 @@ public class FeatureRunner extends ParentRunner<ParentRunner> {
                     throw new CucumberException("Failed to create scenario runner", e);
                 }
             }
+        }
+    }
+
+    private static final class FeatureId implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private final String uri;
+
+        FeatureId(CucumberFeature feature) {
+            this.uri = feature.getPath();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            FeatureId featureId = (FeatureId) o;
+            return uri.equals(featureId.uri);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return uri.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return uri;
         }
     }
 


### PR DESCRIPTION
## Summary

Improve surefire integration.

## Motivation and Context
 Rerunning failed tests with Surefire requires a method to identify the tests.
 Surefire currently uses a tuple of (Class, Method) to identify failed tests.
 Cucumber-jvm uses test suites which do not consist of Classes or methods.
 Therefore another method is needed.

 JUnit provides the option to select tests that match a Description.
 Descriptions are compared using  a unique Id. To identify tests between
 different runs we should provide Descriptions with a predictable unique
 id.

 The current implementation did not suffice. While the provided cucumber
 elements are unique, they are not predictable between runs making it
 impossible to use their descriptions to rerun a failed test.

 After this change it will be possible to update Surefire to use
 descriptions to rerun failed tests.

  Related Issues:
  - https://issues.apache.org/jira/browse/SUREFIRE-1372
  - https://github.com/cucumber/cucumber-jvm/issues/1120
  - https://github.com/temyers/cucumber-jvm-parallel-plugin/issues/31

Closes #1120.

## How Has This Been Tested?

Replaced `ExecutionUnitRunnerTest#shouldPopulateRunnerStepsWithStepsUsedInStepDescriptions` with `FeatureRunnerTest#shouldPopulateDescriptionsWithStableUniqueIds` that creates the same feature twice and tests the id's are unique and predictable.

The reproducer for Surefire can be found [in my fork of Surefire](
https://github.com/mpkorstanje/maven-surefire/tree/SUREFIRE-1372/surefire-integration-tests/src/test/resources/junit47-rerun-failing-tests-with-cucumber). Running with cucumber 1.2.5 results in failed tests, with the result of this PR as 2.0.0-SNAPSHOT results in 2 flakes. 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).

## Checklist:
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
