### PR TITLE
[Core] Use cucumber-ruby rerun file specification

### DIFF
--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -444,8 +444,7 @@ public class RuntimeOptions {
     private void processRerunFiles(ResourceLoader resourceLoader) {
         for (String featurePath : featurePaths) {
             if (featurePath.startsWith("@")) {
-                for (String path : CucumberFeature.loadRerunFile(resourceLoader, featurePath.substring(1))) {
-                    PathWithLines pathWithLines = new PathWithLines(path);
+                for (PathWithLines pathWithLines : CucumberFeature.loadRerunFile(resourceLoader, featurePath.substring(1))) {
                     addLineFilters(lineFilters, pathWithLines.path, pathWithLines.lines);
                 }
             }

--- a/core/src/main/java/cucumber/runtime/model/CucumberFeature.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberFeature.java
@@ -55,20 +55,20 @@ public class CucumberFeature implements Serializable {
     }
 
     private static void loadFromRerunFile(FeatureBuilder builder, ResourceLoader resourceLoader, String rerunPath) {
-        for(String path : loadRerunFile(resourceLoader, rerunPath)){
-            loadFromFileSystemOrClasspath(builder, resourceLoader, new PathWithLines(path).path);
+        for(PathWithLines pathWithLines : loadRerunFile(resourceLoader, rerunPath)){
+            loadFromFileSystemOrClasspath(builder, resourceLoader, pathWithLines.path);
         }
     }
 
-    public static List<String> loadRerunFile(ResourceLoader resourceLoader, String rerunPath) {
-        List<String> featurePaths = new ArrayList<String>();
+    public static List<PathWithLines> loadRerunFile(ResourceLoader resourceLoader, String rerunPath) {
+        List<PathWithLines> featurePaths = new ArrayList<PathWithLines>();
         Iterable<Resource> resources = resourceLoader.resources(rerunPath, null);
         for (Resource resource : resources) {
             String source = read(resource);
             if (!source.isEmpty()) {
                 Matcher matcher = RERUN_PATH_SPECIFICATION.matcher(source);
                 while(matcher.find()){
-                    featurePaths.add(matcher.group(1));
+                    featurePaths.add(new PathWithLines(matcher.group(1)));
                 }
             }
         }

--- a/core/src/test/java/cucumber/runtime/model/CucumberFeatureTest.java
+++ b/core/src/test/java/cucumber/runtime/model/CucumberFeatureTest.java
@@ -259,6 +259,74 @@ public class CucumberFeatureTest {
         assertEquals("scenario bar", features.get(0).getGherkinFeature().getFeature().getChildren().get(0).getName());
     }
 
+
+    @Test
+    public void understands_rerun_files_separated_by_with_whitespace() throws Exception {
+        String featurePath1 = "/home/users/mp/My Documents/tests/bar.feature";
+        String feature1 = "" +
+            "Feature: bar\n" +
+            "  Scenario: scenario bar\n" +
+            "    * step\n";
+        String featurePath2 = "/home/users/mp/My Documents/tests/foo.feature";
+        String feature2 = "" +
+            "Feature: foo\n" +
+            "  Scenario: scenario 1\n" +
+            "    * step\n" +
+            "  Scenario: scenario 2\n" +
+            "    * step\n";
+        String rerunPath = "path/rerun.txt";
+        String rerunFile = featurePath1 + ":2 " + featurePath2 + ":4";
+        ResourceLoader resourceLoader = mockFeatureFileResource(featurePath1, feature1);
+        mockFeatureFileResource(resourceLoader, featurePath2, feature2);
+        mockFileResource(resourceLoader, rerunPath, null, rerunFile);
+
+        List<CucumberFeature> features = CucumberFeature.load(
+            resourceLoader,
+            singletonList("@" + rerunPath),
+            new PrintStream(new ByteArrayOutputStream()));
+
+        assertEquals(2, features.size());
+        assertEquals(1, features.get(0).getGherkinFeature().getFeature().getChildren().size());
+        assertEquals("scenario bar", features.get(0).getGherkinFeature().getFeature().getChildren().get(0).getName());
+        assertEquals(2, features.get(1).getGherkinFeature().getFeature().getChildren().size());
+        assertEquals("scenario 1", features.get(1).getGherkinFeature().getFeature().getChildren().get(0).getName());
+        assertEquals("scenario 2", features.get(1).getGherkinFeature().getFeature().getChildren().get(1).getName());
+    }
+
+
+    @Test
+    public void understands_rerun_files_without_separation_in_rerun_filepath() throws Exception {
+        String featurePath1 = "/home/users/mp/My Documents/tests/bar.feature";
+        String feature1 = "" +
+            "Feature: bar\n" +
+            "  Scenario: scenario bar\n" +
+            "    * step\n";
+        String featurePath2 = "/home/users/mp/My Documents/tests/foo.feature";
+        String feature2 = "" +
+            "Feature: foo\n" +
+            "  Scenario: scenario 1\n" +
+            "    * step\n" +
+            "  Scenario: scenario 2\n" +
+            "    * step\n";
+        String rerunPath = "path/rerun.txt";
+        String rerunFile = featurePath1 + ":2" + featurePath2 + ":4";
+        ResourceLoader resourceLoader = mockFeatureFileResource(featurePath1, feature1);
+        mockFeatureFileResource(resourceLoader, featurePath2, feature2);
+        mockFileResource(resourceLoader, rerunPath, null, rerunFile);
+
+        List<CucumberFeature> features = CucumberFeature.load(
+            resourceLoader,
+            singletonList("@" + rerunPath),
+            new PrintStream(new ByteArrayOutputStream()));
+
+        assertEquals(2, features.size());
+        assertEquals(1, features.get(0).getGherkinFeature().getFeature().getChildren().size());
+        assertEquals("scenario bar", features.get(0).getGherkinFeature().getFeature().getChildren().get(0).getName());
+        assertEquals(2, features.get(1).getGherkinFeature().getFeature().getChildren().size());
+        assertEquals("scenario 1", features.get(1).getGherkinFeature().getFeature().getChildren().get(0).getName());
+        assertEquals("scenario 2", features.get(1).getGherkinFeature().getFeature().getChildren().get(1).getName());
+    }
+
     private ResourceLoader mockFeatureFileResource(String featurePath, String feature)
             throws IOException {
         ResourceLoader resourceLoader = mock(ResourceLoader.class);


### PR DESCRIPTION
Implemented the rerun file specification from cucumber ruby[1]. It
handles spaces, new lines as a separator as well as no separator at all.

References:
 [1] https://github.com/cucumber/cucumber-ruby/blame/master/lib/cucumber/cli/rerun_file.rb

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
