### PR TITLE
[Core] Use the test case duration in the JUnit Formatter.

### DIFF
--- a/android/src/main/java/cucumber/runtime/android/CucumberExecutor.java
+++ b/android/src/main/java/cucumber/runtime/android/CucumberExecutor.java
@@ -6,7 +6,6 @@ import android.util.Log;
 import cucumber.api.CucumberOptions;
 import cucumber.api.StepDefinitionReporter;
 import cucumber.api.event.TestRunFinished;
-import cucumber.api.formatter.Formatter;
 import cucumber.api.java.ObjectFactory;
 import cucumber.runtime.Backend;
 import cucumber.runtime.ClassFinder;

--- a/core/src/main/java/cucumber/runner/TimeService.java
+++ b/core/src/main/java/cucumber/runner/TimeService.java
@@ -10,20 +10,4 @@ public interface TimeService {
         }
     };
 
-    class Stub implements TimeService {
-        private final long duration;
-        private final ThreadLocal<Long> currentTime = new ThreadLocal<Long>();
-
-        public Stub(long duration) {
-            this.duration = duration;
-        }
-
-        @Override
-        public long time() {
-            Long result = currentTime.get();
-            result = result != null ? result : 0l;
-            currentTime.set(result + duration);
-            return result;
-        }
-    }
 }

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -8,7 +8,6 @@ import cucumber.api.event.EventHandler;
 import cucumber.api.event.TestCaseFinished;
 import cucumber.api.event.TestRunFinished;
 import cucumber.api.event.TestStepFinished;
-import cucumber.api.formatter.Formatter;
 import cucumber.runner.EventBus;
 import cucumber.runner.Runner;
 import cucumber.runner.TimeService;

--- a/core/src/test/java/cucumber/api/TestStepTest.java
+++ b/core/src/test/java/cucumber/api/TestStepTest.java
@@ -89,9 +89,13 @@ public class TestStepTest {
 
     @Test
     public void step_execution_time_is_measured() throws Throwable {
-        Long duration = new Long(1234);
+        Long duration = 1234L;
         TestStep step = new PickleTestStep("uri", mock(PickleStep.class), definitionMatch);
         when(bus.getTime()).thenReturn(0l, 1234l);
+
+        when(bus.getTime())
+            .thenReturn(0L)
+            .thenReturn(1234L);
 
         Result result = step.run(bus, language, scenario, false);
 

--- a/core/src/test/java/cucumber/runner/EventBusTest.java
+++ b/core/src/test/java/cucumber/runner/EventBusTest.java
@@ -20,7 +20,7 @@ public class EventBusTest {
         Result result = mock(Result.class);
         TestStepFinished event = new TestStepFinished(0l, testStep, result);
 
-        EventBus bus = new EventBus(new TimeService.Stub(0));
+        EventBus bus = new EventBus(new TimeServiceStub(0));
         bus.registerHandlerFor(TestStepFinished.class, handler);
         bus.send(event);
 
@@ -33,7 +33,7 @@ public class EventBusTest {
         TestStep testStep = mock(TestStep.class);
         TestStepStarted event = new TestStepStarted(0l, testStep);
 
-        EventBus bus = new EventBus(new TimeService.Stub(0));
+        EventBus bus = new EventBus(new TimeServiceStub(0));
         bus.registerHandlerFor(TestStepFinished.class, handler);
         bus.send(event);
 

--- a/core/src/test/java/cucumber/runner/StepDurationTimeService.java
+++ b/core/src/test/java/cucumber/runner/StepDurationTimeService.java
@@ -1,0 +1,39 @@
+package cucumber.runner;
+
+import cucumber.api.event.EventHandler;
+import cucumber.api.event.EventListener;
+import cucumber.api.event.EventPublisher;
+import cucumber.api.event.TestStepStarted;
+import cucumber.runner.TimeService;
+
+public class StepDurationTimeService implements TimeService, EventListener {
+    private long stepDuration;
+    private final ThreadLocal<Long> currentTime = new ThreadLocal<Long>();
+    private EventHandler<TestStepStarted> stepStartedHandler = new EventHandler<TestStepStarted>() {
+        @Override
+        public void receive(TestStepStarted event) {
+            handleTestStepStarted(event);
+        }
+    };
+
+
+    public StepDurationTimeService(long stepDuration) {
+        this.stepDuration = stepDuration;
+    }
+
+    @Override
+    public void setEventPublisher(EventPublisher publisher) {
+        publisher.registerHandlerFor(TestStepStarted.class, stepStartedHandler);
+    }
+
+    @Override
+    public long time() {
+        Long result = currentTime.get();
+        return result != null ? result : 0l;
+    }
+
+    private void handleTestStepStarted(TestStepStarted event) {
+        long time = time();
+        currentTime.set(time + stepDuration);
+    }
+}

--- a/core/src/test/java/cucumber/runner/TimeServiceStub.java
+++ b/core/src/test/java/cucumber/runner/TimeServiceStub.java
@@ -1,0 +1,18 @@
+package cucumber.runner;
+
+public class TimeServiceStub implements TimeService {
+    private final long duration;
+    private final ThreadLocal<Long> currentTime = new ThreadLocal<Long>();
+
+    public TimeServiceStub(long duration) {
+        this.duration = duration;
+    }
+
+    @Override
+    public long time() {
+        Long result = currentTime.get();
+        result = result != null ? result : 0l;
+        currentTime.set(result + duration);
+        return result;
+    }
+}

--- a/core/src/test/java/cucumber/runner/TimeServiceTest.java
+++ b/core/src/test/java/cucumber/runner/TimeServiceTest.java
@@ -2,7 +2,6 @@ package cucumber.runner;
 
 import static org.junit.Assert.assertNull;
 
-import cucumber.runner.TimeService;
 import org.junit.Test;
 
 public class TimeServiceTest {

--- a/core/src/test/java/cucumber/runtime/TestHelper.java
+++ b/core/src/test/java/cucumber/runtime/TestHelper.java
@@ -5,7 +5,7 @@ import cucumber.api.Result;
 import cucumber.api.Scenario;
 import cucumber.api.event.TestRunFinished;
 import cucumber.api.formatter.Formatter;
-import cucumber.runner.TimeService;
+import cucumber.runner.StepDurationTimeService;
 import cucumber.runtime.formatter.PickleStepMatcher;
 import cucumber.runtime.io.ClasspathResourceLoader;
 import cucumber.runtime.model.CucumberFeature;
@@ -141,7 +141,9 @@ public class TestHelper {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final ClasspathResourceLoader resourceLoader = new ClasspathResourceLoader(classLoader);
         final RuntimeGlue glue = createMockedRuntimeGlueThatMatchesTheSteps(stepsToResult, stepsToLocation, hooks, hookLocations, hookActions);
-        final Runtime runtime = new Runtime(resourceLoader, classLoader, asList(mock(Backend.class)), runtimeOptions, new TimeService.Stub(stepHookDuration), glue);
+        final StepDurationTimeService timeService = new StepDurationTimeService(stepHookDuration);
+        final Runtime runtime = new Runtime(resourceLoader, classLoader, asList(mock(Backend.class)), runtimeOptions, timeService, glue);
+        timeService.setEventPublisher(runtime.getEventBus());
 
         formatter.setEventPublisher(runtime.getEventBus());
         for (CucumberFeature feature : features) {

--- a/core/src/test/java/cucumber/runtime/UndefinedStepsTrackerTest.java
+++ b/core/src/test/java/cucumber/runtime/UndefinedStepsTrackerTest.java
@@ -4,7 +4,7 @@ import cucumber.api.Result;
 import cucumber.api.TestCase;
 import cucumber.api.TestStep;
 import cucumber.runner.EventBus;
-import cucumber.runner.TimeService;
+import cucumber.runner.TimeServiceStub;
 import cucumber.runtime.model.CucumberFeature;
 import gherkin.pickles.PickleLocation;
 import gherkin.pickles.PickleStep;
@@ -47,7 +47,7 @@ public class UndefinedStepsTrackerTest {
 
     @Test
     public void uses_given_when_then_keywords() throws IOException {
-        EventBus bus = new EventBus(new TimeService.Stub(0));
+        EventBus bus = new EventBus(new TimeServiceStub(0));
         UndefinedStepsTracker tracker = new UndefinedStepsTracker();
         tracker.setEventPublisher(bus);
         CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
@@ -63,7 +63,7 @@ public class UndefinedStepsTrackerTest {
 
     @Test
     public void converts_and_to_previous_step_keyword() throws IOException {
-        EventBus bus = new EventBus(new TimeService.Stub(0));
+        EventBus bus = new EventBus(new TimeServiceStub(0));
         UndefinedStepsTracker tracker = new UndefinedStepsTracker();
         tracker.setEventPublisher(bus);
         CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
@@ -80,7 +80,7 @@ public class UndefinedStepsTrackerTest {
 
     @Test
     public void backtrack_into_background_to_find_step_keyword() throws IOException {
-        EventBus bus = new EventBus(new TimeService.Stub(0));
+        EventBus bus = new EventBus(new TimeServiceStub(0));
         UndefinedStepsTracker tracker = new UndefinedStepsTracker();
         tracker.setEventPublisher(bus);
         CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
@@ -98,7 +98,7 @@ public class UndefinedStepsTrackerTest {
 
     @Test
     public void doesnt_try_to_use_star_keyword() throws IOException {
-        EventBus bus = new EventBus(new TimeService.Stub(0));
+        EventBus bus = new EventBus(new TimeServiceStub(0));
         UndefinedStepsTracker tracker = new UndefinedStepsTracker();
         tracker.setEventPublisher(bus);
         CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
@@ -115,7 +115,7 @@ public class UndefinedStepsTrackerTest {
 
     @Test
     public void star_keyword_becomes_given_when_no_previous_step() throws IOException {
-        EventBus bus = new EventBus(new TimeService.Stub(0));
+        EventBus bus = new EventBus(new TimeServiceStub(0));
         UndefinedStepsTracker tracker = new UndefinedStepsTracker();
         tracker.setEventPublisher(bus);
         CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
@@ -130,7 +130,7 @@ public class UndefinedStepsTrackerTest {
 
     @Test
     public void snippets_are_generated_for_correct_locale() throws Exception {
-        EventBus bus = new EventBus(new TimeService.Stub(0));
+        EventBus bus = new EventBus(new TimeServiceStub(0));
         UndefinedStepsTracker tracker = new UndefinedStepsTracker();
         tracker.setEventPublisher(bus);
         CucumberFeature feature = TestHelper.feature("path/test.feature", "" +

--- a/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
@@ -1,7 +1,7 @@
 package cucumber.runtime.formatter;
 
 import cucumber.api.Result;
-import cucumber.runner.TimeService;
+import cucumber.runner.TimeServiceStub;
 import cucumber.runtime.Backend;
 import cucumber.runtime.HookDefinition;
 import cucumber.runtime.Runtime;
@@ -874,7 +874,7 @@ public class JSONFormatterTest {
         RuntimeOptions runtimeOptions = new RuntimeOptions(args);
         Backend backend = mock(Backend.class);
         when(backend.getSnippet(any(PickleStep.class), anyString(), any(FunctionNameGenerator.class))).thenReturn("TEST SNIPPET");
-        final Runtime runtime = new Runtime(resourceLoader, classLoader, asList(backend), runtimeOptions, new TimeService.Stub(1234), null);
+        final Runtime runtime = new Runtime(resourceLoader, classLoader, asList(backend), runtimeOptions, new TimeServiceStub(1234), null);
         runtime.getGlue().addBeforeHook(hook);
         runtime.run();
         Scanner scanner = new Scanner(new FileInputStream(report), "UTF-8");

--- a/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
@@ -516,7 +516,7 @@ public class JSONFormatterTest {
                 "            ],\n" +
                 "            \"result\": {\n" +
                 "              \"status\": \"passed\",\n" +
-                "              \"duration\": 2000000\n" +
+                "              \"duration\": 1000000\n" +
                 "            }\n" +
                 "          }\n" +
                 "        ],\n" +
@@ -592,7 +592,7 @@ public class JSONFormatterTest {
                 "            ],\n" +
                 "            \"result\": {\n" +
                 "              \"status\": \"passed\",\n" +
-                "              \"duration\": 2000000\n" +
+                "              \"duration\": 1000000\n" +
                 "            }\n" +
                 "          }\n" +
                 "        ],\n" +

--- a/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
@@ -1,7 +1,7 @@
 package cucumber.runtime.formatter;
 
 import cucumber.api.Result;
-import cucumber.runner.TimeService;
+import cucumber.runner.TimeServiceStub;
 import cucumber.runtime.Backend;
 import cucumber.runtime.Runtime;
 import cucumber.runtime.RuntimeOptions;
@@ -536,7 +536,7 @@ public class JUnitFormatterTest {
         RuntimeOptions runtimeOptions = new RuntimeOptions(args);
         Backend backend = mock(Backend.class);
         when(backend.getSnippet(any(PickleStep.class), anyString(), any(FunctionNameGenerator.class))).thenReturn("TEST SNIPPET");
-        final cucumber.runtime.Runtime runtime = new Runtime(resourceLoader, classLoader, asList(backend), runtimeOptions, new TimeService.Stub(0L), null);
+        final cucumber.runtime.Runtime runtime = new Runtime(resourceLoader, classLoader, asList(backend), runtimeOptions, new TimeServiceStub(0L), null);
         runtime.run();
         return report;
     }

--- a/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
@@ -1,6 +1,7 @@
 package cucumber.runtime.formatter;
 
 import cucumber.api.Result;
+import cucumber.runner.TimeService;
 import cucumber.runtime.Backend;
 import cucumber.runtime.Runtime;
 import cucumber.runtime.RuntimeOptions;
@@ -116,8 +117,8 @@ public class JUnitFormatterTest {
 
         String stackTrace = getStackTrace(exception);
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-                "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.001\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.001\">\n" +
+                "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.003\">\n" +
+                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.003\">\n" +
                 "        <skipped message=\"" + stackTrace.replace("\n\t", "&#10;&#9;") + "\"><![CDATA[" +
                 "Given first step............................................................skipped\n" +
                 "When second step............................................................skipped\n" +
@@ -148,8 +149,8 @@ public class JUnitFormatterTest {
         String formatterOutput = runFeatureWithJUnitFormatter(feature, stepsToResult, stepDuration);
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-                "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.001\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.001\">\n" +
+                "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.003\">\n" +
+                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.003\">\n" +
                 "        <skipped><![CDATA[" +
                 "Given first step............................................................pending\n" +
                 "When second step............................................................skipped\n" +
@@ -211,8 +212,8 @@ public class JUnitFormatterTest {
         String formatterOutput = runFeatureWithJUnitFormatter(feature, stepsToResult, hooks, stepHookDuration);
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-                "<testsuite failures=\"1\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.001\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.001\">\n" +
+                "<testsuite failures=\"1\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.004\">\n" +
+                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.004\">\n" +
                 "        <failure message=\"the stack trace\"><![CDATA[" +
                 "Given first step............................................................skipped\n" +
                 "When second step............................................................skipped\n" +
@@ -245,8 +246,8 @@ public class JUnitFormatterTest {
         String formatterOutput = runFeatureWithJUnitFormatter(feature, stepsToResult, hooks, stepHookDuration);
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-                "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.001\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.001\">\n" +
+                "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.004\">\n" +
+                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.004\">\n" +
                 "        <skipped><![CDATA[" +
                 "Given first step............................................................skipped\n" +
                 "When second step............................................................skipped\n" +
@@ -277,8 +278,8 @@ public class JUnitFormatterTest {
         String formatterOutput = runFeatureWithJUnitFormatter(feature, stepsToResult, hooks, stepHookDuration);
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-                "<testsuite failures=\"1\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.001\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.001\">\n" +
+                "<testsuite failures=\"1\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.004\">\n" +
+                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.004\">\n" +
                 "        <failure message=\"the stack trace\"><![CDATA[" +
                 "Given first step............................................................skipped\n" +
                 "When second step............................................................skipped\n" +
@@ -535,7 +536,7 @@ public class JUnitFormatterTest {
         RuntimeOptions runtimeOptions = new RuntimeOptions(args);
         Backend backend = mock(Backend.class);
         when(backend.getSnippet(any(PickleStep.class), anyString(), any(FunctionNameGenerator.class))).thenReturn("TEST SNIPPET");
-        final cucumber.runtime.Runtime runtime = new Runtime(resourceLoader, classLoader, asList(backend), runtimeOptions);
+        final cucumber.runtime.Runtime runtime = new Runtime(resourceLoader, classLoader, asList(backend), runtimeOptions, new TimeService.Stub(0L), null);
         runtime.run();
         return report;
     }

--- a/core/src/test/java/cucumber/runtime/formatter/PluginFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/PluginFactoryTest.java
@@ -4,7 +4,7 @@ import cucumber.api.Result;
 import cucumber.api.TestStep;
 import cucumber.api.event.TestStepFinished;
 import cucumber.runner.EventBus;
-import cucumber.runner.TimeService;
+import cucumber.runner.TimeServiceStub;
 import cucumber.runtime.CucumberException;
 import cucumber.runtime.Utils;
 import cucumber.runtime.io.UTF8OutputStreamWriter;
@@ -94,7 +94,7 @@ public class PluginFactoryTest {
             fc = new PluginFactory();
 
             ProgressFormatter plugin = (ProgressFormatter) fc.create("progress");
-            EventBus bus = new EventBus(new TimeService.Stub(0));
+            EventBus bus = new EventBus(new TimeServiceStub(0));
             plugin.setEventPublisher(bus);
             Result result = new Result(Result.Type.PASSED, null, null);
             TestStepFinished event = new TestStepFinished(bus.getTime(), mock(TestStep.class), result);

--- a/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
@@ -196,7 +196,13 @@ public class FeatureRunnerTest {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final ClasspathResourceLoader resourceLoader = new ClasspathResourceLoader(classLoader);
         final RuntimeGlue glue = mock(RuntimeGlue.class);
-        final Runtime runtime = new Runtime(resourceLoader, classLoader, asList(mock(Backend.class)), runtimeOptions, new TimeService.Stub(0l), glue);
+        final TimeService timeServiceStub = new TimeService() {
+            @Override
+            public long time() {
+                return 0l;
+            }
+        };
+        final Runtime runtime = new Runtime(resourceLoader, classLoader, asList(mock(Backend.class)), runtimeOptions, timeServiceStub, glue);
         return new FeatureRunner(cucumberFeature, runtime, new JUnitReporter(runtime.getEventBus(), false, junitOption));
     }
 


### PR DESCRIPTION
## Summary

Let the JUnit Formatter use the duration of the test case result.

## Details

Let the JUnit Formatter use the duration of the test case result instead of summing up the durations of the test step results.

Also refactor the TimeService to have the methods startTime(), currentTime(), and finishTime(). These methods actually do the same thing but having them all enables/simplifies the mocking of time in tests. For example when executing a test case with two test steps the following calls to the TimeService will be issued:
```
 startTime()  - for the time stamp of the TestCaseStarted Event
 startTime()  - for the time stamp of the first TestStepStarted Event
 finishTime() - for the time stamp of the first TestStepFinished Event
 startTime()  - for the time stamp of the second TestStepStarted Event
 finishTime() - for the time stamp of the second TestStepFinished Event
 finishTime() - for the time stamp of the TestCaseFinished Event
```
By communicating the use of the time stamp in the called method, it is possible for the TimeService Stub to behave so that the difference between the time stamps of the TestCaseFinished Event and TestCaseStarted Event equals the "test step duration" * "number of test steps in the test case".
## Motivation and Context

The JUnit Formatter only uses the duration of each test case, and since the test case duration is available in the result object of the TestCaseFinished event, it is unnecessary to calculated the duration in the JUnit Formatter from the durations of the test steps.

## How Has This Been Tested?

The automated test suite has been updated to verify this behaviour. 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Internal refactoring.

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
