### PR TITLE
[Build] Use 1.7 as the source and target level for compilation

### DIFF
--- a/openejb/pom.xml
+++ b/openejb/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -33,4 +35,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <!--
+    Using source level 1.7 in combination with openejb-core results in 'An unknown compilation
+    error'. Use 1.6 instead and compile up to 1.7 to avoid this problem.
+     -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.6</source>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -724,8 +724,8 @@
                     <version>3.6.2</version>
                     <configuration>
                         <encoding>UTF-8</encoding>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                         <compilerArgument>-Werror</compilerArgument>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
## Summary

Cucumber-jvm is using some library features that were introduced in Java 7.
Setting the compilation explicitly to Java 7 should avoid any unexpected
surprises.

## Motivation and Context

Java 6 has reached its end of life a while ago and we no longer run our tests against it. Supporting it has become impractical.

## How Has This Been Tested?

Check if the automated tests were still passing. 
Check manually if the Android studio example works

## Types of changes

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
