### PR TITLE
Update the version of the cucumber-jvm-deps dependency

### DIFF
--- a/clojure/pom.xml
+++ b/clojure/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-html</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
         </dependency>
         <dependency>

--- a/examples/clojure_cukes/pom.xml
+++ b/examples/clojure_cukes/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>clojure</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>test</scope>
         </dependency>

--- a/examples/groovy-calculator/pom.xml
+++ b/examples/groovy-calculator/pom.xml
@@ -17,7 +17,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>test</scope>
         </dependency>

--- a/examples/java-calculator-testng/pom.xml
+++ b/examples/java-calculator-testng/pom.xml
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>test</scope>
         </dependency>

--- a/examples/java-calculator/pom.xml
+++ b/examples/java-calculator/pom.xml
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>test</scope>
         </dependency>

--- a/examples/pax-exam/calculator-test/src/test/java/cucumber/examples/java/paxexam/test/CalculatorTest.java
+++ b/examples/pax-exam/calculator-test/src/test/java/cucumber/examples/java/paxexam/test/CalculatorTest.java
@@ -54,7 +54,7 @@ public class CalculatorTest {
 
             mavenBundle("io.cucumber", "gherkin"),
             mavenBundle("io.cucumber", "tag-expressions"),
-            mavenBundle("info.cukes", "cucumber-jvm-deps"),
+            mavenBundle("io.cucumber", "cucumber-jvm-deps"),
             mavenBundle("io.cucumber", "cucumber-core"),
             mavenBundle("io.cucumber", "cucumber-java"),
             mavenBundle("io.cucumber", "cucumber-osgi"),

--- a/examples/scala-calculator/pom.xml
+++ b/examples/scala-calculator/pom.xml
@@ -13,7 +13,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>test</scope>
         </dependency>

--- a/examples/spring-txn/pom.xml
+++ b/examples/spring-txn/pom.xml
@@ -79,7 +79,7 @@
         </dependency>
 
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>test</scope>
         </dependency>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -22,7 +22,7 @@
             <artifactId>cucumber-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
         </dependency>
         <dependency>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
         </dependency>
         <dependency>

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/jython/pom.xml
+++ b/jython/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
         </dependency>
         <dependency>

--- a/needle/pom.xml
+++ b/needle/pom.xml
@@ -22,7 +22,7 @@
             <artifactId>cucumber-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/openejb/pom.xml
+++ b/openejb/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/picocontainer/pom.xml
+++ b/picocontainer/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,9 +95,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>info.cukes</groupId>
+                <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-jvm-deps</artifactId>
-                <version>1.0.5</version>
+                <version>1.0.6</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.thoughtworks.xstream</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,12 @@
                 <groupId>io.cucumber</groupId>
                 <artifactId>gherkin</artifactId>
                 <version>${gherkin.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.cucumber</groupId>
+                        <artifactId>gherkin-jvm-deps</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.cucumber</groupId>

--- a/rhino/pom.xml
+++ b/rhino/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>cucumber-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -18,7 +18,7 @@
             <artifactId>cucumber-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>info.cukes</groupId>
+            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-jvm-deps</artifactId>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
## Summary

To make cucumber-android work out of the box, update the cucumber-jvm-deps dependency to a version which includes non Java8 classes (using bytecode major version 52).

## Details

This RP depends on a new cucumber-jvm-deps release which includes the [downgrading of the xstream version to v1.4.7](https://github.com/cucumber/cucumber-jvm-deps/commit/669ae21ddceac7a31e3804bb5c44cd02bd95fb75). xstream > v1.4.7 includes Java8 classes (using bytecode major version 52), which are used on Jdk8 but cannot be used in an Android dex file. 

The cucumber-jvm-deps dependency is updated to v1.0.6 (not released yet).

Also exclude the gherkin-jvm-deps from the gherkin dependency. Since classes from gherkin-jvm-deps is repackaged in the gherkin jar, this is needed to avoid to add the same class twice when creating the binary for running Cucumber-JVM on Android.

Fixes #893.

## Motivation and Context

To make cucumber-android work out of the box.

## How Has This Been Tested?

The [Android-test](https://github.com/cucumber/cucumber-jvm/tree/master/examples/android/android-test) and [Cukeulator-test](https://github.com/cucumber/cucumber-jvm/tree/master/examples/android/cukeulator-test) example project have been successfully executed on an emulated Android device (to be specific neither the Android SDK nor the emulated device, were of the latest version, SDK version: r23.0.2, emulated device version: android v4.4.2 - API level 19).

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
