### PR TITLE
Use "uri" instead of "path" to reference feature files.

### DIFF
--- a/android/src/main/java/cucumber/runtime/android/AndroidInstrumentationReporter.java
+++ b/android/src/main/java/cucumber/runtime/android/AndroidInstrumentationReporter.java
@@ -163,12 +163,12 @@ public class AndroidInstrumentationReporter implements Formatter {
     }
 
     void testSourceRead(final TestSourceRead event) {
-        testSources.addTestSourceReadEvent(event.path, event);
+        testSources.addTestSourceReadEvent(event.uri, event);
     }
 
     void startTestCase(final TestCase testCase) {
-        if (!testCase.getPath().equals(currentUri)) {
-            currentUri = testCase.getPath();
+        if (!testCase.getUri().equals(currentUri)) {
+            currentUri = testCase.getUri();
             currentFeatureName = testSources.getFeatureName(currentUri);
         }
         currentTestCaseName = testCase.getName();

--- a/android/src/test/java/cucumber/runtime/android/AndroidInstrumentationReporterTest.java
+++ b/android/src/test/java/cucumber/runtime/android/AndroidInstrumentationReporterTest.java
@@ -50,7 +50,7 @@ public class AndroidInstrumentationReporterTest {
 
     @Before
     public void beforeEachTest() {
-        when(testCase.getPath()).thenReturn("path/file.feature");
+        when(testCase.getUri()).thenReturn("path/file.feature");
         when(testCase.getName()).thenReturn("Some important scenario");
     }
 

--- a/core/src/main/java/cucumber/api/CucumberOptions.java
+++ b/core/src/main/java/cucumber/api/CucumberOptions.java
@@ -22,7 +22,7 @@ public @interface CucumberOptions {
     boolean strict() default false;
 
     /**
-     * @return the paths to the feature(s)
+     * @return the uris to the feature(s)
      */
     String[] features() default {};
 

--- a/core/src/main/java/cucumber/api/TestCase.java
+++ b/core/src/main/java/cucumber/api/TestCase.java
@@ -47,7 +47,7 @@ public class TestCase {
         return fileColonLine(pickleEvent.pickle.getLocations().get(0)) + " # " + getName();
     }
 
-    public String getPath() {
+    public String getUri() {
         return pickleEvent.uri;
     }
 

--- a/core/src/main/java/cucumber/api/event/TestSourceRead.java
+++ b/core/src/main/java/cucumber/api/event/TestSourceRead.java
@@ -1,13 +1,13 @@
 package cucumber.api.event;
 
 public final class TestSourceRead extends TimeStampedEvent {
-    public final String path;
+    public final String uri;
     public final String language;
     public final String source;
 
-    public TestSourceRead(Long timeStamp, String path, String language, String source) {
+    public TestSourceRead(Long timeStamp, String uri, String language, String source) {
         super(timeStamp);
-        this.path = path;
+        this.uri = uri;
         this.language = language;
         this.source = source;
     }

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -124,7 +124,7 @@ public class Runtime {
     public List<PickleEvent> compileFeature(CucumberFeature feature) {
         List<PickleEvent> pickleEvents = new ArrayList<PickleEvent>();
         for (Pickle pickle : compiler.compile(feature.getGherkinFeature())) {
-            pickleEvents.add(new PickleEvent(feature.getPath(), pickle));
+            pickleEvents.add(new PickleEvent(feature.getUri(), pickle));
         }
         return pickleEvents;
     }

--- a/core/src/main/java/cucumber/runtime/UndefinedStepsTracker.java
+++ b/core/src/main/java/cucumber/runtime/UndefinedStepsTracker.java
@@ -33,7 +33,7 @@ public class UndefinedStepsTracker implements EventListener {
     private EventHandler<TestSourceRead> testSourceReadHandler = new EventHandler<TestSourceRead>() {
         @Override
         public void receive(TestSourceRead event) {
-            pathToSourceMap.put(event.path, event.source);
+            pathToSourceMap.put(event.uri, event.source);
         }
     };
     private EventHandler<SnippetsSuggestedEvent> snippetsSuggestedHandler = new EventHandler<SnippetsSuggestedEvent>() {

--- a/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
@@ -140,7 +140,7 @@ class HTMLFormatter implements Formatter {
     }
 
     private void handleTestSourceRead(TestSourceRead event) {
-        testSources.addTestSourceReadEvent(event.path, event);
+        testSources.addTestSourceReadEvent(event.uri, event);
     }
 
     private void handleTestCaseStarted(TestCaseStarted event) {
@@ -208,8 +208,8 @@ class HTMLFormatter implements Formatter {
     }
 
     private void handleStartOfFeature(TestCase testCase) {
-        if (currentFeatureFile == null || !currentFeatureFile.equals(testCase.getPath())) {
-            currentFeatureFile = testCase.getPath();
+        if (currentFeatureFile == null || !currentFeatureFile.equals(testCase.getUri())) {
+            currentFeatureFile = testCase.getUri();
             jsFunctionCall("uri", currentFeatureFile);
             jsFunctionCall("feature", createFeature(testCase));
         }
@@ -217,7 +217,7 @@ class HTMLFormatter implements Formatter {
 
     private Map<String, Object> createFeature(TestCase testCase) {
         Map<String, Object> featureMap = new HashMap<String, Object>();
-        Feature feature = testSources.getFeature(testCase.getPath());
+        Feature feature = testSources.getFeature(testCase.getUri());
         if (feature != null) {
             featureMap.put("keyword", feature.getKeyword());
             featureMap.put("name", feature.getName());

--- a/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
@@ -105,12 +105,12 @@ class JSONFormatter implements Formatter {
     }
 
     private void handleTestSourceRead(TestSourceRead event) {
-        testSources.addTestSourceReadEvent(event.path, event);
+        testSources.addTestSourceReadEvent(event.uri, event);
     }
 
     private void handleTestCaseStarted(TestCaseStarted event) {
-        if (currentFeatureFile == null || !currentFeatureFile.equals(event.testCase.getPath())) {
-            currentFeatureFile = event.testCase.getPath();
+        if (currentFeatureFile == null || !currentFeatureFile.equals(event.testCase.getUri())) {
+            currentFeatureFile = event.testCase.getUri();
             Map<String, Object> currentFeatureMap = createFeatureMap(event.testCase);
             featureMaps.add(currentFeatureMap);
             currentElementsList = (List<Map<String, Object>>) currentFeatureMap.get("elements");
@@ -160,9 +160,9 @@ class JSONFormatter implements Formatter {
 
     private Map<String, Object> createFeatureMap(TestCase testCase) {
         Map<String, Object> featureMap = new HashMap<String, Object>();
-        featureMap.put("uri", testCase.getPath());
+        featureMap.put("uri", testCase.getUri());
         featureMap.put("elements", new ArrayList<Map<String, Object>>());
-        Feature feature = testSources.getFeature(testCase.getPath());
+        Feature feature = testSources.getFeature(testCase.getUri());
         if (feature != null) {
             featureMap.put("keyword", feature.getKeyword());
             featureMap.put("name", feature.getName());

--- a/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
@@ -106,12 +106,12 @@ class JUnitFormatter implements Formatter, StrictAware {
     }
 
     private void handleTestSourceRead(TestSourceRead event) {
-        TestCase.testSources.addTestSourceReadEvent(event.path, event);
+        TestCase.testSources.addTestSourceReadEvent(event.uri, event);
     }
 
     private void handleTestCaseStarted(TestCaseStarted event) {
-        if (TestCase.currentFeatureFile == null || !TestCase.currentFeatureFile.equals(event.testCase.getPath())) {
-            TestCase.currentFeatureFile = event.testCase.getPath();
+        if (TestCase.currentFeatureFile == null || !TestCase.currentFeatureFile.equals(event.testCase.getUri())) {
+            TestCase.currentFeatureFile = event.testCase.getUri();
             TestCase.previousTestCaseName = "";
             TestCase.exampleNumber = 1;
         }

--- a/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
@@ -115,7 +115,7 @@ class PrettyFormatter implements Formatter, ColorAware {
     }
 
     private void handleTestSourceRead(TestSourceRead event) {
-        testSources.addTestSourceReadEvent(event.path, event);
+        testSources.addTestSourceReadEvent(event.uri, event);
     }
 
     private void handleTestCaseStarted(TestCaseStarted event) {
@@ -155,11 +155,11 @@ class PrettyFormatter implements Formatter, ColorAware {
     }
 
     private void handleStartOfFeature(TestCaseStarted event) {
-        if (currentFeatureFile == null || !currentFeatureFile.equals(event.testCase.getPath())) {
+        if (currentFeatureFile == null || !currentFeatureFile.equals(event.testCase.getUri())) {
             if (currentFeatureFile != null) {
                 out.println();
             }
-            currentFeatureFile = event.testCase.getPath();
+            currentFeatureFile = event.testCase.getUri();
             printFeature(currentFeatureFile);
         }
     }

--- a/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
@@ -64,7 +64,7 @@ class RerunFormatter implements Formatter, StrictAware {
     }
 
     private void recordTestFailed(TestCase testCase) {
-        String path = testCase.getPath();
+        String path = testCase.getUri();
         ArrayList<Integer> failedTestCases = this.featureAndFailedLinesMapping.get(path);
         if (failedTestCases == null) {
             failedTestCases = new ArrayList<Integer>();

--- a/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
@@ -116,16 +116,16 @@ class TestNGFormatter implements Formatter, StrictAware {
     }
 
     private void handleTestSourceRead(TestSourceRead event) {
-        TestMethod.testSources.addTestSourceReadEvent(event.path, event);
+        TestMethod.testSources.addTestSourceReadEvent(event.uri, event);
     }
 
     private void handleTestCaseStarted(TestCaseStarted event) {
-        if (TestMethod.currentFeatureFile == null || !TestMethod.currentFeatureFile.equals(event.testCase.getPath())) {
-            TestMethod.currentFeatureFile = event.testCase.getPath();
+        if (TestMethod.currentFeatureFile == null || !TestMethod.currentFeatureFile.equals(event.testCase.getUri())) {
+            TestMethod.currentFeatureFile = event.testCase.getUri();
             TestMethod.previousTestCaseName = "";
             TestMethod.exampleNumber = 1;
             clazz = document.createElement("class");
-            clazz.setAttribute("name", TestMethod.testSources.getFeature(event.testCase.getPath()).getName());
+            clazz.setAttribute("name", TestMethod.testSources.getFeature(event.testCase.getUri()).getName());
             test.appendChild(clazz);
         }
         root = document.createElement("test-method");

--- a/core/src/main/java/cucumber/runtime/model/CucumberFeature.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberFeature.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class CucumberFeature implements Serializable {
     private static final long serialVersionUID = 1L;
-    private final String path;
+    private final String uri;
     private String language;
     private GherkinDocument gherkinDocument;
     private String gherkinSource;
@@ -117,9 +117,9 @@ public class CucumberFeature implements Serializable {
         }
     }
 
-    public CucumberFeature(GherkinDocument gherkinDocument, String path, String gherkinSource) {
+    public CucumberFeature(GherkinDocument gherkinDocument, String uri, String gherkinSource) {
         this.gherkinDocument = gherkinDocument;
-        this.path = path;
+        this.uri = uri;
         this.gherkinSource = gherkinSource;
         if (gherkinDocument.getFeature() != null) {
             setLanguage(gherkinDocument.getFeature().getLanguage());
@@ -134,12 +134,12 @@ public class CucumberFeature implements Serializable {
         return language;
     }
 
-    public String getPath() {
-        return path;
+    public String getUri() {
+        return uri;
     }
 
     public void sendTestSourceRead(EventBus bus) {
-        bus.send(new TestSourceRead(bus.getTime(), path, gherkinDocument.getFeature().getLanguage(), gherkinSource));
+        bus.send(new TestSourceRead(bus.getTime(), uri, gherkinDocument.getFeature().getLanguage(), gherkinSource));
     }
 
     private void setLanguage(String language) {
@@ -149,7 +149,7 @@ public class CucumberFeature implements Serializable {
     private static class CucumberFeatureUriComparator implements Comparator<CucumberFeature> {
         @Override
         public int compare(CucumberFeature a, CucumberFeature b) {
-            return a.getPath().compareTo(b.getPath());
+            return a.getUri().compareTo(b.getUri());
         }
     }
 }

--- a/core/src/test/java/cucumber/runtime/FeatureBuilderTest.java
+++ b/core/src/test/java/cucumber/runtime/FeatureBuilderTest.java
@@ -40,7 +40,7 @@ public class FeatureBuilderTest {
         builder.parse(resource);
 
         assertEquals(1, features.size());
-        assertEquals(featurePath, features.get(0).getPath());
+        assertEquals(featurePath, features.get(0).getUri());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class FeatureBuilderTest {
         builder.parse(resource);
 
         assertEquals(1, features.size());
-        assertEquals("path/foo.feature", features.get(0).getPath());
+        assertEquals("path/foo.feature", features.get(0).getUri());
     }
 
     private Resource createResourceMock(String featurePath) throws IOException {

--- a/junit/src/main/java/cucumber/runtime/junit/FeatureRunner.java
+++ b/junit/src/main/java/cucumber/runtime/junit/FeatureRunner.java
@@ -77,7 +77,7 @@ public class FeatureRunner extends ParentRunner<PickleRunner> {
         Compiler compiler = new Compiler();
         List<PickleEvent> pickleEvents = new ArrayList<PickleEvent>();
         for (Pickle pickle : compiler.compile(cucumberFeature.getGherkinFeature())) {
-            pickleEvents.add(new PickleEvent(cucumberFeature.getPath(), pickle));
+            pickleEvents.add(new PickleEvent(cucumberFeature.getUri(), pickle));
         }
         Feature feature = cucumberFeature.getGherkinFeature().getFeature();
         String featureName = feature.getName();
@@ -105,7 +105,7 @@ public class FeatureRunner extends ParentRunner<PickleRunner> {
         private final String uri;
 
         FeatureId(CucumberFeature feature) {
-            this.uri = feature.getPath();
+            this.uri = feature.getUri();
         }
 
         @Override

--- a/junit/src/test/java/cucumber/runtime/junit/PickleRunnerWithStepDescriptionsTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/PickleRunnerWithStepDescriptionsTest.java
@@ -40,7 +40,7 @@ public class PickleRunnerWithStepDescriptionsTest {
         Compiler compiler = new Compiler();
         List<PickleEvent> pickleEvents = new ArrayList<PickleEvent>();
         for (Pickle pickle : compiler.compile(features.getGherkinFeature())) {
-            pickleEvents.add(new PickleEvent(features.getPath(), pickle));
+            pickleEvents.add(new PickleEvent(features.getUri(), pickle));
         };
 
         WithStepDescriptions runner = (WithStepDescriptions) PickleRunners.withStepDescriptions(
@@ -78,7 +78,7 @@ public class PickleRunnerWithStepDescriptionsTest {
         Compiler compiler = new Compiler();
         List<PickleEvent> pickleEvents = new ArrayList<PickleEvent>();
         for (Pickle pickle : compiler.compile(features.getGherkinFeature())) {
-            pickleEvents.add(new PickleEvent(features.getPath(), pickle));
+            pickleEvents.add(new PickleEvent(features.getUri(), pickle));
         };
 
         WithStepDescriptions runner = (WithStepDescriptions) PickleRunners.withStepDescriptions(
@@ -110,7 +110,7 @@ public class PickleRunnerWithStepDescriptionsTest {
         Compiler compiler = new Compiler();
         List<PickleEvent> pickleEvents = new ArrayList<PickleEvent>();
         for (Pickle pickle : compiler.compile(features.getGherkinFeature())) {
-            pickleEvents.add(new PickleEvent(features.getPath(), pickle));
+            pickleEvents.add(new PickleEvent(features.getUri(), pickle));
         }
 
         PickleRunner runner = PickleRunners.withStepDescriptions(

--- a/junit/src/test/java/cucumber/runtime/junit/TestPickleBuilder.java
+++ b/junit/src/test/java/cucumber/runtime/junit/TestPickleBuilder.java
@@ -23,7 +23,7 @@ public class TestPickleBuilder {
 
         CucumberFeature feature = parseFeature(path, source);
         for (Pickle pickle : compiler.compile(feature.getGherkinFeature())) {
-            pickleEvents.add(new PickleEvent(feature.getPath(), pickle));
+            pickleEvents.add(new PickleEvent(feature.getUri(), pickle));
         };
         return pickleEvents;
     }

--- a/testng/src/main/java/cucumber/api/testng/TestNGCucumberRunner.java
+++ b/testng/src/main/java/cucumber/api/testng/TestNGCucumberRunner.java
@@ -60,7 +60,7 @@ public class TestNGCucumberRunner {
     public void runCukes() {
         System.err.println("WARNING: The TestNGCucumberRunner.runCukes() is deprecated. Please create a runner class by subclassing AbstractTestNGCucumberTest.");
         for (CucumberFeature cucumberFeature : getFeatures()) {
-            reporter.uri(cucumberFeature.getPath());
+            reporter.uri(cucumberFeature.getUri());
             runtime.runFeature(cucumberFeature);
         }
         finish();
@@ -71,7 +71,7 @@ public class TestNGCucumberRunner {
 
     public void runCucumber(CucumberFeature cucumberFeature) {
         resultListener.startFeature();
-        reporter.uri(cucumberFeature.getPath());
+        reporter.uri(cucumberFeature.getUri());
         runtime.runFeature(cucumberFeature);
 
         if (!resultListener.isPassed()) {


### PR DESCRIPTION
## Summary

Use "uri" instead of "path" to reference feature files, especially in public methods of classes in the api packages.

## Details

"uri" is used in the Gherkin library to refer to feature files, and has also the advantage of that uri:s use the [same separator, "/", on all platforms](https://stackoverflow.com/a/1589958), whereas path:s use different separators, "/" on Unix/Linux and MacOS, but "\" in Windows.

Technically we are abusing the uri concept by also using "uri"s defined relative the "current directory", an correct uri always define the scheme (`file`, `http(s)` etc), and are in case of the file scheme the absolute path on the host in question.

## Motivation and Context

Consistency with the Gherkin library, enabling using the same output regardless of the platform.

For several releases Cucumber-JVM has regardless of platform used "`/`" when referencing to feature files, but internally the method name `getPath()` has been used to access this reference (which is a contradiction on Windows).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue) - no release external API is changed.
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
