### PR TITLE
[JUnit] Use AssumptionFailed to mark scenarios/steps as skipped

### DIFF
--- a/junit/src/main/java/cucumber/runtime/junit/JUnitOptions.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitOptions.java
@@ -12,7 +12,6 @@ public class JUnitOptions {
     private static final String OPTIONS_RESOURCE = "/cucumber/api/junit/OPTIONS.txt";
     private static String optionsText;
 
-    private boolean allowStartedIgnored = false;
     private boolean filenameCompatibleNames = false;
     private boolean stepNotifications = true;
 
@@ -36,7 +35,9 @@ public class JUnitOptions {
                 printOptions();
                 System.exit(0);
             } else if (arg.equals("--no-allow-started-ignored") || arg.equals("--allow-started-ignored")) {
-                allowStartedIgnored = !arg.startsWith("--no-");
+                System.err.println("WARNING: Found tags option '" + arg + "'. " +
+                        "--allow-started-ignored has no effect, testStarted is always fired before a test is started." +
+                        "--allow-started-ignored will be removed from the next release of Cucumber-JVM");
             } else if (arg.equals("--no-filename-compatible-names") || arg.equals("--filename-compatible-names")) {
                 filenameCompatibleNames = !arg.startsWith("--no-");
             } else if (arg.equals("--no-step-notifications") || arg.equals("--step-notifications")) {
@@ -47,9 +48,6 @@ public class JUnitOptions {
         }
     }
 
-    boolean allowStartedIgnored() {
-        return allowStartedIgnored;
-    }
     boolean filenameCompatibleNames() {
         return filenameCompatibleNames;
     }

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -1,8 +1,10 @@
 package cucumber.runtime.junit;
 
-import cucumber.api.PendingException;
 import cucumber.api.Result;
+import cucumber.api.TestStep;
 import cucumber.api.event.EventHandler;
+import cucumber.api.event.TestCaseFinished;
+import cucumber.api.event.TestCaseStarted;
 import cucumber.api.event.TestStepFinished;
 import cucumber.api.event.TestStepStarted;
 import cucumber.runner.EventBus;
@@ -13,7 +15,7 @@ import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.MultipleFailureException;
 
-import static cucumber.runtime.Runtime.isPending;
+import java.util.ArrayList;
 
 public class JUnitReporter {
 
@@ -24,8 +26,15 @@ public class JUnitReporter {
     private PickleRunner pickleRunner;
     private RunNotifier runNotifier;
     TestNotifier pickleRunnerNotifier; // package-private for testing
-    private boolean failedStep;
-    private boolean ignoredStep;
+    ArrayList<Throwable> stepErrors; // package-private for testing
+    private final EventHandler<TestCaseStarted> testCaseStartedHandler = new EventHandler<TestCaseStarted>() {
+
+        @Override
+        public void receive(TestCaseStarted event) {
+            handleTestCaseStarted();
+        }
+
+    };
     private final EventHandler<TestStepStarted> testStepStartedHandler = new EventHandler<TestStepStarted>() {
 
         @Override
@@ -40,11 +49,19 @@ public class JUnitReporter {
 
         @Override
         public void receive(TestStepFinished event) {
-            if (event.testStep.isHook()) {
-                handleHookResult(event.result);
+            if (!event.testStep.isHook()) {
+                handleStepResult(event.testStep, event.result);
             } else {
-                handleStepResult(event.result);
+                handleHookResult(event.result);
             }
+        }
+
+    };
+    private final EventHandler<TestCaseFinished> testCaseFinishedHandler = new EventHandler<TestCaseFinished>() {
+
+        @Override
+        public void receive(TestCaseFinished event) {
+            handleTestCaseResult(event.result);
         }
 
     };
@@ -52,26 +69,23 @@ public class JUnitReporter {
     public JUnitReporter(EventBus bus, boolean strict, JUnitOptions junitOption) {
         this.strict = strict;
         this.junitOptions = junitOption;
+        bus.registerHandlerFor(TestCaseStarted.class, testCaseStartedHandler);
         bus.registerHandlerFor(TestStepStarted.class, testStepStartedHandler);
         bus.registerHandlerFor(TestStepFinished.class, testStepFinishedHandler);
+        bus.registerHandlerFor(TestCaseFinished.class, testCaseFinishedHandler);
     }
 
     void startExecutionUnit(PickleRunner pickleRunner, RunNotifier runNotifier) {
         this.pickleRunner = pickleRunner;
         this.runNotifier = runNotifier;
         this.stepNotifier = null;
-        this.failedStep = false;
-        this.ignoredStep = false;
 
         pickleRunnerNotifier = new EachTestNotifier(runNotifier, pickleRunner.getDescription());
-        pickleRunnerNotifier.fireTestStarted();
     }
 
-    void finishExecutionUnit() {
-        if (ignoredStep && !failedStep) {
-            pickleRunnerNotifier.fireTestIgnored();
-        }
-        pickleRunnerNotifier.fireTestFinished();
+    void handleTestCaseStarted() {
+        pickleRunnerNotifier.fireTestStarted();
+        stepErrors = new ArrayList<Throwable>();
     }
 
     void handleStepStarted(PickleStep step) {
@@ -81,82 +95,88 @@ public class JUnitReporter {
         } else {
             stepNotifier = new NoTestNotifier();
         }
-        if (junitOptions.allowStartedIgnored()) {
-            stepNotifier.fireTestStarted();
-        }
+        stepNotifier.fireTestStarted();
     }
 
     boolean stepNotifications() {
         return junitOptions.stepNotifications();
     }
 
-    void handleStepResult(Result result) {
+    void handleStepResult(TestStep testStep, Result result) {
         Throwable error = result.getError();
-        if (result.is(Result.Type.SKIPPED)) {
-            if (error != null) {
-                stepNotifier.addFailedAssumption(error);
-                pickleRunnerNotifier.addFailedAssumption(error);
+        switch (result.getStatus()) {
+        case PASSED:
+            // do nothing
+            break;
+        case SKIPPED:
+            if (error == null) {
+                error = new SkippedThrowable(NotificationLevel.STEP);
             } else {
-                stepNotifier.fireTestIgnored();
+                stepErrors.add(error);
             }
-        } else if (isPendingOrUndefined(result)) {
-            addFailureOrIgnoreStep(result);
-        } else {
-            if (stepNotifier != null) {
-                //Should only fireTestStarted if not ignored
-                if (!junitOptions.allowStartedIgnored()) {
-                    stepNotifier.fireTestStarted();
-                }
-                if (error != null) {
-                    stepNotifier.addFailure(error);
-                }
-                stepNotifier.fireTestFinished();
+            stepNotifier.addFailedAssumption(error);
+            break;
+        case PENDING:
+            stepErrors.add(error);
+            addFailureOrFailedAssumptionDependingOnStrictMode(stepNotifier, error);
+            break;
+        case UNDEFINED:
+            if (error == null) {
+                error = new UndefinedThrowable();
             }
-            if (error != null) {
-                failedStep = true;
-                pickleRunnerNotifier.addFailure(error);
-            }
+            stepErrors.add(new UndefinedThrowable(testStep.getStepText()));
+            addFailureOrFailedAssumptionDependingOnStrictMode(stepNotifier, error);
+            break;
+        case FAILED:
+            stepErrors.add(error);
+            stepNotifier.addFailure(error);
         }
+        stepNotifier.fireTestFinished();
     }
 
     void handleHookResult(Result result) {
-        if (result.is(Result.Type.FAILED) || (strict && isPending(result.getError()))) {
-            pickleRunnerNotifier.addFailure(result.getError());
-        } else if (isPending(result.getError())) {
-            ignoredStep = true;
+        if (result.getError() != null) {
+            stepErrors.add(result.getError());
         }
+    }
+
+    void handleTestCaseResult(Result result) {
+        switch (result.getStatus()) {
+        case PASSED:
+            // do nothing
+            break;
+        case SKIPPED:
+            if (stepErrors.isEmpty()) {
+                stepErrors.add(new SkippedThrowable(NotificationLevel.SCENARIO));
+            }
+            for (Throwable error : stepErrors) {
+                pickleRunnerNotifier.addFailedAssumption(error);
+            }
+            break;
+        case PENDING:
+        case UNDEFINED:
+            for (Throwable error : stepErrors) {
+                addFailureOrFailedAssumptionDependingOnStrictMode(pickleRunnerNotifier, error);
+            }
+            break;
+        case FAILED:
+            for (Throwable error : stepErrors) {
+                pickleRunnerNotifier.addFailure(error);
+            }
+        }
+        pickleRunnerNotifier.fireTestFinished();
     }
 
     boolean useFilenameCompatibleNames() {
         return junitOptions.filenameCompatibleNames();
     }
 
-    private boolean isPendingOrUndefined(Result result) {
-        Throwable error = result.getError();
-        return result.is(Result.Type.UNDEFINED) || isPending(error);
-    }
-
-    private void addFailureOrIgnoreStep(Result result) {
+    private void addFailureOrFailedAssumptionDependingOnStrictMode(TestNotifier notifier, Throwable error) {
         if (strict) {
-            if (!junitOptions.allowStartedIgnored()) {
-                stepNotifier.fireTestStarted();
-            }
-            addFailure(result);
-            stepNotifier.fireTestFinished();
+            notifier.addFailure(error);
         } else {
-            ignoredStep = true;
-            stepNotifier.fireTestIgnored();
+            notifier.addFailedAssumption(error);
         }
-    }
-
-    private void addFailure(Result result) {
-        Throwable error = result.getError();
-        if (error == null) {
-            error = new PendingException();
-        }
-        failedStep = true;
-        stepNotifier.addFailure(error);
-        pickleRunnerNotifier.addFailure(error);
     }
 
     private interface TestNotifier {
@@ -167,13 +187,11 @@ public class JUnitReporter {
 
         void addFailedAssumption(Throwable error);
 
-        void fireTestIgnored();
-
         void fireTestFinished();
     }
 
 
-    private static final class NoTestNotifier implements TestNotifier {
+    static final class NoTestNotifier implements TestNotifier {
 
         @Override
         public void fireTestStarted() {
@@ -187,11 +205,6 @@ public class JUnitReporter {
 
         @Override
         public void addFailedAssumption(Throwable error) {
-            // Does nothing
-        }
-
-        @Override
-        public void fireTestIgnored() {
             // Does nothing
         }
 
@@ -235,10 +248,6 @@ public class JUnitReporter {
 
         public void fireTestStarted() {
             notifier.fireTestStarted(description);
-        }
-
-        public void fireTestIgnored() {
-            notifier.fireTestIgnored(description);
         }
     }
 }

--- a/junit/src/main/java/cucumber/runtime/junit/NotificationLevel.java
+++ b/junit/src/main/java/cucumber/runtime/junit/NotificationLevel.java
@@ -1,0 +1,10 @@
+package cucumber.runtime.junit;
+
+public enum NotificationLevel {
+    SCENARIO,
+    STEP;
+
+    String lowerCaseName() {
+        return name().toLowerCase();
+    }
+}

--- a/junit/src/main/java/cucumber/runtime/junit/PickleRunners.java
+++ b/junit/src/main/java/cucumber/runtime/junit/PickleRunners.java
@@ -93,7 +93,6 @@ class PickleRunners {
             jUnitReporter.startExecutionUnit(this, notifier);
             // This causes runChild to never be called, which seems OK.
             runner.runPickle(pickleEvent);
-            jUnitReporter.finishExecutionUnit();
         }
 
         @Override
@@ -139,7 +138,6 @@ class PickleRunners {
         public void run(final RunNotifier notifier) {
             jUnitReporter.startExecutionUnit(this, notifier);
             runner.runPickle(pickleEvent);
-            jUnitReporter.finishExecutionUnit();
         }
     }
 

--- a/junit/src/main/java/cucumber/runtime/junit/SkippedThrowable.java
+++ b/junit/src/main/java/cucumber/runtime/junit/SkippedThrowable.java
@@ -1,0 +1,9 @@
+package cucumber.runtime.junit;
+
+class SkippedThrowable extends Throwable {
+    private static final long serialVersionUID = 1L;
+
+    public SkippedThrowable(NotificationLevel scenarioOrStep) {
+        super(String.format("This %s is skipped", scenarioOrStep.lowerCaseName()), null, false, false);
+    }
+}

--- a/junit/src/main/java/cucumber/runtime/junit/UndefinedThrowable.java
+++ b/junit/src/main/java/cucumber/runtime/junit/UndefinedThrowable.java
@@ -1,0 +1,14 @@
+package cucumber.runtime.junit;
+
+
+public class UndefinedThrowable extends Throwable {
+    private static final long serialVersionUID = 1L;
+
+    public UndefinedThrowable() {
+        super("This step is undefined", null, false, false);
+    }
+
+    public UndefinedThrowable(String stepText) {
+        super(String.format("The step \"%s\" is undefined", stepText), null, false, false);
+    }
+}

--- a/junit/src/main/resources/cucumber/api/junit/OPTIONS.txt
+++ b/junit/src/main/resources/cucumber/api/junit/OPTIONS.txt
@@ -1,13 +1,7 @@
 JUnit Options:
 
   -h, --help                             You're looking at it.
-  --[no-]allow-started-ignored           Fire test started before the execution of a
-                                         step. This makes it possible to use the
-                                         test started and test finished notification
-                                         to calculate the execution time of the step.
-                                         If the step is pending the test started will
-                                         be followed by a test ignored, which can
-                                         confuse some listeners.
+  --[no-]allow-started-ignored           Deprecated, has no effect.
   --[no-]filename-compatible-names       Make sure that the names of the test cases
                                          only is made up of [A-Za-Z0-9_] so that the
                                          names for certain can be used as file names.

--- a/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
@@ -9,6 +9,7 @@ import cucumber.runtime.io.ClasspathResourceLoader;
 import cucumber.runtime.model.CucumberFeature;
 import org.junit.Test;
 import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.InitializationError;
 import org.mockito.ArgumentMatcher;
@@ -43,13 +44,13 @@ public class FeatureRunnerTest {
         InOrder order = inOrder(notifier);
 
         order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario_1 name")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("first step(scenario_1 name)")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("second step(scenario_1 name)")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("third step(scenario_1 name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario_1 name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("second step(scenario_1 name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("third step(scenario_1 name)")));
         order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario_1 name")));
         order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario_2 name")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("first step(scenario_2 name)")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("another second step(scenario_2 name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario_2 name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("another second step(scenario_2 name)")));
         order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario_2 name")));
     }
 
@@ -75,19 +76,19 @@ public class FeatureRunnerTest {
         InOrder order = inOrder(notifier);
 
         order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario outline name")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("first step(scenario outline name)")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("second step(scenario outline name)")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("third step(scenario outline name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario outline name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("second step(scenario outline name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("third step(scenario outline name)")));
         order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario outline name")));
         order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario outline name")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("first step(scenario outline name)")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("second step(scenario outline name)")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("third step(scenario outline name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario outline name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("second step(scenario outline name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("third step(scenario outline name)")));
         order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario outline name")));
         order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario outline name")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("first step(scenario outline name)")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("second step(scenario outline name)")));
-        order.verify(notifier).fireTestIgnored(argThat(new DescriptionMatcher("third step(scenario outline name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario outline name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("second step(scenario outline name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("third step(scenario outline name)")));
         order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario outline name")));
     }
 
@@ -204,6 +205,20 @@ public class FeatureRunnerTest {
         @Override
         public boolean matches(Object argument) {
             return argument instanceof Description && ((Description) argument).getDisplayName().equals(name);
+        }
+
+    }
+
+    private static final class FailureMatcher extends ArgumentMatcher<Failure> {
+        private String name;
+
+        FailureMatcher(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean matches(Object argument) {
+            return argument instanceof Failure && ((Failure) argument).getDescription().getDisplayName().equals(name);
         }
 
     }


### PR DESCRIPTION
## Summary

Send TestAssumptionFailed notifications instead of TestIgnored notifications to mark scenarios/steps as skipped. 

## Details

Since it is only after a step or scenario has been executed we can tell if it should be considered skipped in JUnit terms, TestAssumptionFailed notifications suits better than TestIgnored notifications.

By using TestAssumptionFailed to mark scenarios/steps as skipped, TestStarted can always be fired before the scenario/step is executed, therefore the option `--allow-stared-ignored` is not longer needed.

## Motivation and Context

By using TestIgnored notifications, the passing of the TestStarted had to be delayed until after the step has executed, which is both unexpected and an unnecessary complex solution. It also caused the need for the `--allow-stared-ignored` option (which adds more complexity).

## How Has This Been Tested?

In addition to the automatic tests of the junit module, I have experimented with the java-calculator example from within Eclipse and with maven.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality). Since the `--allow-started-ignored` option is only deprecated it is a non-breaking change.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly (the help for the junit options).
