### PR TITLE
Use latest Gosu release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
 matrix:
   include:
   - jdk: openjdk7
-    script: mvn -q install -P examples
+    script: mvn -q install
   - jdk: oraclejdk7
     script: mvn -q install
     after_success: mvn -q deploy --settings .travis-settings.xml -Dno.gem.deploy=true -DskipTests=true -Dmaven.javadoc.skip=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     after_success: mvn -q deploy --settings .travis-settings.xml -Dno.gem.deploy=true -DskipTests=true -Dmaven.javadoc.skip=true
   - jdk: oraclejdk8
     script: mvn -q install -P java8
-    after_success: mvn -q deploy -P java8 -pl java8 --settings .travis-settings.xml -DskipTests=true -Dmaven.javadoc.skip=true
+    after_success: mvn -q deploy -P java8 -pl java8,gosu --settings .travis-settings.xml -DskipTests=true -Dmaven.javadoc.skip=true
 
 env:
   global:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,8 +128,8 @@ Now release everything (replace X.Y.Z below with the next release number):
 
 ```
 mvn release:clean
-mvn --batch-mode -P release-sign-artifacts release:prepare -DautoVersionSubmodules=true -DdevelopmentVersion=X.Y.Z-SNAPSHOT
-mvn -P release-sign-artifacts release:perform
+mvn --batch-mode release:prepare -DautoVersionSubmodules=true -DdevelopmentVersion=X.Y.Z-SNAPSHOT
+mvn release:perform
 ```
 
 Post release the API docs must be generated for each module and manually copied over to a working copy of the [cucumber.github.com](https://github.com/cucumber/cucumber.github.com) which must be a sibling of `cucumber-jvm` (this repo):

--- a/examples/android/cukeulator-test/pom.xml
+++ b/examples/android/cukeulator-test/pom.xml
@@ -6,7 +6,6 @@
     <parent>
         <groupId>io.cucumber.android-examples</groupId>
         <artifactId>android-examples</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/examples/android/pom.xml
+++ b/examples/android/pom.xml
@@ -5,8 +5,7 @@
 
     <parent>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../../pom.xml</relativePath>
+        <artifactId>cucumber-examples</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/examples/clojure_cukes/pom.xml
+++ b/examples/clojure_cukes/pom.xml
@@ -4,8 +4,7 @@
 
     <parent>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../../pom.xml</relativePath>
+        <artifactId>cucumber-examples</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/examples/groovy-calculator/pom.xml
+++ b/examples/groovy-calculator/pom.xml
@@ -3,8 +3,7 @@
 
     <parent>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../../pom.xml</relativePath>
+        <artifactId>cucumber-examples</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/examples/java-calculator-testng/pom.xml
+++ b/examples/java-calculator-testng/pom.xml
@@ -3,8 +3,7 @@
 
     <parent>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../../pom.xml</relativePath>
+        <artifactId>cucumber-examples</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/examples/java-calculator/pom.xml
+++ b/examples/java-calculator/pom.xml
@@ -3,8 +3,7 @@
 
     <parent>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../../pom.xml</relativePath>
+        <artifactId>cucumber-examples</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/examples/java-webbit-websockets-selenium/.gitignore
+++ b/examples/java-webbit-websockets-selenium/.gitignore
@@ -1,0 +1,2 @@
+selenium_standalone/
+selenium_standalone_zips/

--- a/examples/java-webbit-websockets-selenium/pom.xml
+++ b/examples/java-webbit-websockets-selenium/pom.xml
@@ -1,10 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../../pom.xml</relativePath>
+        <artifactId>cucumber-examples</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
@@ -12,21 +13,82 @@
     <packaging>jar</packaging>
     <name>Examples: Webbit WebSockets tested with Selenium</name>
 
-    <!-- skipTests -->
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.lazerycode.selenium</groupId>
+                <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>selenium</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <!-- we don't want to run these tests on travis TRAVIS will be set to true in the travis CI
-                    They WILL be compiled -->
-                    <!-- TODO: there's PhantomJS, and xvfb, so we could maybe re-enable these -->
-                    <skipTests>${env.TRAVIS}</skipTests>
+                    <systemPropertyVariables>
+                        <!--
+                               Run phantomjs by default. It probably works every where.
+
+                               Check the develop profile to configure which web driver to use
+                               when developing.
+                        -->
+                        <webdriver>phantomjs</webdriver>
+                        <!--Provided by the driver-binary-downloader-maven-plugin-->
+                        <!--suppress MavenModelInspection -->
+                        <webdriver.gecko.driver>${webdriver.gecko.driver}</webdriver.gecko.driver>
+                        <!--suppress MavenModelInspection -->
+                        <webdriver.chrome.driver>${webdriver.chrome.driver}
+                        </webdriver.chrome.driver>
+                        <!--suppress MavenModelInspection -->
+                        <webdriver.opera.driver>${webdriver.opera.driver}</webdriver.opera.driver>
+                        <!--suppress MavenModelInspection -->
+                        <phantomjs.binary.path>${phantomjs.binary.path}</phantomjs.binary.path>
+                        <!--suppress MavenModelInspection -->
+                        <webdriver.ie.driver>${webdriver.ie.driver}</webdriver.ie.driver>
+                        <!--suppress MavenModelInspection -->
+                        <webdriver.edge.driver>${webdriver.ie.driver}</webdriver.edge.driver>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!--
+                            Change this to select the browser to use.  E.g: firefox, chrome, edge, ect.
+                        -->
+                        <webdriver>firefox</webdriver>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>develop</id>
+            <activation>
+                <property>
+                    <name>!env.TRAVIS</name>
+                </property>
+            </activation>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>
@@ -35,8 +97,8 @@
         </dependency>
 
         <dependency>
-            <groupId>info.cukes</groupId>
-            <artifactId>cucumber-jvm-deps</artifactId>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java8</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -56,7 +118,12 @@
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-firefox-driver</artifactId>
+            <artifactId>selenium-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-remote-driver</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/examples/java-webbit-websockets-selenium/src/main/java/cucumber/examples/java/websockets/TemperatureServer.java
+++ b/examples/java-webbit-websockets-selenium/src/main/java/cucumber/examples/java/websockets/TemperatureServer.java
@@ -40,12 +40,14 @@ public class TemperatureServer {
         return (double) Math.round(n * 10) / 10;
     }
 
-    public void start() throws IOException, ExecutionException, InterruptedException {
+    public TemperatureServer start() throws IOException, ExecutionException, InterruptedException {
         webServer.start().get();
+        return this;
     }
 
-    public void stop() throws IOException, ExecutionException, InterruptedException {
+    public TemperatureServer stop() throws IOException, ExecutionException, InterruptedException {
         webServer.stop().get();
+        return this;
     }
 
     public static void main(String[] args) throws IOException, ExecutionException, InterruptedException {

--- a/examples/java-webbit-websockets-selenium/src/test/java/cucumber/examples/java/websockets/NavigationStepdefs.java
+++ b/examples/java-webbit-websockets-selenium/src/test/java/cucumber/examples/java/websockets/NavigationStepdefs.java
@@ -1,25 +1,20 @@
 package cucumber.examples.java.websockets;
 
-import cucumber.api.java.en.Given;
+import cucumber.api.java8.En;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-public class NavigationStepdefs {
-    private final WebDriver webDriver;
+public class NavigationStepdefs implements En {
 
     public NavigationStepdefs(SharedDriver webDriver) {
-        this.webDriver = webDriver;
-    }
+        Given("^I am on the front page$", () -> {
+            webDriver.get("http://localhost:" + ServerHooks.PORT);
 
-    @Given("^I am on the front page$")
-    public void i_am_on_the_front_page() throws InterruptedException {
-        webDriver.get("http://localhost:" + ServerHooks.PORT);
-
-        // The input fields won't be enabled until the WebSocket has established
-        // a connection. Wait for this to happen.
-        WebDriverWait wait = new WebDriverWait(webDriver, 1);
-        wait.until(ExpectedConditions.elementToBeClickable(By.id("celcius")));
+            // The input fields won't be enabled until the WebSocket has established
+            // a connection. Wait for this to happen.
+            WebDriverWait wait = new WebDriverWait(webDriver, 1);
+            wait.until(ExpectedConditions.elementToBeClickable(By.id("celcius")));
+        });
     }
 }

--- a/examples/java-webbit-websockets-selenium/src/test/java/cucumber/examples/java/websockets/ServerHooks.java
+++ b/examples/java-webbit-websockets-selenium/src/test/java/cucumber/examples/java/websockets/ServerHooks.java
@@ -1,24 +1,14 @@
 package cucumber.examples.java.websockets;
 
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
+import cucumber.api.java8.En;
 
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-
-public class ServerHooks {
-    public static final int PORT = 8887;
+public class ServerHooks implements En {
+    static final int PORT = 8887;
 
     private TemperatureServer temperatureServer;
 
-    @Before
-    public void startServer() throws IOException, ExecutionException, InterruptedException {
-        temperatureServer = new TemperatureServer(PORT);
-        temperatureServer.start();
-    }
-
-    @After
-    public void stopServer() throws IOException, ExecutionException, InterruptedException {
-        temperatureServer.stop();
+    public ServerHooks(){
+        Before(() -> temperatureServer = new TemperatureServer(PORT).start());
+        After(() -> temperatureServer.stop());
     }
 }

--- a/examples/java-webbit-websockets-selenium/src/test/java/cucumber/examples/java/websockets/SharedDriver.java
+++ b/examples/java-webbit-websockets-selenium/src/test/java/cucumber/examples/java/websockets/SharedDriver.java
@@ -30,7 +30,8 @@ import org.openqa.selenium.support.events.EventFiringWebDriver;
  * </p>
  */
 public class SharedDriver extends EventFiringWebDriver {
-    private static final WebDriver REAL_DRIVER = new FirefoxDriver();
+    private static final WebDriver REAL_DRIVER = WebDriverFactory.create();
+
     private static final Thread CLOSE_THREAD = new Thread() {
         @Override
         public void run() {
@@ -47,11 +48,11 @@ public class SharedDriver extends EventFiringWebDriver {
     }
 
     @Override
-    public void close() {
+    public void quit() {
         if (Thread.currentThread() != CLOSE_THREAD) {
-            throw new UnsupportedOperationException("You shouldn't close this WebDriver. It's shared and will close when the JVM exits.");
+            throw new UnsupportedOperationException("You shouldn't quit this WebDriver. It's shared and will quit when the JVM exits.");
         }
-        super.close();
+        super.quit();
     }
 
     @Before

--- a/examples/java-webbit-websockets-selenium/src/test/java/cucumber/examples/java/websockets/TemperatureStepdefs.java
+++ b/examples/java-webbit-websockets-selenium/src/test/java/cucumber/examples/java/websockets/TemperatureStepdefs.java
@@ -1,26 +1,18 @@
 package cucumber.examples.java.websockets;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-
 import static org.junit.Assert.assertEquals;
 
-public class TemperatureStepdefs {
-    private final WebDriver webDriver;
+import cucumber.api.java8.En;
+import org.openqa.selenium.By;
+
+public class TemperatureStepdefs implements En {
 
     public TemperatureStepdefs(SharedDriver webDriver) {
-        this.webDriver = webDriver;
-    }
 
-    @When("^I enter (.+) (celcius|fahrenheit)$")
-    public void i_enter_temperature(double value, String unit) {
-        webDriver.findElement(By.id(unit)).sendKeys(String.valueOf(value));
-    }
+        When("^I enter (.+) (celcius|fahrenheit)$", (Double value, String unit) ->
+            webDriver.findElement(By.id(unit)).sendKeys(String.valueOf(value)));
 
-    @Then("^I should see (.+) (celcius|fahrenheit)$")
-    public void i_should_see_temperature(double value, String unit) {
-        assertEquals(String.valueOf(value), webDriver.findElement(By.id(unit)).getAttribute("value"));
+        Then("^I should see (.+) (celcius|fahrenheit)$", (Double value, String unit) ->
+            assertEquals(String.valueOf(value), webDriver.findElement(By.id(unit)).getAttribute("value")));
     }
 }

--- a/examples/java-webbit-websockets-selenium/src/test/java/cucumber/examples/java/websockets/WebDriverFactory.java
+++ b/examples/java-webbit-websockets-selenium/src/test/java/cucumber/examples/java/websockets/WebDriverFactory.java
@@ -1,0 +1,88 @@
+package cucumber.examples.java.websockets;
+
+import static java.lang.String.format;
+import static java.lang.System.getProperty;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.opera.OperaDriver;
+import org.openqa.selenium.phantomjs.PhantomJSDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+final class WebDriverFactory {
+
+    private WebDriverFactory() {
+
+    }
+
+    static WebDriver create() {
+        String webDriverProperty = getProperty("webdriver");
+
+        if (webDriverProperty == null || webDriverProperty.isEmpty()) {
+            throw new IllegalStateException("The webdriver system property must be set");
+        }
+
+        try {
+            return Drivers.valueOf(webDriverProperty.toUpperCase()).newDriver();
+        } catch (IllegalArgumentException e) {
+            String msg = format("The webdriver system property '%s' did not match any " +
+                    "existing browser or the browser was not supported on your operating system. " +
+                    "Valid values are %s",
+                webDriverProperty, stream(Drivers
+                    .values())
+                    .map(Enum::name)
+                    .map(String::toLowerCase)
+                    .collect(toList()));
+
+            throw new IllegalStateException(msg, e);
+        }
+    }
+
+    private enum Drivers {
+        FIREFOX {
+            @Override
+            public WebDriver newDriver() {
+                DesiredCapabilities capabilities = DesiredCapabilities.firefox();
+                return new FirefoxDriver(capabilities);
+            }
+        }, CHROME {
+            @Override
+            public WebDriver newDriver() {
+                DesiredCapabilities capabilities = DesiredCapabilities.chrome();
+                return new ChromeDriver(capabilities);
+            }
+        }, OPERA {
+            @Override
+            public WebDriver newDriver() {
+                DesiredCapabilities capabilities = DesiredCapabilities.operaBlink();
+                return new OperaDriver(capabilities);
+            }
+        }, PHANTOMJS {
+            @Override
+            public WebDriver newDriver() {
+                DesiredCapabilities capabilities = DesiredCapabilities.phantomjs();
+                return new PhantomJSDriver(capabilities);
+            }
+        }, IE {
+            @Override
+            public WebDriver newDriver() {
+                DesiredCapabilities capabilities = DesiredCapabilities.internetExplorer();
+                return new InternetExplorerDriver(capabilities);
+            }
+        }, EDGE {
+            @Override
+            public WebDriver newDriver() {
+                DesiredCapabilities capabilities = DesiredCapabilities.edge();
+                return new EdgeDriver(capabilities);
+            }
+        };
+
+        public abstract org.openqa.selenium.WebDriver newDriver();
+
+    }
+}

--- a/examples/java-wicket/java-wicket-main/src/main/java/cucumber/examples/java/wicket/view/Available.java
+++ b/examples/java-wicket/java-wicket-main/src/main/java/cucumber/examples/java/wicket/view/Available.java
@@ -5,17 +5,14 @@ import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.markup.html.basic.Label;
 
 public class Available extends WebPage {
-    private Application application;
 
     public Available() {
-        application = (Application) getApplication();
-
         String availableCars = "" + getAvailableCars();
         Label message = new Label("availableCars", availableCars);
         add(message);
     }
 
     public int getAvailableCars() {
-        return application.getNumberOfAvailableCars();
+        return ((Application)getApplication()).getNumberOfAvailableCars();
     }
 }

--- a/examples/java-wicket/java-wicket-main/src/main/java/cucumber/examples/java/wicket/view/Create.java
+++ b/examples/java-wicket/java-wicket-main/src/main/java/cucumber/examples/java/wicket/view/Create.java
@@ -9,14 +9,11 @@ import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.util.value.ValueMap;
 
 public class Create extends WebPage {
-    private Application application;
     private int numberOfCars;
 
     public Create() {
         CreateCarsForm createCarsForm = new CreateCarsForm("createCarsForm");
         add(createCarsForm);
-
-        application = (Application) getApplication();
     }
 
     public void setNumberOfCars(int initialNumberOfCars) {
@@ -25,7 +22,7 @@ public class Create extends WebPage {
 
     public void create() {
         for (int i = 0; i < numberOfCars; i++) {
-            application.createCar();
+            ((Application) getApplication()).createCar();
         }
     }
 

--- a/examples/java-wicket/java-wicket-main/src/main/java/cucumber/examples/java/wicket/view/Rent.java
+++ b/examples/java-wicket/java-wicket-main/src/main/java/cucumber/examples/java/wicket/view/Rent.java
@@ -7,17 +7,14 @@ import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.util.value.ValueMap;
 
 public class Rent extends WebPage {
-    private Application application;
 
     public Rent() {
         RentCarForm rentCarForm = new RentCarForm("rentCarForm");
         add(rentCarForm);
-
-        application = (Application) getApplication();
     }
 
     public void rent() {
-        application.rentCar();
+        ((Application) getApplication()).rentCar();
     }
 
     private class RentCarForm extends Form<ValueMap> {

--- a/examples/java-wicket/pom.xml
+++ b/examples/java-wicket/pom.xml
@@ -2,8 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../../pom.xml</relativePath>
+        <artifactId>cucumber-examples</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket</artifactId>

--- a/examples/pax-exam/pom.xml
+++ b/examples/pax-exam/pom.xml
@@ -3,8 +3,7 @@
 
     <parent>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../../pom.xml</relativePath>
+        <artifactId>cucumber-examples</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.cucumber</groupId>
+        <artifactId>cucumber-jvm</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cucumber-examples</artifactId>
+    <packaging>pom</packaging>
+    <name>Examples</name>
+
+    <modules>
+        <module>spring-txn</module>
+        <module>clojure_cukes</module>
+        <module>java-calculator</module>
+        <module>java-calculator-testng</module>
+        <module>groovy-calculator</module>
+        <module>scala-calculator</module>
+        <module>pax-exam</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <modules>
+                <module>java-wicket</module>
+                <module>java-webbit-websockets-selenium</module>
+            </modules>
+        </profile>
+
+        <profile>
+            <id>android-examples</id>
+            <modules>
+                <module>android</module>
+            </modules>
+        </profile>
+    </profiles>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>
+

--- a/examples/spring-txn/pom.xml
+++ b/examples/spring-txn/pom.xml
@@ -3,8 +3,7 @@
 
     <parent>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../../pom.xml</relativePath>
+        <artifactId>cucumber-examples</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/gosu/pom.xml
+++ b/gosu/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -12,20 +14,23 @@
     <packaging>jar</packaging>
     <name>Cucumber-JVM: Gosu</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>info.cukes</groupId>
-            <artifactId>cucumber-jvm-deps</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.cucumber</groupId>
-            <artifactId>gherkin</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/gosu/src/main/java/cucumber/runtime/gosu/GlueSource.java
+++ b/gosu/src/main/java/cucumber/runtime/gosu/GlueSource.java
@@ -1,73 +1,34 @@
 package cucumber.runtime.gosu;
 
 import cucumber.runtime.io.Resource;
-import gw.lang.launch.IArgInfo;
-import gw.lang.launch.IBooleanArgKey;
-import gw.lang.launch.IProgramSource;
-import gw.lang.launch.IStringArgKey;
+import gw.lang.reflect.ReflectUtil;
+import gw.lang.reflect.gs.GosuClassPathThing;
+import gw.lang.reflect.gs.IProgramInstance;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
+class GlueSource {
 
-class GlueSource implements IProgramSource {
-    private final StringBuilder sourceBuilder = new StringBuilder();
-
-    @Override
-    public String getRawPath() {
-        // This file doesn't really exist, but we have to say something I guess!
-        return "cucumber.gsp";
+    /**
+     * Performs minimal initialization of the Gosu TypeSystem; this is required for later calls to ReflectUtil#getClass
+     */
+    public GlueSource() {
+        GosuClassPathThing.init();
     }
 
-    @Override
-    public File getFile() {
-        return null;
-    }
-
-    @Override
-    public InputStream openInputStream() throws IOException {
-        return new ByteArrayInputStream(sourceBuilder.toString().getBytes("UTF-8"));
-    }
-
+    /**
+     * Given a glue Resource, calculates the FQN of the Gosu Program as a class, 
+     * loads it via reflection and calls its evaluate method. 
+     * @param glueScript
+     */
     public void addGlueScript(Resource glueScript) {
-        // https://groups.google.com/d/msg/gosu-lang/yMJnzQwuFpo/msg81GNGlAYJ
         String className = glueScript.getClassName(".gsp");
-        sourceBuilder.append("(" + className + ".Type as java.lang.Class).getDeclaredMethod( \"evaluate\", {gw.lang.reflect.gs.IExternalSymbolMap} ).invoke( new " + className + "(), {null})\n");
+        Class clazz = ReflectUtil.getClass(className).getBackingClass();
+        try {
+            ((IProgramInstance)(clazz.newInstance())).evaluate(null);
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
     }
 
-    public IArgInfo toArgInfo() {
-        return new IArgInfo() {
-            @Override
-            public boolean consumeArg(IBooleanArgKey iBooleanArgKey) {
-                return false;
-            }
-
-            @Override
-            public String consumeArg(IStringArgKey iStringArgKey) {
-                return null;
-            }
-
-            @Override
-            public void processUnknownArgs() {
-
-            }
-
-            @Override
-            public String getErrorMessage() {
-                return null;
-            }
-
-            @Override
-            public IProgramSource getProgramSource() {
-                return GlueSource.this;
-            }
-
-            @Override
-            public List<String> getArgsList() {
-                return null;
-            }
-        };
-    }
 }

--- a/gosu/src/main/java/cucumber/runtime/gosu/GosuBackend.java
+++ b/gosu/src/main/java/cucumber/runtime/gosu/GosuBackend.java
@@ -7,8 +7,7 @@ import cucumber.runtime.io.Resource;
 import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.snippets.FunctionNameGenerator;
 import cucumber.runtime.snippets.SnippetGenerator;
-import gherkin.formatter.model.Step;
-import gw.lang.Gosu;
+import gherkin.pickles.PickleStep;
 import gw.lang.function.AbstractBlock;
 
 import java.util.List;
@@ -36,9 +35,6 @@ public class GosuBackend implements Backend {
                 source.addGlueScript(glueScript);
             }
         }
-
-        Gosu gosu = new Gosu();
-        gosu.start(source.toArgInfo());
     }
 
     @Override
@@ -57,10 +53,12 @@ public class GosuBackend implements Backend {
     }
 
     @Override
-    public String getSnippet(Step step, FunctionNameGenerator functionNameGenerator) {
-        return snippetGenerator.getSnippet(step, null);    }
+    public String getSnippet(PickleStep step, String keyword, FunctionNameGenerator functionNameGenerator) {
+        return snippetGenerator.getSnippet(step, keyword, functionNameGenerator);
+    }
 
-    public void addStepDefinition(String regexp, Object body) {
+    @SuppressWarnings("unused") // this is indeed invoked by static methods on cucumber.api.gosu.en.Dsl
+    public void addStepDefinition( String regexp, Object body) {
         AbstractBlock block = (AbstractBlock) body;
         glue.addStepDefinition(new GosuStepDefinition(Pattern.compile(regexp), block, currentLocation()));
     }

--- a/gosu/src/main/java/cucumber/runtime/gosu/GosuStepDefinition.java
+++ b/gosu/src/main/java/cucumber/runtime/gosu/GosuStepDefinition.java
@@ -1,11 +1,10 @@
 package cucumber.runtime.gosu;
 
+import cucumber.runtime.Argument;
 import cucumber.runtime.JdkPatternArgumentMatcher;
 import cucumber.runtime.ParameterInfo;
 import cucumber.runtime.StepDefinition;
-import gherkin.I18n;
-import gherkin.formatter.Argument;
-import gherkin.formatter.model.Step;
+import gherkin.pickles.PickleStep;
 import gw.lang.function.AbstractBlock;
 import gw.lang.reflect.IType;
 
@@ -41,8 +40,8 @@ public class GosuStepDefinition implements StepDefinition {
         return result;
     }
     @Override
-    public List<Argument> matchedArguments(Step step) {
-        return argumentMatcher.argumentsFrom(step.getName());
+    public List<Argument> matchedArguments(PickleStep step) {
+        return argumentMatcher.argumentsFrom(step.getText());
     }
 
     @Override
@@ -61,7 +60,7 @@ public class GosuStepDefinition implements StepDefinition {
     }
 
     @Override
-    public void execute(I18n i18n, Object[] args) throws Throwable {
+    public void execute(String language, Object[] args) throws Throwable {
         // TODO: Add timeout
         block.invokeWithArgs(args);
     }

--- a/gosu/src/test/java/cucumber/runtime/gosu/GosuSnippetTest.java
+++ b/gosu/src/test/java/cucumber/runtime/gosu/GosuSnippetTest.java
@@ -1,21 +1,21 @@
 package cucumber.runtime.gosu;
 
 import cucumber.runtime.snippets.SnippetGenerator;
-import gherkin.formatter.model.Comment;
-import gherkin.formatter.model.DataTableRow;
-import gherkin.formatter.model.DocString;
-import gherkin.formatter.model.Step;
+import gherkin.pickles.Argument;
+import gherkin.pickles.PickleCell;
+import gherkin.pickles.PickleRow;
+import gherkin.pickles.PickleStep;
+import gherkin.pickles.PickleString;
+import gherkin.pickles.PickleTable;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
 public class GosuSnippetTest {
-
-    private static final List<Comment> NO_COMMENTS = Collections.emptyList();
+    private static final String GIVEN_KEYWORD = "Given";
 
     @Test
     public void generatesPlainSnippet() {
@@ -66,7 +66,7 @@ public class GosuSnippetTest {
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException()\n" +
                 "})\n";
-        assertEquals(expected, snippetForDocString("I have:", new DocString("text/plain", "hello", 1)));
+        assertEquals(expected, snippetForDocString("I have:", new PickleString(null, "hello")));
     }
 
     @Test
@@ -76,22 +76,22 @@ public class GosuSnippetTest {
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException()\n" +
                 "})\n";
-        List<DataTableRow> dataTable = asList(new DataTableRow(NO_COMMENTS, asList("col1"), 1));
+        PickleTable dataTable = new PickleTable(asList(new PickleRow(asList(new PickleCell(null, "col1")))));
         assertEquals(expected, snippetForDataTable("I have:", dataTable));
     }
 
     private String snippetFor(String name) {
-        Step step = new Step(NO_COMMENTS, "Given ", name, 0, null, null);
-        return new SnippetGenerator(new GosuSnippet()).getSnippet(step, null);
+        PickleStep step = new PickleStep(name, Collections.emptyList(), Collections.emptyList());
+        return new SnippetGenerator(new GosuSnippet()).getSnippet(step, GIVEN_KEYWORD, null);
     }
 
-    private String snippetForDocString(String name, DocString docString) {
-        Step step = new Step(NO_COMMENTS, "Given ", name, 0, null, docString);
-        return new SnippetGenerator(new GosuSnippet()).getSnippet(step, null);
+    private String snippetForDocString(String name, PickleString docString) {
+        PickleStep step = new PickleStep(name, asList((Argument)docString), Collections.emptyList());
+        return new SnippetGenerator(new GosuSnippet()).getSnippet(step, GIVEN_KEYWORD, null);
     }
 
-    private String snippetForDataTable(String name, List<DataTableRow> dataTable) {
-        Step step = new Step(NO_COMMENTS, "Given ", name, 0, dataTable, null);
-        return new SnippetGenerator(new GosuSnippet()).getSnippet(step, null);
+    private String snippetForDataTable(String name, PickleTable dataTable) {
+        PickleStep step = new PickleStep(name, asList((Argument)dataTable), Collections.emptyList());
+        return new SnippetGenerator(new GosuSnippet()).getSnippet(step, GIVEN_KEYWORD, null);
     }
 }

--- a/kotlin-java8/pom.xml
+++ b/kotlin-java8/pom.xml
@@ -1,6 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
         <junit.version>4.12</junit.version>
         <jython.version>2.7.0</jython.version>
         <mockito.version>1.10.19</mockito.version>
-        <selenium.version>2.45.0</selenium.version>
+        <selenium.version>3.4.0</selenium.version>
+        <driver-binary-downloader-maven-plugin.version>1.0.14</driver-binary-downloader-maven-plugin.version>
         <webbit.version>0.4.15</webbit.version>
         <webbit-rest.version>0.3.0</webbit-rest.version>
         <jruby.version>9.1.5.0</jruby.version>
@@ -87,7 +88,7 @@
         <connection>scm:git:git://github.com/cucumber/cucumber-jvm.git</connection>
         <developerConnection>scm:git:git@github.com:cucumber/cucumber-jvm.git</developerConnection>
         <url>git://github.com/cucumber/cucumber-jvm.git</url>
-        <tag>HEAD</tag>
+        <tag>cucumber-jvm-2.0.0</tag>
     </scm>
 
     <dependencyManagement>
@@ -369,7 +370,7 @@
             </dependency>
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
-                <artifactId>selenium-firefox-driver</artifactId>
+                <artifactId>selenium-remote-driver</artifactId>
                 <version>${selenium.version}</version>
                 <exclusions>
                     <exclusion>
@@ -382,6 +383,12 @@
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-server</artifactId>
                 <version>${selenium.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
@@ -581,6 +588,7 @@
         <module>scala</module>
         <module>needle</module>
         <module>android</module>
+        <module>examples</module>
     </modules>
 
     <profiles>
@@ -596,13 +604,6 @@
         </profile>
 
         <profile>
-            <id>android-examples</id>
-            <modules>
-                <module>examples/android</module>
-            </modules>
-        </profile>
-
-        <profile>
             <id>junit-4.12</id>
             <properties>
                 <junit.version>4.12</junit.version>
@@ -610,32 +611,7 @@
         </profile>
 
         <profile>
-            <id>examples</id>
-            <modules>
-                <module>examples/java-wicket</module>
-                <module>examples/spring-txn</module>
-                <module>examples/clojure_cukes</module>
-                <module>examples/java-calculator</module>
-                <module>examples/java-calculator-testng</module>
-                <module>examples/groovy-calculator</module>
-                <module>examples/scala-calculator</module>
-                <module>examples/java-webbit-websockets-selenium</module>
-                <module>examples/pax-exam</module>
-            </modules>
-        </profile>
-
-        <profile>
             <id>release-sign-artifacts</id>
-            <modules>
-                <module>examples/java-wicket</module>
-                <module>examples/spring-txn</module>
-                <module>examples/clojure_cukes</module>
-                <module>examples/java-calculator</module>
-                <module>examples/java-calculator-testng</module>
-                <module>examples/groovy-calculator</module>
-                <module>examples/scala-calculator</module>
-                <module>examples/java-webbit-websockets-selenium</module>
-            </modules>
             <activation>
                 <property>
                     <name>performRelease</name>
@@ -743,7 +719,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.6.1</version>
                     <configuration>
                         <encoding>UTF-8</encoding>
                         <source>1.6</source>
@@ -860,6 +836,11 @@
                 </plugin>
 
                 <!-- Non-standard plugins -->
+                <plugin>
+                    <groupId>com.lazerycode.selenium</groupId>
+                    <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+                    <version>${driver-binary-downloader-maven-plugin.version}</version>
+                </plugin>
 
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <clojure.version>1.8.0</clojure.version>
         <!-- This is only here for the example project to use, the 3 scala projects maintain their own versions -->
         <scala.latest.version>2.11.8</scala.latest.version>
-        <gosu.version>1.14.2</gosu.version>
+        <gosu.version>1.14.6</gosu.version>
         <rhino.version>1.7.7.1</rhino.version>
         <jsoup.version>1.9.2</jsoup.version>
         <testng.version>6.9.10</testng.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <clojure.version>1.8.0</clojure.version>
         <!-- This is only here for the example project to use, the 3 scala projects maintain their own versions -->
         <scala.latest.version>2.11.8</scala.latest.version>
-        <gosu.version>1.2</gosu.version>
+        <gosu.version>1.14.2</gosu.version>
         <rhino.version>1.7.7.1</rhino.version>
         <jsoup.version>1.9.2</jsoup.version>
         <testng.version>6.9.10</testng.version>
@@ -549,14 +549,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <repositories>
-        <!--<repository>-->
-        <!--<id>gosu-lang.org-releases</id>-->
-        <!--<name>Official Gosu website (releases)</name>-->
-        <!--<url>http://gosu-lang.org/repositories/m2/releases</url>-->
-        <!--</repository>-->
-    </repositories>
-
     <!--
      this adds a repository that the plugins will use for dependency resolution
      Any items that we use in a plugin's <dependency> phase can be resolved from here, as well as central
@@ -569,7 +561,6 @@
     </pluginRepositories>
 
     <modules>
-        <!--<module>gosu</module>-->
         <module>core</module>
         <module>java</module>
         <module>testng</module>
@@ -598,6 +589,7 @@
                 <jdk>1.8</jdk>
             </activation>
             <modules>
+                <module>gosu</module>
                 <module>java8</module>
                 <module>kotlin-java8</module>
             </modules>

--- a/scala/scala_2.12/pom.xml
+++ b/scala/scala_2.12/pom.xml
@@ -16,8 +16,7 @@
         <!--
         Upgrading to 2.12.0-M2 or higher causes:
 
-        initializationError(cucumber.runtime.scala.test.RunCukesTest)  Time elapsed: 0.006 sec  <<< ERROR! java.util.NoSuchElementException: next on empty iterator [no stack trace]
-        -->
+        initializationError(cucumber.runtime.scala.test.RunCukesTest)  Time elapsed: 0.006 sec  <<< ERROR! java.util.NoSuchElementException: next on empty iterator [no stack trace] -->
         <scala.version>2.12.0-M1</scala.version>
     </properties>
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
Gosu language support has been broken for a while now; I had a PR to re-enable it (see https://github.com/cucumber/cucumber-jvm/pull/1086). At @mpkorstanje 's request I retested locally using Java 8 and the command `mvn -pl gosu test`; everything is fine.

I also bumped the Gosu release to the newest release version.

AFAICT, this is good-to-go with the caveat that Gosu _only_ supports Java 8 these days (I tweaked the maven profile so that Travis won't try to run Gosu using Java 7).
