### PR TITLE
[JUnit] Make no step notifications the default.

### DIFF
--- a/junit/src/main/java/cucumber/runtime/junit/JUnitOptions.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitOptions.java
@@ -13,7 +13,7 @@ public class JUnitOptions {
     private static String optionsText;
 
     private boolean filenameCompatibleNames = false;
-    private boolean stepNotifications = true;
+    private boolean stepNotifications = false;
 
     /**
      * Create a new instance from a list of options, for example:

--- a/junit/src/main/resources/cucumber/api/junit/OPTIONS.txt
+++ b/junit/src/main/resources/cucumber/api/junit/OPTIONS.txt
@@ -7,9 +7,11 @@ JUnit Options:
                                          names for certain can be used as file names.
                                          For instance gradle will use these names in 
                                          the file names of the JUnit xml report files.
-  --[no-]step-notifications              By default steps are included in notifications
-                                         and descriptions. When interacting with cucumber
-                                         in an IDE it is nice to see the step executions.
-                                         However presenting step executions as tests to
-                                         various reporters such as surefire results in
-                                         strange test counts and weird reports.
+  --[no-]step-notifications              By default steps are not included in
+                                         notifications and descriptions. This aligns
+					 test case in the Cucumber-JVM domain
+					 (Scenarios) with the test case in the JUnit
+					 domain (the leafs in the description tree),
+					 and works better with the report files of
+					 the notification listeners like maven surefire
+					 or gradle.

--- a/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
@@ -20,15 +20,17 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 public class FeatureRunnerTest {
 
     @Test
-    public void should_call_formatter_for_two_scenarios_with_background() throws Throwable {
+    public void should_not_issue_notification_for_steps_by_default_two_scenarios_with_background() throws Throwable {
         CucumberFeature feature = TestPickleBuilder.parseFeature("path/test.feature", "" +
                 "Feature: feature name\n" +
                 "  Background: background\n" +
@@ -43,19 +45,16 @@ public class FeatureRunnerTest {
 
         InOrder order = inOrder(notifier);
 
-        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario_1 name")));
-        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario_1 name)")));
-        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("second step(scenario_1 name)")));
-        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("third step(scenario_1 name)")));
-        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario_1 name")));
-        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario_2 name")));
-        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario_2 name)")));
-        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("another second step(scenario_2 name)")));
-        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario_2 name")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario_1 name(feature name)")));
+        order.verify(notifier, times(3)).fireTestAssumptionFailed(argThat(new FailureMatcher("scenario_1 name(feature name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario_1 name(feature name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario_2 name(feature name)")));
+        order.verify(notifier, times(2)).fireTestAssumptionFailed(argThat(new FailureMatcher("scenario_2 name(feature name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario_2 name(feature name)")));
     }
 
     @Test
-    public void should_call_formatter_for_scenario_outline_with_two_examples_table_and_background() throws Throwable {
+    public void should_not_issue_notification_for_steps_by_default_scenario_outline_with_two_examples_table_and_background() throws Throwable {
         CucumberFeature feature = TestPickleBuilder.parseFeature("path/test.feature", "" +
                 "Feature: feature name\n" +
                 "  Background: background\n" +
@@ -75,25 +74,112 @@ public class FeatureRunnerTest {
 
         InOrder order = inOrder(notifier);
 
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario outline name(feature name)")));
+        order.verify(notifier, times(3)).fireTestAssumptionFailed(argThat(new FailureMatcher("scenario outline name(feature name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario outline name(feature name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario outline name(feature name)")));
+        order.verify(notifier, times(3)).fireTestAssumptionFailed(argThat(new FailureMatcher("scenario outline name(feature name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario outline name(feature name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario outline name(feature name)")));
+        order.verify(notifier, times(3)).fireTestAssumptionFailed(argThat(new FailureMatcher("scenario outline name(feature name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario outline name(feature name)")));
+    }
+
+    @Test
+    public void step_notification_can_be_turned_on_two_scenarios_with_background() throws Throwable {
+        CucumberFeature feature = TestPickleBuilder.parseFeature("path/test.feature", "" +
+                "Feature: feature name\n" +
+                "  Background: background\n" +
+                "    Given first step\n" +
+                "  Scenario: scenario_1 name\n" +
+                "    When second step\n" +
+                "    Then third step\n" +
+                "  Scenario: scenario_2 name\n" +
+                "    Then another second step\n");
+
+        RunNotifier notifier = runFeatureWithNotifier(feature, "--step-notifications");
+
+        InOrder order = inOrder(notifier);
+
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario_1 name")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("first step(scenario_1 name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario_1 name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("first step(scenario_1 name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("second step(scenario_1 name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("second step(scenario_1 name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("second step(scenario_1 name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("third step(scenario_1 name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("third step(scenario_1 name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("third step(scenario_1 name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario_1 name")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario_2 name")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("first step(scenario_2 name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario_2 name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("first step(scenario_2 name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("another second step(scenario_2 name)")));
+        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("another second step(scenario_2 name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("another second step(scenario_2 name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario_2 name")));
+    }
+
+    @Test
+    public void step_notification_can_be_turned_on_scenario_outline_with_two_examples_table_and_background() throws Throwable {
+        CucumberFeature feature = TestPickleBuilder.parseFeature("path/test.feature", "" +
+                "Feature: feature name\n" +
+                "  Background: background\n" +
+                "    Given first step\n" +
+                "  Scenario Outline: scenario outline name\n" +
+                "    When <x> step\n" +
+                "    Then <y> step\n" +
+                "    Examples: examples 1 name\n" +
+                "      |   x    |   y   |\n" +
+                "      | second | third |\n" +
+                "      | second | third |\n" +
+                "    Examples: examples 2 name\n" +
+                "      |   x    |   y   |\n" +
+                "      | second | third |\n");
+
+        RunNotifier notifier = runFeatureWithNotifier(feature, "--step-notifications");
+
+        InOrder order = inOrder(notifier);
+
         order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario outline name")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("first step(scenario outline name)")));
         order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario outline name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("first step(scenario outline name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("second step(scenario outline name)")));
         order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("second step(scenario outline name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("second step(scenario outline name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("third step(scenario outline name)")));
         order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("third step(scenario outline name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("third step(scenario outline name)")));
         order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario outline name")));
         order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario outline name")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("first step(scenario outline name)")));
         order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario outline name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("first step(scenario outline name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("second step(scenario outline name)")));
         order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("second step(scenario outline name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("second step(scenario outline name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("third step(scenario outline name)")));
         order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("third step(scenario outline name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("third step(scenario outline name)")));
         order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario outline name")));
         order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("scenario outline name")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("first step(scenario outline name)")));
         order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("first step(scenario outline name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("first step(scenario outline name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("second step(scenario outline name)")));
         order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("second step(scenario outline name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("second step(scenario outline name)")));
+        order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("third step(scenario outline name)")));
         order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("third step(scenario outline name)")));
+        order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("third step(scenario outline name)")));
         order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario outline name")));
     }
 
-    private RunNotifier runFeatureWithNotifier(CucumberFeature cucumberFeature) throws InitializationError {
-        FeatureRunner runner = createFeatureRunner(cucumberFeature);
+    private RunNotifier runFeatureWithNotifier(CucumberFeature cucumberFeature, String... options) throws InitializationError {
+        FeatureRunner runner = createFeatureRunner(cucumberFeature, options);
         RunNotifier notifier = mock(RunNotifier.class);
         runner.run(notifier);
         return notifier;
@@ -116,7 +202,7 @@ public class FeatureRunnerTest {
 
 
     @Test
-    public void shouldPopulateDescriptionsWithStableUniqueIds() throws Exception {
+    public void should_populate_descriptions_with_stable_unique_ids() throws Exception {
         CucumberFeature cucumberFeature = TestPickleBuilder.parseFeature("path/test.feature", "" +
             "Feature: feature name\n" +
             "  Background:\n" +
@@ -146,7 +232,7 @@ public class FeatureRunnerTest {
     }
 
     @Test
-    public void shouldNotCreateStepDescriptions() throws Exception {
+    public void should_not_create_step_descriptions_by_default() throws Exception {
         CucumberFeature cucumberFeature = TestPickleBuilder.parseFeature("path/test.feature", "" +
             "Feature: feature name\n" +
             "  Background:\n" +
@@ -165,7 +251,7 @@ public class FeatureRunnerTest {
 
         );
 
-        FeatureRunner runner = createFeatureRunner(cucumberFeature, "--no-step-notifications");
+        FeatureRunner runner = createFeatureRunner(cucumberFeature);
 
         Description feature = runner.getDescription();
         Description scenarioA = feature.getChildren().get(0);
@@ -178,6 +264,41 @@ public class FeatureRunnerTest {
         assertTrue(scenarioC1.getChildren().isEmpty());
         Description scenarioC2 = feature.getChildren().get(4);
         assertTrue(scenarioC2.getChildren().isEmpty());
+    }
+
+    @Test
+    public void step_descriptions_can_be_turned_on() throws Exception {
+        CucumberFeature cucumberFeature = TestPickleBuilder.parseFeature("path/test.feature", "" +
+            "Feature: feature name\n" +
+            "  Background:\n" +
+            "    Given background step\n" +
+            "  Scenario: A\n" +
+            "    Then scenario name\n" +
+            "  Scenario: B\n" +
+            "    Then scenario name\n" +
+            "  Scenario Outline: C\n" +
+            "    Then scenario <name>\n" +
+            "  Examples:\n" +
+            "    | name |\n" +
+            "    | C    |\n" +
+            "    | D    |\n" +
+            "    | E    |\n"
+
+        );
+
+        FeatureRunner runner = createFeatureRunner(cucumberFeature, "--step-notifications");
+
+        Description feature = runner.getDescription();
+        Description scenarioA = feature.getChildren().get(0);
+        assertEquals(2, scenarioA.getChildren().size());
+        Description scenarioB = feature.getChildren().get(1);
+        assertEquals(2, scenarioB.getChildren().size());
+        Description scenarioC0 = feature.getChildren().get(2);
+        assertEquals(2, scenarioC0.getChildren().size());
+        Description scenarioC1 = feature.getChildren().get(3);
+        assertEquals(2, scenarioC1.getChildren().size());
+        Description scenarioC2 = feature.getChildren().get(4);
+        assertEquals(2, scenarioC2.getChildren().size());
     }
 
     private static void assertDescriptionIsUnique(Description description, Set<Description> descriptions) {


### PR DESCRIPTION
## Summary

Make the default for the JUnit module not to issue step notifications.

## Details

Make the default for the JUnit module not to issue step notifications. Step notifications can be turn on with the `--step-notification` option to the Junit module.

## Motivation and Context

This aligns test case in the Cucumber-JVM domain (Scenarios) with the test cases in the JUnit domain (the leafs in the description tree).

## How Has This Been Tested?

The automated test suite has been updated to verify this behaviour.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).

It depends on ones perspective if this is a bug fix or a breaking change. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
