### PR TITLE
Map AssumptionViolatedException to Skipped status.

### DIFF
--- a/core/src/main/java/cucumber/api/TestStep.java
+++ b/core/src/main/java/cucumber/api/TestStep.java
@@ -12,12 +12,12 @@ import java.util.Arrays;
 import java.util.List;
 
 public abstract class TestStep {
-    private static final String[] PENDING_EXCEPTIONS = {
+    private static final String[] ASSUMPTION_VIOLATED_EXCEPTIONS = {
             "org.junit.AssumptionViolatedException",
             "org.junit.internal.AssumptionViolatedException"
     };
     static {
-        Arrays.sort(PENDING_EXCEPTIONS);
+        Arrays.sort(ASSUMPTION_VIOLATED_EXCEPTIONS);
     }
     protected final DefinitionMatch definitionMatch;
 
@@ -83,8 +83,11 @@ public abstract class TestStep {
     }
 
     private Result.Type mapThrowableToStatus(Throwable t) {
-        if (t.getClass().isAnnotationPresent(Pending.class) || Arrays.binarySearch(PENDING_EXCEPTIONS, t.getClass().getName()) >= 0) {
+        if (t.getClass().isAnnotationPresent(Pending.class)) {
             return Result.Type.PENDING;
+        }
+        if (Arrays.binarySearch(ASSUMPTION_VIOLATED_EXCEPTIONS, t.getClass().getName()) >= 0) {
+            return Result.Type.SKIPPED;
         }
         if (t.getClass() == UndefinedStepDefinitionException.class) {
             return Result.Type.UNDEFINED;
@@ -94,7 +97,7 @@ public abstract class TestStep {
 
     private Result mapStatusToResult(Result.Type status, Throwable error, long duration) {
         Long resultDuration = duration;
-        if (status == Result.Type.SKIPPED) {
+        if (status == Result.Type.SKIPPED && error == null) {
             return Result.SKIPPED;
         }
         if (status == Result.Type.UNDEFINED) {

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -217,7 +217,7 @@ public class Runtime {
 
     private boolean hasErrors() {
         for (Throwable error : errors) {
-            if (!isPending(error)) {
+            if (!isPending(error) && !isAssumptionViolated(error)) {
                 return true;
             }
         }
@@ -236,7 +236,7 @@ public class Runtime {
         if (t == null) {
             return false;
         }
-        return t.getClass().isAnnotationPresent(Pending.class) || isAssumptionViolated(t);
+        return t.getClass().isAnnotationPresent(Pending.class);
     }
 
     public static boolean isAssumptionViolated(Throwable t) {

--- a/core/src/test/java/cucumber/api/TestStepTest.java
+++ b/core/src/test/java/cucumber/api/TestStepTest.java
@@ -6,6 +6,7 @@ import cucumber.runner.EventBus;
 import cucumber.runner.PickleTestStep;
 import cucumber.runtime.DefinitionMatch;
 import gherkin.pickles.PickleStep;
+import org.junit.AssumptionViolatedException;
 import org.junit.Test;
 import org.mockito.InOrder;
 
@@ -55,6 +56,15 @@ public class TestStepTest {
     @Test
     public void result_is_skipped_when_skip_step_is_true() throws Throwable {
         Result result = step.run(bus, language, scenario, true);
+
+        assertEquals(Result.Type.SKIPPED, result.getStatus());
+    }
+
+    @Test
+    public void result_is_skipped_when_step_definition_throws_assumption_violated_exception() throws Throwable {
+        doThrow(AssumptionViolatedException.class).when(definitionMatch).runStep(anyString(), (Scenario)any());
+
+        Result result = step.run(bus, language, scenario, false);
 
         assertEquals(Result.Type.SKIPPED, result.getStatus());
     }

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -171,7 +171,7 @@ public class RuntimeTest {
     @Test
     public void non_strict_with_failed_junit_assumption_prior_to_junit_412() {
         Runtime runtime = createNonStrictRuntime();
-        runtime.addError(new org.junit.internal.AssumptionViolatedException("should be treated like pending"));
+        runtime.addError(new org.junit.internal.AssumptionViolatedException("should be treated like skipped"));
 
         assertEquals(0x0, runtime.exitStatus());
     }
@@ -179,7 +179,7 @@ public class RuntimeTest {
     @Test
     public void non_strict_with_failed_junit_assumption_from_junit_412_on() {
         Runtime runtime = createNonStrictRuntime();
-        runtime.addError(new AssumptionViolatedException("should be treated like pending"));
+        runtime.addError(new AssumptionViolatedException("should be treated like skipped"));
 
         assertEquals(0x0, runtime.exitStatus());
     }

--- a/core/src/test/java/cucumber/runtime/TestHelper.java
+++ b/core/src/test/java/cucumber/runtime/TestHelper.java
@@ -178,6 +178,8 @@ public class TestHelper {
             doThrow(new PendingException()).when(matchStep).runStep(anyString(), (Scenario) any());
         } else if (stepResult.is(Result.Type.FAILED)) {
             doThrow(stepResult.getError()).when(matchStep).runStep(anyString(), (Scenario) any());
+        } else if (stepResult.is(Result.Type.SKIPPED) && stepResult.getError() != null) {
+            doThrow(stepResult.getError()).when(matchStep).runStep(anyString(), (Scenario) any());
         } else if (!stepResult.is(Result.Type.PASSED) &&
                    !stepResult.is(Result.Type.SKIPPED)) {
             fail("Cannot mock step to the result: " + stepResult.getStatus());

--- a/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
@@ -69,7 +69,7 @@ public class JUnitReporterTest {
     @Test
     public void result_with_assumption_violated() {
         createStrictReporter();
-        Result result = mock(Result.class);
+        Result result = mockResult(Result.Type.SKIPPED);
         Throwable exception = new AssumptionViolatedException("Oops");
         when(result.getError()).thenReturn(exception);
 
@@ -131,10 +131,6 @@ public class JUnitReporterTest {
         verify(stepNotifier, times(0)).fireTestIgnored();
     }
 
-    private void verifyAddFailureWithAssumptionViolatedException(JUnitReporter.EachTestNotifier stepNotifier) {
-        verifyAddFailureWithException(AssumptionViolatedException.class, stepNotifier);
-    }
-
     private void verifyAddFailureWithPendingException(JUnitReporter.EachTestNotifier stepNotifier) {
         verifyAddFailureWithException(PendingException.class, stepNotifier);
     }
@@ -183,44 +179,6 @@ public class JUnitReporterTest {
         verifyAddFailureWithPendingException(stepNotifier);
         verifyAddFailureWithPendingException(pickleRunnerNotifier);
         verify(stepNotifier, times(0)).fireTestIgnored();
-    }
-
-    @Test
-    public void result_with_assumption_violated_strict() {
-        createStrictReporter();
-        createDefaultRunNotifier();
-        Result result = mock(Result.class);
-        when(result.getError()).thenReturn(new AssumptionViolatedException("Oops"));
-
-        JUnitReporter.EachTestNotifier stepNotifier = mock(JUnitReporter.EachTestNotifier.class);
-        jUnitReporter.stepNotifier = stepNotifier;
-        JUnitReporter.EachTestNotifier pickleRunnerNotifier = mock(JUnitReporter.EachTestNotifier.class);
-        jUnitReporter.pickleRunnerNotifier = pickleRunnerNotifier;
-
-        jUnitReporter.handleStepResult(result);
-
-        verify(stepNotifier, times(1)).fireTestStarted();
-        verify(stepNotifier, times(1)).fireTestFinished();
-        verifyAddFailureWithAssumptionViolatedException(stepNotifier);
-        verifyAddFailureWithAssumptionViolatedException(pickleRunnerNotifier);
-        verify(stepNotifier, times(0)).fireTestIgnored();
-    }
-
-    @Test
-    public void result_with_assumption_violated_non_strict() {
-        createNonStrictReporter();
-        Result result = mock(Result.class);
-        when(result.getError()).thenReturn(new AssumptionViolatedException("Oops"));
-
-        JUnitReporter.EachTestNotifier stepNotifier = mock(JUnitReporter.EachTestNotifier.class);
-        jUnitReporter.stepNotifier = stepNotifier;
-
-        jUnitReporter.handleStepResult(result);
-
-        verify(stepNotifier, times(0)).fireTestStarted();
-        verify(stepNotifier, times(0)).fireTestFinished();
-        verify(stepNotifier, times(0)).addFailure(Matchers.<Throwable>any(Throwable.class));
-        verify(stepNotifier).fireTestIgnored();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Map AssumptionViolatedException to Skipped status, so that the exit code is zero in presence of them also in strict mode.

## Details

AssumptionViolatedExceptions are used in JUnit to signal after the test has started that it is not meaningful given the current conditions. Currently these exceptions are mapped to the Pending status, but it is a better match to map them to the Skipped status, so that the exit code is zero in the presence of them also in the strict mode.

## Motivation and Context

Fixes #1007.

## How Has This Been Tested?

The automatic tests has been updated accordingly.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
