### PR TITLE
Change constructor parameter type to interface

### DIFF
--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -86,12 +86,12 @@ public class Runtime {
     }
 
     public Runtime(ResourceLoader resourceLoader, ClassLoader classLoader, Collection<? extends Backend> backends,
-                   RuntimeOptions runtimeOptions, RuntimeGlue optionalGlue) {
+                   RuntimeOptions runtimeOptions, Glue optionalGlue) {
         this(resourceLoader, classLoader, backends, runtimeOptions, TimeService.SYSTEM, optionalGlue);
     }
 
     public Runtime(ResourceLoader resourceLoader, ClassLoader classLoader, Collection<? extends Backend> backends,
-                   RuntimeOptions runtimeOptions, TimeService stopWatch, RuntimeGlue optionalGlue) {
+                   RuntimeOptions runtimeOptions, TimeService stopWatch, Glue optionalGlue) {
         if (backends.isEmpty()) {
             throw new CucumberException("No backends were found. Please make sure you have a backend module on your CLASSPATH.");
         }


### PR DESCRIPTION
## Summary

This is a minor change to the Runtime.java class to use Glue.java interface instead of RuntimeGlue.java for the parameters to the Runtime.java's constructors.

## Motivation and Context

See Effective Java 52
Specifically, I'm trying to create a custom Runtime for the Cucumber JVM to better meet my company's business needs. It would be more useful to provide the Glue type as the parameter to the Runtime rather than RuntimeGlue. Currently, I have to extend the RuntimeGlue and override all of the interface methods, effectively ignoring the RuntimeGlue implementation.

## How Has This Been Tested?

These changes should already be covered by existing tests. They have essentially no effect on existing code.