### PR TITLE
Issue #159 Diffing a table with an empty list: Added two tests diffin…

### DIFF
--- a/core/src/test/java/cucumber/runtime/table/TableDifferTest.java
+++ b/core/src/test/java/cucumber/runtime/table/TableDifferTest.java
@@ -234,7 +234,7 @@ public class TableDifferTest {
         try {
             DataTable emptyTable = DataTable.create(Collections.emptyList());
             table().diff(emptyTable);
-        } catch (IndexOutOfBoundsException e) {
+        } catch (TableDiffException e) {
             String expected = "" +
                 "Tables were not identical:\n" +
                 "    - | Aslak | aslak@email.com | 123 |\n" +
@@ -248,20 +248,9 @@ public class TableDifferTest {
 
     @Test
     public void empty_list_should_not_diff_with_empty_table() {
-        try {
-            List<List<String>> emptyList = new ArrayList<List<String>>();
-            DataTable emptyTable = DataTable.create(Collections.emptyList());
-            emptyTable.diff(emptyList);
-        } catch (IndexOutOfBoundsException e) {
-            String expected = "" +
-                "Tables were not identical:\n" +
-                "    - | Aslak | aslak@email.com | 123 |\n" +
-                "    - | Joe   | joe@email.com   | 234 |\n" +
-                "    - | Bryan | bryan@email.org | 456 |\n" +
-                "    - | Ni    | ni@email.com    | 654 |\n";
-            assertEquals(expected, e.getMessage());
-            throw e;
-        }
+        List<List<String>> emptyList = new ArrayList<List<String>>();
+        DataTable emptyTable = DataTable.create(Collections.emptyList());
+        assertEquals(emptyTable.raw(), emptyList);
     }
 
     @Test(expected = TableDiffException.class)

--- a/core/src/test/java/cucumber/runtime/table/TableDifferTest.java
+++ b/core/src/test/java/cucumber/runtime/table/TableDifferTest.java
@@ -4,6 +4,7 @@ import cucumber.api.DataTable;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -223,6 +224,41 @@ public class TableDifferTest {
                     "    - | Joe   | joe@email.com   | 234 |\n" +
                     "    - | Bryan | bryan@email.org | 456 |\n" +
                     "    - | Ni    | ni@email.com    | 654 |\n";
+            assertEquals(expected, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Test(expected = TableDiffException.class)
+    public void should_diff_with_empty_table() {
+        try {
+            DataTable emptyTable = DataTable.create(Collections.emptyList());
+            table().diff(emptyTable);
+        } catch (IndexOutOfBoundsException e) {
+            String expected = "" +
+                "Tables were not identical:\n" +
+                "    - | Aslak | aslak@email.com | 123 |\n" +
+                "    - | Joe   | joe@email.com   | 234 |\n" +
+                "    - | Bryan | bryan@email.org | 456 |\n" +
+                "    - | Ni    | ni@email.com    | 654 |\n";
+            assertEquals(expected, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Test
+    public void empty_list_should_not_diff_with_empty_table() {
+        try {
+            List<List<String>> emptyList = new ArrayList<List<String>>();
+            DataTable emptyTable = DataTable.create(Collections.emptyList());
+            emptyTable.diff(emptyList);
+        } catch (IndexOutOfBoundsException e) {
+            String expected = "" +
+                "Tables were not identical:\n" +
+                "    - | Aslak | aslak@email.com | 123 |\n" +
+                "    - | Joe   | joe@email.com   | 234 |\n" +
+                "    - | Bryan | bryan@email.org | 456 |\n" +
+                "    - | Ni    | ni@email.com    | 654 |\n";
             assertEquals(expected, e.getMessage());
             throw e;
         }


### PR DESCRIPTION
…g with empty table to TableDifferTest

## Summary
Added two tests for issue #159

## Details
One test to verify that diffing a non-empty table with an empty table throws expected TableDiffException.
One test to verify that diffing an empty table with an empty list does not throw an Exception.

## Motivation and Context
Show that the issue has been resolved

## How Has This Been Tested?
Test code only, to show issue has been resolved.

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [x ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.