### PR TITLE
Use Weld SE 2.4.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <webbit.version>0.4.15</webbit.version>
         <webbit-rest.version>0.3.0</webbit-rest.version>
         <jruby.version>9.1.5.0</jruby.version>
-        <weld-se.version>2.3.5.Final</weld-se.version>
+        <weld-se.version>2.4.4.Final</weld-se.version>
         <cdi-api.version>1.2</cdi-api.version>
         <openejb-core.version>4.7.4</openejb-core.version>
         <needle.version>2.2</needle.version>

--- a/weld/src/main/java/cucumber/runtime/java/weld/WeldFactory.java
+++ b/weld/src/main/java/cucumber/runtime/java/weld/WeldFactory.java
@@ -5,14 +5,14 @@ import cucumber.api.java.ObjectFactory;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 
-public class WeldFactory extends Weld implements ObjectFactory {
+public class WeldFactory implements ObjectFactory {
 
-    private WeldContainer weld;
+    private WeldContainer containerInstance;
 
     @Override
     public void start() {
         try {
-            weld = super.initialize();
+            containerInstance = new Weld().initialize();
         } catch (IllegalArgumentException e) {
             throw new CucumberException("" +
                     "\n" +
@@ -31,7 +31,9 @@ public class WeldFactory extends Weld implements ObjectFactory {
     @Override
     public void stop() {
         try {
-            this.shutdown();
+            if (containerInstance.isRunning()) {
+                containerInstance.close();
+            }
         } catch (NullPointerException npe) {
             System.err.println("" +
                     "\nIf you have set enabled=false in org.jboss.weld.executor.properties and you are seeing\n" +
@@ -49,6 +51,6 @@ public class WeldFactory extends Weld implements ObjectFactory {
 
     @Override
     public <T> T getInstance(Class<T> type) {
-        return weld.instance().select(type).get();
+        return containerInstance.select(type).get();
     }
 }

--- a/weld/src/test/resources/cucumber/runtime/java/weld/cukes.feature
+++ b/weld/src/test/resources/cucumber/runtime/java/weld/cukes.feature
@@ -3,3 +3,7 @@ Feature: Cukes
   Scenario: Eat some cukes
     Given I have 4 cukes in my belly
     Then there are 4 cukes in my belly
+
+  Scenario: Eat some more cukes
+    Given I have 6 cukes in my belly
+    Then there are 6 cukes in my belly


### PR DESCRIPTION
## Summary

I mainly changed the `WeldFactory` to create a single WeldContainer instance per factory, using the Weld builder.

## Details

The WeldFactory is no longer a subclass of the Weld builder class. It uses now a private member of type WeldContainer to hold a single weld container instance per factory (scenario).

The instance is created in the start method by using the weld builder method initialize and released in the stop method with the close method.

The resolving of class types in the getInstance method is also simplified, because it can use the select method directly on the container instance.

## Motivation and Context

I've come to develop this change as described in issue #1165. See this issue for details.

## How Has This Been Tested?

The fix uses the scenario tests in cukes.feature as well as the WeldFactoryTest within the cucumber-weld module to prove it's effectiveness.

The fix was tested using the 'mvn clean test' command on Windows 10 using an Oracle JDK8

There should be no impact on other parts of the cucumber code, due to the fact that only internal details within the WeldFactoryTest are changed.

But keep in mind, that the fix **cannot be used with the Weld SE version 2.3.5.Final** and is therefore **not backward compatible** to this version. This should be mentioned in the release notes, if applicable.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
