### PR TITLE
[JUnit] Provide class in description

### DIFF
--- a/junit/src/main/java/cucumber/api/junit/Cucumber.java
+++ b/junit/src/main/java/cucumber/api/junit/Cucumber.java
@@ -64,7 +64,7 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
         final JUnitOptions junitOptions = new JUnitOptions(runtimeOptions.getJunitOptions());
         final List<CucumberFeature> cucumberFeatures = runtimeOptions.cucumberFeatures(resourceLoader, runtime.getEventBus());
         jUnitReporter = new JUnitReporter(runtime.getEventBus(), runtimeOptions.isStrict(), junitOptions);
-        addChildren(cucumberFeatures);
+        addChildren(clazz, cucumberFeatures);
     }
 
     /**
@@ -105,9 +105,9 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
         runtime.printSummary();
     }
 
-    private void addChildren(List<CucumberFeature> cucumberFeatures) throws InitializationError {
+    private void addChildren(Class clazz, List<CucumberFeature> cucumberFeatures) throws InitializationError {
         for (CucumberFeature cucumberFeature : cucumberFeatures) {
-            FeatureRunner featureRunner = new FeatureRunner(cucumberFeature, runtime, jUnitReporter);
+            FeatureRunner featureRunner = new FeatureRunner(clazz, cucumberFeature, runtime, jUnitReporter);
             if (!featureRunner.isEmpty()) {
                 children.add(featureRunner);
             }

--- a/junit/src/main/java/cucumber/runtime/junit/FeatureRunner.java
+++ b/junit/src/main/java/cucumber/runtime/junit/FeatureRunner.java
@@ -26,10 +26,10 @@ public class FeatureRunner extends ParentRunner<PickleRunner> {
     private final CucumberFeature cucumberFeature;
     private Description description;
 
-    public FeatureRunner(CucumberFeature cucumberFeature, Runtime runtime, JUnitReporter jUnitReporter) throws InitializationError {
-        super(null);
+    public FeatureRunner(Class<?> runnerClass, CucumberFeature cucumberFeature, Runtime runtime, JUnitReporter jUnitReporter) throws InitializationError {
+        super(null); //Don't pass runnerClass to super. It should have been scanned by Cucumber already
         this.cucumberFeature = cucumberFeature;
-        buildFeatureElementRunners(runtime, jUnitReporter);
+        buildFeatureElementRunners(runnerClass, runtime, jUnitReporter);
     }
 
     @Override
@@ -73,7 +73,7 @@ public class FeatureRunner extends ParentRunner<PickleRunner> {
         super.run(notifier);
     }
 
-    private void buildFeatureElementRunners(Runtime runtime, JUnitReporter jUnitReporter) {
+    private void buildFeatureElementRunners(Class<?> runnerClass, Runtime runtime, JUnitReporter jUnitReporter) {
         Compiler compiler = new Compiler();
         List<PickleEvent> pickleEvents = new ArrayList<PickleEvent>();
         for (Pickle pickle : compiler.compile(cucumberFeature.getGherkinFeature())) {
@@ -88,7 +88,7 @@ public class FeatureRunner extends ParentRunner<PickleRunner> {
                         children.add(picklePickleRunner);
                     } else {
                         PickleRunner picklePickleRunner;
-                        picklePickleRunner = withNoStepDescriptions(runtime.getRunner(), pickleEvent, jUnitReporter);
+                        picklePickleRunner = withNoStepDescriptions(runnerClass, runtime.getRunner(), pickleEvent, jUnitReporter);
                         children.add(picklePickleRunner);
                     }
                 } catch (InitializationError e) {

--- a/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
@@ -110,28 +110,27 @@ public class FeatureRunnerTest {
         final ClasspathResourceLoader resourceLoader = new ClasspathResourceLoader(classLoader);
         final RuntimeGlue glue = mock(RuntimeGlue.class);
         final Runtime runtime = new Runtime(resourceLoader, classLoader, asList(mock(Backend.class)), runtimeOptions, new TimeService.Stub(0l), glue);
-        return new FeatureRunner(cucumberFeature, runtime, new JUnitReporter(runtime.getEventBus(), false, junitOption));
+        return new FeatureRunner(RunCukesTest.class, cucumberFeature, runtime, new JUnitReporter(runtime.getEventBus(), false, junitOption));
     }
 
 
     @Test
-    public void shouldPopulateDescriptionsWithStableUniqueIds() throws Exception {
+    public void should_populate_descriptions_with_deterministic_unique_ids() throws Exception {
         CucumberFeature cucumberFeature = TestPickleBuilder.parseFeature("path/test.feature", "" +
             "Feature: feature name\n" +
             "  Background:\n" +
             "    Given background step\n" +
             "  Scenario: A\n" +
             "    Then scenario name\n" +
-            "  Scenario: B\n" +
+            "  Scenario: A\n" +
             "    Then scenario name\n" +
-            "  Scenario Outline: C\n" +
+            "  Scenario Outline: B\n" +
             "    Then scenario <name>\n" +
             "  Examples:\n" +
             "    | name |\n" +
             "    | C    |\n" +
-            "    | D    |\n" +
-            "    | E    |\n"
-
+            "    | C    |\n" +
+            "    | C    |\n"
         );
 
         FeatureRunner runner = createFeatureRunner(cucumberFeature);
@@ -145,7 +144,36 @@ public class FeatureRunnerTest {
     }
 
     @Test
-    public void shouldNotCreateStepDescriptions() throws Exception {
+    public void no_step_notifications_should_populate_descriptions_with_deterministic_unique_ids_without() throws Exception {
+        CucumberFeature cucumberFeature = TestPickleBuilder.parseFeature("path/test.feature", "" +
+            "Feature: feature name\n" +
+            "  Background:\n" +
+            "    Given background step\n" +
+            "  Scenario: A\n" +
+            "    Then scenario name\n" +
+            "  Scenario: A\n" +
+            "    Then scenario name\n" +
+            "  Scenario Outline: B\n" +
+            "    Then scenario <name>\n" +
+            "  Examples:\n" +
+            "    | name |\n" +
+            "    | C    |\n" +
+            "    | C    |\n" +
+            "    | C    |\n"
+        );
+
+        FeatureRunner runner = createFeatureRunner(cucumberFeature, "--no-step-notifications");
+        FeatureRunner rerunner = createFeatureRunner(cucumberFeature, "--no-step-notifications");
+
+        Set<Description> descriptions = new HashSet<Description>();
+        assertDescriptionIsUnique(runner.getDescription(), descriptions);
+        assertDescriptionIsPredictable(runner.getDescription(), descriptions);
+        assertDescriptionIsPredictable(rerunner.getDescription(), descriptions);
+
+    }
+
+    @Test
+    public void no_step_notifications_should_not_create_step_descriptions() throws Exception {
         CucumberFeature cucumberFeature = TestPickleBuilder.parseFeature("path/test.feature", "" +
             "Feature: feature name\n" +
             "  Background:\n" +

--- a/junit/src/test/java/cucumber/runtime/junit/PickleRunnerWithNoStepDescriptionsTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/PickleRunnerWithNoStepDescriptionsTest.java
@@ -1,6 +1,7 @@
 package cucumber.runtime.junit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 
 import cucumber.runner.EventBus;
@@ -16,51 +17,105 @@ import java.util.List;
 public class PickleRunnerWithNoStepDescriptionsTest {
 
     @Test
-    public void shouldUseScenarioNameForDisplayName() throws Exception {
-        List<PickleEvent> pickles = TestPickleBuilder.pickleEventsFromFeature("featurePath", "" +
-                "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    Then it works\n");
-
-        PickleRunner runner = PickleRunners.withNoStepDescriptions(
-                mock(Runner.class),
-                pickles.get(0),
-                createStandardJUnitReporter()
-        );
-
-        assertEquals("scenario name", runner.getDescription().getDisplayName());
-    }
-
-    @Test
-    public void shouldUseScenarioNameForDescriptionDisplayName() throws Exception {
+    public void should_use_runner_class_in_pickle_description() throws Exception {
         List<PickleEvent> pickles = TestPickleBuilder.pickleEventsFromFeature("featurePath", "" +
             "Feature: feature name\n" +
             "  Scenario: scenario name\n" +
             "    Then it works\n");
 
         PickleRunner runner = PickleRunners.withNoStepDescriptions(
+            RunCukesTest.class,
             mock(Runner.class),
             pickles.get(0),
             createStandardJUnitReporter()
         );
 
-        assertEquals("scenario name", runner.getDescription().getDisplayName());
+        // Surefire 47 uses class names to group test reports. To ensure the tests results
+        // end up in the proper report we provide the class of the runner. We can't fake
+        // this because the class must be loadable by surefire.
+        assertEquals(RunCukesTest.class, runner.getDescription().getTestClass());
     }
 
     @Test
-    public void shouldConvertTextFromFeatureFileForNamesWithFilenameCompatibleNameOption() throws Exception {
+    public void should_create_unequal_descriptions_for_scenarios_with_equal_names() throws Exception {
         List<PickleEvent> pickles = TestPickleBuilder.pickleEventsFromFeature("featurePath", "" +
-                "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    Then it works\n");
+            "Feature: feature name\n" +
+            "  Scenario: scenario name\n" +
+            "    Then it works\n" +
+            "  Scenario: scenario name\n" +
+            "    Then it works\n");
 
         PickleRunner runner = PickleRunners.withNoStepDescriptions(
-                mock(Runner.class),
-                pickles.get(0),
-                createJUnitReporterWithOption("--filename-compatible-names")
+            RunCukesTest.class,
+            mock(Runner.class),
+            pickles.get(0),
+            createStandardJUnitReporter()
         );
 
-        assertEquals("scenario_name", runner.getDescription().getDisplayName());
+        PickleRunner runner1 = PickleRunners.withNoStepDescriptions(
+            RunCukesTest.class,
+            mock(Runner.class),
+            pickles.get(1),
+            createStandardJUnitReporter()
+        );
+
+        // Also note that we must provide the canonical name as a string because
+        // createTestDescription(Class<?>, String) carries the implicit assumption that the
+        // combination of class and name is unique which we can not grantee as the runner
+        // run contain one or more feature files with the same scenario.
+        assertNotEquals(runner.getDescription(), runner1.getDescription());
+    }
+
+
+    @Test
+    public void should_use_scenario_name_for_display_name() throws Exception {
+        List<PickleEvent> pickles = TestPickleBuilder.pickleEventsFromFeature("featurePath", "" +
+            "Feature: feature name\n" +
+            "  Scenario: scenario name\n" +
+            "    Then it works\n");
+
+        PickleRunner runner = PickleRunners.withNoStepDescriptions(
+            RunCukesTest.class,
+            mock(Runner.class),
+            pickles.get(0),
+            createStandardJUnitReporter()
+        );
+
+        assertEquals("scenario name(cucumber.runtime.junit.RunCukesTest)", runner.getDescription().getDisplayName());
+    }
+
+    @Test
+    public void should_use_scenario_name_for_description_display_name() throws Exception {
+        List<PickleEvent> pickles = TestPickleBuilder.pickleEventsFromFeature("featurePath", "" +
+            "Feature: feature name\n" +
+            "  Scenario: scenario name\n" +
+            "    Then it works\n");
+
+        PickleRunner runner = PickleRunners.withNoStepDescriptions(
+            RunCukesTest.class,
+            mock(Runner.class),
+            pickles.get(0),
+            createStandardJUnitReporter()
+        );
+
+        assertEquals("scenario name(cucumber.runtime.junit.RunCukesTest)", runner.getDescription().getDisplayName());
+    }
+
+    @Test
+    public void should_convert_text_from_feature_file_for_names_with_filename_compatible_name_option() throws Exception {
+        List<PickleEvent> pickles = TestPickleBuilder.pickleEventsFromFeature("featurePath", "" +
+            "Feature: feature name\n" +
+            "  Scenario: scenario name\n" +
+            "    Then it works\n");
+
+        PickleRunner runner = PickleRunners.withNoStepDescriptions(
+            RunCukesTest.class,
+            mock(Runner.class),
+            pickles.get(0),
+            createJUnitReporterWithOption("--filename-compatible-names")
+        );
+
+        assertEquals("scenario_name(cucumber.runtime.junit.RunCukesTest)", runner.getDescription().getDisplayName());
     }
 
     private JUnitReporter createStandardJUnitReporter() {

--- a/junit/src/test/java/cucumber/runtime/junit/PickleRunnerWithStepDescriptionsTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/PickleRunnerWithStepDescriptionsTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class PickleRunnerWithStepDescriptionsTest {
 
     @Test
-    public void shouldAssignUnequalDescriptionsToDifferentOccurrencesOfSameStepInAScenario() throws Exception {
+    public void should_assign_unequal_descriptions_to_different_occurrences_of_same_step_in_a_scenario() throws Exception {
         CucumberFeature features = TestPickleBuilder.parseFeature("path/test.feature", "" +
             "Feature: FB\n" +
             "# Scenario with same step occurring twice\n" +
@@ -64,7 +64,7 @@ public class PickleRunnerWithStepDescriptionsTest {
     }
 
     @Test
-    public void shouldIncludeScenarioNameAsClassNameInStepDescriptions() throws Exception {
+    public void should_include_scenario_name_as_class_name_in_step_descriptions() throws Exception {
         CucumberFeature features = TestPickleBuilder.parseFeature("path/test.feature", "" +
             "Feature: In cucumber.junit\n" +
             "  Scenario: first\n" +
@@ -99,7 +99,7 @@ public class PickleRunnerWithStepDescriptionsTest {
     }
 
     @Test
-    public void shouldUseScenarioNameForDisplayName() throws Exception {
+    public void should_use_scenario_name_for_display_name() throws Exception {
         List<PickleEvent> pickles = TestPickleBuilder.pickleEventsFromFeature("featurePath", "" +
                 "Feature: feature name\n" +
                 "  Scenario: scenario name\n" +
@@ -115,13 +115,13 @@ public class PickleRunnerWithStepDescriptionsTest {
     }
 
     @Test
-    public void shouldUseScenarioNameForDescriptionDisplayName() throws Exception {
+    public void should_use_scenario_name_for_description_display_name() throws Exception {
         List<PickleEvent> pickles = TestPickleBuilder.pickleEventsFromFeature("featurePath", "" +
             "Feature: feature name\n" +
             "  Scenario: scenario name\n" +
             "    Then it works\n");
 
-        PickleRunner runner = PickleRunners.withNoStepDescriptions(
+        PickleRunner runner = PickleRunners.withStepDescriptions(
             mock(Runner.class),
             pickles.get(0),
             createStandardJUnitReporter()
@@ -131,7 +131,7 @@ public class PickleRunnerWithStepDescriptionsTest {
     }
 
     @Test
-    public void shouldUseStepKeyworkAndNameForChildName() throws Exception {
+    public void should_use_step_keyword_and_name_for_child_name() throws Exception {
         List<PickleEvent> pickleEvents = TestPickleBuilder.pickleEventsFromFeature("featurePath", "" +
                 "Feature: feature name\n" +
                 "  Scenario: scenario name\n" +
@@ -147,7 +147,7 @@ public class PickleRunnerWithStepDescriptionsTest {
     }
 
     @Test
-    public void shouldConvertTextFromFeatureFileForNamesWithFilenameCompatibleNameOption() throws Exception {
+    public void should_convert_text_from_feature_file_for_names_with_filename_compatible_name_option() throws Exception {
         List<PickleEvent> pickles = TestPickleBuilder.pickleEventsFromFeature("featurePath", "" +
                 "Feature: feature name\n" +
                 "  Scenario: scenario name\n" +


### PR DESCRIPTION
## Summary

Surefire 47 uses class names to group test reports. To ensure the tests results
end up in the proper report we provide the class of the runner. We can't fake
this because the class must be loadable by surefire.

## Details

Surefire uses [NonConcurrentRunListener#describesNewTestSet](https://github.com/apache/maven-surefire/blob/master/surefire-providers/surefire-junit47/src/main/java/org/apache/maven/surefire/junitcore/NonConcurrentRunListener.java#L120) to determine if a new file needs to be made.

The downside is that when running manually an IDE might show the class name. But as this only works with  `--no-step-notifications` enabled this should not be a major issue as `--no-step-notifications` is some what intended for machine use.

![image](https://cloud.githubusercontent.com/assets/6946919/26532479/09e31ee8-4402-11e7-80ca-04120e3deafe.png)

The other downside is that scenarios with the same name end up as duplicate entries in the report which makes tracking back harder. However I don't expect this to happen in practice.

## Motivation and Context

See: https://github.com/cucumber/cucumber-jvm/issues/865

## How Has This Been Tested?

Added unit tests for this specific scenario and executed a manual integration test with surefire.

## Screenshots (if appropriate):

Each test runner now has its own file with results.

![image](https://cloud.githubusercontent.com/assets/6946919/26532478/ff075b38-4401-11e7-9bd6-f9a5299fac5d.png)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
