### PR TITLE
[Java8] Allow lambda steps to throw checked Exceptions

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,6 @@
 ## [2.0.0-SNAPSHOT](https://github.com/cucumber/cucumber-jvm/compare/v1.2.5...master) (In Git)
 
+* [Java8] Allow lambda steps to throw checked Exceptions ([#1001](https://github.com/cucumber/cucumber-jvm/issues/1001), [#1110](https://github.com/cucumber/cucumber-jvm/pull/1110) Christian Hujer)
 * [JUnit] Add `--[no-]step-notifications` option to JunitOptions ([#1135](https://github.com/cucumber/cucumber-jvm/pull/1135), [#263](https://github.com/cucumber/cucumber-jvm/issues/263), [#577](https://github.com/cucumber/cucumber-jvm/issues/577) mpkorstanje)
 * [JUnit] Use deterministic unique ids in Descriptions ([#1134](https://github.com/cucumber/cucumber-jvm/pull/1134), [#1120](https://github.com/cucumber/cucumber-jvm/issues/1120) mpkorstanje)
 * [All] Support [Tag Expressions](https://github.com/cucumber/cucumber/tree/master/tag-expressions) (part of [#1035](https://github.com/cucumber/cucumber-jvm/pull/1035) Björn Rasmusson)

--- a/java/src/main/java/cucumber/api/java8/HookBody.java
+++ b/java/src/main/java/cucumber/api/java8/HookBody.java
@@ -3,5 +3,5 @@ package cucumber.api.java8;
 import cucumber.api.Scenario;
 
 public interface HookBody {
-    void accept(Scenario scenario);
+    void accept(Scenario scenario) throws Throwable;
 }

--- a/java/src/main/java/cucumber/api/java8/HookNoArgsBody.java
+++ b/java/src/main/java/cucumber/api/java8/HookNoArgsBody.java
@@ -1,5 +1,5 @@
 package cucumber.api.java8;
 
 public interface HookNoArgsBody {
-    void accept();
+    void accept() throws Throwable;
 }

--- a/java/src/main/java/cucumber/api/java8/StepdefBody.java
+++ b/java/src/main/java/cucumber/api/java8/StepdefBody.java
@@ -2,42 +2,42 @@ package cucumber.api.java8;
 
 public interface StepdefBody {
     public static interface A0 extends StepdefBody {
-        void accept();
+        void accept() throws Throwable;
     }
 
     public static interface A1<T1> extends StepdefBody {
-        void accept(T1 p1);
+        void accept(T1 p1) throws Throwable;
     }
 
     public static interface A2<T1, T2> extends StepdefBody {
-        void accept(T1 p1, T2 p2);
+        void accept(T1 p1, T2 p2) throws Throwable;
     }
 
     public static interface A3<T1, T2, T3> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3);
+        void accept(T1 p1, T2 p2, T3 p3) throws Throwable;
     }
 
     public static interface A4<T1, T2, T3, T4> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4) throws Throwable;
     }
 
     public static interface A5<T1, T2, T3, T4, T5> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5) throws Throwable;
     }
 
     public static interface A6<T1, T2, T3, T4, T5, T6> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6) throws Throwable;
     }
 
     public static interface A7<T1, T2, T3, T4, T5, T6, T7> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7) throws Throwable;
     }
 
     public static interface A8<T1, T2, T3, T4, T5, T6, T7, T8> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7, T8 p8);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7, T8 p8) throws Throwable;
     }
 
     public static interface A9<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends StepdefBody {
-        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7, T8 p8, T9 p9);
+        void accept(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5, T6 p6, T7 p7, T8 p8, T9 p9) throws Throwable;
     }
 }

--- a/java/src/test/java/cucumber/runtime/java/java8test/AnonInnerClassStepdefs.java
+++ b/java/src/test/java/cucumber/runtime/java/java8test/AnonInnerClassStepdefs.java
@@ -11,7 +11,7 @@ public class AnonInnerClassStepdefs implements GlueBase {
     public AnonInnerClassStepdefs() {
         JavaBackend.INSTANCE.get().addStepDefinition("^I have (\\d+) cukes in my (.*)", 0, new StepdefBody.A2<Integer, String>() {
             @Override
-            public void accept(Integer cukes, String what) {
+            public void accept(Integer cukes, String what) throws Throwable {
                 assertEquals(42, cukes.intValue());
                 assertEquals("belly", what);
             }

--- a/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
+++ b/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
@@ -18,6 +18,11 @@ public class LambdaStepdefs implements En {
             lastInstance = this;
         });
 
+        Before(this::methodThatDeclaresException);
+
+        Before(this::hookWithArgs);
+
+
         Given("^this data table:$", (DataTable peopleTable) -> {
             List<Person> people = peopleTable.asList(Person.class);
             assertEquals("Hellesøy", people.get(0).last);
@@ -49,7 +54,17 @@ public class LambdaStepdefs implements En {
             assertEquals("three", c);
             assertEquals((Integer) 4, d);
         });
+
+        Given("^A lambda that declares an exception$", this::methodThatDeclaresException);
     }
+
+    private void methodThatDeclaresException() throws Throwable {
+    }
+
+
+    private void hookWithArgs(Scenario scenario) throws Throwable {
+    }
+
 
     public static class Person {
         String first;

--- a/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
+++ b/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
@@ -19,3 +19,6 @@ Feature: Java8
       | first  | last     |
       | Aslak  | Hellesøy |
       | Donald | Duck     |
+
+  Scenario: using lambdas with exceptions
+    Given A lambda that declares an exception


### PR DESCRIPTION
Allow Java8 lambda steps to throw checked Exceptions

Implemented requested changes on PR https://github.com/cucumber/cucumber-jvm/pull/1110.

Related issues:
 - https://github.com/cucumber/cucumber-jvm/issues/1001

