### PR TITLE
[Spring] Do not share ContextCache between threads

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,7 +2,7 @@
 
 * [Guice] Use the ContextClassLoader when loading InjectorSource. ([#1036](https://github.com/cucumber/cucumber-jvm/pull/1036), [#1037](https://github.com/cucumber/cucumber-jvm/pull/1037) Kyle Moore)
 * [Core] Allow global registration of custom XStream converters. ([#1010](https://github.com/cucumber/cucumber-jvm/pull/1010), [#1009](https://github.com/cucumber/cucumber-jvm/issues/1009) Chris Rankin) 
-* [Spring] Support multithreaded execution of scenarios ([#1106](https://github.com/cucumber/cucumber-jvm/issues/1106), [#1107](https://github.com/cucumber/cucumber-jvm/issues/1107), [#1148](https://github.com/cucumber/cucumber-jvm/issues/1148) Ismail Bhana, M.P. Korstanje) 
+* [Spring] Support multithreaded execution of scenarios ([#1106](https://github.com/cucumber/cucumber-jvm/issues/1106), [#1107](https://github.com/cucumber/cucumber-jvm/issues/1107), [#1148](https://github.com/cucumber/cucumber-jvm/issues/1148), [#1153](https://github.com/cucumber/cucumber-jvm/pull/1153) Ismail Bhana, M.P. Korstanje) 
 * [Java8, Kotlin Java8] Support java 8 method references ([#1140](https://github.com/cucumber/cucumber-jvm/pull/1140) M.P. Korstanje) 
 * [Core] Show explicit error message when field name missed in table header ([#1014](https://github.com/cucumber/cucumber-jvm/pull/1014) Mykola Gurov) 
 * [Examples] Properly quit selenium in webbit examples ([#1146](https://github.com/cucumber/cucumber-jvm/pull/1146) Alberto Scotto)

--- a/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
+++ b/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
@@ -1,7 +1,10 @@
 package cucumber.runtime.java.spring;
 
-import cucumber.runtime.CucumberException;
+import static org.springframework.test.context.FixBootstrapUtils.createBootstrapContext;
+import static org.springframework.test.context.FixBootstrapUtils.resolveTestContextBootstrapper;
+
 import cucumber.api.java.ObjectFactory;
+import cucumber.runtime.CucumberException;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -202,12 +205,14 @@ public class SpringFactory implements ObjectFactory {
 
 class CucumberTestContextManager extends TestContextManager {
 
-    public CucumberTestContextManager(Class<?> testClass) {
-        super(testClass);
+    CucumberTestContextManager(Class<?> testClass) {
+        // Does the same as TestContextManager(Class<?>) but creates a
+        // DefaultCacheAwareContextLoaderDelegate that uses a thread local contextCache.
+        super(resolveTestContextBootstrapper(createBootstrapContext(testClass)));
         registerGlueCodeScope(getContext());
     }
 
-    public ConfigurableListableBeanFactory getBeanFactory() {
+    ConfigurableListableBeanFactory getBeanFactory() {
         return getContext().getBeanFactory();
     }
 

--- a/spring/src/main/java/org/springframework/test/context/FixBootstrapUtils.java
+++ b/spring/src/main/java/org/springframework/test/context/FixBootstrapUtils.java
@@ -1,0 +1,25 @@
+package org.springframework.test.context;
+
+import org.springframework.test.context.cache.ContextCache;
+import org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate;
+import org.springframework.test.context.cache.DefaultContextCache;
+import org.springframework.test.context.support.DefaultBootstrapContext;
+
+public class FixBootstrapUtils extends BootstrapUtils {
+
+    private static ThreadLocal<ContextCache> contextCache = new ThreadLocal<ContextCache>(){
+        @Override
+        protected ContextCache initialValue() {
+            return new DefaultContextCache();
+        }
+    };
+
+    public static BootstrapContext createBootstrapContext(Class<?> testClass) {
+        CacheAwareContextLoaderDelegate contextLoader = new DefaultCacheAwareContextLoaderDelegate(contextCache.get());
+        return new DefaultBootstrapContext(testClass, contextLoader);
+    }
+
+    public static TestContextBootstrapper resolveTestContextBootstrapper(BootstrapContext bootstrapContext) {
+        return BootstrapUtils.resolveTestContextBootstrapper(bootstrapContext);
+    }
+}


### PR DESCRIPTION
 The `TestContextManager(Class<?>)` uses a static ContextCache. This meant
 that step definitions from different threads could be registered in
 same context multiple times when running in parallel.

 This is resolved by creating a ThreadLocal ContextCache for each
 SpringFactory.

 Related issues:
  - https://travis-ci.org/cucumber/cucumber-jvm/jobs/244215644
  - https://github.com/cucumber/cucumber-jvm/pull/1148