### PR TITLE
[Scala] Compile cucumber-scala_2.12 against Java 8

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 ## [2.0.0-SNAPSHOT](https://github.com/cucumber/cucumber-jvm/compare/v1.2.5...master) (In Git)
-
+* [Scala] Compile cucumber-scala_2.12 against Java 8 ([#1171](https://github.com/cucumber/cucumber-jvm/pull/1171), [#1087](https://github.com/cucumber/cucumber-jvm/issues/1087) M.P. Korstanje, Paolo Ambrosio). This includes:
+  * Update Scala Versions
+    - 2.12.0-M1 to 2.12.2
+    - 2.11.8 to 2.11.11
+  * Use Manifest instead of Java reflection to provide type information
 * [Core] Add TestRunStarted event, let Stats handle the exit code ([#1162](https://github.com/cucumber/cucumber-jvm/pull/1162) Björn Rasmusson)
 * [Core, JUnit, Android] Add the ambiguous result type ([#1168](https://github.com/cucumber/cucumber-jvm/pull/1168) Björn Rasmusson)
 * [Core] Add the SnippetsSuggestedEvent ([#1163](https://github.com/cucumber/cucumber-jvm/pull/1163) Björn Rasmusson)

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -17,7 +17,6 @@
         <module>java-calculator</module>
         <module>java-calculator-testng</module>
         <module>groovy-calculator</module>
-        <module>scala-calculator</module>
         <module>pax-exam</module>
     </modules>
 
@@ -28,6 +27,7 @@
                 <jdk>1.8</jdk>
             </activation>
             <modules>
+                <module>scala-calculator</module>
                 <module>java-wicket</module>
                 <module>java-webbit-websockets-selenium</module>
             </modules>

--- a/examples/scala-calculator/pom.xml
+++ b/examples/scala-calculator/pom.xml
@@ -3,8 +3,7 @@
 
     <parent>
         <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../../pom.xml</relativePath>
+        <artifactId>cucumber-examples</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
@@ -20,7 +19,8 @@
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-scala_2.11</artifactId>
+            <artifactId>cucumber-scala_2.12</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -36,23 +36,28 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.latest.version}</version>
-            <scope>test</scope>
+            <version>${scala.2.12.version}</version>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>${scala.latest.version}</version>
-            <scope>test</scope>
+            <version>${scala.2.12.version}</version>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
-                <version>2.15.2</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
                 <configuration>
                     <!--encoding>UTF-8</encoding-->
                     <excludes>

--- a/examples/scala-calculator/src/main/scala/cucumber/examples/scalacalculator/RpnCalculator.scala
+++ b/examples/scala-calculator/src/main/scala/cucumber/examples/scalacalculator/RpnCalculator.scala
@@ -1,6 +1,7 @@
 package cucumber.examples.scalacalculator
 
-import collection.mutable.Stack
+import scala.collection.mutable.Queue
+
 
 sealed trait Arg
 
@@ -13,10 +14,10 @@ case class Op(value: String) extends Arg
 case class Val(value: Double) extends Arg
 
 class RpnCalculator {
-  private val stack = new Stack[Double]
+  private val stack = new Queue[Double]
 
   private def op(f: (Double, Double) => Double) =
-    stack push f(stack.pop(), stack.pop())
+    stack += f(stack.dequeue(), stack.dequeue())
 
   def push(arg: Arg) {
     arg match {
@@ -24,7 +25,7 @@ class RpnCalculator {
       case Op("-") => op(_ - _)
       case Op("*") => op(_ * _)
       case Op("/") => op(_ / _)
-      case Val(value) => stack push value
+      case Val(value) => stack += value
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,9 @@
         <guice.version>4.0</guice.version>
         <!-- Remember to bounce version in examples/clojure_cukes/project.clj as well -->
         <clojure.version>1.8.0</clojure.version>
-        <!-- This is only here for the example project to use, the 3 scala projects maintain their own versions -->
-        <scala.latest.version>2.11.8</scala.latest.version>
+        <scala.2.12.version>2.12.2</scala.2.12.version>
+        <scala.2.11.version>2.11.11</scala.2.11.version>
+        <scala.2.10.version>2.10.6</scala.2.10.version>
         <gosu.version>1.14.6</gosu.version>
         <rhino.version>1.7.7.1</rhino.version>
         <jsoup.version>1.9.2</jsoup.version>
@@ -161,11 +162,6 @@
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-picocontainer</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.cucumber</groupId>
-                <artifactId>cucumber-scala_2.11</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -15,8 +17,19 @@
     <modules>
         <module>scala_2.11</module>
         <module>scala_2.10</module>
-        <module>scala_2.12</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <modules>
+                <module>scala_2.12</module>
+            </modules>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>
@@ -104,7 +117,9 @@
                             <phase>generate-sources</phase>
                             <configuration>
                                 <target>
-                                    <taskdef name="groovy" classname="org.codehaus.groovy.ant.Groovy" classpathref="maven.plugin.classpath" />
+                                    <taskdef name="groovy"
+                                             classname="org.codehaus.groovy.ant.Groovy"
+                                             classpathref="maven.plugin.classpath"/>
 
                                     <groovy><![CDATA[
 import groovy.text.SimpleTemplateEngine

--- a/scala/scala_2.10/pom.xml
+++ b/scala/scala_2.10/pom.xml
@@ -12,22 +12,18 @@
     <packaging>jar</packaging>
     <name>Cucumber-JVM: Scala (2.10)</name>
 
-    <properties>
-        <scala.version>2.10.6</scala.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.10.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.10.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/scala/scala_2.11/pom.xml
+++ b/scala/scala_2.11/pom.xml
@@ -12,22 +12,18 @@
     <packaging>jar</packaging>
     <name>Cucumber-JVM: Scala (2.11)</name>
 
-    <properties>
-        <scala.version>2.11.8</scala.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.11.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.11.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/scala/scala_2.12/pom.xml
+++ b/scala/scala_2.12/pom.xml
@@ -12,26 +12,18 @@
     <packaging>jar</packaging>
     <name>Cucumber-JVM: Scala (2.12)</name>
 
-    <properties>
-        <!--
-        Upgrading to 2.12.0-M2 or higher causes:
-
-        initializationError(cucumber.runtime.scala.test.RunCukesTest)  Time elapsed: 0.006 sec  <<< ERROR! java.util.NoSuchElementException: next on empty iterator [no stack trace] -->
-        <scala.version>2.12.0-M1</scala.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.12.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.2.12.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -45,6 +37,14 @@
           </testResource>
         </testResources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>

--- a/scala/sources/gen.scala
+++ b/scala/sources/gen.scala
@@ -7,7 +7,7 @@ for (i <- 1 to 22) {
   val f = "(" + ts + ") => Any"
   val p1 = "def apply[" + ts + "](f: " + f + ")"
   val p2 = "(implicit " + (1 to i).map(n => "m" + n + ":Manifest[T" + n + "]").mkString(", ") + ")"
-  val register = "\n  register(functionParams(f)) {\n"
+  val register = "\n  register(" +(1 to i).map(n => "m" + n).mkString(", ")  + ") {\n"
   val pf = "    case List(" + (1 to i).map("a" + _ + ":AnyRef").mkString(", ") + ") => \n      f(" + (1 to i).map(n => "a" + n + ".asInstanceOf[T" + n + "]").mkString(",\n        ") + ")"
   val closeRegister = "\n  }\n}"
 

--- a/scala/sources/src/main/scala/cucumber/api/scala/ScalaDsl.scala
+++ b/scala/sources/src/main/scala/cucumber/api/scala/ScalaDsl.scala
@@ -1,46 +1,49 @@
 package cucumber.api.scala
 
-import _root_.cucumber.api.Scenario
-import _root_.cucumber.runtime.scala.ScalaHookDefinition
-import _root_.cucumber.runtime.scala.ScalaStepDefinition
-import _root_.cucumber.runtime.HookDefinition
-import _root_.cucumber.runtime.StepDefinition
-import collection.mutable.ArrayBuffer
-import java.lang.reflect.Type
+import java.lang.reflect.{ParameterizedType, Type}
+
+import cucumber.api.Scenario
+import cucumber.runtime.{HookDefinition, StepDefinition}
+import cucumber.runtime.scala.{ScalaHookDefinition, ScalaStepDefinition}
+
+import scala.collection.mutable.ArrayBuffer
+
 
 /**
- * Base trait for a scala step definition implementation.
- */
-trait ScalaDsl { self =>
+  * Base trait for a scala step definition implementation.
+  */
+trait ScalaDsl {
+  self =>
   import scala.language.implicitConversions
 
-  private [cucumber] val stepDefinitions = new ArrayBuffer[StepDefinition]
 
-  private [cucumber] val beforeHooks = new ArrayBuffer[HookDefinition]
+  private[cucumber] val stepDefinitions = new ArrayBuffer[StepDefinition]
 
-  private [cucumber] val afterHooks = new ArrayBuffer[HookDefinition]
+  private[cucumber] val beforeHooks = new ArrayBuffer[HookDefinition]
 
-  def Before(f: Scenario => Unit){
+  private[cucumber] val afterHooks = new ArrayBuffer[HookDefinition]
+
+  def Before(f: Scenario => Unit) {
     Before()(f)
   }
 
   def Before(tags: String*)(f: Scenario => Unit) {
-    Before(Int.MaxValue, tags :_*)(f)
+    Before(Int.MaxValue, tags: _*)(f)
   }
 
-  def Before(order:Int, tags:String*)(f: Scenario => Unit){
+  def Before(order: Int, tags: String*)(f: Scenario => Unit) {
     beforeHooks += new ScalaHookDefinition(f, order, tags)
   }
 
-  def After(f: Scenario => Unit){
+  def After(f: Scenario => Unit) {
     After()(f)
   }
 
   def After(tags: String*)(f: Scenario => Unit) {
-    After(Int.MaxValue, tags:_*)(f)
+    After(Int.MaxValue, tags: _*)(f)
   }
 
-  def After(order:Int, tags: String*)(f: Scenario => Unit){
+  def After(order: Int, tags: String*)(f: Scenario => Unit) {
     afterHooks += new ScalaHookDefinition(f, order, tags)
   }
 
@@ -51,74 +54,73 @@ trait ScalaDsl { self =>
   final class Fun0(val f: Function0[Any])
 
   object Fun0 {
-    implicit def function02Fun0(f: Function0[Any]) = new Fun0(f)
+    implicit def function0AsFun0(f: Function0[Any]) = new Fun0(f)
   }
 
-  final class StepBody(name:String, regex:String) {
+  final class StepBody(name: String, regex: String) {
 
-    def apply(f: => Unit){ apply(f _) }
-
-    def apply(fun: Fun0) {
-      register(Array[Type]()) {case Nil => fun.f()}
+    /*
+      * apply0 needs to be able to handle both calls by value and reference.
+      *
+      * Call by value:
+      *
+      *    And("^multipy the things$") {
+      *      z = x * y;
+      *    }
+      *
+      * Call by reference:
+      *
+      *    And("^multipy the things$") { ()=>
+      *      z = x * y;
+      *    }
+      *
+      * Call by value has the signature => Unit while call by reference has the signature () => Any
+      *
+      * Due to type erasure both would end up with the signature () => Unit.
+      *
+      * Fun0 and the implicit conversion lets us work around this.
+      *
+      **/
+    def apply(f: => Unit) {
+      apply(f _)
     }
 
-    /**
-     * Concerning the type handling in all apply methods below.
-     *
-     * Unfortunately the obvious approach (as follows) doesn't work as expected in all scenarios :
-     *
-     * {{{
-     *   def apply[T1](f: (T1) => Any)(implicit m1:Manifest[T1]) = {
-     *     register(List(m1)) {
-     *       case List(a1:T1) => f(a1)
-     *     }
-     *   }
-     * }}}
-     *
-     * This is due to the Scala 'Value Classes' being boxed when moving into the Java world,
-     * and then returned into the Scala layer as these boxed types, which causes the following use case.
-     *
-     * - Step definition is defined with expected argument of scala type 'Int'
-     * - Step is 'registered' passing the Scala Int type into the Java layer
-     * - Inside the Java layer this is boxed from a 'primitive' into a java.lang.Integer
-     * - The parsed value is returned into Scala layer, retaining it's boxed type
-     * - When we perform the pattern match in the partial function, a List[Int] is expected but List[java.lang.Integer]
-     *   is passed in and fails the match (causing a match exception)
-     *
-     * Therefore by casting we unbox the java.util.Integer (or other boxed type) back into the expected value working
-     * around this issue - anything else should be the expected object anyway, so it makes no difference in that case.
-     *
-     * There's likely a cleaner way of doing this - please refactor if so.
-     *
-     */
+    def apply(fun: Fun0) {
+      register() {
+        case Nil => fun.f()
+      }
+    }
 
-    def apply[T1](f: (T1) => Any)(implicit m1:Manifest[T1]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef) =>
+    /*
+     * Generated apply1 to apply22 below
+     */
+    def apply[T1](f: (T1) => Any)(implicit m1: Manifest[T1]) {
+      register(m1) {
+        case List(a1: AnyRef) =>
           f(a1.asInstanceOf[T1])
       }
     }
 
-    def apply[T1, T2](f: (T1, T2) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef) =>
+    def apply[T1, T2](f: (T1, T2) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2]) {
+      register(m1, m2) {
+        case List(a1: AnyRef, a2: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2])
       }
     }
 
-    def apply[T1, T2, T3](f: (T1, T2, T3) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef) =>
+    def apply[T1, T2, T3](f: (T1, T2, T3) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3]) {
+      register(m1, m2, m3) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3])
       }
     }
 
-    def apply[T1, T2, T3, T4](f: (T1, T2, T3, T4) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef) =>
+    def apply[T1, T2, T3, T4](f: (T1, T2, T3, T4) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4]) {
+      register(m1, m2, m3, m4) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -126,9 +128,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5](f: (T1, T2, T3, T4, T5) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5](f: (T1, T2, T3, T4, T5) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5]) {
+      register(m1, m2, m3, m4, m5) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -137,9 +139,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6](f: (T1, T2, T3, T4, T5, T6) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6](f: (T1, T2, T3, T4, T5, T6) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6]) {
+      register(m1, m2, m3, m4, m5, m6) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -149,9 +151,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7](f: (T1, T2, T3, T4, T5, T6, T7) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7](f: (T1, T2, T3, T4, T5, T6, T7) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7]) {
+      register(m1, m2, m3, m4, m5, m6, m7) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -162,9 +164,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8](f: (T1, T2, T3, T4, T5, T6, T7, T8) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8](f: (T1, T2, T3, T4, T5, T6, T7, T8) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -176,9 +178,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -191,9 +193,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -207,9 +209,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -224,9 +226,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef, a12: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -242,9 +244,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef, a12: AnyRef, a13: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -261,9 +263,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef, a12: AnyRef, a13: AnyRef, a14: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -281,9 +283,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef, a12: AnyRef, a13: AnyRef, a14: AnyRef, a15: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -302,9 +304,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef, a12: AnyRef, a13: AnyRef, a14: AnyRef, a15: AnyRef, a16: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -324,9 +326,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef, a12: AnyRef, a13: AnyRef, a14: AnyRef, a15: AnyRef, a16: AnyRef, a17: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -347,9 +349,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17], m18:Manifest[T18]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef, a12: AnyRef, a13: AnyRef, a14: AnyRef, a15: AnyRef, a16: AnyRef, a17: AnyRef, a18: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -371,9 +373,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17], m18:Manifest[T18], m19:Manifest[T19]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef, a12: AnyRef, a13: AnyRef, a14: AnyRef, a15: AnyRef, a16: AnyRef, a17: AnyRef, a18: AnyRef, a19: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -396,9 +398,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17], m18:Manifest[T18], m19:Manifest[T19], m20:Manifest[T20]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef, a20:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19], m20: Manifest[T20]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef, a12: AnyRef, a13: AnyRef, a14: AnyRef, a15: AnyRef, a16: AnyRef, a17: AnyRef, a18: AnyRef, a19: AnyRef, a20: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -422,9 +424,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17], m18:Manifest[T18], m19:Manifest[T19], m20:Manifest[T20], m21:Manifest[T21]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef, a20:AnyRef, a21:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19], m20: Manifest[T20], m21: Manifest[T21]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef, a12: AnyRef, a13: AnyRef, a14: AnyRef, a15: AnyRef, a16: AnyRef, a17: AnyRef, a18: AnyRef, a19: AnyRef, a20: AnyRef, a21: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -449,9 +451,9 @@ trait ScalaDsl { self =>
       }
     }
 
-    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => Any)(implicit m1:Manifest[T1], m2:Manifest[T2], m3:Manifest[T3], m4:Manifest[T4], m5:Manifest[T5], m6:Manifest[T6], m7:Manifest[T7], m8:Manifest[T8], m9:Manifest[T9], m10:Manifest[T10], m11:Manifest[T11], m12:Manifest[T12], m13:Manifest[T13], m14:Manifest[T14], m15:Manifest[T15], m16:Manifest[T16], m17:Manifest[T17], m18:Manifest[T18], m19:Manifest[T19], m20:Manifest[T20], m21:Manifest[T21], m22:Manifest[T22]) {
-      register(functionParams(f)) {
-        case List(a1:AnyRef, a2:AnyRef, a3:AnyRef, a4:AnyRef, a5:AnyRef, a6:AnyRef, a7:AnyRef, a8:AnyRef, a9:AnyRef, a10:AnyRef, a11:AnyRef, a12:AnyRef, a13:AnyRef, a14:AnyRef, a15:AnyRef, a16:AnyRef, a17:AnyRef, a18:AnyRef, a19:AnyRef, a20:AnyRef, a21:AnyRef, a22:AnyRef) =>
+    def apply[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => Any)(implicit m1: Manifest[T1], m2: Manifest[T2], m3: Manifest[T3], m4: Manifest[T4], m5: Manifest[T5], m6: Manifest[T6], m7: Manifest[T7], m8: Manifest[T8], m9: Manifest[T9], m10: Manifest[T10], m11: Manifest[T11], m12: Manifest[T12], m13: Manifest[T13], m14: Manifest[T14], m15: Manifest[T15], m16: Manifest[T16], m17: Manifest[T17], m18: Manifest[T18], m19: Manifest[T19], m20: Manifest[T20], m21: Manifest[T21], m22: Manifest[T22]) {
+      register(m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17, m18, m19, m20, m21, m22) {
+        case List(a1: AnyRef, a2: AnyRef, a3: AnyRef, a4: AnyRef, a5: AnyRef, a6: AnyRef, a7: AnyRef, a8: AnyRef, a9: AnyRef, a10: AnyRef, a11: AnyRef, a12: AnyRef, a13: AnyRef, a14: AnyRef, a15: AnyRef, a16: AnyRef, a17: AnyRef, a18: AnyRef, a19: AnyRef, a20: AnyRef, a21: AnyRef, a22: AnyRef) =>
           f(a1.asInstanceOf[T1],
             a2.asInstanceOf[T2],
             a3.asInstanceOf[T3],
@@ -477,22 +479,35 @@ trait ScalaDsl { self =>
       }
     }
 
-    private def register(types: Array[Type])(pf: PartialFunction[List[Any], Any]) = {
-      val frame: StackTraceElement = obtainFrame
+    private def register(ms: Manifest[_ <: Any]*)(pf: PartialFunction[List[Any], Any]) = {
+      val types = ms.map(m => toJavaType(m)).toArray
       stepDefinitions += new ScalaStepDefinition(frame, name, regex, types, pf)
     }
 
-    /**
-     * Return the stack frame to allow us to identify where in a step definition file
-     * we are currently based
-     */
-    private def obtainFrame: StackTraceElement = {
-      val frames = Thread.currentThread().getStackTrace
-      val currentClass = self.getClass.getName
-      frames.find(_.getClassName == currentClass).get
-    }
+    private def toJavaType(m: Manifest[_]): Type = {
+      val typeArgs = m.typeArguments
+      if (typeArgs.isEmpty) {
+        m.runtimeClass
+      } else {
+        new ParameterizedType {
+          override def getActualTypeArguments: Array[Type] = typeArgs.map(toJavaType(_)).toArray
 
-    private def functionParams(f: Any) =
-      f.getClass.getDeclaredMethods.filter(m => "apply".equals(m.getName) && !m.isBridge).head.getGenericParameterTypes
+          override def getRawType: Type = m.runtimeClass
+
+          override def getOwnerType: Type = ???
+        }
+      }
+    }
   }
+
+  /**
+    * Return the stack frame to allow us to identify where in a step definition file
+    * we are currently based
+    */
+  private def frame: StackTraceElement = {
+    val frames = Thread.currentThread().getStackTrace
+    val currentClass = self.getClass.getName
+    frames.find(_.getClassName == currentClass).get
+  }
+
 }

--- a/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaBackend.scala
+++ b/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaBackend.scala
@@ -1,19 +1,19 @@
 package cucumber.runtime.scala
 
-import _root_.java.util.{List => JList}
-import _root_.gherkin.pickles.PickleStep
-import _root_.java.lang.reflect.Modifier
-import _root_.cucumber.runtime.snippets.SnippetGenerator
-import _root_.cucumber.runtime.snippets.FunctionNameGenerator
-import _root_.cucumber.api.scala.ScalaDsl
-import _root_.cucumber.runtime.ClassFinder
-import _root_.cucumber.runtime.io.ResourceLoaderClassFinder
-import _root_.cucumber.runtime.io.ResourceLoader
-import _root_.cucumber.runtime.io.MultiLoader
-import _root_.cucumber.runtime.Backend
-import _root_.cucumber.runtime.UnreportedStepExecutor
-import _root_.cucumber.runtime.Glue
-import collection.JavaConversions._
+import java.util.{List => JList}
+import gherkin.pickles.PickleStep
+import java.lang.reflect.Modifier
+import cucumber.runtime.snippets.SnippetGenerator
+import cucumber.runtime.snippets.FunctionNameGenerator
+import cucumber.api.scala.ScalaDsl
+import cucumber.runtime.ClassFinder
+import cucumber.runtime.io.ResourceLoaderClassFinder
+import cucumber.runtime.io.ResourceLoader
+import cucumber.runtime.io.MultiLoader
+import cucumber.runtime.Backend
+import cucumber.runtime.UnreportedStepExecutor
+import cucumber.runtime.Glue
+import scala.collection.JavaConverters._
 
 class ScalaBackend(resourceLoader:ResourceLoader) extends Backend {
   private var snippetGenerator = new SnippetGenerator(new ScalaSnippetGenerator())
@@ -36,10 +36,11 @@ class ScalaBackend(resourceLoader:ResourceLoader) extends Backend {
   }
 
   def loadGlue(glue: Glue, gluePaths: JList[String]) {
+
     val cl = Thread.currentThread().getContextClassLoader
     val classFinder = new ResourceLoaderClassFinder(resourceLoader, cl)
-    val packages = gluePaths map { cucumber.runtime.io.MultiLoader.packageName(_) }
-    val dslClasses = packages flatMap { classFinder.getDescendants(classOf[ScalaDsl], _) } filter { cls =>
+    val packages = gluePaths.asScala map { cucumber.runtime.io.MultiLoader.packageName(_) }
+    val dslClasses = packages flatMap { classFinder.getDescendants(classOf[ScalaDsl], _).asScala } filter { cls =>
       try {
         cls.getDeclaredConstructor()
         true
@@ -47,6 +48,7 @@ class ScalaBackend(resourceLoader:ResourceLoader) extends Backend {
         case e : Throwable => false
       }
     }
+
     val (clsClasses, objClasses) = dslClasses partition { cls =>
       try {
         Modifier.isPublic (cls.getConstructor().getModifiers)

--- a/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaHookDefinition.scala
+++ b/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaHookDefinition.scala
@@ -1,11 +1,11 @@
 package cucumber.runtime.scala
 
-import _root_.gherkin.pickles.PickleTag
-import _root_.java.util.Collection
-import _root_.cucumber.api.Scenario
-import _root_.cucumber.runtime.HookDefinition
-import _root_.cucumber.runtime.TagPredicate
-import collection.JavaConverters._
+import gherkin.pickles.PickleTag
+import java.util.Collection
+import cucumber.api.Scenario
+import cucumber.runtime.HookDefinition
+import cucumber.runtime.TagPredicate
+import scala.collection.JavaConverters._
 
 class ScalaHookDefinition(f:Scenario => Unit,
                           order:Int,

--- a/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaSnippetGenerator.scala
+++ b/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaSnippetGenerator.scala
@@ -1,8 +1,8 @@
 package cucumber.runtime.scala
 
-import _root_.cucumber.runtime.snippets.Snippet
-import _root_.gherkin.pickles.PickleStep
-import _root_.java.util.List
+import cucumber.runtime.snippets.Snippet
+import gherkin.pickles.PickleStep
+import java.util.List
 import collection.JavaConverters._
 
 class ScalaSnippetGenerator extends Snippet {

--- a/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaStepDefinition.scala
+++ b/scala/sources/src/main/scala/cucumber/runtime/scala/ScalaStepDefinition.scala
@@ -1,11 +1,11 @@
 package cucumber.runtime.scala
 
-import _root_.java.lang.reflect.Type
-import _root_.gherkin.pickles.PickleStep
-import _root_.java.util.regex.Pattern
-import _root_.cucumber.runtime.StepDefinition
-import _root_.cucumber.runtime.JdkPatternArgumentMatcher
-import _root_.cucumber.runtime.ParameterInfo
+import java.lang.reflect.Type
+import gherkin.pickles.PickleStep
+import java.util.regex.Pattern
+import cucumber.runtime.StepDefinition
+import cucumber.runtime.JdkPatternArgumentMatcher
+import cucumber.runtime.ParameterInfo
 import collection.JavaConversions._
 import cucumber.api.Transform
 

--- a/scala/sources/src/test/resources/cucumber/runtime/scala/test/cukes.feature
+++ b/scala/sources/src/test/resources/cucumber/runtime/scala/test/cukes.feature
@@ -82,3 +82,8 @@ Feature: Cukes
       | Blue  |      2 |
     Then I should have eaten 6 cukes
     And they should have been Green, Red, Blue
+
+  Scenario: Did you know that we can handle call by name and zero arity
+    Given I drink gin and vermouth
+    When I shake my belly
+    Then I should have lots of martinis

--- a/scala/sources/src/test/scala/cucumber/runtime/scala/test/StepDefs.scala
+++ b/scala/sources/src/test/scala/cucumber/runtime/scala/test/StepDefs.scala
@@ -4,149 +4,149 @@ import _root_.cucumber.api.scala._
 
 import cucumber.api.DataTable
 import junit.framework.Assert._
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import cucumber.runtime.scala.model.{Cukes, Person, Snake}
 import java.util.{List => JList, Map => JMap}
 
 /**
- * Test step definitions to exercise Scala cucumber
- */
+  * Test step definitions to exercise Scala cucumber
+  */
 class CukesStepDefinitions extends ScalaDsl with EN {
 
-  Given("""^I have (\d+) "([^"]*)" in my belly$"""){ (howMany:Int, what:String) =>
+  Given("""^I have (\d+) "([^"]*)" in my belly$""") { (howMany: Int, what: String) =>
 
   }
 
   var calorieCount = 0.0
 
-  Given("""^I have the following foods :$"""){ (table:DataTable) =>
+  Given("""^I have the following foods :$""") { (table: DataTable) =>
     val maps: JList[JMap[String, String]] = table.asMaps(classOf[String], classOf[String])
-    calorieCount = maps.map(_.get("CALORIES")).map(_.toDouble).fold(0.0)(_+_)
+    calorieCount = maps.asScala.map(_.get("CALORIES")).map(_.toDouble).fold(0.0)(_ + _)
   }
-  And("""^have eaten (.*) calories today""") { (calories:Double) =>
+  And("""^have eaten (.*) calories today""") { (calories: Double) =>
     assertEquals(calories, calorieCount)
   }
 
-  var intBelly:Int = 0
+  var intBelly: Int = 0
 
-  Given("""^I have eaten an int (\d+)$"""){ (arg0:Int) =>
+  Given("""^I have eaten an int (\d+)$""") { (arg0: Int) =>
     intBelly = arg0
   }
-  Then("""^I should have one hundred in my belly$"""){ () =>
+  Then("""^I should have one hundred in my belly$""") { () =>
     assertEquals(100, intBelly)
   }
 
-  var longBelly:Long = 0L
+  var longBelly: Long = 0L
 
-  Given("""^I have eaten a long (\d+)$"""){ (arg0:Long) =>
+  Given("""^I have eaten a long (\d+)$""") { (arg0: Long) =>
     longBelly = arg0
   }
-  Then("""^I should have long one hundred in my belly$"""){ () =>
+  Then("""^I should have long one hundred in my belly$""") { () =>
     assertEquals(100L, longBelly)
   }
 
-  var stringBelly:String = ""
+  var stringBelly: String = ""
 
-  Given("""^I have eaten "(.*)"$"""){ (arg0:String) =>
+  Given("""^I have eaten "(.*)"$""") { (arg0: String) =>
     stringBelly = arg0
   }
-  Then("""^I should have numnumnum in my belly$"""){ () =>
+  Then("""^I should have numnumnum in my belly$""") { () =>
     assertEquals("numnumnum", stringBelly)
   }
 
-  var doubleBelly:Double = 0.0
+  var doubleBelly: Double = 0.0
 
-  Given("""^I have eaten (.*) doubles$"""){ (arg0:Double) =>
+  Given("""^I have eaten (.*) doubles$""") { (arg0: Double) =>
     doubleBelly = arg0
   }
-  Then("""^I should have one and a half doubles in my belly$"""){ () =>
+  Then("""^I should have one and a half doubles in my belly$""") { () =>
     assertEquals(1.5, doubleBelly)
   }
 
-  var floatBelly:Float = 0.0f
+  var floatBelly: Float = 0.0f
 
-  Given("""^I have eaten (.*) floats$"""){ (arg0:Float) =>
+  Given("""^I have eaten (.*) floats$""") { (arg0: Float) =>
     floatBelly = arg0
   }
-  Then("""^I should have one and a half floats in my belly$"""){ () =>
+  Then("""^I should have one and a half floats in my belly$""") { () =>
     assertEquals(1.5f, floatBelly)
   }
 
-  var shortBelly:Short = 0.toShort
+  var shortBelly: Short = 0.toShort
 
-  Given("""^I have eaten a short (\d+)$"""){ (arg0:Short) =>
+  Given("""^I have eaten a short (\d+)$""") { (arg0: Short) =>
     shortBelly = arg0
   }
-  Then("""^I should have short one hundred in my belly$"""){ () =>
+  Then("""^I should have short one hundred in my belly$""") { () =>
     assertEquals(100.toShort, shortBelly)
   }
 
-  var byteBelly:Byte = 0.toByte
+  var byteBelly: Byte = 0.toByte
 
-  Given("""^I have eaten a byte (\d+)$"""){ (arg0:Byte) =>
+  Given("""^I have eaten a byte (\d+)$""") { (arg0: Byte) =>
     byteBelly = arg0
   }
-  Then("""^I should have two byte in my belly$"""){ () =>
+  Then("""^I should have two byte in my belly$""") { () =>
     assertEquals(2.toByte, byteBelly)
   }
 
-  var bigDecimalBelly:BigDecimal = BigDecimal(0)
+  var bigDecimalBelly: BigDecimal = BigDecimal(0)
 
-  Given("""^I have eaten (.*) big decimals$"""){ (arg0:java.math.BigDecimal) =>
+  Given("""^I have eaten (.*) big decimals$""") { (arg0: java.math.BigDecimal) =>
     bigDecimalBelly = arg0
   }
-  Then("""^I should have one and a half big decimals in my belly$"""){ () =>
+  Then("""^I should have one and a half big decimals in my belly$""") { () =>
     assertEquals(BigDecimal(1.5), bigDecimalBelly)
   }
 
-  var bigIntBelly:BigInt = BigInt(0)
+  var bigIntBelly: BigInt = BigInt(0)
 
-  Given("""^I have eaten (\d+) big int$"""){ (arg0:java.math.BigInteger) =>
+  Given("""^I have eaten (\d+) big int$""") { (arg0: java.math.BigInteger) =>
     bigIntBelly = arg0.intValue()
   }
-  Then("""^I should have a ten big int in my belly$"""){ () =>
+  Then("""^I should have a ten big int in my belly$""") { () =>
     assertEquals(BigInt(10), bigIntBelly)
   }
 
-  var charBelly:Char = 'A'
+  var charBelly: Char = 'A'
 
-  Given("""^I have eaten char '(.*)'$"""){ (arg0:Char) =>
+  Given("""^I have eaten char '(.*)'$""") { (arg0: Char) =>
     charBelly = 'C'
   }
-  Then("""^I should have character C in my belly$"""){ () =>
+  Then("""^I should have character C in my belly$""") { () =>
     assertEquals('C', charBelly)
   }
 
-  var boolBelly:Boolean = false
+  var boolBelly: Boolean = false
 
-  Given("""^I have eaten boolean (.*)"""){ (arg0:Boolean) =>
+  Given("""^I have eaten boolean (.*)""") { (arg0: Boolean) =>
     boolBelly = arg0
   }
-  Then("""^I should have truth in my belly$"""){ () =>
+  Then("""^I should have truth in my belly$""") { () =>
     assertEquals(true, boolBelly)
   }
 
-  Given("""^I have a table the sum of all rows should be (\d+) :$"""){ (value:Int, table:DataTable) =>
-    assertEquals(value, table.asList(classOf[String]).drop(1).map(_.toInt).foldLeft(0)(_+_))
+  Given("""^I have a table the sum of all rows should be (\d+) :$""") { (value: Int, table: DataTable) =>
+    assertEquals(value, table.asList(classOf[String]).asScala.drop(1).map(_.toInt).foldLeft(0)(_ + _))
   }
 
-  var snake:Snake = null
+  var snake: Snake = null
 
-  Given("""^I see in the distance ... (.*)$"""){ (s:Snake) =>
+  Given("""^I see in the distance ... (.*)$""") { (s: Snake) =>
     snake = s
   }
-  Then("""^I have a snake of length (\d+) moving (.*)$"""){ (size:Int, dir:String) =>
+  Then("""^I have a snake of length (\d+) moving (.*)$""") { (size: Int, dir: String) =>
     assertEquals(size, snake.length)
     assertEquals(Symbol(dir), snake.direction)
   }
 
-  var person:Person = null
+  var person: Person = null
 
-  Given("""^I have a person (.*)""") { (p:Person) =>
+  Given("""^I have a person (.*)""") { (p: Person) =>
     person = p
   }
 
-  Then("""^he should say \"(.*)\"""") { s:String =>
+  Then("""^he should say \"(.*)\"""") { s: String =>
     assertEquals(person.hello, s)
   }
 
@@ -157,15 +157,32 @@ class CukesStepDefinitions extends ScalaDsl with EN {
   }
 
   Then("""^I should have eaten (\d) cukes$""") { total: Int =>
-    assertEquals(total, cukes.map(_.number).sum)
+    assertEquals(total, cukes.asScala.map(_.number).sum)
   }
 
   And("^they should have been (.*)$") { colors: String =>
-    assertEquals(colors, cukes.map(_.color).mkString(", "))
+    assertEquals(colors, cukes.asScala.map(_.color).mkString(", "))
+  }
+
+  var gin : Int = 13
+  var vermouth : Int = 42
+  var maritinis : Int = 0
+
+  Given("^I drink gin and vermouth$"){ () =>
+    gin = 13
+    vermouth = 42
+  }
+
+  When("^I shake my belly$") { //note the lack of  () =>
+    maritinis += vermouth * gin
+  }
+
+  Then("^I should have lots of martinis$") { () =>
+    assertEquals(13 * 42, maritinis)
   }
 }
 
 class ThenDefs extends ScalaDsl with EN {
-  Then("""^I am "([^"]*)"$"""){ (arg0:String) =>
+  Then("""^I am "([^"]*)"$""") { (arg0: String) =>
   }
 }


### PR DESCRIPTION
## Summary

Fix cucumber-scala_2.12 compatibility with Scala 2.12.

## Details

* cucumber-scala_2.12 is compiled as Java 8 bytecode, along with scala-calculator
* Scala versions have been upgraded 
   - `2.12.0-M1` to `2.12.2` 
   - `2.11.8` to `2.11.11`
* Use `Manifest` instead of Java reflection to provide type information

## Motivation and Context

Issue #1087, #1091

## How Has This Been Tested?

Existing tests and Scala example passing.

Manually tested against [szarnyasg/cucumber-scala-2-12](https://github.com/szarnyasg/cucumber-scala-2-12). 
The expected result is that the test runs but fails.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Todo:

 - [X] Credit @paoloambrosio 