### PR TITLE
[Core] Separate rerun paths by a new line character

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
@@ -76,17 +76,13 @@ class RerunFormatter implements Formatter, StrictAware {
 
     private void reportFailedTestCases() {
         Set<Map.Entry<String, ArrayList<Integer>>> entries = featureAndFailedLinesMapping.entrySet();
-        boolean firstFeature = true;
         for (Map.Entry<String, ArrayList<Integer>> entry : entries) {
             if (!entry.getValue().isEmpty()) {
-                if (!firstFeature) {
-                    out.append(" ");
-                }
                 out.append(entry.getKey());
-                firstFeature = false;
                 for (Integer line : entry.getValue()) {
                     out.append(":").append(line.toString());
                 }
+                out.println();
             }
         }
     }

--- a/core/src/main/java/cucumber/runtime/model/CucumberFeature.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberFeature.java
@@ -57,7 +57,7 @@ public class CucumberFeature implements Serializable {
         for (Resource resource : resources) {
             String source = read(resource);
             if (!source.isEmpty()) {
-                for (String featurePath : source.split(" ")) {
+                for (String featurePath : source.split("[\r\n]+")) {
                     PathWithLines pathWithLines = new PathWithLines(featurePath);
                     loadFromFileSystemOrClasspath(builder, resourceLoader, pathWithLines.path);
                 }

--- a/core/src/test/java/cucumber/runtime/formatter/RerunFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/RerunFormatterTest.java
@@ -55,7 +55,7 @@ public class RerunFormatterTest {
 
         String formatterOutput = runFeatureWithRerunFormatter(feature, stepsToResult, strict(true));
 
-        assertEquals("path/test.feature:2:4:6", formatterOutput);
+        assertEquals("path/test.feature:2:4:6\n", formatterOutput);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class RerunFormatterTest {
 
         String formatterOutput = runFeatureWithRerunFormatter(feature, stepsToResult);
 
-        assertEquals("path/test.feature:2", formatterOutput);
+        assertEquals("path/test.feature:2\n", formatterOutput);
     }
 
     @Test
@@ -92,7 +92,7 @@ public class RerunFormatterTest {
 
         String formatterOutput = runFeatureWithRerunFormatter(feature, stepsToResult);
 
-        assertEquals("path/test.feature:4", formatterOutput);
+        assertEquals("path/test.feature:4\n", formatterOutput);
     }
 
     @Test
@@ -113,7 +113,7 @@ public class RerunFormatterTest {
 
         String formatterOutput = runFeatureWithRerunFormatter(feature, stepsToResult);
 
-        assertEquals("path/test.feature:8", formatterOutput);
+        assertEquals("path/test.feature:8\n", formatterOutput);
     }
 
     @Test
@@ -133,7 +133,7 @@ public class RerunFormatterTest {
 
         String formatterOutput = runFeatureWithRerunFormatter(feature, stepsToResult, hooks);
 
-        assertEquals("path/test.feature:2", formatterOutput);
+        assertEquals("path/test.feature:2\n", formatterOutput);
     }
 
     @Test
@@ -153,7 +153,7 @@ public class RerunFormatterTest {
 
         String formatterOutput = runFeatureWithRerunFormatter(feature, stepsToResult, hooks);
 
-        assertEquals("path/test.feature:2", formatterOutput);
+        assertEquals("path/test.feature:2\n", formatterOutput);
     }
 
     @Test
@@ -174,7 +174,7 @@ public class RerunFormatterTest {
 
         String formatterOutput = runFeatureWithRerunFormatter(feature, stepsToResult);
 
-        assertEquals("path/test.feature:2:5", formatterOutput);
+        assertEquals("path/test.feature:2:5\n", formatterOutput);
     }
 
     @Test
@@ -197,7 +197,7 @@ public class RerunFormatterTest {
 
         String formatterOutput = runFeaturesWithRerunFormatter(Arrays.asList(feature1, feature2), stepsToResult);
 
-        assertEquals("path/second.feature:2 path/first.feature:2", formatterOutput);
+        assertEquals("path/second.feature:2\npath/first.feature:2\n", formatterOutput);
     }
 
     private String runFeatureWithRerunFormatter(final CucumberFeature feature, final Map<String, Result> stepsToResult)

--- a/core/src/test/java/cucumber/runtime/model/CucumberFeatureTest.java
+++ b/core/src/test/java/cucumber/runtime/model/CucumberFeatureTest.java
@@ -64,7 +64,7 @@ public class CucumberFeatureTest {
                 "  Scenario: scenario 2\n" +
                 "    * step\n";
         String rerunPath = "path/rerun.txt";
-        String rerunFile = featurePath1 + ":2 " + featurePath2 + ":4";
+        String rerunFile = featurePath1 + ":2\n" + featurePath2 + ":4\n";
         ResourceLoader resourceLoader = mockFeatureFileResource(featurePath1, feature1);
         mockFeatureFileResource(resourceLoader, featurePath2, feature2);
         mockFileResource(resourceLoader, rerunPath, null, rerunFile);
@@ -99,6 +99,96 @@ public class CucumberFeatureTest {
                 new PrintStream(new ByteArrayOutputStream()));
 
         assertEquals(0, features.size());
+    }
+
+    @Test
+    public void loads_no_features_when_rerun_file_contains_new_line() throws Exception {
+        String feature = "" +
+            "Feature: bar\n" +
+            "  Scenario: scenario bar\n" +
+            "    * step\n";
+        String rerunPath = "path/rerun.txt";
+        String rerunFile = "\n";
+        ResourceLoader resourceLoader = mockFeatureFileResourceForAnyFeaturePath(feature);
+        mockFileResource(resourceLoader, rerunPath, null, rerunFile);
+
+        List<CucumberFeature> features = CucumberFeature.load(
+            resourceLoader,
+            singletonList("@" + rerunPath),
+            new PrintStream(new ByteArrayOutputStream()));
+
+        assertEquals(0, features.size());
+    }
+
+    @Test
+    public void loads_no_features_when_rerun_file_contains_carriage_return() throws Exception {
+        String feature = "" +
+            "Feature: bar\n" +
+            "  Scenario: scenario bar\n" +
+            "    * step\n";
+        String rerunPath = "path/rerun.txt";
+        String rerunFile = "\r";
+        ResourceLoader resourceLoader = mockFeatureFileResourceForAnyFeaturePath(feature);
+        mockFileResource(resourceLoader, rerunPath, null, rerunFile);
+
+        List<CucumberFeature> features = CucumberFeature.load(
+            resourceLoader,
+            singletonList("@" + rerunPath),
+            new PrintStream(new ByteArrayOutputStream()));
+
+        assertEquals(0, features.size());
+    }
+
+    @Test
+    public void loads_no_features_when_rerun_file_contains_new_line_and_carriage_return() throws Exception {
+        String feature = "" +
+            "Feature: bar\n" +
+            "  Scenario: scenario bar\n" +
+            "    * step\n";
+        String rerunPath = "path/rerun.txt";
+        String rerunFile = "\r\n";
+        ResourceLoader resourceLoader = mockFeatureFileResourceForAnyFeaturePath(feature);
+        mockFileResource(resourceLoader, rerunPath, null, rerunFile);
+
+        List<CucumberFeature> features = CucumberFeature.load(
+            resourceLoader,
+            singletonList("@" + rerunPath),
+            new PrintStream(new ByteArrayOutputStream()));
+
+        assertEquals(0, features.size());
+    }
+
+    @Test
+    public void last_new_line_is_optinal() throws Exception {
+        String featurePath1 = "path/bar.feature";
+        String feature1 = "" +
+            "Feature: bar\n" +
+            "  Scenario: scenario bar\n" +
+            "    * step\n";
+        String featurePath2 = "path/foo.feature";
+        String feature2 = "" +
+            "Feature: foo\n" +
+            "  Scenario: scenario 1\n" +
+            "    * step\n" +
+            "  Scenario: scenario 2\n" +
+            "    * step\n";
+        String rerunPath = "path/rerun.txt";
+        String rerunFile = featurePath1 + ":2\n" + featurePath2 + ":4";
+        ResourceLoader resourceLoader = mockFeatureFileResource(featurePath1, feature1);
+        mockFeatureFileResource(resourceLoader, featurePath2, feature2);
+        mockFileResource(resourceLoader, rerunPath, null, rerunFile);
+
+        List<CucumberFeature> features = CucumberFeature.load(
+            resourceLoader,
+            singletonList("@" + rerunPath),
+            new PrintStream(new ByteArrayOutputStream()));
+
+        assertEquals(2, features.size());
+        assertEquals(1, features.get(0).getGherkinFeature().getFeature().getChildren().size());
+        assertEquals("scenario bar", features.get(0).getGherkinFeature().getFeature().getChildren().get(0).getName());
+        assertEquals(2, features.get(1).getGherkinFeature().getFeature().getChildren().size());
+        assertEquals("scenario 1", features.get(1).getGherkinFeature().getFeature().getChildren().get(0).getName());
+        assertEquals("scenario 2", features.get(1).getGherkinFeature().getFeature().getChildren().get(1).getName());
     }
 
     @Test
@@ -145,6 +235,28 @@ public class CucumberFeatureTest {
                             "Not a file or directory: path/bar.feature, No resource found for: classpath:path/bar.feature",
                     exception.getMessage());
         }
+    }
+
+    @Test
+    public void understands_whitespace_in_rerun_filepath() throws Exception {
+        String featurePath1 = "/home/users/mp/My Documents/tests/bar.feature";
+        String feature1 = "" +
+            "Feature: bar\n" +
+            "  Scenario: scenario bar\n" +
+            "    * step\n";
+        String rerunPath = "rerun.txt";
+        String rerunFile = featurePath1 + ":2\n";
+        ResourceLoader resourceLoader = mockFeatureFileResource(featurePath1, feature1);
+        mockFileResource(resourceLoader, rerunPath, null, rerunFile);
+
+        List<CucumberFeature> features = CucumberFeature.load(
+            resourceLoader,
+            singletonList("@" + rerunPath),
+            new PrintStream(new ByteArrayOutputStream()));
+
+        assertEquals(1, features.size());
+        assertEquals(1, features.get(0).getGherkinFeature().getFeature().getChildren().size());
+        assertEquals("scenario bar", features.get(0).getGherkinFeature().getFeature().getChildren().get(0).getName());
     }
 
     private ResourceLoader mockFeatureFileResource(String featurePath, String feature)


### PR DESCRIPTION
 Separating features by whitespace may cause issues when the path contains
 whitespace characters. E.g:

  ```
  /home/users/mpkorstanje/My Documents/tests/bar.feature
  ```

Separating features to be rerun by a new line avoids this problem and creates
a  more readable format. E.g:

  ```
  /home/users/mpkorstanje/My Documents/tests/bar01.feature:12:14:15
  /home/users/mpkorstanje/My Documents/tests/bar02.feature:1
  /home/users/mpkorstanje/My Documents/tests/bar03.feature:14
  /home/users/mpkorstanje/My Documents/tests/bar04.feature:15
  ```

Related issues:
 - #1059 
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
