### PR TITLE
[Core] Decouple UndefinedStepsTracker from Glue

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,6 @@
 ## [2.0.0-SNAPSHOT](https://github.com/cucumber/cucumber-jvm/compare/v1.2.5...master) (In Git)
 
-* [Core] Use UndefinedStepsTracker from provided RuntimeGlue ([#1019](https://github.com/cucumber/cucumber-jvm/pull/1019) Illapikov)
+* [Core] Decouple UndefinedStepsTracker from Glue ([#1019](https://github.com/cucumber/cucumber-jvm/pull/1019) [#1172](https://github.com/cucumber/cucumber-jvm/pull/1172) Illapikov, M.P. Korstanje)
 * [Core] Add TestRunStarted event, let Stats handle the exit code ([#1162](https://github.com/cucumber/cucumber-jvm/pull/1162) Björn Rasmusson)
 * [Core, JUnit, Android] Add the ambiguous result type ([#1168](https://github.com/cucumber/cucumber-jvm/pull/1168) Björn Rasmusson)
 * [Core] Add the SnippetsSuggestedEvent ([#1163](https://github.com/cucumber/cucumber-jvm/pull/1163) Björn Rasmusson)

--- a/core/src/main/java/cucumber/runtime/Glue.java
+++ b/core/src/main/java/cucumber/runtime/Glue.java
@@ -26,6 +26,4 @@ public interface Glue {
     void reportStepDefinitions(StepDefinitionReporter stepDefinitionReporter);
 
     void removeScenarioScopedGlue();
-
-    UndefinedStepsTracker getTracker();
 }

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -27,7 +27,7 @@ import java.util.regex.Pattern;
 public class Runtime {
 
     final Stats stats; // package private to be avaiable for tests.
-    private final UndefinedStepsTracker undefinedStepsTracker;
+    private final UndefinedStepsTracker undefinedStepsTracker = new UndefinedStepsTracker();
 
     private final RuntimeOptions runtimeOptions;
 
@@ -59,13 +59,7 @@ public class Runtime {
         this.classLoader = classLoader;
         this.runtimeOptions = runtimeOptions;
         final Glue glue;
-        if (optionalGlue == null) {
-            this.undefinedStepsTracker = new UndefinedStepsTracker();
-            glue = new RuntimeGlue(undefinedStepsTracker, new LocalizedXStreams(classLoader));
-        } else {
-            this.undefinedStepsTracker = optionalGlue.getTracker();
-            glue = optionalGlue;
-        }
+        glue = optionalGlue == null ? new RuntimeGlue(new LocalizedXStreams(classLoader)) : optionalGlue;
         this.stats = new Stats(runtimeOptions.isMonochrome());
         this.bus = new EventBus(stopWatch);
         this.runner = new Runner(glue, bus, backends, runtimeOptions);

--- a/core/src/main/java/cucumber/runtime/RuntimeGlue.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeGlue.java
@@ -16,11 +16,14 @@ public class RuntimeGlue implements Glue {
     final List<HookDefinition> beforeHooks = new ArrayList<HookDefinition>();
     final List<HookDefinition> afterHooks = new ArrayList<HookDefinition>();
 
-    private final UndefinedStepsTracker tracker;
     private final LocalizedXStreams localizedXStreams;
 
+    public RuntimeGlue(LocalizedXStreams localizedXStreams) {
+        this(null, localizedXStreams);
+    }
+
+    @Deprecated
     public RuntimeGlue(UndefinedStepsTracker tracker, LocalizedXStreams localizedXStreams) {
-        this.tracker = tracker;
         this.localizedXStreams = localizedXStreams;
     }
 
@@ -113,7 +116,4 @@ public class RuntimeGlue implements Glue {
         }
     }
 
-    public UndefinedStepsTracker getTracker() {
-        return tracker;
-    }
 }

--- a/core/src/main/java/cucumber/runtime/UndefinedStepsTracker.java
+++ b/core/src/main/java/cucumber/runtime/UndefinedStepsTracker.java
@@ -1,8 +1,5 @@
 package cucumber.runtime;
 
-import cucumber.api.Result;
-import cucumber.api.TestCase;
-import cucumber.api.TestStep;
 import cucumber.api.event.EventHandler;
 import cucumber.api.event.EventListener;
 import cucumber.api.event.EventPublisher;
@@ -32,7 +29,6 @@ public class UndefinedStepsTracker implements EventListener {
     private final Map<String, String> pathToSourceMap = new HashMap<String, String>();
     private final Map<String, FeatureStepMap> pathToStepMap = new HashMap<String, FeatureStepMap>();
     private boolean hasUndefinedSteps = false;
-    private String currentUri;
 
     private EventHandler<TestSourceRead> testSourceReadHandler = new EventHandler<TestSourceRead>() {
         @Override
@@ -160,21 +156,21 @@ public class UndefinedStepsTracker implements EventListener {
         return keyword.replaceAll("[\\s',!]", "");
     }
 
-    private class FeatureStepMap {
-        public final GherkinDialect dialect;
-        public final Map<Integer, StepNode> stepMap;
+    private static final class FeatureStepMap {
+        final GherkinDialect dialect;
+        final Map<Integer, StepNode> stepMap;
 
-        public FeatureStepMap(GherkinDialect dialect, Map<Integer, StepNode> stepMap) {
+        FeatureStepMap(GherkinDialect dialect, Map<Integer, StepNode> stepMap) {
             this.dialect = dialect;
             this.stepMap = stepMap;
         }
     }
 
-    private class StepNode {
-        public final Step step;
-        public final StepNode previous;
+    private static final class StepNode {
+        final Step step;
+        final StepNode previous;
 
-        public StepNode(Step step, StepNode previous) {
+        StepNode(Step step, StepNode previous) {
             this.step = step;
             this.previous = previous;
         }

--- a/core/src/test/java/cucumber/runtime/RuntimeGlueTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeGlueTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.when;
 public class RuntimeGlueTest {
     @Test
     public void throws_duplicate_error_on_dupe_stepdefs() {
-        RuntimeGlue glue = new RuntimeGlue(new UndefinedStepsTracker(), new LocalizedXStreams(Thread.currentThread().getContextClassLoader()));
+        RuntimeGlue glue = new RuntimeGlue(new LocalizedXStreams(Thread.currentThread().getContextClassLoader()));
 
         StepDefinition a = mock(StepDefinition.class);
         when(a.getPattern()).thenReturn("hello");
@@ -35,7 +35,7 @@ public class RuntimeGlueTest {
         // But it was too much hassle creating a better test without refactoring RuntimeGlue
         // and probably some of its immediate collaborators... Aslak.
 
-        RuntimeGlue glue = new RuntimeGlue(new UndefinedStepsTracker(), new LocalizedXStreams(Thread.currentThread().getContextClassLoader()));
+        RuntimeGlue glue = new RuntimeGlue(new LocalizedXStreams(Thread.currentThread().getContextClassLoader()));
 
         StepDefinition sd = mock(StepDefinition.class);
         when(sd.isScenarioScoped()).thenReturn(true);

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -543,18 +543,12 @@ public class RuntimeTest {
         }
         RuntimeOptions runtimeOptions = new RuntimeOptions(args);
         Backend backend = mock(Backend.class);
-        RuntimeGlue glue = mockGlue();
+        RuntimeGlue glue = mock(RuntimeGlue.class);
         mockMatch(glue, match, isAmbiguous);
         mockHook(glue, hook, isBefore);
         Collection<Backend> backends = Arrays.asList(backend);
 
         return new Runtime(resourceLoader, classLoader, backends, runtimeOptions, glue);
-    }
-
-    private RuntimeGlue mockGlue() {
-        RuntimeGlue glue = mock(RuntimeGlue.class);
-        when(glue.getTracker()).thenReturn(new UndefinedStepsTracker());
-        return glue;
     }
 
     private void mockMatch(RuntimeGlue glue, StepDefinitionMatch match, boolean isAmbiguous) {

--- a/core/src/test/java/cucumber/runtime/TestHelper.java
+++ b/core/src/test/java/cucumber/runtime/TestHelper.java
@@ -159,7 +159,6 @@ public class TestHelper {
                                                                           final List<SimpleEntry<String, Result>> hooks, final List<String> hookLocations,
                                                                           final List<Answer<Object>> hookActions) throws Throwable {
         RuntimeGlue glue = mock(RuntimeGlue.class);
-        when(glue.getTracker()).thenReturn(new UndefinedStepsTracker());
         TestHelper.mockSteps(glue, stepsToResult, stepsToLocation);
         TestHelper.mockHooks(glue, hooks, hookLocations, hookActions);
         return glue;

--- a/java/src/test/java/cucumber/runtime/java/JavaHookTest.java
+++ b/java/src/test/java/cucumber/runtime/java/JavaHookTest.java
@@ -41,7 +41,7 @@ public class JavaHookTest {
     private final SingletonFactory objectFactory = new SingletonFactory();
     private final JavaBackend backend = new JavaBackend(objectFactory);
     private final LocalizedXStreams localizedXStreams = new LocalizedXStreams(Thread.currentThread().getContextClassLoader());
-    private final Glue glue = new RuntimeGlue(new UndefinedStepsTracker(), localizedXStreams);
+    private final Glue glue = new RuntimeGlue(localizedXStreams);
 
     @org.junit.Before
     public void loadNoGlue() {

--- a/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
@@ -198,7 +198,6 @@ public class FeatureRunnerTest {
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         final ClasspathResourceLoader resourceLoader = new ClasspathResourceLoader(classLoader);
         final RuntimeGlue glue = mock(RuntimeGlue.class);
-        when(glue.getTracker()).thenReturn(new UndefinedStepsTracker());
         final TimeService timeServiceStub = new TimeService() {
             @Override
             public long time() {


### PR DESCRIPTION
 Glue only served to pass the UndefinedStepsTracker between Runtime and
 Runtime. Decoupling this removes some pointless complexity.

 The constructor `RuntimeGlue(UndefinedStepsTracker, LocalizedXStreams)`
 has been deprecated to avoid breaking existing implementations.

 The Runtime will not use the provided UndefinedStepsTracker but this is
 consistent with the behaviour prior to  #1019.

 Third parties interested in undefined steps can use the subscribe their own
 UndefinedStepsTracker to the event bus.