### PR TITLE
[Core] Add TestRunStarted event, let Stats handle the exit code

### DIFF
--- a/core/src/main/java/cucumber/api/event/TestRunStarted.java
+++ b/core/src/main/java/cucumber/api/event/TestRunStarted.java
@@ -1,0 +1,8 @@
+package cucumber.api.event;
+
+public final class TestRunStarted extends TimeStampedEvent {
+
+    public TestRunStarted(Long timeStamp) {
+        super(timeStamp);
+    }
+}

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -1,11 +1,7 @@
 package cucumber.runtime;
 
-import cucumber.api.Pending;
-import cucumber.api.Result;
 import cucumber.api.StepDefinitionReporter;
 import cucumber.api.SummaryPrinter;
-import cucumber.api.event.EventHandler;
-import cucumber.api.event.TestCaseFinished;
 import cucumber.api.event.TestRunFinished;
 import cucumber.api.event.TestStepFinished;
 import cucumber.runner.EventBus;
@@ -21,7 +17,6 @@ import gherkin.pickles.Pickle;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -32,50 +27,17 @@ import java.util.regex.Pattern;
  */
 public class Runtime {
 
-    private static final String[] ASSUMPTION_VIOLATED_EXCEPTIONS = {
-            "org.junit.AssumptionViolatedException",
-            "org.junit.internal.AssumptionViolatedException"
-    };
-
-    static {
-        Arrays.sort(ASSUMPTION_VIOLATED_EXCEPTIONS);
-    }
-
-    private static final byte ERRORS = 0x1;
-
-    private final Stats stats;
-    UndefinedStepsTracker undefinedStepsTracker = new UndefinedStepsTracker(); // package private to be avaiable for tests.
+    final Stats stats; // package private to be avaiable for tests.
+    private final UndefinedStepsTracker undefinedStepsTracker = new UndefinedStepsTracker();
 
     private final RuntimeOptions runtimeOptions;
 
-    private final List<Throwable> errors = new ArrayList<Throwable>();
     private final ResourceLoader resourceLoader;
     private final ClassLoader classLoader;
     private final Runner runner;
     private final List<PicklePredicate> filters;
     private final EventBus bus;
     private final Compiler compiler = new Compiler();
-    private final EventHandler<TestStepFinished> stepFinishedHandler = new EventHandler<TestStepFinished>() {
-        @Override
-        public void receive(TestStepFinished event) {
-            Result result = event.result;
-            if (result.getError() != null) {
-                addError(result.getError());
-            }
-            if (event.testStep.isHook()) {
-                addHookToCounterAndResult(result);
-            } else {
-                addStepToCounterAndResult(result);
-            }
-        }
-    };
-    private final EventHandler<TestCaseFinished> testCaseFinishedHandler = new EventHandler<TestCaseFinished>() {
-        @Override
-        public void receive(TestCaseFinished event) {
-            stats.addScenario(event.result.getStatus(), event.testCase.getScenarioDesignation());
-        }
-    };
-
     public Runtime(ResourceLoader resourceLoader, ClassFinder classFinder, ClassLoader classLoader, RuntimeOptions runtimeOptions) {
         this(resourceLoader, classLoader, loadBackends(resourceLoader, classFinder), runtimeOptions);
     }
@@ -115,8 +77,7 @@ public class Runtime {
             this.filters.add(new LinePredicate(lineFilters));
         }
 
-        bus.registerHandlerFor(TestStepFinished.class, stepFinishedHandler);
-        bus.registerHandlerFor(TestCaseFinished.class, testCaseFinishedHandler);
+        stats.setEventPublisher(bus);
         undefinedStepsTracker.setEventPublisher(bus);
         runtimeOptions.setEventBus(bus);
     }
@@ -124,10 +85,6 @@ public class Runtime {
     private static Collection<? extends Backend> loadBackends(ResourceLoader resourceLoader, ClassFinder classFinder) {
         Reflections reflections = new Reflections(classFinder);
         return reflections.instantiateSubclasses(Backend.class, "cucumber.runtime", new Class[]{ResourceLoader.class}, new Object[]{resourceLoader});
-    }
-
-    public void addError(Throwable error) {
-        errors.add(error);
     }
 
     /**
@@ -191,40 +148,11 @@ public class Runtime {
     }
 
     public List<Throwable> getErrors() {
-        return errors;
+        return stats.getErrors();
     }
 
     public byte exitStatus() {
-        byte result = 0x0;
-        if (hasErrors() || hasUndefinedOrPendingStepsAndIsStrict()) {
-            result |= ERRORS;
-        }
-        return result;
-    }
-
-    private boolean hasUndefinedOrPendingStepsAndIsStrict() {
-        return runtimeOptions.isStrict() && hasUndefinedOrPendingSteps();
-    }
-
-    private boolean hasUndefinedOrPendingSteps() {
-        return hasUndefinedSteps() || hasPendingSteps();
-    }
-
-    private boolean hasUndefinedSteps() {
-        return undefinedStepsTracker.hasUndefinedSteps();
-    }
-
-    private boolean hasPendingSteps() {
-        return !errors.isEmpty() && !hasErrors();
-    }
-
-    private boolean hasErrors() {
-        for (Throwable error : errors) {
-            if (!isPending(error) && !isAssumptionViolated(error)) {
-                return true;
-            }
-        }
-        return false;
+        return stats.exitStatus(runtimeOptions.isStrict());
     }
 
     public List<String> getSnippets() {
@@ -233,28 +161,6 @@ public class Runtime {
 
     public Glue getGlue() {
         return runner.getGlue();
-    }
-
-    public static boolean isPending(Throwable t) {
-        if (t == null) {
-            return false;
-        }
-        return t.getClass().isAnnotationPresent(Pending.class);
-    }
-
-    public static boolean isAssumptionViolated(Throwable t) {
-        if (t == null) {
-            return false;
-        }
-        return Arrays.binarySearch(ASSUMPTION_VIOLATED_EXCEPTIONS, t.getClass().getName()) >= 0;
-    }
-
-    private void addStepToCounterAndResult(Result result) {
-        stats.addStep(result);
-    }
-
-    private void addHookToCounterAndResult(Result result) {
-        stats.addHookTime(result.getDuration());
     }
 
     public EventBus getEventBus() {

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -3,6 +3,7 @@ package cucumber.runtime;
 import cucumber.api.SnippetType;
 import cucumber.api.StepDefinitionReporter;
 import cucumber.api.SummaryPrinter;
+import cucumber.api.event.TestRunStarted;
 import cucumber.api.formatter.ColorAware;
 import cucumber.api.formatter.Formatter;
 import cucumber.api.formatter.StrictAware;
@@ -308,6 +309,7 @@ public class RuntimeOptions {
     public List<CucumberFeature> cucumberFeatures(ResourceLoader resourceLoader, EventBus bus) {
         List<CucumberFeature> features = load(resourceLoader, featurePaths, System.out);
         getPlugins(); // to create the formatter objects
+        bus.send(new TestRunStarted(bus.getTime()));
         for (CucumberFeature feature : features) {
             feature.sendTestSourceRead(bus);
         }

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -5,7 +5,6 @@ import cucumber.api.Result;
 import cucumber.api.Scenario;
 import cucumber.api.StepDefinitionReporter;
 import cucumber.api.TestCase;
-import cucumber.api.TestStep;
 import cucumber.api.event.TestCaseFinished;
 import cucumber.runtime.formatter.FormatterSpy;
 import cucumber.runtime.io.ClasspathResourceLoader;
@@ -13,14 +12,12 @@ import cucumber.runtime.io.Resource;
 import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.model.CucumberFeature;
 import gherkin.events.PickleEvent;
-import gherkin.pickles.Argument;
 import gherkin.pickles.Pickle;
 import gherkin.pickles.PickleLocation;
 import gherkin.pickles.PickleStep;
 import gherkin.pickles.PickleTag;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.AssumptionViolatedException;
 import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayOutputStream;
@@ -129,76 +126,79 @@ public class RuntimeTest {
     }
 
     @Test
-    public void strict_without_pending_steps_or_errors() {
+    public void strict_with_passed_scenarios() {
         Runtime runtime = createStrictRuntime();
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.PASSED));
 
         assertEquals(0x0, runtime.exitStatus());
     }
 
     @Test
-    public void non_strict_without_pending_steps_or_errors() {
+    public void non_strict_with_passed_scenarios() {
         Runtime runtime = createNonStrictRuntime();
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.PASSED));
 
         assertEquals(0x0, runtime.exitStatus());
     }
 
     @Test
-    public void non_strict_with_undefined_steps() {
+    public void non_strict_with_undefined_scenarios() {
         Runtime runtime = createNonStrictRuntime();
         runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.UNDEFINED));
         assertEquals(0x0, runtime.exitStatus());
     }
 
-    public void strict_with_undefined_steps() {
+    @Test
+    public void strict_with_undefined_scenarios() {
         Runtime runtime = createStrictRuntime();
         runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.UNDEFINED));
         assertEquals(0x1, runtime.exitStatus());
     }
 
     @Test
-    public void strict_with_pending_steps_and_no_errors() {
+    public void strict_with_pending_scenarios() {
         Runtime runtime = createStrictRuntime();
-        runtime.addError(new PendingException());
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.PENDING));
 
         assertEquals(0x1, runtime.exitStatus());
     }
 
     @Test
-    public void non_strict_with_pending_steps() {
+    public void non_strict_with_pending_scenarios() {
         Runtime runtime = createNonStrictRuntime();
-        runtime.addError(new PendingException());
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.PENDING));
 
         assertEquals(0x0, runtime.exitStatus());
     }
 
     @Test
-    public void non_strict_with_failed_junit_assumption_prior_to_junit_412() {
+    public void non_strict_with_skipped_scenarios() {
         Runtime runtime = createNonStrictRuntime();
-        runtime.addError(new org.junit.internal.AssumptionViolatedException("should be treated like skipped"));
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.SKIPPED));
 
         assertEquals(0x0, runtime.exitStatus());
     }
 
     @Test
-    public void non_strict_with_failed_junit_assumption_from_junit_412_on() {
+    public void strict_with_skipped_scenarios() {
         Runtime runtime = createNonStrictRuntime();
-        runtime.addError(new AssumptionViolatedException("should be treated like skipped"));
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.SKIPPED));
 
         assertEquals(0x0, runtime.exitStatus());
     }
 
     @Test
-    public void non_strict_with_errors() {
+    public void non_strict_with_failed_scenarios() {
         Runtime runtime = createNonStrictRuntime();
-        runtime.addError(new RuntimeException());
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.FAILED));
 
         assertEquals(0x1, runtime.exitStatus());
     }
 
     @Test
-    public void strict_with_errors() {
+    public void strict_with_failed_scenarios() {
         Runtime runtime = createStrictRuntime();
-        runtime.addError(new RuntimeException());
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.FAILED));
 
         assertEquals(0x1, runtime.exitStatus());
     }


### PR DESCRIPTION
## Summary

Add TestRunStarted event, move the exit code handling to the Stats class.

## Details

Add the TestRunStarted event and present the duration between the TestRunStarted and TestRunFinished events in the summary print out.

Move the handling of exit code and errors to the summary print out to the Stats class.

## Motivation and Context

The duration of a test step is the duration between the TestStepStarted and TestStepFinished events. The duration of a test case is the duration between the TestCaseStarted and TestCaseFinished events. 
Therefore it is natural that the duration of the test run (presented in the summary print out) is the duration between the TestRunStarted and TestRunFinished events

## How Has This Been Tested?

The automated test suite has been updated to verify this behaviour.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Internal refactoring

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
