### PR TITLE
[JUnit] Invoke (Before|After)Class and TestRules around Cucumber execution

### DIFF
--- a/junit/src/main/java/cucumber/api/junit/Cucumber.java
+++ b/junit/src/main/java/cucumber/api/junit/Cucumber.java
@@ -19,6 +19,7 @@ import org.junit.runner.Description;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.ParentRunner;
 import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -75,7 +76,7 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
      * @param runtimeOptions configuration
      * @return a new runtime
      * @throws InitializationError if a JUnit error occurred
-     * @throws IOException if a class or resource could not be loaded
+     * @throws IOException         if a class or resource could not be loaded
      */
     protected Runtime createRuntime(ResourceLoader resourceLoader, ClassLoader classLoader,
                                     RuntimeOptions runtimeOptions) throws InitializationError, IOException {
@@ -99,10 +100,16 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
     }
 
     @Override
-    public void run(RunNotifier notifier) {
-        super.run(notifier);
-        runtime.getEventBus().send(new TestRunFinished(runtime.getEventBus().getTime()));
-        runtime.printSummary();
+    protected Statement childrenInvoker(RunNotifier notifier) {
+        final Statement features = super.childrenInvoker(notifier);
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                features.evaluate();
+                runtime.getEventBus().send(new TestRunFinished(runtime.getEventBus().getTime()));
+                runtime.printSummary();
+            }
+        };
     }
 
     private void addChildren(List<CucumberFeature> cucumberFeatures) throws InitializationError {


### PR DESCRIPTION
Junit invokes several framework methods around the test execution.
The cucumber runner should finish its whole execution inside these.

To be precises these two should be equivalent:

```
@BeforeClass
public static void before {
   // Do stuff
}

@Test
public void test(){
    cucumber.api.cli.Main.main(some arguments....)
}

@AfterClass
public static void after {
   // Do stuff
}

```

```
@RunWith(Cucumber.class)
public class Test {
    @BeforeClass
    public static void before {
       // Do stuff
    }

    @AfterClass
    public static void after {
     // Do stuff
    }
}
```

By firing the TestRunFinished event and printing the summary directly
after invoking the children rather then after the completion of the
whole test run these are made equivalent again.

Firing the TestRunFinished event before the JUnit execution 
is done might look a bit odd but semantically this is a cucumber event
not a junit event and cucumber has finished its execution at this point.

## Context

https://cucumberbdd.slack.com/archives/C590XDQQH/p1501620355467970

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Awaiting confirmation from toothpicks131

I've manually placed breakpoints in the examples above to verify the methods are called in the correct order. 




