### PR TITLE
[Java8, Kotlin Java8] Support java 8 method references

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,6 @@
 ## [2.0.0-SNAPSHOT](https://github.com/cucumber/cucumber-jvm/compare/v1.2.5...master) (In Git)
 
+* [Java8, Kotlin Java8] Support java 8 method references ([#1140](https://github.com/cucumber/cucumber-jvm/pull/1140) M.P. Korstanje) 
 * [Core] Show explicit error message when field name missed in table header ([#1014](https://github.com/cucumber/cucumber-jvm/pull/1014) Mykola Gurov) 
 * [Examples] Properly quit selenium in webbit examples ([#1146](https://github.com/cucumber/cucumber-jvm/pull/1146) Alberto Scotto)
 * [JUnit] Use AssumptionFailed to mark scenarios/steps as skipped ([#1142](https://github.com/cucumber/cucumber-jvm/pull/1142) Björn Rasmusson)

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -29,11 +29,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>net.sourceforge.cobertura</groupId>
             <artifactId>cobertura</artifactId>
             <scope>test</scope>

--- a/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
+++ b/java8/src/main/java/cucumber/runtime/java8/ConstantPoolTypeIntrospector.java
@@ -35,6 +35,11 @@ public class ConstantPoolTypeIntrospector implements TypeIntrospector {
         final String[] member = getMemberReference(constantPool);
         final int parameterCount = interfac3.getTypeParameters().length;
 
+        // Kotlin lambda expression without arguments or closure variables
+        if (member[REFERENCE_METHOD].equals("INSTANCE")) {
+            return handleKotlinInstance();
+        }
+
         final jdk.internal.org.objectweb.asm.Type[] argumentTypes = jdk.internal.org.objectweb.asm.Type.getArgumentTypes(member[REFERENCE_ARGUMENT_TYPES]);
 
         // If we are one parameter short, this is a
@@ -73,6 +78,10 @@ public class ConstantPoolTypeIntrospector implements TypeIntrospector {
             typeArguments[i] = forName(interestingArgumentTypes[i].getClassName());
         }
         return typeArguments;
+    }
+
+    private static Type[] handleKotlinInstance() {
+        return new Type[0];
     }
 
     private static String[] getMemberReference(ConstantPool constantPool) {

--- a/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
+++ b/java8/src/test/java/cucumber/runtime/java8/test/LambdaStepdefs.java
@@ -1,16 +1,19 @@
 package cucumber.runtime.java8.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
 import cucumber.api.DataTable;
 import cucumber.api.Scenario;
 import cucumber.api.java8.En;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-
 public class LambdaStepdefs implements En {
     private static LambdaStepdefs lastInstance;
+
+    private final int outside = 41;
 
     public LambdaStepdefs() {
         Before((Scenario scenario) -> {
@@ -41,33 +44,72 @@ public class LambdaStepdefs implements En {
             assertEquals("hello", localState);
         });
 
-        int localInt = 1;
         Given("^A statement with a simple match$", () -> {
-            assertEquals(2, localInt+1);
+            assertTrue(true);
+        });
+
+        int localInt = 1;
+        Given("^A statement with a scoped argument$", () -> {
+            assertEquals(2, localInt + 1);
+            assertEquals(42, outside + 1);
         });
 
         Given("^I will give you (\\d+) and ([\\d\\.]+) and (\\w+) and (\\d+)$", (Integer a, Float b, String c,
                                                                                  Integer d)
-                -> {
+            -> {
             assertEquals((Integer) 1, a);
             assertEquals((Float) 2.2f, b);
             assertEquals("three", c);
             assertEquals((Integer) 4, d);
         });
 
-        Given("^A lambda that declares an exception$", this::methodThatDeclaresException);
+        Given("^A method reference that declares an exception$", this::methodThatDeclaresException);
+        Given("^A method reference with an argument (\\d+)$", this::methodWithAnArgument);
+        Given("^A constructor reference with an argument (.*)$", Contact::new);
+        Given("^A static method reference with an argument (\\d+)$", LambdaStepdefs::staticMethodWithAnArgument);
+
+        Given("^A method reference to an arbitrary object of a particular type (\\d+)$", Contact::call);
+        Given("^A method reference to an arbitrary object of a particular type (.*) with argument (.*)$", Contact::update);
+
     }
 
     private void methodThatDeclaresException() throws Throwable {
+    }
+    private void methodWithAnArgument(Integer cuckes) throws Throwable {
+        assertEquals(42, cuckes.intValue());
+    }
+
+    public static void staticMethodWithAnArgument(Integer cuckes) throws Throwable {
+        assertEquals(42, cuckes.intValue());
     }
 
 
     private void hookWithArgs(Scenario scenario) throws Throwable {
     }
 
-
     public static class Person {
         String first;
         String last;
     }
+
+    public static class Contact {
+
+        private final String number;
+
+        public Contact(String number){
+            this.number = number;
+            assertEquals("42", number);
+        }
+
+        public void call(){
+            assertEquals("42", number);
+        }
+
+        public void update(String number){
+            assertEquals("42", this.number);
+            assertEquals("314", number);
+        }
+    }
+
+
 }

--- a/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
+++ b/java8/src/test/resources/cucumber/runtime/java8/test/java8.feature
@@ -10,6 +10,7 @@ Feature: Java8
 
   Scenario: Parameterless lambdas
     Given A statement with a simple match
+    Given A statement with a scoped argument
 
   Scenario: Multi-param lambdas
     Given I will give you 1 and 2.2 and three and 4
@@ -20,5 +21,10 @@ Feature: Java8
       | Aslak  | Hellesøy |
       | Donald | Duck     |
 
-  Scenario: using lambdas with exceptions
-    Given A lambda that declares an exception
+  Scenario: using method references
+    Given A method reference that declares an exception
+    Given A method reference with an argument 42
+    Given A static method reference with an argument 42
+    Given A constructor reference with an argument 42
+    Given A method reference to an arbitrary object of a particular type 42
+    Given A method reference to an arbitrary object of a particular type 42 with argument 314

--- a/kotlin-java8/README.md
+++ b/kotlin-java8/README.md
@@ -1,0 +1,6 @@
+Java 8 Bindings for Kotlin
+==========================
+
+This module only runs tests.
+
+You can use `cucumber-java` or `cucumber-java8` directly in Kotlin.

--- a/kotlin-java8/pom.xml
+++ b/kotlin-java8/pom.xml
@@ -1,0 +1,93 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.cucumber</groupId>
+        <artifactId>cucumber-jvm</artifactId>
+        <relativePath>../pom.xml</relativePath>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cucumber-kotlin-java8</artifactId>
+    <packaging>jar</packaging>
+    <name>Cucumber-JVM: Kotlin Java8</name>
+
+    <properties>
+        <kotlin.version>1.1.2-2</kotlin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.cobertura</groupId>
+            <artifactId>cobertura</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kotlin-java8/src/test/kotlin/cucumber/runtime/kotlin/test/LambdaStepdefs.kt
+++ b/kotlin-java8/src/test/kotlin/cucumber/runtime/kotlin/test/LambdaStepdefs.kt
@@ -1,0 +1,55 @@
+package cucumber.runtime.kotlin.test;
+
+import cucumber.api.DataTable
+import cucumber.api.Scenario
+import cucumber.api.java8.En
+import org.junit.Assert.*
+
+var lastInstance : LambdaStepdefs? = null
+
+class LambdaStepdefs : En {
+
+    init {
+        Before { scenario: Scenario ->
+            assertNotSame(this, lastInstance)
+            lastInstance = this
+        }
+
+        Given("^this data table:$") { peopleTable: DataTable ->
+            val people = peopleTable.asList(Person::class.java)
+            assertEquals("Aslak", people[0].first)
+            assertEquals("Hellesøy", people[0].last)
+        }
+
+        val alreadyHadThisManyCukes = 1
+        Given("^I have (\\d+) cukes in my belly$") { n: Long ->
+            assertEquals(1, alreadyHadThisManyCukes)
+            assertEquals(42L, n)
+        }
+
+        val localState = "hello"
+        Then("^I really have (\\d+) cukes in my belly") { i: Int ->
+            assertEquals(42, i)
+            assertEquals("hello", localState)
+        }
+
+        Given("^A statement with a body expression$") { assertTrue(true) }
+
+        Given("^A statement with a simple match$", { -> assertTrue(true) })
+
+        val localInt = 1
+        Given("^A statement with a scoped argument$", { assertEquals(2, localInt + 1) })
+
+        Given("^I will give you (\\d+) and ([\\d\\.]+) and (\\w+) and (\\d+)$") { a: Int, b: Float, c: String, d: Int ->
+            assertEquals(1, a)
+            assertEquals(2.2f, b)
+            assertEquals("three", c)
+            assertEquals(4, d)
+        }
+    }
+
+    class Person {
+        internal var first: String? = null
+        internal var last: String? = null
+    }
+}

--- a/kotlin-java8/src/test/kotlin/cucumber/runtime/kotlin/test/RunCukesTest.kt
+++ b/kotlin-java8/src/test/kotlin/cucumber/runtime/kotlin/test/RunCukesTest.kt
@@ -1,0 +1,8 @@
+package cucumber.runtime.kotlin.test
+
+import cucumber.api.junit.Cucumber
+import org.junit.runner.RunWith
+
+@RunWith(Cucumber::class)
+class RunCukesTest {
+}

--- a/kotlin-java8/src/test/resources/cucumber/runtime/kotlin/test/kotlin.feature
+++ b/kotlin-java8/src/test/resources/cucumber/runtime/kotlin/test/kotlin.feature
@@ -1,0 +1,25 @@
+Feature: Kotlin
+
+  Scenario: use the API with Java8 style
+    Given I have 42 cukes in my belly
+    Then I really have 42 cukes in my belly
+
+  Scenario: another scenario which should have isolated state
+    Given I have 42 cukes in my belly
+    And something that isn't defined
+
+  Scenario: Parameterless lambdas
+    Given A statement with a simple match
+    Given A statement with a scoped argument
+
+  Scenario: I can use body expressions
+    Given A statement with a body expression
+
+  Scenario: Multi-param lambdas
+    Given I will give you 1 and 2.2 and three and 4
+
+  Scenario: use a table
+    Given this data table:
+      | first  | last     |
+      | Aslak  | Hellesøy |
+      | Donald | Duck     |

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,16 @@
                 <artifactId>android-examples</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.cucumber</groupId>
+                <artifactId>cucumber-java8</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.cucumber</groupId>
+                <artifactId>cucumber-kotlin-java8</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- Spring stuff -->
             <dependency>
@@ -581,6 +591,7 @@
             </activation>
             <modules>
                 <module>java8</module>
+                <module>kotlin-java8</module>
             </modules>
         </profile>
 


### PR DESCRIPTION
## Summary

The ConstantPoolTypeIntrospector did not know how to handle references to an instance method of an arbitrary object of a particular type and Kotlin lambda expression without arguments or closure variables. This lead to issues:
- https://github.com/cucumber/cucumber-jvm/issues/1123
- https://github.com/cucumber/cucumber-jvm/issues/1126

## Details

Updated the ConstantPoolTypeIntrospector to check for instance methods by counting the parameters expected by the interface and those bound to the anonymous class. Only iff this is an instance method the result will come up one short.

Resolved Kotlin specific problems by checking if the reference method equals the magic constant "INSTANCE".

## How Has This Been Tested?

Extended examples in features to include kotlin and all 4 types of method references.

Still awaiting confirmation from:
- https://github.com/cucumber/cucumber-jvm/issues/1123
- https://github.com/cucumber/cucumber-jvm/issues/1126

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
