### PR TITLE
Implementing support for passing the response of a step to the subsequent step

### DIFF
--- a/core/src/main/java/cucumber/api/PreviousStepState.java
+++ b/core/src/main/java/cucumber/api/PreviousStepState.java
@@ -1,0 +1,17 @@
+package cucumber.api;
+
+import java.util.Optional;
+
+public class PreviousStepState {
+	
+	private final Optional<Object> responseFromPreviousStep;
+
+	public PreviousStepState(Optional<Object> responseFromPreviousStep) {
+		this.responseFromPreviousStep = responseFromPreviousStep;
+	}
+
+	public Optional<Object> getResponseFromPreviousStep() {
+		return responseFromPreviousStep;
+	}
+
+}

--- a/core/src/main/java/cucumber/api/Result.java
+++ b/core/src/main/java/cucumber/api/Result.java
@@ -4,14 +4,18 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 public class Result {
-    private static final long serialVersionUID = 1L;
+    @SuppressWarnings("unused")
+	private static final long serialVersionUID = 2L;
 
     private final Result.Type status;
     private final Long duration;
     private final Throwable error;
     private final List<String> snippets;
+    private final Object returnValue; 
+    
     public static final Result SKIPPED = new Result(Result.Type.SKIPPED, null, null);
     public static enum Type {
         PASSED,
@@ -34,7 +38,7 @@ public class Result {
 
 
     }
-
+    
     /**
      * Used at runtime
      *
@@ -43,8 +47,8 @@ public class Result {
      * @param error
      */
     public Result(Result.Type status, Long duration, Throwable error) {
-        this(status, duration, error, Collections.<String>emptyList());
-    }
+        this(status, duration, error, Collections.<String>emptyList(), null);
+    }    
 
     /**
      * Used at runtime
@@ -54,11 +58,12 @@ public class Result {
      * @param error
      * @param snippets
      */
-    public Result(Result.Type status, Long duration, Throwable error, List<String> snippets) {
+    public Result(Result.Type status, Long duration, Throwable error, List<String> snippets, Object returnValue) {
         this.status = status;
         this.duration = duration;
         this.error = error;
         this.snippets = snippets;
+        this.returnValue = returnValue;
     }
 
     public Result.Type getStatus() {
@@ -88,6 +93,10 @@ public class Result {
     public boolean isOk(boolean isStrict) {
         return hasAlwaysOkStatus() || !isStrict && hasOkWhenNotStrictStatus();
     }
+    
+    public Optional<Object> getReturnValue(){
+    	return Optional.ofNullable(returnValue);
+    }
 
     private boolean hasAlwaysOkStatus() {
         return is(Result.Type.PASSED) || is(Result.Type.SKIPPED);
@@ -103,4 +112,5 @@ public class Result {
         error.printStackTrace(printWriter);
         return stringWriter.getBuffer().toString();
     }
+    
 }

--- a/core/src/main/java/cucumber/api/Result.java
+++ b/core/src/main/java/cucumber/api/Result.java
@@ -14,7 +14,7 @@ public class Result {
     private final Long duration;
     private final Throwable error;
     private final List<String> snippets;
-    private final Object returnValue; 
+    private final Optional<Object> returnValue; 
     
     public static final Result SKIPPED = new Result(Result.Type.SKIPPED, null, null);
     public static enum Type {
@@ -47,7 +47,7 @@ public class Result {
      * @param error
      */
     public Result(Result.Type status, Long duration, Throwable error) {
-        this(status, duration, error, Collections.<String>emptyList(), null);
+        this(status, duration, error, Collections.<String>emptyList(), Optional.empty());
     }    
 
     /**
@@ -58,7 +58,7 @@ public class Result {
      * @param error
      * @param snippets
      */
-    public Result(Result.Type status, Long duration, Throwable error, List<String> snippets, Object returnValue) {
+    public Result(Result.Type status, Long duration, Throwable error, List<String> snippets, Optional<Object> returnValue) {
         this.status = status;
         this.duration = duration;
         this.error = error;
@@ -94,8 +94,8 @@ public class Result {
         return hasAlwaysOkStatus() || !isStrict && hasOkWhenNotStrictStatus();
     }
     
-    public Optional<Object> getReturnValue(){
-    	return Optional.ofNullable(returnValue);
+    public Optional<Object> getReturnValue() {
+    	return returnValue;
     }
 
     private boolean hasAlwaysOkStatus() {

--- a/core/src/main/java/cucumber/api/Scenario.java
+++ b/core/src/main/java/cucumber/api/Scenario.java
@@ -1,6 +1,7 @@
 package cucumber.api;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Before or After Hooks that declare a parameter of this type will receive an instance of this class.
@@ -51,4 +52,6 @@ public interface Scenario {
      * @return the name of the Scenario
      */
     String getName();
+    
+    Optional<Object> getResponseFromPreviousStep();
 }

--- a/core/src/main/java/cucumber/runner/UnskipableStep.java
+++ b/core/src/main/java/cucumber/runner/UnskipableStep.java
@@ -9,6 +9,7 @@ import gherkin.pickles.Argument;
 import gherkin.pickles.PickleStep;
 
 import java.util.List;
+import java.util.Optional;
 
 public class UnskipableStep extends TestStep {
     private final HookType hookType;
@@ -18,8 +19,13 @@ public class UnskipableStep extends TestStep {
         this.hookType = hookType;
     }
 
-    protected Result.Type executeStep(String language, Scenario scenario, boolean skipSteps) throws Throwable {
-        definitionMatch.runStep(language, scenario);
+    @Override
+    protected Optional<Object> executeStep(String language, Scenario scenario, boolean skipSteps) throws Throwable {
+    	return Optional.ofNullable(definitionMatch.runStep(language, scenario));
+    }
+    
+    @Override
+    protected Result.Type nonExceptionStatus(boolean skipSteps) {
         return Result.Type.PASSED;
     }
 

--- a/core/src/main/java/cucumber/runtime/AmbiguousStepDefinitionsMatch.java
+++ b/core/src/main/java/cucumber/runtime/AmbiguousStepDefinitionsMatch.java
@@ -12,13 +12,13 @@ public class AmbiguousStepDefinitionsMatch extends StepDefinitionMatch {
     }
 
     @Override
-    public void runStep(String language, Scenario scenario) throws Throwable {
+    public Object runStep(String language, Scenario scenario) throws Throwable {
         throw exception;
     }
 
     @Override
-    public void dryRunStep(String language, Scenario scenario) throws Throwable {
-        runStep(language, scenario);
+    public Object dryRunStep(String language, Scenario scenario) throws Throwable {
+        return runStep(language, scenario);
     }
 
     @Override

--- a/core/src/main/java/cucumber/runtime/DefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/DefinitionMatch.java
@@ -5,9 +5,9 @@ import cucumber.api.Scenario;
 import java.util.List;
 
 public interface DefinitionMatch {
-    void runStep(String language, Scenario scenario) throws Throwable;
+    Object runStep(String language, Scenario scenario) throws Throwable;
 
-    void dryRunStep(String language, Scenario scenario) throws Throwable;
+    Object dryRunStep(String language, Scenario scenario) throws Throwable;
 
     Match getMatch();
 

--- a/core/src/main/java/cucumber/runtime/FailedStepInstantiationMatch.java
+++ b/core/src/main/java/cucumber/runtime/FailedStepInstantiationMatch.java
@@ -14,13 +14,13 @@ public class FailedStepInstantiationMatch extends StepDefinitionMatch {
     }
 
     @Override
-    public void runStep(String language, Scenario scenario) throws Throwable {
+    public Object runStep(String language, Scenario scenario) throws Throwable {
         throw throwable;
     }
 
     @Override
-    public void dryRunStep(String language, Scenario scenario) throws Throwable {
-        runStep(language, scenario);
+    public Object dryRunStep(String language, Scenario scenario) throws Throwable {
+        return runStep(language, scenario);
     }
 
     @Override

--- a/core/src/main/java/cucumber/runtime/HookDefinition.java
+++ b/core/src/main/java/cucumber/runtime/HookDefinition.java
@@ -14,7 +14,7 @@ public interface HookDefinition {
      */
     String getLocation(boolean detail);
 
-    void execute(Scenario scenario) throws Throwable;
+    Object execute(Scenario scenario) throws Throwable;
 
     boolean matches(Collection<PickleTag> tags);
 

--- a/core/src/main/java/cucumber/runtime/HookDefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/HookDefinitionMatch.java
@@ -13,13 +13,14 @@ public class HookDefinitionMatch implements DefinitionMatch {
     }
 
     @Override
-    public void runStep(String language, Scenario scenario) throws Throwable {
-        hookDefinition.execute(scenario);
+    public Object runStep(String language, Scenario scenario) throws Throwable {
+        return hookDefinition.execute(scenario);
     }
 
     @Override
-    public void dryRunStep(String language, Scenario scenario) throws Throwable {
+    public Object dryRunStep(String language, Scenario scenario) throws Throwable {
         // Do nothing
+    	return null;
     }
 
     @Override

--- a/core/src/main/java/cucumber/runtime/NoStepDefinition.java
+++ b/core/src/main/java/cucumber/runtime/NoStepDefinition.java
@@ -29,7 +29,8 @@ class NoStepDefinition implements StepDefinition {
     }
 
     @Override
-    public void execute(String language, Object[] args) throws Throwable {
+    public Object execute(String language, Object[] args) throws Throwable {
+    	return null;
     }
 
     @Override

--- a/core/src/main/java/cucumber/runtime/ScenarioImpl.java
+++ b/core/src/main/java/cucumber/runtime/ScenarioImpl.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
@@ -28,7 +29,7 @@ public class ScenarioImpl implements Scenario {
         this.tags = gherkinScenario.getTags();
         this.scenarioName = gherkinScenario.getName();
     }
-
+    
     public void add(Result result) {
         stepResults.add(result);
     }
@@ -88,4 +89,12 @@ public class ScenarioImpl implements Scenario {
         }
         return error;
     }
+
+	@Override
+	public Optional<Object> getResponseFromPreviousStep() {
+		if (stepResults.isEmpty()) {
+			return Optional.empty();
+		}
+		return stepResults.get(stepResults.size() - 1).getReturnValue();  
+	}
 }

--- a/core/src/main/java/cucumber/runtime/StepDefinition.java
+++ b/core/src/main/java/cucumber/runtime/StepDefinition.java
@@ -39,7 +39,7 @@ public interface StepDefinition {
      * Invokes the step definition. The method should raise a Throwable
      * if the invocation fails, which will cause the step to fail.
      */
-    void execute(String language, Object[] args) throws Throwable;
+    Object execute(String language, Object[] args) throws Throwable;
 
     /**
      * Return true if this matches the location. This is used to filter

--- a/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
@@ -39,11 +39,17 @@ public class StepDefinitionMatch extends Match implements DefinitionMatch {
     @Override
     public Object runStep(String language, Scenario scenario) throws Throwable {
         try {
-        	Optional<Object> responseFromPreviousStep = scenario.getResponseFromPreviousStep();
+        	Optional<Object> responseFromPreviousStep;
+        	if (scenario != null) {
+        		responseFromPreviousStep = scenario.getResponseFromPreviousStep();
+        	} else {
+        		responseFromPreviousStep = Optional.empty();
+        	}
             return stepDefinition.execute(language, transformedArgs(step, localizedXStreams.get(localeFor(language)), new PreviousStepState(responseFromPreviousStep)));
         } catch (CucumberException e) {
             throw e;
         } catch (Throwable t) {
+        	t.printStackTrace();
             throw removeFrameworkFramesAndAppendStepLocation(t, getStepLocation());
         }
     }

--- a/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
@@ -1,6 +1,7 @@
 package cucumber.runtime;
 
 import cucumber.api.DataTable;
+import cucumber.api.PreviousStepState;
 import cucumber.api.Scenario;
 import cucumber.runtime.table.TableConverter;
 import cucumber.runtime.xstream.LocalizedXStreams;
@@ -15,6 +16,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import static cucumber.util.FixJava.map;
 
@@ -35,9 +37,10 @@ public class StepDefinitionMatch extends Match implements DefinitionMatch {
     }
 
     @Override
-    public void runStep(String language, Scenario scenario) throws Throwable {
+    public Object runStep(String language, Scenario scenario) throws Throwable {
         try {
-            stepDefinition.execute(language, transformedArgs(step, localizedXStreams.get(localeFor(language))));
+        	Optional<Object> responseFromPreviousStep = scenario.getResponseFromPreviousStep();
+            return stepDefinition.execute(language, transformedArgs(step, localizedXStreams.get(localeFor(language)), new PreviousStepState(responseFromPreviousStep)));
         } catch (CucumberException e) {
             throw e;
         } catch (Throwable t) {
@@ -46,24 +49,33 @@ public class StepDefinitionMatch extends Match implements DefinitionMatch {
     }
 
     @Override
-    public void dryRunStep(String language, Scenario scenario) throws Throwable {
+    public Object dryRunStep(String language, Scenario scenario) throws Throwable {
         // Do nothing
+    	return null;
     }
 
     /**
      * @param step    the step to run
      * @param xStream used to convert a string to declared stepdef arguments
+     * @param previousStepState used to cpature the state of the previous step that was run
      * @return an Array matching the types or {@code parameterTypes}, or an array of String if {@code parameterTypes} is null
      */
-    private Object[] transformedArgs(PickleStep step, LocalizedXStreams.LocalizedXStream xStream) {
+    private Object[] transformedArgs(PickleStep step, LocalizedXStreams.LocalizedXStream xStream, PreviousStepState previousStepState) {
         int argumentCount = getArguments().size();
 
         if (!step.getArgument().isEmpty()) {
             argumentCount++;
         }
         Integer parameterCount = stepDefinition.getParameterCount();
-        if (parameterCount != null && argumentCount != parameterCount) {
-            throw arityMismatch(parameterCount);
+        boolean lastArgumentInstanceOfPreviousStepState = false;
+        
+        if ((parameterCount != null) && (argumentCount != parameterCount)) {
+        	if (parameterCount > 0) {
+        		lastArgumentInstanceOfPreviousStepState = stepDefinition.getParameterType(parameterCount - 1, PreviousStepState.class).getRawType().equals(PreviousStepState.class);
+        	}
+        	if (!lastArgumentInstanceOfPreviousStepState) {
+        		throw arityMismatch(parameterCount);
+        	}
         }
 
         List<Object> result = new ArrayList<Object>();
@@ -86,6 +98,12 @@ public class StepDefinitionMatch extends Match implements DefinitionMatch {
                 result.add(arg);
             }
         }
+        
+        if (lastArgumentInstanceOfPreviousStepState) {
+        	//TODO: add the previous state
+        	result.add(previousStepState);
+        }
+        
         return result.toArray(new Object[result.size()]);
     }
 

--- a/core/src/main/java/cucumber/runtime/UndefinedStepDefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/UndefinedStepDefinitionMatch.java
@@ -15,13 +15,13 @@ public class UndefinedStepDefinitionMatch extends StepDefinitionMatch {
     }
 
     @Override
-    public void runStep(String language, Scenario scenario) throws Throwable {
+    public Object runStep(String language, Scenario scenario) throws Throwable {
         throw new UndefinedStepDefinitionException();
     }
 
     @Override
-    public void dryRunStep(String language, Scenario scenario) throws Throwable {
-        runStep(language, scenario);
+    public Object dryRunStep(String language, Scenario scenario) throws Throwable {
+        return runStep(language, scenario);
     }
 
     @Override

--- a/core/src/test/java/cucumber/runtime/StubStepDefinition.java
+++ b/core/src/test/java/cucumber/runtime/StubStepDefinition.java
@@ -40,8 +40,8 @@ public class StubStepDefinition implements StepDefinition {
     }
 
     @Override
-    public void execute(String language, Object[] args) throws Throwable {
-        Utils.invoke(target, method, 0, args);
+    public Object execute(String language, Object[] args) throws Throwable {
+        return Utils.invoke(target, method, 0, args);
     }
 
     @Override

--- a/core/src/test/java/cucumber/runtime/autocomplete/StepdefGeneratorTest.java
+++ b/core/src/test/java/cucumber/runtime/autocomplete/StepdefGeneratorTest.java
@@ -133,7 +133,7 @@ public class StepdefGeneratorTest {
             }
 
             @Override
-            public void execute(String language, Object[] args) throws Throwable {
+            public Object execute(String language, Object[] args) throws Throwable {
                 throw new UnsupportedOperationException();
             }
 

--- a/examples/java-calculator/src/main/java/cucumber/examples/java/calculator/StatelessCalculator.java
+++ b/examples/java-calculator/src/main/java/cucumber/examples/java/calculator/StatelessCalculator.java
@@ -1,0 +1,12 @@
+package cucumber.examples.java.calculator;
+
+public class StatelessCalculator {
+	
+	public int add(int operand1, int operand2) {
+		return operand1 + operand2;
+	}
+
+	public int subtract(int operand1, int operand2) {
+		return operand1 - operand2;
+	}
+}

--- a/examples/java-calculator/src/test/java/cucumber/examples/java/calculator/StatelessCalculatorStepDefs.java
+++ b/examples/java-calculator/src/test/java/cucumber/examples/java/calculator/StatelessCalculatorStepDefs.java
@@ -1,0 +1,34 @@
+package cucumber.examples.java.calculator;
+
+import static org.junit.Assert.assertEquals;
+
+import cucumber.api.PreviousStepState;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+
+public class StatelessCalculatorStepDefs {
+
+	@Given("^I turned on the stateless calculator$")
+	public StatelessCalculator statelessCalculatorIsTurnedOn() {
+		return new StatelessCalculator();
+	}
+
+	@When("^I add (\\d+) to (\\d+)$")
+	public int adding(int arg1, int arg2, PreviousStepState previousStepState) {
+		StatelessCalculator statelessCalculator = (StatelessCalculator) previousStepState.getResponseFromPreviousStep().get();
+		return statelessCalculator.add(arg1, arg2);
+	}
+	
+	@When("^I subtract (\\d+) from (\\d+)$")
+	public int subtracting(int arg1, int arg2, PreviousStepState previousStepState) {
+		StatelessCalculator statelessCalculator = (StatelessCalculator) previousStepState.getResponseFromPreviousStep().get();
+		return statelessCalculator.subtract(arg2, arg1);
+	}
+
+	@Then("^The result should be (\\d+)$")
+	public void the_result_is(int expected, PreviousStepState previousStepState) {
+		assertEquals(expected, previousStepState.getResponseFromPreviousStep().get());
+	}
+
+}

--- a/examples/java-calculator/src/test/resources/cucumber/examples/java/calculator/stateless_calculator.feature
+++ b/examples/java-calculator/src/test/resources/cucumber/examples/java/calculator/stateless_calculator.feature
@@ -1,0 +1,13 @@
+Feature: Stateless Calculator
+
+  Background: A Stateless Calculator
+    Given I turned on the stateless calculator
+
+  Scenario: Addition
+    When I add 4 to 5
+    Then The result should be 9
+ 
+  Scenario: Subtraction
+    When I subtract 21 from 56
+    Then The result should be 35
+

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -174,40 +174,5 @@ GherkinDialectProvider.DIALECTS.keySet().each { language ->
                 </configuration>
             </plugin>
         </plugins>
-        <pluginManagement>
-        	<plugins>
-        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        		<plugin>
-        			<groupId>org.eclipse.m2e</groupId>
-        			<artifactId>lifecycle-mapping</artifactId>
-        			<version>1.0.0</version>
-        			<configuration>
-        				<lifecycleMappingMetadata>
-        					<pluginExecutions>
-        						<pluginExecution>
-        							<pluginExecutionFilter>
-        								<groupId>
-        									org.apache.maven.plugins
-        								</groupId>
-        								<artifactId>
-        									maven-antrun-plugin
-        								</artifactId>
-        								<versionRange>
-        									[1.8,)
-        								</versionRange>
-        								<goals>
-        									<goal>run</goal>
-        								</goals>
-        							</pluginExecutionFilter>
-        							<action>
-        								<ignore></ignore>
-        							</action>
-        						</pluginExecution>
-        					</pluginExecutions>
-        				</lifecycleMappingMetadata>
-        			</configuration>
-        		</plugin>
-        	</plugins>
-        </pluginManagement>
     </build>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -174,5 +174,40 @@ GherkinDialectProvider.DIALECTS.keySet().each { language ->
                 </configuration>
             </plugin>
         </plugins>
+        <pluginManagement>
+        	<plugins>
+        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        		<plugin>
+        			<groupId>org.eclipse.m2e</groupId>
+        			<artifactId>lifecycle-mapping</artifactId>
+        			<version>1.0.0</version>
+        			<configuration>
+        				<lifecycleMappingMetadata>
+        					<pluginExecutions>
+        						<pluginExecution>
+        							<pluginExecutionFilter>
+        								<groupId>
+        									org.apache.maven.plugins
+        								</groupId>
+        								<artifactId>
+        									maven-antrun-plugin
+        								</artifactId>
+        								<versionRange>
+        									[1.8,)
+        								</versionRange>
+        								<goals>
+        									<goal>run</goal>
+        								</goals>
+        							</pluginExecutionFilter>
+        							<action>
+        								<ignore></ignore>
+        							</action>
+        						</pluginExecution>
+        					</pluginExecutions>
+        				</lifecycleMappingMetadata>
+        			</configuration>
+        		</plugin>
+        	</plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/java/src/main/java/cucumber/runtime/java/Java8HookDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/Java8HookDefinition.java
@@ -43,8 +43,8 @@ public class Java8HookDefinition implements HookDefinition {
     }
 
     @Override
-    public void execute(final Scenario scenario) throws Throwable {
-        Timeout.timeout(new Timeout.Callback<Object>() {
+    public Object execute(final Scenario scenario) throws Throwable {
+        return Timeout.timeout(new Timeout.Callback<Object>() {
             @Override
             public Object call() throws Throwable {
                 if (hookBody != null) {

--- a/java/src/main/java/cucumber/runtime/java/Java8StepDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/Java8StepDefinition.java
@@ -110,8 +110,8 @@ public class Java8StepDefinition implements StepDefinition {
     }
 
     @Override
-    public void execute(final String language, final Object[] args) throws Throwable {
-        Utils.invoke(body, method, timeoutMillis, args);
+    public Object execute(final String language, final Object[] args) throws Throwable {
+        return Utils.invoke(body, method, timeoutMillis, args);
     }
 
     @Override

--- a/java/src/main/java/cucumber/runtime/java/JavaHookDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaHookDefinition.java
@@ -41,7 +41,7 @@ class JavaHookDefinition implements HookDefinition {
     }
 
     @Override
-    public void execute(Scenario scenario) throws Throwable {
+    public Object execute(Scenario scenario) throws Throwable {
         Object[] args;
         switch (method.getParameterTypes().length) {
             case 0:
@@ -57,7 +57,7 @@ class JavaHookDefinition implements HookDefinition {
                 throw new CucumberException("Hooks must declare 0 or 1 arguments. " + method.toString());
         }
 
-        Utils.invoke(objectFactory.getInstance(method.getDeclaringClass()), method, timeoutMillis, args);
+        return Utils.invoke(objectFactory.getInstance(method.getDeclaringClass()), method, timeoutMillis, args);
     }
 
     @Override

--- a/java/src/main/java/cucumber/runtime/java/JavaStepDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaStepDefinition.java
@@ -33,8 +33,8 @@ class JavaStepDefinition implements StepDefinition {
         this.parameterInfos = ParameterInfo.fromMethod(method);
     }
 
-    public void execute(String language, Object[] args) throws Throwable {
-        Utils.invoke(objectFactory.getInstance(method.getDeclaringClass()), method, timeoutMillis, args);
+    public Object execute(String language, Object[] args) throws Throwable {
+        return Utils.invoke(objectFactory.getInstance(method.getDeclaringClass()), method, timeoutMillis, args);
     }
 
     public List<Argument> matchedArguments(PickleStep step) {

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -127,5 +127,40 @@ GherkinDialectProvider.DIALECTS.keySet().each { language ->
                 </executions>
             </plugin>
         </plugins>
+        <pluginManagement>
+        	<plugins>
+        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        		<plugin>
+        			<groupId>org.eclipse.m2e</groupId>
+        			<artifactId>lifecycle-mapping</artifactId>
+        			<version>1.0.0</version>
+        			<configuration>
+        				<lifecycleMappingMetadata>
+        					<pluginExecutions>
+        						<pluginExecution>
+        							<pluginExecutionFilter>
+        								<groupId>
+        									org.apache.maven.plugins
+        								</groupId>
+        								<artifactId>
+        									maven-antrun-plugin
+        								</artifactId>
+        								<versionRange>
+        									[1.8,)
+        								</versionRange>
+        								<goals>
+        									<goal>run</goal>
+        								</goals>
+        							</pluginExecutionFilter>
+        							<action>
+        								<ignore></ignore>
+        							</action>
+        						</pluginExecution>
+        					</pluginExecutions>
+        				</lifecycleMappingMetadata>
+        			</configuration>
+        		</plugin>
+        	</plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -127,40 +127,5 @@ GherkinDialectProvider.DIALECTS.keySet().each { language ->
                 </executions>
             </plugin>
         </plugins>
-        <pluginManagement>
-        	<plugins>
-        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        		<plugin>
-        			<groupId>org.eclipse.m2e</groupId>
-        			<artifactId>lifecycle-mapping</artifactId>
-        			<version>1.0.0</version>
-        			<configuration>
-        				<lifecycleMappingMetadata>
-        					<pluginExecutions>
-        						<pluginExecution>
-        							<pluginExecutionFilter>
-        								<groupId>
-        									org.apache.maven.plugins
-        								</groupId>
-        								<artifactId>
-        									maven-antrun-plugin
-        								</artifactId>
-        								<versionRange>
-        									[1.8,)
-        								</versionRange>
-        								<goals>
-        									<goal>run</goal>
-        								</goals>
-        							</pluginExecutionFilter>
-        							<action>
-        								<ignore></ignore>
-        							</action>
-        						</pluginExecution>
-        					</pluginExecutions>
-        				</lifecycleMappingMetadata>
-        			</configuration>
-        		</plugin>
-        	</plugins>
-        </pluginManagement>
     </build>
 </project>

--- a/jruby/src/main/java/cucumber/runtime/jruby/JRubyBackend.java
+++ b/jruby/src/main/java/cucumber/runtime/jruby/JRubyBackend.java
@@ -143,15 +143,15 @@ public class JRubyBackend implements Backend {
         unreportedStepExecutor.runUnreportedStep(featurePath, language, stepName, line, dataTableRows, docString);
     }
 
-    public void executeHook(RubyObject hookRunner, Scenario scenario) {
+    public IRubyObject executeHook(RubyObject hookRunner, Scenario scenario) {
         IRubyObject[] jrubyArgs = new IRubyObject[2];
         jrubyArgs[0] = currentWorld;
         jrubyArgs[1] = JavaEmbedUtils.javaToRuby(hookRunner.getRuntime(), scenario);
-        hookRunner.callMethod("execute", jrubyArgs);
+        return hookRunner.callMethod("execute", jrubyArgs);
     }
 
-    void executeStepdef(RubyObject stepdef, String language, Object[] args) {
-        ArrayList<IRubyObject> jrubyArgs = new ArrayList<IRubyObject>();
+    IRubyObject executeStepdef(RubyObject stepdef, String language, Object[] args) {
+        ArrayList<IRubyObject> jrubyArgs = new ArrayList<IRubyObject>(); 
 
         // jrubyWorld.@__gherkin_language = language
         RubyObject jrubyI18n = (RubyObject) JavaEmbedUtils.javaToRuby(stepdef.getRuntime(), language);
@@ -170,6 +170,6 @@ public class JRubyBackend implements Backend {
             }
         }
 
-        stepdef.callMethod("execute", jrubyArgs.toArray(new IRubyObject[jrubyArgs.size()]));
+        return stepdef.callMethod("execute", jrubyArgs.toArray(new IRubyObject[jrubyArgs.size()]));
     }
 }

--- a/jruby/src/main/java/cucumber/runtime/jruby/JRubyHookDefinition.java
+++ b/jruby/src/main/java/cucumber/runtime/jruby/JRubyHookDefinition.java
@@ -5,6 +5,7 @@ import cucumber.runtime.HookDefinition;
 import cucumber.runtime.TagPredicate;
 import gherkin.pickles.PickleTag;
 import org.jruby.RubyObject;
+import org.jruby.runtime.builtin.IRubyObject;
 
 import java.util.Collection;
 import java.util.List;
@@ -36,8 +37,8 @@ public class JRubyHookDefinition implements HookDefinition {
     }
 
     @Override
-    public void execute(Scenario scenario) throws Throwable {
-        jRubyBackend.executeHook(hookRunner, scenario);
+    public IRubyObject execute(Scenario scenario) throws Throwable {
+        return jRubyBackend.executeHook(hookRunner, scenario);
     }
 
     @Override

--- a/jruby/src/main/java/cucumber/runtime/jruby/JRubyStepDefinition.java
+++ b/jruby/src/main/java/cucumber/runtime/jruby/JRubyStepDefinition.java
@@ -57,8 +57,8 @@ public class JRubyStepDefinition implements StepDefinition {
     }
 
     @Override
-    public void execute(String language, Object[] args) throws Throwable {
-        jRubyBackend.executeStepdef(stepdefRunner, language, args);
+    public IRubyObject execute(String language, Object[] args) throws Throwable {
+        return jRubyBackend.executeStepdef(stepdefRunner, language, args);
     }
 
     @Override


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Implementing support for passing the response of a step to the subsequent step

This would make step-definition files stateless, and true re-use of
step-definition across feature file. I have also added an example in
examples/java-calculator.

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I was writing a cucumber based test for a web-service. The problem was, how do I pass the response of my webservice from the WHEN step to the THEN step? I did not like the idea of storing the response as an instance variable in my step-definition class. There are 2 problems:
1. It becomes inherently thread-un-safe
2. It will not work across different feature files, across different step-definition classes, as it has now become stateful

The only solution imho was to pass the response of each step to the next one. This is an attempt to do that.

## How Has This Been Tested?

I have run mvn clean install on the projects core, java, java8, junit. Also, added an ene-to-end test of how the stateless thing is supposed to work in /examples/java-calculator/src/test/resources/cucumber/examples/java/calculator/stateless_calculator.feature

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
