### PR TITLE
 [Core, TestNg] Clean up stream closing

### DIFF
--- a/core/src/main/java/cucumber/api/formatter/NiceAppendable.java
+++ b/core/src/main/java/cucumber/api/formatter/NiceAppendable.java
@@ -65,7 +65,7 @@ public class NiceAppendable {
     public void close() {
         try {
             tryFlush();
-            if (out instanceof Closeable && out != System.out && out != System.err) {
+            if (out instanceof Closeable) {
                 ((Closeable) out).close();
             }
         } catch (IOException e) {

--- a/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
@@ -37,6 +37,7 @@ import gherkin.pickles.PickleString;
 import gherkin.pickles.PickleTable;
 import gherkin.pickles.PickleTag;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -119,11 +120,11 @@ class HTMLFormatter implements Formatter {
     };
 
     public HTMLFormatter(URL htmlReportDir) {
-        this.htmlReportDir = htmlReportDir;
+        this(htmlReportDir, createJsOut(htmlReportDir));
     }
 
-    public HTMLFormatter(URL htmlReportDir, NiceAppendable jsOut) {
-        this(htmlReportDir);
+    HTMLFormatter(URL htmlReportDir, NiceAppendable jsOut) {
+        this.htmlReportDir = htmlReportDir;
         this.jsOut = jsOut;
     }
 
@@ -144,7 +145,7 @@ class HTMLFormatter implements Formatter {
 
     private void handleTestCaseStarted(TestCaseStarted event) {
         if (firstFeature) {
-            jsOut().append("$(document).ready(function() {").append("var ")
+            jsOut.append("$(document).ready(function() {").append("var ")
                     .append(JS_FORMATTER_VAR).append(" = new CucumberHTML.DOMFormatter($('.cucumber-report'));");
             firstFeature = false;
         }
@@ -188,7 +189,7 @@ class HTMLFormatter implements Formatter {
             String extension = MIME_TYPES_EXTENSIONS.get(mimeType);
             if (extension != null) {
                 StringBuilder fileName = new StringBuilder("embedded").append(embeddedIndex++).append(".").append(extension);
-                writeBytesAndClose(event.data, reportFileOutputStream(fileName.toString()));
+                writeBytesToURL(event.data, toUrl(fileName.toString()));
                 jsFunctionCall("embedding", mimeType, fileName);
             }
         }
@@ -200,10 +201,10 @@ class HTMLFormatter implements Formatter {
 
     private void finishReport() {
         if (!firstFeature) {
-            jsOut().append("});");
+            jsOut.append("});");
             copyReportFiles();
         }
-        jsOut().close();
+        jsOut.close();
     }
 
     private void handleStartOfFeature(TestCase testCase) {
@@ -441,7 +442,7 @@ class HTMLFormatter implements Formatter {
     }
 
     private void jsFunctionCall(String functionName, Object... args) {
-        NiceAppendable out = jsOut().append(JS_FORMATTER_VAR + ".").append(functionName).append("(");
+        NiceAppendable out = jsOut.append(JS_FORMATTER_VAR + ".").append(functionName).append("(");
         boolean comma = false;
         for (Object arg : args) {
             if (comma) {
@@ -463,12 +464,22 @@ class HTMLFormatter implements Formatter {
             if (textAssetStream == null) {
                 throw new CucumberException("Couldn't find " + textAsset + ". Is cucumber-html on your classpath? Make sure you have the right version.");
             }
-            String baseName = new File(textAsset).getName();
-            writeStreamAndClose(textAssetStream, reportFileOutputStream(baseName));
+            String fileName = new File(textAsset).getName();
+            writeStreamToURL(textAssetStream, toUrl(fileName));
         }
     }
 
-    private void writeStreamAndClose(InputStream in, OutputStream out) {
+    private URL toUrl(String fileName) {
+        try {
+            return new URL(htmlReportDir, fileName);
+        } catch (IOException e) {
+           throw new CucumberException(e);
+        }
+    }
+
+    private static void writeStreamToURL(InputStream in, URL url) {
+        OutputStream out = createReportFileOutputStream(url);
+
         byte[] buffer = new byte[16 * 1024];
         try {
             int len = in.read(buffer);
@@ -476,36 +487,45 @@ class HTMLFormatter implements Formatter {
                 out.write(buffer, 0, len);
                 len = in.read(buffer);
             }
-            out.close();
         } catch (IOException e) {
             throw new CucumberException("Unable to write to report file item: ", e);
+        } finally {
+            closeQuietly(out);
         }
     }
 
-    private void writeBytesAndClose(byte[] buf, OutputStream out) {
+    private static void writeBytesToURL(byte[] buf, URL url) throws CucumberException {
+        OutputStream out = createReportFileOutputStream(url);
         try {
             out.write(buf);
         } catch (IOException e) {
             throw new CucumberException("Unable to write to report file item: ", e);
+        } finally {
+            closeQuietly(out);
         }
     }
 
-    private NiceAppendable jsOut() {
-        if (jsOut == null) {
-            try {
-                jsOut = new NiceAppendable(new OutputStreamWriter(reportFileOutputStream(JS_REPORT_FILENAME), "UTF-8"));
-            } catch (IOException e) {
-                throw new CucumberException(e);
-            }
-        }
-        return jsOut;
-    }
-
-    private OutputStream reportFileOutputStream(String fileName) {
+    private static NiceAppendable createJsOut(URL htmlReportDir) {
         try {
-            return new URLOutputStream(new URL(htmlReportDir, fileName));
+            return new NiceAppendable(new OutputStreamWriter(createReportFileOutputStream(new URL(htmlReportDir, JS_REPORT_FILENAME)), "UTF-8"));
         } catch (IOException e) {
             throw new CucumberException(e);
+        }
+    }
+
+    private static OutputStream createReportFileOutputStream(URL url) {
+        try {
+            return new URLOutputStream(url);
+        } catch (IOException e) {
+            throw new CucumberException(e);
+        }
+    }
+
+    private static void closeQuietly(Closeable out) {
+        try {
+            out.close();
+        } catch (IOException ignored) {
+            // go gentle into that good night
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
@@ -28,7 +28,10 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+
+import java.io.Closeable;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -151,6 +154,7 @@ class JUnitFormatter implements Formatter, StrictAware {
             StreamResult result = new StreamResult(out);
             DOMSource source = new DOMSource(doc);
             trans.transform(source, result);
+            closeQuietly(out);
         } catch (TransformerException e) {
             throw new CucumberException("Error while transforming.", e);
         }
@@ -332,4 +336,11 @@ class JUnitFormatter implements Formatter, StrictAware {
 
     }
 
+    private static void closeQuietly(Closeable out) {
+        try {
+            out.close();
+        } catch (IOException ignored) {
+            // go gentle into that good night
+        }
+    }
 }

--- a/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
@@ -28,6 +28,8 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -149,6 +151,7 @@ class TestNGFormatter implements Formatter, StrictAware {
             StreamResult streamResult = new StreamResult(writer);
             DOMSource domSource = new DOMSource(document);
             transformer.transform(domSource, streamResult);
+            closeQuietly(writer);
         } catch (TransformerException e) {
             throw new CucumberException("Error transforming report.", e);
         }
@@ -299,6 +302,14 @@ class TestNGFormatter implements Formatter, StrictAware {
             exceptionElement.appendChild(stacktraceElement);
 
             return exceptionElement;
+        }
+    }
+
+    private static void closeQuietly(Closeable out) {
+        try {
+            out.close();
+        } catch (IOException ignored) {
+            // go gentle into that good night
         }
     }
 }

--- a/testng/src/main/java/cucumber/api/testng/TestNGCucumberRunner.java
+++ b/testng/src/main/java/cucumber/api/testng/TestNGCucumberRunner.java
@@ -11,6 +11,7 @@ import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.io.ResourceLoaderClassFinder;
 import cucumber.runtime.model.CucumberFeature;
 
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,7 +37,12 @@ public class TestNGCucumberRunner {
         RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(clazz);
         runtimeOptions = runtimeOptionsFactory.create();
 
-        reporter = new TestNgReporter(System.out);
+        reporter = new TestNgReporter(new PrintStream(System.out) {
+                @Override
+                public void close() {
+                    // We have no intention to close System.out
+                }
+            });
         ClassFinder classFinder = new ResourceLoaderClassFinder(resourceLoader, classLoader);
         resultListener = new FeatureResultListener(runtimeOptions.isStrict());
         runtime = new Runtime(resourceLoader, classFinder, classLoader, runtimeOptions);


### PR DESCRIPTION
## Summary

  Refactored the code around streams so it follows these rules:
   - Streams should be closed by their owners
   - A stream is owned by its creator or when provided as a constructor argument
   - Stream ownership should be the smallest possible unit. The method, class, process, system.
   - System.out and System.error may never be closed

 Fixes #1108 

## How Has This Been Tested?

Checked the code for all occurrences of ` .close()`,`System.out`, `System.error`, `new NiceAppendable`, `new .*OutputStream` and `new .*Writer`in non-test code.

Automated tests should be passing. 

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
