### PR TITLE
Use the feature name as class name in reports.

### DIFF
--- a/android/src/main/java/cucumber/runtime/android/AndroidInstrumentationReporter.java
+++ b/android/src/main/java/cucumber/runtime/android/AndroidInstrumentationReporter.java
@@ -62,7 +62,7 @@ public class AndroidInstrumentationReporter implements Formatter {
      * The collected TestSourceRead events.
      */
     private final TestSourcesModel testSources = new TestSourcesModel();
-    
+
     /**
      * The current cucumber runtime.
      */
@@ -142,14 +142,10 @@ public class AndroidInstrumentationReporter implements Formatter {
     /**
      * Creates a new instance for the given parameters
      *
-     * @param runtime the {@link cucumber.runtime.Runtime} to use
+     * @param runtime         the {@link cucumber.runtime.Runtime} to use
      * @param instrumentation the {@link android.app.Instrumentation} to report statuses to
-     * @param numberOfTests the total number of tests to be executed, this is expected to include all scenario outline runs
      */
-    public AndroidInstrumentationReporter(
-            final Runtime runtime,
-            final Instrumentation instrumentation) {
-
+    public AndroidInstrumentationReporter(final Runtime runtime, final Instrumentation instrumentation) {
         this.runtime = runtime;
         this.instrumentation = instrumentation;
     }
@@ -165,16 +161,16 @@ public class AndroidInstrumentationReporter implements Formatter {
     public void setNumberOfTests(final int numberOfTests) {
         this.numberOfTests = numberOfTests;
     }
-    
+
     void testSourceRead(final TestSourceRead event) {
-	testSources.addTestSourceReadEvent(event.path, event);
+        testSources.addTestSourceReadEvent(event.path, event);
     }
 
     void startTestCase(final TestCase testCase) {
-	if (!testCase.getPath().equals(currentUri)) {
-	    currentUri = testCase.getPath();
-	    currentFeatureName = testSources.getFeatureName(currentUri);
-	}
+        if (!testCase.getPath().equals(currentUri)) {
+            currentUri = testCase.getPath();
+            currentFeatureName = testSources.getFeatureName(currentUri);
+        }
         currentTestCaseName = testCase.getName();
         resetSeverestResult();
         final Bundle testStart = createBundle(currentFeatureName, currentTestCaseName);
@@ -189,29 +185,29 @@ public class AndroidInstrumentationReporter implements Formatter {
         final Bundle testResult = createBundle(currentFeatureName, currentTestCaseName);
 
         switch (severestResult.getStatus()) {
-        case FAILED:
-            if (severestResult.getError() instanceof AssertionError) {
+            case FAILED:
+                if (severestResult.getError() instanceof AssertionError) {
+                    testResult.putString(StatusKeys.STACK, severestResult.getErrorMessage());
+                    instrumentation.sendStatus(StatusCodes.FAILURE, testResult);
+                } else {
+                    testResult.putString(StatusKeys.STACK, getStackTrace(severestResult.getError()));
+                    instrumentation.sendStatus(StatusCodes.ERROR, testResult);
+                }
+                break;
+            case PENDING:
                 testResult.putString(StatusKeys.STACK, severestResult.getErrorMessage());
-                instrumentation.sendStatus(StatusCodes.FAILURE, testResult);
-            } else {
-                testResult.putString(StatusKeys.STACK, getStackTrace(severestResult.getError()));
                 instrumentation.sendStatus(StatusCodes.ERROR, testResult);
-            }
-            break;
-        case PENDING:
-            testResult.putString(StatusKeys.STACK, severestResult.getErrorMessage());
-            instrumentation.sendStatus(StatusCodes.ERROR, testResult);
-            break;
-        case PASSED:
-        case SKIPPED:
-            instrumentation.sendStatus(StatusCodes.OK, testResult);
-            break;
-        case UNDEFINED:
-            testResult.putString(StatusKeys.STACK, getStackTrace(new MissingStepDefinitionError(getLastSnippet())));
-            instrumentation.sendStatus(StatusCodes.ERROR, testResult);
-            break;
-        default:
-            throw new IllegalStateException("Unexpected result status: " + severestResult.getStatus());
+                break;
+            case PASSED:
+            case SKIPPED:
+                instrumentation.sendStatus(StatusCodes.OK, testResult);
+                break;
+            case UNDEFINED:
+                testResult.putString(StatusKeys.STACK, getStackTrace(new MissingStepDefinitionError(getLastSnippet())));
+                instrumentation.sendStatus(StatusCodes.ERROR, testResult);
+                break;
+            default:
+                throw new IllegalStateException("Unexpected result status: " + severestResult.getStatus());
         }
     }
 
@@ -219,7 +215,7 @@ public class AndroidInstrumentationReporter implements Formatter {
      * Creates a template bundle for reporting the start and end of a test.
      *
      * @param path of the feature file of the current execution
-     * @param name of the test case of the current execution
+     * @param testCaseName of the test case of the current execution
      * @return the new {@link Bundle}
      */
     private Bundle createBundle(final String path, final String testCaseName) {
@@ -247,8 +243,8 @@ public class AndroidInstrumentationReporter implements Formatter {
     }
 
     /**
-     * Checks if the given {@code result} is more severe than the current {@code severestResult} and updates
-     * the {@code severestResult} if that should be the case.
+     * Checks if the given {@code result} is more severe than the current {@code severestResult} and
+     * updates the {@code severestResult} if that should be the case.
      *
      * @param result the {@link Result} to check
      */
@@ -272,7 +268,7 @@ public class AndroidInstrumentationReporter implements Formatter {
      * @param throwable the {@link Throwable} to get the stacktrace from
      * @return the stacktrace as a string
      */
-    private  static String getStackTrace(final Throwable throwable) {
+    private static String getStackTrace(final Throwable throwable) {
         final StringWriter stringWriter = new StringWriter();
         final PrintWriter printWriter = new PrintWriter(stringWriter, true);
         throwable.printStackTrace(printWriter);

--- a/android/src/main/java/cucumber/runtime/android/AndroidInstrumentationReporter.java
+++ b/android/src/main/java/cucumber/runtime/android/AndroidInstrumentationReporter.java
@@ -8,9 +8,11 @@ import cucumber.api.event.EventHandler;
 import cucumber.api.event.EventPublisher;
 import cucumber.api.event.TestCaseFinished;
 import cucumber.api.event.TestCaseStarted;
+import cucumber.api.event.TestSourceRead;
 import cucumber.api.event.TestStepFinished;
 import cucumber.api.formatter.Formatter;
 import cucumber.runtime.Runtime;
+import cucumber.runtime.formatter.TestSourcesModel;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -57,6 +59,11 @@ public class AndroidInstrumentationReporter implements Formatter {
     }
 
     /**
+     * The collected TestSourceRead events.
+     */
+    private final TestSourcesModel testSources = new TestSourcesModel();
+    
+    /**
      * The current cucumber runtime.
      */
     private final Runtime runtime;
@@ -69,7 +76,7 @@ public class AndroidInstrumentationReporter implements Formatter {
     /**
      * The total number of tests which will be executed.
      */
-    private final int numberOfTests;
+    private int numberOfTests;
 
     /**
      * The severest step result of the current test execution.
@@ -78,14 +85,29 @@ public class AndroidInstrumentationReporter implements Formatter {
     private Result severestResult;
 
     /**
-     * The location in the feature file of the current test case.
+     * The uri of the feature file of the current test case.
      */
-    private String currentPath;
+    private String currentUri;
+
+    /**
+     * The name of the current feature.
+     */
+    private String currentFeatureName;
 
     /**
      * The name of the current test case.
      */
     private String currentTestCaseName;
+
+    /**
+     * The event handler for the {@link TestSourceRead} events.
+     */
+    private final EventHandler<TestSourceRead> testSourceReadHandler = new EventHandler<TestSourceRead>() {
+        @Override
+        public void receive(TestSourceRead event) {
+            testSourceRead(event);
+        }
+    };
 
     /**
      * The event handler for the {@link TestCaseStarted} events.
@@ -126,26 +148,36 @@ public class AndroidInstrumentationReporter implements Formatter {
      */
     public AndroidInstrumentationReporter(
             final Runtime runtime,
-            final Instrumentation instrumentation,
-            final int numberOfTests) {
+            final Instrumentation instrumentation) {
 
         this.runtime = runtime;
         this.instrumentation = instrumentation;
-        this.numberOfTests = numberOfTests;
     }
 
     @Override
     public void setEventPublisher(final EventPublisher publisher) {
+        publisher.registerHandlerFor(TestSourceRead.class, testSourceReadHandler);
         publisher.registerHandlerFor(TestCaseStarted.class, testCaseStartedHandler);
         publisher.registerHandlerFor(TestCaseFinished.class, testCaseFinishedHandler);
         publisher.registerHandlerFor(TestStepFinished.class, testStepFinishedHandler);
     }
 
+    public void setNumberOfTests(final int numberOfTests) {
+        this.numberOfTests = numberOfTests;
+    }
+    
+    void testSourceRead(final TestSourceRead event) {
+	testSources.addTestSourceReadEvent(event.path, event);
+    }
+
     void startTestCase(final TestCase testCase) {
-        currentPath = testCase.getPath();
+	if (!testCase.getPath().equals(currentUri)) {
+	    currentUri = testCase.getPath();
+	    currentFeatureName = testSources.getFeatureName(currentUri);
+	}
         currentTestCaseName = testCase.getName();
         resetSeverestResult();
-        final Bundle testStart = createBundle(currentPath, currentTestCaseName);
+        final Bundle testStart = createBundle(currentFeatureName, currentTestCaseName);
         instrumentation.sendStatus(StatusCodes.START, testStart);
     }
 
@@ -154,7 +186,7 @@ public class AndroidInstrumentationReporter implements Formatter {
     }
 
     void finishTestCase() {
-        final Bundle testResult = createBundle(currentPath, currentTestCaseName);
+        final Bundle testResult = createBundle(currentFeatureName, currentTestCaseName);
 
         switch (severestResult.getStatus()) {
         case FAILED:

--- a/android/src/main/java/cucumber/runtime/android/CucumberExecutor.java
+++ b/android/src/main/java/cucumber/runtime/android/CucumberExecutor.java
@@ -74,7 +74,8 @@ public class CucumberExecutor {
     /**
      * Creates a new instance for the given parameters.
      *
-     * @param arguments       the {@link cucumber.runtime.android.Arguments} which configure this execution
+     * @param arguments       the {@link cucumber.runtime.android.Arguments} which configure this
+     *                        execution
      * @param instrumentation the {@link android.app.Instrumentation} to report to
      */
     public CucumberExecutor(final Arguments arguments, final Instrumentation instrumentation) {
@@ -89,13 +90,13 @@ public class CucumberExecutor {
 
         ResourceLoader resourceLoader = new AndroidResourceLoader(context);
         this.runtime = new Runtime(resourceLoader, classLoader, createBackends(), runtimeOptions);
-	AndroidInstrumentationReporter instrumentationReporter = new AndroidInstrumentationReporter(runtime, instrumentation);
+        AndroidInstrumentationReporter instrumentationReporter = new AndroidInstrumentationReporter(runtime, instrumentation);
         runtimeOptions.addPlugin(instrumentationReporter);
         runtimeOptions.addPlugin(new AndroidLogcatReporter(runtime, TAG));
 
         List<CucumberFeature> cucumberFeatures = runtimeOptions.cucumberFeatures(resourceLoader, runtime.getEventBus());
         this.pickleEvents = FeatureCompiler.compile(cucumberFeatures, this.runtime);
-	instrumentationReporter.setNumberOfTests(getNumberOfConcreteScenarios());
+        instrumentationReporter.setNumberOfTests(getNumberOfConcreteScenarios());
     }
 
     /**

--- a/android/src/main/java/cucumber/runtime/android/CucumberExecutor.java
+++ b/android/src/main/java/cucumber/runtime/android/CucumberExecutor.java
@@ -89,17 +89,19 @@ public class CucumberExecutor {
 
         ResourceLoader resourceLoader = new AndroidResourceLoader(context);
         this.runtime = new Runtime(resourceLoader, classLoader, createBackends(), runtimeOptions);
+	AndroidInstrumentationReporter instrumentationReporter = new AndroidInstrumentationReporter(runtime, instrumentation);
+        runtimeOptions.addPlugin(instrumentationReporter);
+        runtimeOptions.addPlugin(new AndroidLogcatReporter(runtime, TAG));
+
         List<CucumberFeature> cucumberFeatures = runtimeOptions.cucumberFeatures(resourceLoader, runtime.getEventBus());
         this.pickleEvents = FeatureCompiler.compile(cucumberFeatures, this.runtime);
+	instrumentationReporter.setNumberOfTests(getNumberOfConcreteScenarios());
     }
 
     /**
      * Runs the cucumber scenarios with the specified arguments.
      */
     public void execute() {
-
-        runtimeOptions.addPlugin(new AndroidInstrumentationReporter(runtime, instrumentation, getNumberOfConcreteScenarios()));
-        runtimeOptions.addPlugin(new AndroidLogcatReporter(runtime, TAG));
 
         // TODO: This is duplicated in info.cucumber.Runtime.
 

--- a/android/src/test/java/cucumber/runtime/android/AndroidInstrumentationReporterTest.java
+++ b/android/src/test/java/cucumber/runtime/android/AndroidInstrumentationReporterTest.java
@@ -2,6 +2,7 @@ package cucumber.runtime.android;
 
 import android.app.Instrumentation;
 import android.os.Bundle;
+import cucumber.api.event.TestSourceRead;
 import cucumber.api.PendingException;
 import cucumber.api.Result;
 import cucumber.api.TestCase;
@@ -36,6 +37,11 @@ public class AndroidInstrumentationReporterTest {
     private final Runtime runtime = mock(Runtime.class);
     private final Instrumentation instrumentation = mock(Instrumentation.class);
 
+    private final TestSourceRead testSourceRead = new TestSourceRead(
+	    0l,
+	    "path/file.feature",
+	    "en",
+	    "Feature: feature name\n  Scenario: some important scenario\n");
     private final TestCase testCase = mock(TestCase.class);
     private final Result firstResult = mock(Result.class);
     private final Result secondResult = mock(Result.class);
@@ -51,9 +57,11 @@ public class AndroidInstrumentationReporterTest {
     public void feature_name_and_keyword_is_contained_in_start_signal() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 1);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
 
         // when
+        formatter.testSourceRead(testSourceRead);
+	formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
 
         // then
@@ -63,17 +71,19 @@ public class AndroidInstrumentationReporterTest {
 
         final Bundle actualBundle = captor.getValue();
 
-        assertThat(actualBundle.getString(AndroidInstrumentationReporter.StatusKeys.CLASS), containsString(testCase.getPath()));
+        assertThat(actualBundle.getString(AndroidInstrumentationReporter.StatusKeys.CLASS), containsString("feature name"));
     }
 
     @Test
     public void feature_name_and_keyword_is_contained_in_end_signal() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 1);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.PASSED);
 
         // when
+        formatter.testSourceRead(testSourceRead);
+	formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -85,16 +95,17 @@ public class AndroidInstrumentationReporterTest {
 
         final Bundle actualBundle = captor.getValue();
 
-        assertThat(actualBundle.getString(AndroidInstrumentationReporter.StatusKeys.CLASS), containsString(testCase.getPath()));
+        assertThat(actualBundle.getString(AndroidInstrumentationReporter.StatusKeys.CLASS), containsString("feature name"));
     }
 
     @Test
     public void scenario_name_is_contained_in_start_signal() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 1);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
 
         // when
+	formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
 
         // then
@@ -111,10 +122,11 @@ public class AndroidInstrumentationReporterTest {
     public void scenario_name_is_contained_in_end_signal() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 1);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.PASSED);
 
         // when
+	formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -133,11 +145,12 @@ public class AndroidInstrumentationReporterTest {
     public void any_step_exception_causes_test_error() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 1);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.FAILED);
         when(firstResult.getError()).thenReturn(new RuntimeException("some random runtime exception"));
 
         // when
+	formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -155,12 +168,13 @@ public class AndroidInstrumentationReporterTest {
     public void any_failing_step_causes_test_failure() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 1);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.FAILED);
         when(firstResult.getError()).thenReturn(new AssertionError("some test assertion went wrong"));
         when(firstResult.getErrorMessage()).thenReturn("some test assertion went wrong");
 
         // when
+	formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -177,11 +191,12 @@ public class AndroidInstrumentationReporterTest {
     public void any_undefined_step_causes_test_error() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 1);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.UNDEFINED);
         when(runtime.getSnippets()).thenReturn(Collections.singletonList("some snippet"));
 
         // when
+	formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -198,10 +213,11 @@ public class AndroidInstrumentationReporterTest {
     public void passing_step_causes_test_success() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 1);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.PASSED);
 
         // when
+	formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -214,11 +230,12 @@ public class AndroidInstrumentationReporterTest {
     public void skipped_step_causes_test_success() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 2);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.PASSED);
         mockResultStatus(secondResult, Result.Type.SKIPPED);
 
         // when
+	formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -233,7 +250,7 @@ public class AndroidInstrumentationReporterTest {
     public void first_step_result_exception_is_reported() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 2);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.FAILED);
         when(firstResult.getError()).thenReturn(new RuntimeException("first exception"));
 
@@ -241,6 +258,7 @@ public class AndroidInstrumentationReporterTest {
         when(secondResult.getError()).thenReturn(new RuntimeException("second exception"));
 
         // when
+	formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -258,13 +276,14 @@ public class AndroidInstrumentationReporterTest {
     public void undefined_step_overrides_preceding_passed_step() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 2);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.PASSED);
 
         mockResultStatus(secondResult, Result.Type.UNDEFINED);
         when(runtime.getSnippets()).thenReturn(Collections.singletonList("some snippet"));
 
         // when
+	formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -282,7 +301,7 @@ public class AndroidInstrumentationReporterTest {
     public void pending_step_overrides_preceding_passed_step() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 2);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.PASSED);
 
         mockResultStatus(secondResult, Result.Type.PENDING);
@@ -290,6 +309,7 @@ public class AndroidInstrumentationReporterTest {
         when(secondResult.getErrorMessage()).thenReturn("step is pending");
 
         // when
+	formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -307,7 +327,7 @@ public class AndroidInstrumentationReporterTest {
     public void failed_step_overrides_preceding_passed_step() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 2);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.PASSED);
 
         mockResultStatus(secondResult, Result.Type.FAILED);
@@ -315,6 +335,7 @@ public class AndroidInstrumentationReporterTest {
         when(secondResult.getErrorMessage()).thenReturn("some assertion went wrong");
 
         // when
+	formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -332,13 +353,14 @@ public class AndroidInstrumentationReporterTest {
     public void error_step_overrides_preceding_passed_step() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 2);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.PASSED);
 
         mockResultStatus(secondResult, Result.Type.FAILED);
         when(secondResult.getError()).thenReturn(new RuntimeException("some exception"));
 
         // when
+	formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -356,7 +378,7 @@ public class AndroidInstrumentationReporterTest {
     public void failed_step_does_not_overrides_preceding_undefined_step() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 2);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.UNDEFINED);
         when(runtime.getSnippets()).thenReturn(Collections.singletonList("some snippet"));
 
@@ -365,6 +387,7 @@ public class AndroidInstrumentationReporterTest {
         when(secondResult.getErrorMessage()).thenReturn("some assertion went wrong");
 
         // when
+	formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -382,7 +405,7 @@ public class AndroidInstrumentationReporterTest {
     public void error_step_does_not_override_preceding_failed_step() {
 
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 2);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.FAILED);
         when(firstResult.getError()).thenReturn(new AssertionError("some assertion went wrong"));
         when(firstResult.getErrorMessage()).thenReturn("some assertion went wrong");
@@ -391,6 +414,7 @@ public class AndroidInstrumentationReporterTest {
         when(secondResult.getError()).thenReturn(new RuntimeException("some exception"));
 
         // when
+	formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -407,7 +431,7 @@ public class AndroidInstrumentationReporterTest {
     @Test
     public void step_result_contains_only_the_current_scenarios_severest_result() {
         // given
-        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation, 2);
+        final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
         mockResultStatus(firstResult, Result.Type.FAILED);
         when(firstResult.getError()).thenReturn(new AssertionError("some assertion went wrong"));
         when(firstResult.getErrorMessage()).thenReturn("some assertion went wrong");
@@ -415,6 +439,7 @@ public class AndroidInstrumentationReporterTest {
         mockResultStatus(secondResult, Result.Type.PASSED);
 
         // when
+	formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();

--- a/android/src/test/java/cucumber/runtime/android/AndroidInstrumentationReporterTest.java
+++ b/android/src/test/java/cucumber/runtime/android/AndroidInstrumentationReporterTest.java
@@ -1,11 +1,21 @@
 package cucumber.runtime.android;
 
+import static cucumber.runtime.android.AndroidInstrumentationReporter.StatusCodes;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import android.app.Instrumentation;
 import android.os.Bundle;
-import cucumber.api.event.TestSourceRead;
 import cucumber.api.PendingException;
 import cucumber.api.Result;
 import cucumber.api.TestCase;
+import cucumber.api.event.TestSourceRead;
 import cucumber.runtime.Runtime;
 import edu.emory.mathcs.backport.java.util.Collections;
 import org.junit.Before;
@@ -17,15 +27,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-import static cucumber.runtime.android.AndroidInstrumentationReporter.StatusCodes;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
@@ -38,10 +39,10 @@ public class AndroidInstrumentationReporterTest {
     private final Instrumentation instrumentation = mock(Instrumentation.class);
 
     private final TestSourceRead testSourceRead = new TestSourceRead(
-	    0l,
-	    "path/file.feature",
-	    "en",
-	    "Feature: feature name\n  Scenario: some important scenario\n");
+        0l,
+        "path/file.feature",
+        "en",
+        "Feature: feature name\n  Scenario: some important scenario\n");
     private final TestCase testCase = mock(TestCase.class);
     private final Result firstResult = mock(Result.class);
     private final Result secondResult = mock(Result.class);
@@ -61,7 +62,7 @@ public class AndroidInstrumentationReporterTest {
 
         // when
         formatter.testSourceRead(testSourceRead);
-	formatter.setNumberOfTests(1);
+        formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
 
         // then
@@ -83,7 +84,7 @@ public class AndroidInstrumentationReporterTest {
 
         // when
         formatter.testSourceRead(testSourceRead);
-	formatter.setNumberOfTests(1);
+        formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -105,7 +106,7 @@ public class AndroidInstrumentationReporterTest {
         final AndroidInstrumentationReporter formatter = new AndroidInstrumentationReporter(runtime, instrumentation);
 
         // when
-	formatter.setNumberOfTests(1);
+        formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
 
         // then
@@ -126,7 +127,7 @@ public class AndroidInstrumentationReporterTest {
         mockResultStatus(firstResult, Result.Type.PASSED);
 
         // when
-	formatter.setNumberOfTests(1);
+        formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -150,7 +151,7 @@ public class AndroidInstrumentationReporterTest {
         when(firstResult.getError()).thenReturn(new RuntimeException("some random runtime exception"));
 
         // when
-	formatter.setNumberOfTests(1);
+        formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -174,7 +175,7 @@ public class AndroidInstrumentationReporterTest {
         when(firstResult.getErrorMessage()).thenReturn("some test assertion went wrong");
 
         // when
-	formatter.setNumberOfTests(1);
+        formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -196,7 +197,7 @@ public class AndroidInstrumentationReporterTest {
         when(runtime.getSnippets()).thenReturn(Collections.singletonList("some snippet"));
 
         // when
-	formatter.setNumberOfTests(1);
+        formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -217,7 +218,7 @@ public class AndroidInstrumentationReporterTest {
         mockResultStatus(firstResult, Result.Type.PASSED);
 
         // when
-	formatter.setNumberOfTests(1);
+        formatter.setNumberOfTests(1);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();
@@ -235,7 +236,7 @@ public class AndroidInstrumentationReporterTest {
         mockResultStatus(secondResult, Result.Type.SKIPPED);
 
         // when
-	formatter.setNumberOfTests(2);
+        formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -258,7 +259,7 @@ public class AndroidInstrumentationReporterTest {
         when(secondResult.getError()).thenReturn(new RuntimeException("second exception"));
 
         // when
-	formatter.setNumberOfTests(2);
+        formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -283,7 +284,7 @@ public class AndroidInstrumentationReporterTest {
         when(runtime.getSnippets()).thenReturn(Collections.singletonList("some snippet"));
 
         // when
-	formatter.setNumberOfTests(2);
+        formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -309,7 +310,7 @@ public class AndroidInstrumentationReporterTest {
         when(secondResult.getErrorMessage()).thenReturn("step is pending");
 
         // when
-	formatter.setNumberOfTests(2);
+        formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -335,7 +336,7 @@ public class AndroidInstrumentationReporterTest {
         when(secondResult.getErrorMessage()).thenReturn("some assertion went wrong");
 
         // when
-	formatter.setNumberOfTests(2);
+        formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -360,7 +361,7 @@ public class AndroidInstrumentationReporterTest {
         when(secondResult.getError()).thenReturn(new RuntimeException("some exception"));
 
         // when
-	formatter.setNumberOfTests(2);
+        formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -387,7 +388,7 @@ public class AndroidInstrumentationReporterTest {
         when(secondResult.getErrorMessage()).thenReturn("some assertion went wrong");
 
         // when
-	formatter.setNumberOfTests(2);
+        formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -414,7 +415,7 @@ public class AndroidInstrumentationReporterTest {
         when(secondResult.getError()).thenReturn(new RuntimeException("some exception"));
 
         // when
-	formatter.setNumberOfTests(2);
+        formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestStep(secondResult);
@@ -439,7 +440,7 @@ public class AndroidInstrumentationReporterTest {
         mockResultStatus(secondResult, Result.Type.PASSED);
 
         // when
-	formatter.setNumberOfTests(2);
+        formatter.setNumberOfTests(2);
         formatter.startTestCase(testCase);
         formatter.finishTestStep(firstResult);
         formatter.finishTestCase();

--- a/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
@@ -139,7 +139,7 @@ class HTMLFormatter implements Formatter {
     }
 
     private void handleTestSourceRead(TestSourceRead event) {
-        testSources.addSource(event.path, event.source);
+        testSources.addTestSourceReadEvent(event.path, event);
     }
 
     private void handleTestCaseStarted(TestCaseStarted event) {

--- a/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
@@ -105,7 +105,7 @@ class JSONFormatter implements Formatter {
     }
 
     private void handleTestSourceRead(TestSourceRead event) {
-        testSources.addSource(event.path, event.source);
+        testSources.addTestSourceReadEvent(event.path, event);
     }
 
     private void handleTestCaseStarted(TestCaseStarted event) {

--- a/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
@@ -36,10 +36,8 @@ import java.net.URL;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 class JUnitFormatter implements Formatter, StrictAware {
     private final Writer out;
@@ -105,7 +103,7 @@ class JUnitFormatter implements Formatter, StrictAware {
     }
 
     private void handleTestSourceRead(TestSourceRead event) {
-        TestCase.sourceMap.put(event.path, event);
+        TestCase.testSources.addTestSourceReadEvent(event.path, event);
     }
 
     private void handleTestCaseStarted(TestCaseStarted event) {
@@ -201,7 +199,7 @@ class JUnitFormatter implements Formatter, StrictAware {
 
     private static class TestCase {
         private static final DecimalFormat NUMBER_FORMAT = (DecimalFormat) NumberFormat.getNumberInstance(Locale.US);
-        private static final Map<String, TestSourceRead> sourceMap = new HashMap<String, TestSourceRead>();
+        private static final TestSourcesModel testSources = new TestSourcesModel();
 
         static {
             NUMBER_FORMAT.applyPattern("0.######");
@@ -224,7 +222,7 @@ class JUnitFormatter implements Formatter, StrictAware {
         }
 
         private void writeElement(Document doc, Element tc) {
-            tc.setAttribute("classname", testCase.getPath());
+            tc.setAttribute("classname", testSources.getFeatureName(currentFeatureFile));
             tc.setAttribute("name", calculateElementName(testCase));
         }
 
@@ -299,7 +297,7 @@ class JUnitFormatter implements Formatter, StrictAware {
         }
 
         private String getKeywordFromSource(int stepLine) {
-            TestSourceRead event = sourceMap.get(currentFeatureFile);
+            TestSourceRead event = testSources.getTestSourceReadEvent(currentFeatureFile);
             String trimmedSourceLine = event.source.split("\n")[stepLine - 1].trim();
             GherkinDialect dialect = new GherkinDialectProvider(event.language).getDefaultDialect();
             for (String keyword : dialect.getStepKeywords()) {

--- a/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
@@ -115,7 +115,7 @@ class PrettyFormatter implements Formatter, ColorAware {
     }
 
     private void handleTestSourceRead(TestSourceRead event) {
-        testSources.addSource(event.path, event.source);
+        testSources.addTestSourceReadEvent(event.path, event);
     }
 
     private void handleTestCaseStarted(TestCaseStarted event) {

--- a/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
@@ -87,7 +87,7 @@ public class JUnitFormatterTest {
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.003\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
                 "        <system-out><![CDATA[" +
                 "Given first step............................................................passed\n" +
                 "When second step............................................................passed\n" +
@@ -118,7 +118,7 @@ public class JUnitFormatterTest {
         String stackTrace = getStackTrace(exception);
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.003\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
                 "        <skipped message=\"" + stackTrace.replace("\n\t", "&#10;&#9;") + "\"><![CDATA[" +
                 "Given first step............................................................skipped\n" +
                 "When second step............................................................skipped\n" +
@@ -150,7 +150,7 @@ public class JUnitFormatterTest {
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.003\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
                 "        <skipped><![CDATA[" +
                 "Given first step............................................................pending\n" +
                 "When second step............................................................skipped\n" +
@@ -179,7 +179,7 @@ public class JUnitFormatterTest {
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"1\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.003\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
                 "        <failure message=\"the stack trace\"><![CDATA[" +
                 "Given first step............................................................passed\n" +
                 "When second step............................................................passed\n" +
@@ -213,7 +213,7 @@ public class JUnitFormatterTest {
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"1\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.004\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.004\">\n" +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
                 "        <failure message=\"the stack trace\"><![CDATA[" +
                 "Given first step............................................................skipped\n" +
                 "When second step............................................................skipped\n" +
@@ -247,7 +247,7 @@ public class JUnitFormatterTest {
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.004\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.004\">\n" +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
                 "        <skipped><![CDATA[" +
                 "Given first step............................................................skipped\n" +
                 "When second step............................................................skipped\n" +
@@ -279,7 +279,7 @@ public class JUnitFormatterTest {
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"1\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.004\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.004\">\n" +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
                 "        <failure message=\"the stack trace\"><![CDATA[" +
                 "Given first step............................................................skipped\n" +
                 "When second step............................................................skipped\n" +
@@ -313,7 +313,7 @@ public class JUnitFormatterTest {
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"1\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.004\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.004\">\n" +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
                 "        <failure message=\"the stack trace\"><![CDATA[" +
                 "Given first step............................................................passed\n" +
                 "When second step............................................................passed\n" +
@@ -346,7 +346,7 @@ public class JUnitFormatterTest {
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.004\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"scenario name\" time=\"0.004\">\n" +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
                 "        <system-out><![CDATA[" +
                 "* first step................................................................passed\n" +
                 "* second step...............................................................passed\n" +
@@ -379,14 +379,14 @@ public class JUnitFormatterTest {
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"2\" time=\"0.006\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"outline_name\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"outline_name\" time=\"0.003\">\n" +
                 "        <system-out><![CDATA[" +
                 "Given first step \"a\"........................................................passed\n" +
                 "When second step............................................................passed\n" +
                 "Then third step.............................................................passed\n" +
                 "]]></system-out>\n" +
                 "    </testcase>\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"outline_name_2\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"outline_name_2\" time=\"0.003\">\n" +
                 "        <system-out><![CDATA[" +
                 "Given first step \"b\"........................................................passed\n" +
                 "When second step............................................................passed\n" +
@@ -426,28 +426,28 @@ public class JUnitFormatterTest {
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"4\" time=\"0.012\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"outline name\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"outline name\" time=\"0.003\">\n" +
                 "        <system-out><![CDATA[" +
                 "Given first step \"a\"........................................................passed\n" +
                 "When second step............................................................passed\n" +
                 "Then third step.............................................................passed\n" +
                 "]]></system-out>\n" +
                 "    </testcase>\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"outline name 2\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"outline name 2\" time=\"0.003\">\n" +
                 "        <system-out><![CDATA[" +
                 "Given first step \"b\"........................................................passed\n" +
                 "When second step............................................................passed\n" +
                 "Then third step.............................................................passed\n" +
                 "]]></system-out>\n" +
                 "    </testcase>\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"outline name 3\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"outline name 3\" time=\"0.003\">\n" +
                 "        <system-out><![CDATA[" +
                 "Given first step \"c\"........................................................passed\n" +
                 "When second step............................................................passed\n" +
                 "Then third step.............................................................passed\n" +
                 "]]></system-out>\n" +
                 "    </testcase>\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"outline name 4\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"outline name 4\" time=\"0.003\">\n" +
                 "        <system-out><![CDATA[" +
                 "Given first step \"d\"........................................................passed\n" +
                 "When second step............................................................passed\n" +
@@ -481,14 +481,14 @@ public class JUnitFormatterTest {
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
                 "<testsuite failures=\"0\" name=\"cucumber.runtime.formatter.JUnitFormatter\" skipped=\"0\" tests=\"2\" time=\"0.006\">\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"outline name a\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"outline name a\" time=\"0.003\">\n" +
                 "        <system-out><![CDATA[" +
                 "Given first step \"a\"........................................................passed\n" +
                 "When second step............................................................passed\n" +
                 "Then third step.............................................................passed\n" +
                 "]]></system-out>\n" +
                 "    </testcase>\n" +
-                "    <testcase classname=\"path/test.feature\" name=\"outline name b\" time=\"0.003\">\n" +
+                "    <testcase classname=\"feature name\" name=\"outline name b\" time=\"0.003\">\n" +
                 "        <system-out><![CDATA[" +
                 "Given first step \"b\"........................................................passed\n" +
                 "When second step............................................................passed\n" +

--- a/core/src/test/resources/cucumber/runtime/formatter/JUnitFormatterTest_1.report.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/JUnitFormatterTest_1.report.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <testsuite tests="2" failures="0" skipped="2" time="0" name="cucumber.runtime.formatter.JUnitFormatter">
-    <testcase classname="cucumber/runtime/formatter/JUnitFormatterTest_1.feature" name="Scenario_1" time="0">
+    <testcase classname="Feature_1" name="Scenario_1" time="0">
         <skipped><![CDATA[Given step_1................................................................undefined
 When step_2.................................................................undefined
 Then step_3.................................................................undefined
 ]]></skipped>
     </testcase>
-    <testcase classname="cucumber/runtime/formatter/JUnitFormatterTest_1.feature" name="Scenario_2" time="0">
+    <testcase classname="Feature_1" name="Scenario_2" time="0">
         <skipped><![CDATA[Given step_1................................................................undefined
 When step_2.................................................................undefined
 Then step_3.................................................................undefined

--- a/core/src/test/resources/cucumber/runtime/formatter/JUnitFormatterTest_1_strict.report.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/JUnitFormatterTest_1_strict.report.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <testsuite failures="2" name="cucumber.runtime.formatter.JUnitFormatter" skipped="0" tests="2" time="0">
-    <testcase classname="cucumber/runtime/formatter/JUnitFormatterTest_1.feature" name="Scenario_1" time="0">
+    <testcase classname="Feature_1" name="Scenario_1" time="0">
         <failure message="The scenario has pending or undefined step(s)"><![CDATA[Given step_1................................................................undefined
 When step_2.................................................................undefined
 Then step_3.................................................................undefined
 ]]></failure>
     </testcase>
-    <testcase classname="cucumber/runtime/formatter/JUnitFormatterTest_1.feature" name="Scenario_2" time="0">
+    <testcase classname="Feature_1" name="Scenario_2" time="0">
         <failure message="The scenario has pending or undefined step(s)"><![CDATA[Given step_1................................................................undefined
 When step_2.................................................................undefined
 Then step_3.................................................................undefined

--- a/core/src/test/resources/cucumber/runtime/formatter/JUnitFormatterTest_2.report.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/JUnitFormatterTest_2.report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <testsuite tests="2" failures="0" skipped="2" time="0" name="cucumber.runtime.formatter.JUnitFormatter">
-    <testcase classname="cucumber/runtime/formatter/JUnitFormatterTest_2.feature" name="Scenario_1" time="0">
+    <testcase classname="Feature_2" name="Scenario_1" time="0">
         <skipped><![CDATA[Given bg_1..................................................................undefined
 When bg_2...................................................................undefined
 Then bg_3...................................................................undefined
@@ -9,7 +9,7 @@ When step_2.................................................................unde
 Then step_3.................................................................undefined
 ]]></skipped>
     </testcase>
-    <testcase classname="cucumber/runtime/formatter/JUnitFormatterTest_2.feature" name="Scenario_2" time="0">
+    <testcase classname="Feature_2" name="Scenario_2" time="0">
         <skipped><![CDATA[Given bg_1..................................................................undefined
 When bg_2...................................................................undefined
 Then bg_3...................................................................undefined

--- a/core/src/test/resources/cucumber/runtime/formatter/JUnitFormatterTest_3.report.xml
+++ b/core/src/test/resources/cucumber/runtime/formatter/JUnitFormatterTest_3.report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <testsuite failures="0" tests="4" skipped="4" time="0" name="cucumber.runtime.formatter.JUnitFormatter">
-    <testcase classname="cucumber/runtime/formatter/JUnitFormatterTest_3.feature" name="Scenario_1" time="0">
+    <testcase classname="Feature_3" name="Scenario_1" time="0">
         <skipped><![CDATA[Given bg_1..................................................................undefined
 When bg_2...................................................................undefined
 Then bg_3...................................................................undefined
@@ -9,7 +9,7 @@ When step_2.................................................................unde
 Then step_3.................................................................undefined
 ]]></skipped>
     </testcase>
-    <testcase classname="cucumber/runtime/formatter/JUnitFormatterTest_3.feature" name="ScenarioOutline_1" time="0">
+    <testcase classname="Feature_3" name="ScenarioOutline_1" time="0">
         <skipped><![CDATA[Given bg_1..................................................................undefined
 When bg_2...................................................................undefined
 Then bg_3...................................................................undefined
@@ -18,7 +18,7 @@ When so_2 7 cucumbers.......................................................unde
 Then 5 so_3.................................................................undefined
 ]]></skipped>
     </testcase>
-    <testcase classname="cucumber/runtime/formatter/JUnitFormatterTest_3.feature" name="ScenarioOutline_1_2" time="0">
+    <testcase classname="Feature_3" name="ScenarioOutline_1_2" time="0">
         <skipped><![CDATA[Given bg_1..................................................................undefined
 When bg_2...................................................................undefined
 Then bg_3...................................................................undefined
@@ -27,7 +27,7 @@ When so_2 15 cucumbers......................................................unde
 Then 5 so_3.................................................................undefined
 ]]></skipped>
     </testcase>
-    <testcase classname="cucumber/runtime/formatter/JUnitFormatterTest_3.feature" name="Scenario_2" time="0">
+    <testcase classname="Feature_3" name="Scenario_2" time="0">
         <skipped><![CDATA[Given bg_1..................................................................undefined
 When bg_2...................................................................undefined
 Then bg_3...................................................................undefined


### PR DESCRIPTION
## Summary

Change both the JUnit Formatter and the Android Instrumentation Reporter to use the feature name as the class name in the reports.

## Details

Change both the JUnit Formatter and the Android Instrumentation Reporter to use the feature name as the class name reports. This is the behaviour in v1.2.5, but to avoid having to extract the feature name from the TestSourceRead event it was changed in the upgrade to Gherkin v4.

## Motivation and Context

To avoid a regression between v1.2.5 and v2.0.0.

## How Has This Been Tested?

The automated test suite has been update to verify this behaviour.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
