### PR TITLE
[Core] Add the SnippetsSuggestedEvent.

### DIFF
--- a/core/src/main/java/cucumber/api/Result.java
+++ b/core/src/main/java/cucumber/api/Result.java
@@ -2,8 +2,6 @@ package cucumber.api;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Collections;
-import java.util.List;
 
 public class Result {
     private static final long serialVersionUID = 1L;
@@ -11,7 +9,6 @@ public class Result {
     private final Result.Type status;
     private final Long duration;
     private final Throwable error;
-    private final List<String> snippets;
     public static final Result SKIPPED = new Result(Result.Type.SKIPPED, null, null);
     public static enum Type {
         PASSED,
@@ -43,22 +40,9 @@ public class Result {
      * @param error
      */
     public Result(Result.Type status, Long duration, Throwable error) {
-        this(status, duration, error, Collections.<String>emptyList());
-    }
-
-    /**
-     * Used at runtime
-     *
-     * @param status
-     * @param duration
-     * @param error
-     * @param snippets
-     */
-    public Result(Result.Type status, Long duration, Throwable error, List<String> snippets) {
         this.status = status;
         this.duration = duration;
         this.error = error;
-        this.snippets = snippets;
     }
 
     public Result.Type getStatus() {
@@ -75,10 +59,6 @@ public class Result {
 
     public Throwable getError() {
         return error;
-    }
-
-    public List<String> getSnippets() {
-        return snippets;
     }
 
     public boolean is(Result.Type status) {

--- a/core/src/main/java/cucumber/api/TestStep.java
+++ b/core/src/main/java/cucumber/api/TestStep.java
@@ -101,7 +101,7 @@ public abstract class TestStep {
             return Result.SKIPPED;
         }
         if (status == Result.Type.UNDEFINED) {
-            return new Result(status, null, null, definitionMatch.getSnippets());
+            return new Result(status, null, null);
         }
         return new Result(status, resultDuration, error);
     }

--- a/core/src/main/java/cucumber/api/event/SnippetsSuggestedEvent.java
+++ b/core/src/main/java/cucumber/api/event/SnippetsSuggestedEvent.java
@@ -1,0 +1,20 @@
+package cucumber.api.event;
+
+import gherkin.pickles.PickleLocation;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SnippetsSuggestedEvent extends TimeStampedEvent {
+    public final String uri;
+    public final List<PickleLocation> stepLocations;
+    public final List<String> snippets;
+
+    public SnippetsSuggestedEvent(Long timeStamp, String uri, List<PickleLocation> stepLocations, List<String> snippets) {
+        super(timeStamp);
+        this.uri = uri;
+        this.stepLocations = stepLocations;
+        this.snippets = Collections.unmodifiableList(snippets);
+    }
+
+}

--- a/core/src/main/java/cucumber/runner/Runner.java
+++ b/core/src/main/java/cucumber/runner/Runner.java
@@ -4,6 +4,7 @@ import cucumber.api.HookType;
 import cucumber.api.StepDefinitionReporter;
 import cucumber.api.TestCase;
 import cucumber.api.TestStep;
+import cucumber.api.event.SnippetsSuggestedEvent;
 import cucumber.runtime.AmbiguousStepDefinitionsMatch;
 import cucumber.runtime.AmbiguousStepDefinitionsException;
 import cucumber.runtime.Backend;
@@ -114,7 +115,10 @@ public class Runner implements UnreportedStepExecutor {
                             snippets.add(snippet);
                         }
                     }
-                    match = new UndefinedStepDefinitionMatch(step, snippets);
+                    if (!snippets.isEmpty()) {
+                        bus.send(new SnippetsSuggestedEvent(bus.getTime(), pickleEvent.uri, step.getLocations(), snippets));
+                    }
+                    match = new UndefinedStepDefinitionMatch(step);
                 }
             } catch (AmbiguousStepDefinitionsException e) {
                 match = new AmbiguousStepDefinitionsMatch(step, e);

--- a/core/src/main/java/cucumber/runtime/DefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/DefinitionMatch.java
@@ -16,6 +16,4 @@ public interface DefinitionMatch {
     String getCodeLocation();
 
     List<Argument> getArguments();
-
-    List<String> getSnippets();
 }

--- a/core/src/main/java/cucumber/runtime/HookDefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/HookDefinitionMatch.java
@@ -41,9 +41,4 @@ public class HookDefinitionMatch implements DefinitionMatch {
     public List<Argument> getArguments() {
         return Collections.<Argument>emptyList();
     }
-
-    @Override
-    public List<String> getSnippets() {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
@@ -188,11 +188,6 @@ public class StepDefinitionMatch extends Match implements DefinitionMatch {
         return stepDefinition.getLocation(false);
     }
 
-    @Override
-    public List<String> getSnippets() {
-        throw new UnsupportedOperationException();
-    }
-
     public static int getStepLine(PickleStep step) {
         return step.getLocations().get(step.getLocations().size() - 1).getLine();
     }

--- a/core/src/main/java/cucumber/runtime/UndefinedStepDefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/UndefinedStepDefinitionMatch.java
@@ -4,14 +4,11 @@ import cucumber.api.Scenario;
 import gherkin.pickles.PickleStep;
 
 import java.util.Collections;
-import java.util.List;
 
 public class UndefinedStepDefinitionMatch extends StepDefinitionMatch {
-    private final List<String> snippets;
 
-    public UndefinedStepDefinitionMatch(PickleStep step, List<String> snippets) {
+    public UndefinedStepDefinitionMatch(PickleStep step) {
         super(Collections.<Argument>emptyList(), new NoStepDefinition(), null, step, null);
-        this.snippets = snippets;
     }
 
     @Override
@@ -27,10 +24,5 @@ public class UndefinedStepDefinitionMatch extends StepDefinitionMatch {
     @Override
     public Match getMatch() {
         return Match.UNDEFINED;
-    }
-
-    @Override
-    public List<String> getSnippets() {
-        return snippets;
     }
 }

--- a/core/src/main/java/cucumber/runtime/UndefinedStepsTracker.java
+++ b/core/src/main/java/cucumber/runtime/UndefinedStepsTracker.java
@@ -6,9 +6,8 @@ import cucumber.api.TestStep;
 import cucumber.api.event.EventHandler;
 import cucumber.api.event.EventListener;
 import cucumber.api.event.EventPublisher;
-import cucumber.api.event.TestCaseStarted;
+import cucumber.api.event.SnippetsSuggestedEvent;
 import cucumber.api.event.TestSourceRead;
-import cucumber.api.event.TestStepFinished;
 import gherkin.AstBuilder;
 import gherkin.GherkinDialect;
 import gherkin.GherkinDialectProvider;
@@ -21,7 +20,6 @@ import gherkin.ast.GherkinDocument;
 import gherkin.ast.ScenarioDefinition;
 import gherkin.ast.Step;
 import gherkin.pickles.PickleLocation;
-import gherkin.pickles.PickleStep;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,24 +40,17 @@ public class UndefinedStepsTracker implements EventListener {
             pathToSourceMap.put(event.path, event.source);
         }
     };
-    private EventHandler<TestCaseStarted> testCaseStartedHandler = new EventHandler<TestCaseStarted>() {
+    private EventHandler<SnippetsSuggestedEvent> snippetsSuggestedHandler = new EventHandler<SnippetsSuggestedEvent>() {
         @Override
-        public void receive(TestCaseStarted event) {
-            handleTestCaseStarted(event.testCase);
-        }
-    };
-    private EventHandler<TestStepFinished> testStepFinishedHandler = new EventHandler<TestStepFinished>() {
-        @Override
-        public void receive(TestStepFinished event) {
-            handleTestStepFinished(event.testStep, event.result);
+        public void receive(SnippetsSuggestedEvent event) {
+            handleSnippetsSuggested(event.uri, event.stepLocations, event.snippets);
         }
     };
 
     @Override
     public void setEventPublisher(EventPublisher publisher) {
         publisher.registerHandlerFor(TestSourceRead.class, testSourceReadHandler);
-        publisher.registerHandlerFor(TestCaseStarted.class, testCaseStartedHandler);
-        publisher.registerHandlerFor(TestStepFinished.class, testStepFinishedHandler);
+        publisher.registerHandlerFor(SnippetsSuggestedEvent.class, snippetsSuggestedHandler);
     }
 
     public boolean hasUndefinedSteps() {
@@ -70,29 +61,22 @@ public class UndefinedStepsTracker implements EventListener {
         return snippets;
     }
 
-    void handleTestCaseStarted(TestCase testCase) {
-        currentUri = testCase.getPath();
-    }
-
-    void handleTestStepFinished(TestStep step, Result result) {
-        if (result.is(Result.Type.UNDEFINED)) {
-            hasUndefinedSteps = true;
-            String keyword = givenWhenThenKeyword(step.getPickleStep());
-            for (String rawSnippet : result.getSnippets()) {
-                String snippet = rawSnippet.replace("**KEYWORD**", keyword);
-                if (!snippets.contains(snippet)) {
-                    snippets.add(snippet);
-                }
+    void handleSnippetsSuggested(String uri, List<PickleLocation> stepLocations, List<String> snippets) {
+        hasUndefinedSteps = true;
+        String keyword = givenWhenThenKeyword(uri, stepLocations);
+        for (String rawSnippet : snippets) {
+            String snippet = rawSnippet.replace("**KEYWORD**", keyword);
+            if (!this.snippets.contains(snippet)) {
+                this.snippets.add(snippet);
             }
         }
     }
 
-    private String givenWhenThenKeyword(PickleStep step) {
+    private String givenWhenThenKeyword(String uri, List<PickleLocation> stepLocations) {
         String keyword = null;
-        if (!step.getLocations().isEmpty()) {
-            List<PickleLocation> stepLocations = step.getLocations();
-            if (pathToSourceMap.containsKey(currentUri)) {
-                keyword = getKeywordFromSource(currentUri, stepLocations);
+        if (!stepLocations.isEmpty()) {
+            if (pathToSourceMap.containsKey(uri)) {
+                keyword = getKeywordFromSource(uri, stepLocations);
             }
         }
         return keyword != null ? keyword : getFirstGivenKeyword(dialectProvider.getDefaultDialect());

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -4,7 +4,9 @@ import cucumber.api.PendingException;
 import cucumber.api.Result;
 import cucumber.api.Scenario;
 import cucumber.api.StepDefinitionReporter;
+import cucumber.api.TestCase;
 import cucumber.api.TestStep;
+import cucumber.api.event.TestCaseFinished;
 import cucumber.runtime.formatter.FormatterSpy;
 import cucumber.runtime.io.ClasspathResourceLoader;
 import cucumber.runtime.io.Resource;
@@ -53,6 +55,7 @@ import static org.mockito.Mockito.when;
 
 public class RuntimeTest {
     private final static String ENGLISH = "en";
+    private final static long ANY_TIMESTAMP = 1234567890;
 
     @Ignore
     @Test
@@ -142,13 +145,13 @@ public class RuntimeTest {
     @Test
     public void non_strict_with_undefined_steps() {
         Runtime runtime = createNonStrictRuntime();
-        runtime.undefinedStepsTracker.handleTestStepFinished(testStep(), mockResultWithSnippets());
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.UNDEFINED));
         assertEquals(0x0, runtime.exitStatus());
     }
 
     public void strict_with_undefined_steps() {
         Runtime runtime = createStrictRuntime();
-        runtime.undefinedStepsTracker.handleTestStepFinished(testStep(), mockResultWithSnippets());
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.UNDEFINED));
         assertEquals(0x1, runtime.exitStatus());
     }
 
@@ -579,17 +582,7 @@ public class RuntimeTest {
         return stepCount;
     }
 
-    private TestStep testStep() {
-        TestStep testStep = mock(TestStep.class);
-        PickleStep pickleStep = new PickleStep("step text", Collections.<Argument>emptyList(), Collections.<PickleLocation>emptyList());
-        when(testStep.getPickleStep()).thenReturn(pickleStep);
-        return testStep;
-    }
-
-    private Result mockResultWithSnippets() {
-        Result result = mock(Result.class);
-        when(result.getStatus()).thenReturn(Result.Type.UNDEFINED);
-        when(result.getSnippets()).thenReturn(asList(""));
-        return result;
+    private TestCaseFinished testCaseFinishedWithStatus(Result.Type resultStatus) {
+        return new TestCaseFinished(ANY_TIMESTAMP, mock(TestCase.class), new Result(resultStatus, null, null));
     }
 }

--- a/core/src/test/java/cucumber/runtime/UndefinedStepDefinitionMatchTest.java
+++ b/core/src/test/java/cucumber/runtime/UndefinedStepDefinitionMatchTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.mock;
 
 public class UndefinedStepDefinitionMatchTest {
     public final static String ENGLISH = "en";
-    public final UndefinedStepDefinitionMatch match = new UndefinedStepDefinitionMatch(mock(PickleStep.class), null);
+    public final UndefinedStepDefinitionMatch match = new UndefinedStepDefinitionMatch(mock(PickleStep.class));
 
     @Test(expected=UndefinedStepDefinitionException.class)
     public void throws_ambiguous_step_definitions_exception_when_run() throws Throwable {


### PR DESCRIPTION
## Summary

Add the SnippetsSuggestedEvent and remove the snippets from the undefined results.

## Details

Generate the snippets directly when not match is found for a step and communication them in a separate event, instead of pass them on the result object with the TestStepFinished event.

## Motivation and Context

Better separation of concerns.

## How Has This Been Tested?

The automated test suite is updated to verify this behaviour.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
