### PR TITLE
[Spring] Support multithreaded execution of scenarios

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,6 @@
 ## [2.0.0-SNAPSHOT](https://github.com/cucumber/cucumber-jvm/compare/v1.2.5...master) (In Git)
 
+* [Spring] Support multithreaded execution of scenarios ([#1106](https://github.com/cucumber/cucumber-jvm/issues/1106), [#1107](https://github.com/cucumber/cucumber-jvm/issues/1107), [#1148](https://github.com/cucumber/cucumber-jvm/issues/1148) Ismail Bhana, M.P. Korstanje) 
 * [Java8, Kotlin Java8] Support java 8 method references ([#1140](https://github.com/cucumber/cucumber-jvm/pull/1140) M.P. Korstanje) 
 * [Core] Show explicit error message when field name missed in table header ([#1014](https://github.com/cucumber/cucumber-jvm/pull/1014) Mykola Gurov) 
 * [Examples] Properly quit selenium in webbit examples ([#1146](https://github.com/cucumber/cucumber-jvm/pull/1146) Alberto Scotto)

--- a/spring/src/main/java/cucumber/runtime/java/spring/GlueCodeContext.java
+++ b/spring/src/main/java/cucumber/runtime/java/spring/GlueCodeContext.java
@@ -4,12 +4,22 @@ import java.util.HashMap;
 import java.util.Map;
 
 class GlueCodeContext {
-    public static final GlueCodeContext INSTANCE = new GlueCodeContext();
+
+    private static final ThreadLocal<GlueCodeContext> localContext = new ThreadLocal<GlueCodeContext>() {
+        protected GlueCodeContext initialValue() {
+            return new GlueCodeContext();
+        }
+    };
+
     private final Map<String, Object> objects = new HashMap<String, Object>();
     private final Map<String, Runnable> callbacks = new HashMap<String, Runnable>();
     private int counter;
 
     private GlueCodeContext() {
+    }
+
+    public static GlueCodeContext getInstance() {
+        return localContext.get();
     }
 
     public void start() {

--- a/spring/src/main/java/cucumber/runtime/java/spring/GlueCodeScope.java
+++ b/spring/src/main/java/cucumber/runtime/java/spring/GlueCodeScope.java
@@ -6,10 +6,9 @@ import org.springframework.beans.factory.config.Scope;
 class GlueCodeScope implements Scope {
     public static final String NAME = "cucumber-glue";
 
-    private final GlueCodeContext context = GlueCodeContext.INSTANCE;
-
     @Override
     public Object get(String name, ObjectFactory<?> objectFactory) {
+        GlueCodeContext context = GlueCodeContext.getInstance();
         Object obj = context.get(name);
         if (obj == null) {
             obj = objectFactory.getObject();
@@ -21,11 +20,13 @@ class GlueCodeScope implements Scope {
 
     @Override
     public Object remove(String name) {
+        GlueCodeContext context = GlueCodeContext.getInstance();
         return context.remove(name);
     }
 
     @Override
     public void registerDestructionCallback(String name, Runnable callback) {
+        GlueCodeContext context = GlueCodeContext.getInstance();
         context.registerDestructionCallback(name, callback);
     }
 
@@ -36,6 +37,7 @@ class GlueCodeScope implements Scope {
 
     @Override
     public String getConversationId() {
+        GlueCodeContext context = GlueCodeContext.getInstance();
         return context.getId();
     }
 }

--- a/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
+++ b/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
@@ -112,7 +112,7 @@ public class SpringFactory implements ObjectFactory {
                 registerStepClassBeanDefinition(beanFactory, stepClass);
             }
         }
-        GlueCodeContext.INSTANCE.start();
+        GlueCodeContext.getInstance().start();
     }
 
     @SuppressWarnings("resource")
@@ -161,7 +161,7 @@ public class SpringFactory implements ObjectFactory {
     @Override
     public void stop() {
         notifyContextManagerAboutTestClassFinished();
-        GlueCodeContext.INSTANCE.stop();
+        GlueCodeContext.getInstance().stop();
     }
 
     private void notifyContextManagerAboutTestClassFinished() {

--- a/spring/src/test/java/cucumber/runtime/java/spring/threading/RunParallelCukesTest.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/threading/RunParallelCukesTest.java
@@ -1,0 +1,38 @@
+package cucumber.runtime.java.spring.threading;
+
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.junit.Assert.assertEquals;
+
+import cucumber.api.cli.Main;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+
+public class RunParallelCukesTest {
+
+    private final Callable<Byte> runCuke = new Callable<Byte>() {
+        @Override
+        public Byte call() throws Exception {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            String[] args = {
+                "--glue", "cucumber.runtime.java.spring.threading",
+                "classpath:cucumber/runtime/java/spring/threadingCukes.feature",
+                "--strict"
+            };
+            return Main.run(args, classLoader);
+        }
+    };
+
+    @Test
+    public void test() throws InterruptedException, ExecutionException {
+        ExecutorService executorService = newFixedThreadPool(2);
+        Future<Byte> result1 = executorService.submit(runCuke);
+        Future<Byte> result2 = executorService.submit(runCuke);
+        assertEquals(result1.get().byteValue(), 0x0);
+        assertEquals(result2.get().byteValue(), 0x0);
+    }
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/threading/ThreadingStepDefs.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/threading/ThreadingStepDefs.java
@@ -1,0 +1,48 @@
+package cucumber.runtime.java.spring.threading;
+
+import static java.lang.Thread.currentThread;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@WebAppConfiguration
+@ContextConfiguration("classpath:cucumber.xml")
+public class ThreadingStepDefs {
+
+    private static final ConcurrentHashMap<Thread, ThreadingStepDefs> map = new ConcurrentHashMap<Thread, ThreadingStepDefs>();
+
+    private static final CountDownLatch latch = new CountDownLatch(2);
+
+    @Given("^I am a step definition$")
+    public void iAmAStepDefinition() throws Throwable {
+        map.put(currentThread(), this);
+    }
+
+    @When("^when executed in parallel$")
+    public void whenExecutedInParallel() throws Throwable {
+        latch.await(10, TimeUnit.SECONDS);
+    }
+
+    @Then("^I should not be shared between threads$")
+    public void iShouldNotBeSharedBetweenThreads() throws Throwable {
+        for (Map.Entry<Thread, ThreadingStepDefs> entries : map.entrySet()) {
+            if (entries.getKey().equals(currentThread())) {
+                assertSame(entries.getValue(), this);
+            } else {
+                assertNotSame(entries.getValue(), this);
+            }
+        }
+        assertEquals(2, map.size());
+    }
+}

--- a/spring/src/test/resources/cucumber/runtime/java/spring/threadingCukes.feature
+++ b/spring/src/test/resources/cucumber/runtime/java/spring/threadingCukes.feature
@@ -1,0 +1,9 @@
+Feature: Spring Threading Cukes
+  In order to have a completely clean system for each scenario
+  As a purity activist
+  I want that beans have both scenario and thread scope.
+
+  Scenario: A parallel execution
+    Given I am a step definition
+    When when executed in parallel
+    Then I should not be shared between threads


### PR DESCRIPTION
## Summary

When running in parallel the dependency injection context was shared between
scenarios. This made it impossible to run cucumber test with spring without
forking the JVM.

To reduce the resources required to execute a test each thread now will
have its own dependency injection context allowing tests to be executed in
parallel threads.

Related issues:
 - https://github.com/cucumber/cucumber-jvm/issues/1106

 This fixes #1106

## How Has This Been Tested?

Created a unit tests that executes the same cucumber scenario in parallel. The scenario knows it is being executed in parallel and checks if it has not been re-used by any other threads.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
