### PR TITLE
Use whole path for uri:s for file system feature files.

### DIFF
--- a/core/src/main/java/cucumber/runtime/io/FileResource.java
+++ b/core/src/main/java/cucumber/runtime/io/FileResource.java
@@ -8,10 +8,20 @@ import java.io.InputStream;
 public class FileResource implements Resource {
     private final File root;
     private final File file;
+    private final boolean classpathFileResource;
 
-    public FileResource(File root, File file) {
+    public static FileResource createFileResource(File root, File file) {
+        return new FileResource(root, file, false);
+    }
+
+    public static FileResource createClasspathFileResource(File root, File file) {
+        return new FileResource(root, file, true);
+    }
+
+    private FileResource(File root, File file, boolean classpathFileResource) {
         this.root = root;
         this.file = file;
+        this.classpathFileResource = classpathFileResource;
         if (!file.getAbsolutePath().startsWith(root.getAbsolutePath())) {
             throw new IllegalArgumentException(file.getAbsolutePath() + " is not a parent of " + root.getAbsolutePath());
         }
@@ -19,10 +29,10 @@ public class FileResource implements Resource {
 
     @Override
     public String getPath() {
-        if (file.equals(root)) {
-            return file.getPath();
-        } else {
+        if (classpathFileResource) {
             return file.getAbsolutePath().substring(root.getAbsolutePath().length() + 1);
+        } else {
+            return file.getPath();
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/io/FileResourceIterable.java
+++ b/core/src/main/java/cucumber/runtime/io/FileResourceIterable.java
@@ -16,6 +16,6 @@ public class FileResourceIterable implements Iterable<Resource> {
 
     @Override
     public Iterator<Resource> iterator() {
-        return new FileResourceIterator(root, file, suffix);
+        return FileResourceIterator.createFileResourceIterator(root, file, suffix);
     }
 }

--- a/core/src/main/java/cucumber/runtime/io/FileResourceIteratorFactory.java
+++ b/core/src/main/java/cucumber/runtime/io/FileResourceIteratorFactory.java
@@ -27,6 +27,6 @@ public class FileResourceIteratorFactory implements ResourceIteratorFactory {
     public Iterator<Resource> createIterator(URL url, String path, String suffix) {
         File file = new File(filePath(url));
         File rootDir = new File(file.getAbsolutePath().substring(0, file.getAbsolutePath().length() - path.length()));
-        return new FileResourceIterator(rootDir, file, suffix);
+        return FileResourceIterator.createClasspathFileResourceIterator(rootDir, file, suffix);
     }
 }

--- a/core/src/test/java/cucumber/runtime/io/FileResourceTest.java
+++ b/core/src/test/java/cucumber/runtime/io/FileResourceTest.java
@@ -9,20 +9,24 @@ import static org.junit.Assert.assertEquals;
 public class FileResourceTest {
 
     @Test
-    public void get_path_should_return_short_path_when_root_same_as_file() {
+    public void for_classpath_files_get_path_should_return_relative_path_from_classpath_root() {
         // setup
-        FileResource toTest = new FileResource(new File("test1/test.feature"), new File("test1/test.feature"));
+        FileResource toTest1 = FileResource.createClasspathFileResource(new File("/testPath"), new File("/testPath/test1/test.feature"));
+        FileResource toTest2 = FileResource.createClasspathFileResource(new File("testPath"), new File("testPath/test1/test.feature"));
 
         // test
-        assertEquals("test1" + File.separator + "test.feature", toTest.getPath());
+        assertEquals("test1" + File.separator + "test.feature", toTest1.getPath());
+        assertEquals("test1" + File.separator + "test.feature", toTest2.getPath());
     }
 
     @Test
-    public void get_path_should_return_truncated_path_when_absolute_file_paths_are_input() {
+    public void for_filesystem_files_get_path_should_return_the_path() {
         // setup
-        FileResource toTest = new FileResource(new File("/testPath/test1"), new File("/testPath/test1/test.feature"));
+        FileResource toTest1 = FileResource.createFileResource(new File("test1"), new File("test1/test.feature"));
+        FileResource toTest2 = FileResource.createFileResource(new File("test1/test.feature"), new File("test1/test.feature"));
 
         // test
-        assertEquals("test.feature", toTest.getPath());
+        assertEquals("test1" + File.separator + "test.feature", toTest1.getPath());
+        assertEquals("test1" + File.separator + "test.feature", toTest2.getPath());
     }
 }


### PR DESCRIPTION
## Summary

When a features argument does not uses the classpath, use the whole feature file path as the uri of the feature file.

## Details

Current behaviour:
Given the following folder structure:
```
features
    | - subdir
          |- test1.feature
```
Using the features argument `features/subdir/test1.feature` 
-> the uri becomes `features/subdir/test1.feature`
Using the features argument `features` 
-> the uri becomes `subdir/test1.feature`

Apart from being inconsistent and confusing this also makes the rerun feature not working when loading feature file from the file system directly, instead of loading them using the classpath.
 
The new behaviour:
Given the same folder structure
Using the features argument `features/subdir/test1.feature` 
-> the uri becomes `features/subdir/test1.feature`
Using the features argument `features` 
-> the uri becomes `features/subdir/test1.feature`
Using the features argument `/projects/project/features`
-> the uri becomes `/projects/project/features/subdir/test1.feature`

This is the same behaviour as Cucumber-Ruby.

The behaviour when loading feature file from the classpath (using `classpath:<path>` or using the implicit features argument defined by the runner class - that is the package path of the runner class) is not changed. In these cases the uri still becomes the path from the classpath root directory (for instance `cucumber/examples/java/calculator/<file>.feature` for a feature file loaded from the `target/test-classes/cucumber/examples/java/calculator/` directory in the java-calculator example - `target/test-classes` is when using maven a directory on the classpath)

This makes the rerun feature work also when loading feature file from the file system directly, instead of loading them using the classpath.

Closes #854.

## Motivation and Context

The current behaviour is inconsistent and confusing, and makes the rerun feature not working when loading feature file from the file system directly, instead of loading them using the classpath.

## How Has This Been Tested?

In addition to the modified unit tests, I have manually verified the the rerun feature does work when using file system features argument in the java-calculator example.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
