### PR TITLE
[Core, JUnit, Android] Add the ambiguous result type.

### DIFF
--- a/android/src/main/java/cucumber/runtime/android/AndroidInstrumentationReporter.java
+++ b/android/src/main/java/cucumber/runtime/android/AndroidInstrumentationReporter.java
@@ -194,6 +194,10 @@ public class AndroidInstrumentationReporter implements Formatter {
                     instrumentation.sendStatus(StatusCodes.ERROR, testResult);
                 }
                 break;
+            case AMBIGUOUS:
+                testResult.putString(StatusKeys.STACK, getStackTrace(severestResult.getError()));
+                instrumentation.sendStatus(StatusCodes.ERROR, testResult);
+                break;
             case PENDING:
                 testResult.putString(StatusKeys.STACK, severestResult.getErrorMessage());
                 instrumentation.sendStatus(StatusCodes.ERROR, testResult);
@@ -214,7 +218,7 @@ public class AndroidInstrumentationReporter implements Formatter {
     /**
      * Creates a template bundle for reporting the start and end of a test.
      *
-     * @param path of the feature file of the current execution
+     * @param path         of the feature file of the current execution
      * @param testCaseName of the test case of the current execution
      * @return the new {@link Bundle}
      */

--- a/core/src/main/java/cucumber/api/Result.java
+++ b/core/src/main/java/cucumber/api/Result.java
@@ -15,6 +15,7 @@ public class Result {
         SKIPPED,
         PENDING,
         UNDEFINED,
+        AMBIGUOUS,
         FAILED;
 
         public static Type fromLowerCaseName(String lowerCaseName) {

--- a/core/src/main/java/cucumber/api/TestStep.java
+++ b/core/src/main/java/cucumber/api/TestStep.java
@@ -3,6 +3,7 @@ package cucumber.api;
 import cucumber.api.event.TestStepFinished;
 import cucumber.api.event.TestStepStarted;
 import cucumber.runner.EventBus;
+import cucumber.runtime.AmbiguousStepDefinitionsException;
 import cucumber.runtime.DefinitionMatch;
 import cucumber.runtime.UndefinedStepDefinitionException;
 import gherkin.pickles.Argument;
@@ -91,6 +92,9 @@ public abstract class TestStep {
         }
         if (t.getClass() == UndefinedStepDefinitionException.class) {
             return Result.Type.UNDEFINED;
+        }
+        if (t.getClass() == AmbiguousStepDefinitionsException.class) {
+            return Result.Type.AMBIGUOUS;
         }
         return Result.Type.FAILED;
     }

--- a/core/src/main/java/cucumber/runner/Runner.java
+++ b/core/src/main/java/cucumber/runner/Runner.java
@@ -121,7 +121,7 @@ public class Runner implements UnreportedStepExecutor {
                     match = new UndefinedStepDefinitionMatch(step);
                 }
             } catch (AmbiguousStepDefinitionsException e) {
-                match = new AmbiguousStepDefinitionsMatch(step, e);
+                match = new AmbiguousStepDefinitionsMatch(pickleEvent.uri, step, e);
             } catch (Throwable t) {
                 match = new FailedStepInstantiationMatch(pickleEvent.uri, step, t);
             }

--- a/core/src/main/java/cucumber/runtime/AmbiguousStepDefinitionsMatch.java
+++ b/core/src/main/java/cucumber/runtime/AmbiguousStepDefinitionsMatch.java
@@ -3,11 +3,13 @@ package cucumber.runtime;
 import cucumber.api.Scenario;
 import gherkin.pickles.PickleStep;
 
+import java.util.Collections;
+
 public class AmbiguousStepDefinitionsMatch extends StepDefinitionMatch {
     private AmbiguousStepDefinitionsException exception;
 
-    public AmbiguousStepDefinitionsMatch(PickleStep step, AmbiguousStepDefinitionsException e) {
-        super(null, new NoStepDefinition(), null, step, null);
+    public AmbiguousStepDefinitionsMatch(String uri, PickleStep step, AmbiguousStepDefinitionsException e) {
+        super(Collections.<Argument>emptyList(), new NoStepDefinition(), uri, step, null);
         this.exception = e;
     }
 

--- a/core/src/main/java/cucumber/runtime/ScenarioImpl.java
+++ b/core/src/main/java/cucumber/runtime/ScenarioImpl.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import static java.util.Arrays.asList;
 
 public class ScenarioImpl implements Scenario {
-    private static final List<Result.Type> SEVERITY = asList(Result.Type.PASSED, Result.Type.SKIPPED, Result.Type.PENDING, Result.Type.UNDEFINED, Result.Type.FAILED);
+    private static final List<Result.Type> SEVERITY = asList(Result.Type.PASSED, Result.Type.SKIPPED, Result.Type.PENDING, Result.Type.UNDEFINED, Result.Type.AMBIGUOUS, Result.Type.FAILED);
     private final List<Result> stepResults = new ArrayList<Result>();
     private final List<PickleTag> tags;
     private final String uri;

--- a/core/src/main/java/cucumber/runtime/Stats.java
+++ b/core/src/main/java/cucumber/runtime/Stats.java
@@ -22,6 +22,7 @@ class Stats {
     private Formats formats;
     private Locale locale;
     private List<String> failedScenarios = new ArrayList<String>();
+    private List<String> ambiguousScenarios = new ArrayList<String>();
     private List<String> pendingScenarios = new ArrayList<String>();
     private List<String> undefinedScenarios = new ArrayList<String>();
 
@@ -67,6 +68,7 @@ class Stats {
     private void printSubCounts(PrintStream out, SubCounts subCounts) {
         boolean addComma = false;
         addComma = printSubCount(out, subCounts.failed, Result.Type.FAILED, addComma);
+        addComma = printSubCount(out, subCounts.ambiguous, Result.Type.AMBIGUOUS, addComma);
         addComma = printSubCount(out, subCounts.skipped, Result.Type.SKIPPED, addComma);
         addComma = printSubCount(out, subCounts.pending, Result.Type.PENDING, addComma);
         addComma = printSubCount(out, subCounts.undefined, Result.Type.UNDEFINED, addComma);
@@ -93,6 +95,7 @@ class Stats {
 
     private void printNonZeroResultScenarios(PrintStream out, boolean isStrict) {
         printScenarios(out, failedScenarios, Result.Type.FAILED);
+        printScenarios(out, ambiguousScenarios, Result.Type.AMBIGUOUS);
         if (isStrict) {
             printScenarios(out, pendingScenarios, Result.Type.PENDING);
             printScenarios(out, undefinedScenarios, Result.Type.UNDEFINED);
@@ -138,6 +141,9 @@ class Stats {
         case FAILED:
             subCounts.failed++;
             break;
+        case AMBIGUOUS:
+            subCounts.ambiguous++;
+            break;
         case PENDING:
             subCounts.pending++;
             break;
@@ -158,6 +164,9 @@ class Stats {
         case FAILED:
             failedScenarios.add(scenarioDesignation);
             break;
+        case AMBIGUOUS:
+            ambiguousScenarios.add(scenarioDesignation);
+            break;
         case PENDING:
             pendingScenarios.add(scenarioDesignation);
             break;
@@ -172,12 +181,13 @@ class Stats {
     class SubCounts {
         public int passed = 0;
         public int failed = 0;
+        public int ambiguous = 0;
         public int skipped = 0;
         public int pending = 0;
         public int undefined = 0;
 
         public int getTotal() {
-            return passed + failed + skipped + pending + undefined;
+            return passed + failed + ambiguous + skipped + pending + undefined;
         }
     }
 }

--- a/core/src/main/java/cucumber/runtime/formatter/AnsiFormats.java
+++ b/core/src/main/java/cucumber/runtime/formatter/AnsiFormats.java
@@ -15,6 +15,8 @@ public class AnsiFormats implements Formats {
         put("executing_arg", new ColorFormat(AnsiEscapes.GREY, AnsiEscapes.INTENSITY_BOLD));
         put("failed", new ColorFormat(AnsiEscapes.RED));
         put("failed_arg", new ColorFormat(AnsiEscapes.RED, AnsiEscapes.INTENSITY_BOLD));
+        put("ambiguous", new ColorFormat(AnsiEscapes.RED));
+        put("ambiguous_arg", new ColorFormat(AnsiEscapes.RED, AnsiEscapes.INTENSITY_BOLD));
         put("passed", new ColorFormat(AnsiEscapes.GREEN));
         put("passed_arg", new ColorFormat(AnsiEscapes.GREEN, AnsiEscapes.INTENSITY_BOLD));
         put("outline", new ColorFormat(AnsiEscapes.CYAN));

--- a/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
@@ -250,6 +250,9 @@ class JUnitFormatter implements Formatter, StrictAware {
             if (result.is(Result.Type.FAILED)) {
                 addStackTrace(sb, result);
                 child = createElementWithMessage(doc, sb, "failure", result.getErrorMessage());
+            } else if (result.is(Result.Type.AMBIGUOUS)) {
+                addStackTrace(sb, result);
+                child = createElementWithMessage(doc, sb, "failure", result.getErrorMessage());
             } else if (result.is(Result.Type.PENDING) || result.is(Result.Type.UNDEFINED)) {
                 if (treatConditionallySkippedAsFailure) {
                     child = createElementWithMessage(doc, sb, "failure", "The scenario has pending or undefined step(s)");

--- a/core/src/main/java/cucumber/runtime/formatter/ProgressFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/ProgressFormatter.java
@@ -21,6 +21,7 @@ class ProgressFormatter implements Formatter, ColorAware {
         put(Result.Type.PENDING, 'P');
         put(Result.Type.SKIPPED, '-');
         put(Result.Type.FAILED, 'F');
+        put(Result.Type.AMBIGUOUS, 'A');
     }};
     private static final Map<Result.Type, AnsiEscapes> ANSI_ESCAPES = new HashMap<Result.Type, AnsiEscapes>() {{
         put(Result.Type.PASSED, AnsiEscapes.GREEN);
@@ -28,6 +29,7 @@ class ProgressFormatter implements Formatter, ColorAware {
         put(Result.Type.PENDING, AnsiEscapes.YELLOW);
         put(Result.Type.SKIPPED, AnsiEscapes.CYAN);
         put(Result.Type.FAILED, AnsiEscapes.RED);
+        put(Result.Type.AMBIGUOUS, AnsiEscapes.RED);
     }};
 
     private final NiceAppendable out;

--- a/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
@@ -226,7 +226,7 @@ class TestNGFormatter implements Formatter, StrictAware {
             Result skipped = null;
             Result failed = null;
             for (Result result : results) {
-                if (result.is(Result.Type.FAILED)) {
+                if (result.is(Result.Type.FAILED) || result.is(Result.Type.AMBIGUOUS)) {
                     failed = result;
                 }
                 if (result.is(Result.Type.UNDEFINED) || result.is(Result.Type.PENDING)) {

--- a/core/src/test/java/cucumber/runtime/AmbiguousStepDefinitionMatchsTest.java
+++ b/core/src/test/java/cucumber/runtime/AmbiguousStepDefinitionMatchsTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.fail;
 public class AmbiguousStepDefinitionMatchsTest {
     public static final String ENGLISH = "en";
     public final AmbiguousStepDefinitionsException e = mock(AmbiguousStepDefinitionsException.class);
-    public final AmbiguousStepDefinitionsMatch match = new AmbiguousStepDefinitionsMatch(mock(PickleStep.class), e);
+    public final AmbiguousStepDefinitionsMatch match = new AmbiguousStepDefinitionsMatch("uri", mock(PickleStep.class), e);
 
     @Test
     public void throws_ambiguous_step_definitions_exception_when_run() {

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -302,8 +302,8 @@ public class RuntimeTest {
         runtime.printStats(new PrintStream(baos));
 
         assertThat(baos.toString(), containsString(String.format(""+
-                "1 Scenarios (1 failed)%n" +
-                "1 Steps (1 failed)%n")));
+                "1 Scenarios (1 ambiguous)%n" +
+                "1 Steps (1 ambiguous)%n")));
     }
 
     @Test

--- a/core/src/test/java/cucumber/runtime/StatsTest.java
+++ b/core/src/test/java/cucumber/runtime/StatsTest.java
@@ -48,43 +48,46 @@ public class StatsTest {
     }
 
     @Test
-    public void should_print_sub_counts_in_order_failed_skipped_pending_undefined_passed() {
+    public void should_print_sub_counts_in_order_failed_ambiguous_skipped_pending_undefined_passed() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         addOneStepScenario(counter, Result.Type.PASSED);
         addOneStepScenario(counter, Result.Type.FAILED);
+        addOneStepScenario(counter, Result.Type.AMBIGUOUS);
         addOneStepScenario(counter, Result.Type.PENDING);
         addOneStepScenario(counter, Result.Type.UNDEFINED);
         addOneStepScenario(counter, Result.Type.SKIPPED);
         counter.printStats(new PrintStream(baos), isStrict(false));
 
         assertThat(baos.toString(), containsString(String.format("" +
-                "5 Scenarios (1 failed, 1 skipped, 1 pending, 1 undefined, 1 passed)%n" +
-                "5 Steps (1 failed, 1 skipped, 1 pending, 1 undefined, 1 passed)%n")));
+                "6 Scenarios (1 failed, 1 ambiguous, 1 skipped, 1 pending, 1 undefined, 1 passed)%n" +
+                "6 Steps (1 failed, 1 ambiguous, 1 skipped, 1 pending, 1 undefined, 1 passed)%n")));
     }
 
     @Test
-    public void should_print_sub_counts_in_order_failed_skipped_undefined_passed_in_color() {
+    public void should_print_sub_counts_in_order_failed_ambiguous_skipped_undefined_passed_in_color() {
         Stats counter = createColorSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         addOneStepScenario(counter, Result.Type.PASSED);
         addOneStepScenario(counter, Result.Type.FAILED);
+        addOneStepScenario(counter, Result.Type.AMBIGUOUS);
         addOneStepScenario(counter, Result.Type.PENDING);
         addOneStepScenario(counter, Result.Type.UNDEFINED);
         addOneStepScenario(counter, Result.Type.SKIPPED);
         counter.printStats(new PrintStream(baos), isStrict(false));
 
-        String colorSubCounts =
+        String colorSubCounts = "" +
                 AnsiEscapes.RED + "1 failed" + AnsiEscapes.RESET + ", " +
+                AnsiEscapes.RED + "1 ambiguous" + AnsiEscapes.RESET + ", " +
                 AnsiEscapes.CYAN + "1 skipped" + AnsiEscapes.RESET + ", " +
                 AnsiEscapes.YELLOW + "1 pending" + AnsiEscapes.RESET + ", " +
                 AnsiEscapes.YELLOW + "1 undefined" + AnsiEscapes.RESET + ", " +
                 AnsiEscapes.GREEN + "1 passed" + AnsiEscapes.RESET;
         assertThat(baos.toString(), containsString(String.format("" +
-                "5 Scenarios (" + colorSubCounts + ")%n" +
-                "5 Steps (" + colorSubCounts + ")%n")));
+                "6 Scenarios (" + colorSubCounts + ")%n" +
+                "6 Steps (" + colorSubCounts + ")%n")));
     }
 
     @Test
@@ -155,12 +158,14 @@ public class StatsTest {
     }
 
     @Test
-    public void should_print_failed_scenarios() {
+    public void should_print_failed_ambiguous_scenarios() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         counter.addStep(createResultWithStatus(Result.Type.FAILED));
         counter.addScenario(Result.Type.FAILED, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addStep(createResultWithStatus(Result.Type.AMBIGUOUS));
+        counter.addScenario(Result.Type.AMBIGUOUS, "path/file.feature:3 # Scenario: scenario_name");
         counter.addStep(createResultWithStatus(Result.Type.UNDEFINED));
         counter.addScenario(Result.Type.UNDEFINED, "path/file.feature:3 # Scenario: scenario_name");
         counter.addStep(createResultWithStatus(Result.Type.PENDING));
@@ -171,16 +176,21 @@ public class StatsTest {
                 "Failed scenarios:%n" +
                 "path/file.feature:3 # Scenario: scenario_name%n" +
                 "%n" +
-                "3 Scenarios")));
+                "Ambiguous scenarios:%n" +
+                "path/file.feature:3 # Scenario: scenario_name%n" +
+                "%n" +
+                "4 Scenarios")));
     }
 
     @Test
-    public void should_print_failed_pending_undefined_scenarios_if_strict() {
+    public void should_print_failed_ambiguous_pending_undefined_scenarios_if_strict() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         counter.addStep(createResultWithStatus(Result.Type.FAILED));
         counter.addScenario(Result.Type.FAILED, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addStep(createResultWithStatus(Result.Type.AMBIGUOUS));
+        counter.addScenario(Result.Type.AMBIGUOUS, "path/file.feature:3 # Scenario: scenario_name");
         counter.addStep(createResultWithStatus(Result.Type.UNDEFINED));
         counter.addScenario(Result.Type.UNDEFINED, "path/file.feature:3 # Scenario: scenario_name");
         counter.addStep(createResultWithStatus(Result.Type.PENDING));
@@ -191,13 +201,16 @@ public class StatsTest {
                 "Failed scenarios:%n" +
                 "path/file.feature:3 # Scenario: scenario_name%n" +
                 "%n" +
+                "Ambiguous scenarios:%n" +
+                "path/file.feature:3 # Scenario: scenario_name%n" +
+                "%n" +
                 "Pending scenarios:%n" +
                 "path/file.feature:3 # Scenario: scenario_name%n" +
                 "%n" +
                 "Undefined scenarios:%n" +
                 "path/file.feature:3 # Scenario: scenario_name%n" +
                 "%n" +
-                "3 Scenarios")));
+                "4 Scenarios")));
     }
 
     private void addOneStepScenario(Stats counter, Result.Type status) {

--- a/core/src/test/java/cucumber/runtime/TestHelper.java
+++ b/core/src/test/java/cucumber/runtime/TestHelper.java
@@ -69,6 +69,8 @@ public class TestHelper {
         switch (status) {
         case FAILED:
             return result(status, mockAssertionFailedError());
+        case AMBIGUOUS:
+            return result(status, mockAmbiguousStepDefinitionException());
         case PENDING:
             return result(status, new PendingException());
         default:
@@ -249,6 +251,20 @@ public class TestHelper {
         };
         doAnswer(printStackTraceHandler).when(error).printStackTrace((PrintWriter) any());
         return error;
+    }
+
+    private static AmbiguousStepDefinitionsException mockAmbiguousStepDefinitionException() {
+        AmbiguousStepDefinitionsException exception = mock(AmbiguousStepDefinitionsException.class);
+        Answer<Object> printStackTraceHandler = new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                PrintWriter writer = (PrintWriter) invocation.getArguments()[0];
+                writer.print("the stack trace");
+                return null;
+            }
+        };
+        doAnswer(printStackTraceHandler).when(exception).printStackTrace((PrintWriter) any());
+        return exception;
     }
 
     public static SimpleEntry<String, Result> hookEntry(String type, Result result) {

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -127,9 +127,11 @@ public class JUnitReporter {
             stepErrors.add(new UndefinedThrowable(testStep.getStepText()));
             addFailureOrFailedAssumptionDependingOnStrictMode(stepNotifier, error);
             break;
+        case AMBIGUOUS:
         case FAILED:
             stepErrors.add(error);
             stepNotifier.addFailure(error);
+            break;
         }
         stepNotifier.fireTestFinished();
     }
@@ -159,10 +161,12 @@ public class JUnitReporter {
                 addFailureOrFailedAssumptionDependingOnStrictMode(pickleRunnerNotifier, error);
             }
             break;
+        case AMBIGUOUS:
         case FAILED:
             for (Throwable error : stepErrors) {
                 pickleRunnerNotifier.addFailure(error);
             }
+            break;
         }
         pickleRunnerNotifier.fireTestFinished();
     }

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -132,6 +132,8 @@ public class JUnitReporter {
             stepErrors.add(error);
             stepNotifier.addFailure(error);
             break;
+        default:
+            throw new IllegalStateException("Unexpected result status: " + result.getStatus());
         }
         stepNotifier.fireTestFinished();
     }

--- a/testng/src/main/java/cucumber/api/testng/TestNgReporter.java
+++ b/testng/src/main/java/cucumber/api/testng/TestNgReporter.java
@@ -51,7 +51,7 @@ class TestNgReporter implements Formatter {
     private void result(String stepText, Result result) {
         logResult(stepText, result);
 
-        if (result.is(Result.Type.FAILED)) {
+        if (result.is(Result.Type.FAILED) || result.is(Result.Type.AMBIGUOUS)) {
             ITestResult tr = getCurrentTestResult();
             tr.setThrowable(result.getError());
             tr.setStatus(ITestResult.FAILURE);
@@ -59,7 +59,7 @@ class TestNgReporter implements Formatter {
             ITestResult tr = getCurrentTestResult();
             tr.setThrowable(result.getError());
             tr.setStatus(ITestResult.SKIP);
-        } else if (result.is(Result.Type.UNDEFINED)) {
+        } else if (result.is(Result.Type.UNDEFINED) || result.is(Result.Type.PENDING)) {
             ITestResult tr = getCurrentTestResult();
             tr.setThrowable(result.getError());
             tr.setStatus(ITestResult.FAILURE);

--- a/testng/src/main/java/cucumber/api/testng/TestNgReporter.java
+++ b/testng/src/main/java/cucumber/api/testng/TestNgReporter.java
@@ -3,7 +3,6 @@ package cucumber.api.testng;
 import static org.testng.Reporter.getCurrentTestResult;
 import static org.testng.Reporter.log;
 
-import cucumber.runtime.Utils;
 import cucumber.api.Result;
 import cucumber.api.event.EventHandler;
 import cucumber.api.event.EventPublisher;
@@ -11,6 +10,7 @@ import cucumber.api.event.TestRunFinished;
 import cucumber.api.event.TestStepFinished;
 import cucumber.api.formatter.Formatter;
 import cucumber.api.formatter.NiceAppendable;
+import cucumber.runtime.Utils;
 import org.testng.ITestResult;
 
 class TestNgReporter implements Formatter {
@@ -50,19 +50,27 @@ class TestNgReporter implements Formatter {
 
     private void result(String stepText, Result result) {
         logResult(stepText, result);
+        ITestResult tr = getCurrentTestResult();
 
-        if (result.is(Result.Type.FAILED) || result.is(Result.Type.AMBIGUOUS)) {
-            ITestResult tr = getCurrentTestResult();
-            tr.setThrowable(result.getError());
-            tr.setStatus(ITestResult.FAILURE);
-        } else if (result.is(Result.Type.SKIPPED)) {
-            ITestResult tr = getCurrentTestResult();
-            tr.setThrowable(result.getError());
-            tr.setStatus(ITestResult.SKIP);
-        } else if (result.is(Result.Type.UNDEFINED) || result.is(Result.Type.PENDING)) {
-            ITestResult tr = getCurrentTestResult();
-            tr.setThrowable(result.getError());
-            tr.setStatus(ITestResult.FAILURE);
+        switch (result.getStatus()) {
+            case PASSED:
+                // do nothing
+                break;
+            case FAILED:
+            case AMBIGUOUS:
+                tr.setThrowable(result.getError());
+                tr.setStatus(ITestResult.FAILURE);
+                break;
+            case SKIPPED:
+                tr.setThrowable(result.getError());
+                tr.setStatus(ITestResult.SKIP);
+            case UNDEFINED:
+            case PENDING:
+                tr.setThrowable(result.getError());
+                tr.setStatus(ITestResult.FAILURE);
+                break;
+            default:
+                throw new IllegalStateException("Unexpected result status: " + result.getStatus());
         }
     }
 


### PR DESCRIPTION
## Summary

Report ambiguous steps as a separate result type, instead of reporting them as failed.

## Details
Report ambiguous steps as a separate result type, instead of reporting them as failed. The new ambiguous result type will make the exit code non-zero (the same as the failed result type currently used when ambiguous step matches are found).

## Motivation and Context

Cucumber-JS already has a separate result type for [ambiguous step matches](https://github.com/cucumber/cucumber-js/blob/a45574104647b6340f4218b942f00280e44174e1/features/ambiguous_step.feature#L33-L34). In Cucumber-Ruby there is an [initiative to introduce them](https://github.com/cucumber/cucumber-ruby/pull/1132#issuecomment-311181056)

## How Has This Been Tested?

The automated test suite has been updated to verify this behaviour.

I have manually introduces ambiguous step matches in the java-calculator example to manually check the implementation.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
