### PR TITLE
Remove relative path to parent pom

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/clojure/pom.xml
+++ b/clojure/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/examples/android/cukeulator/pom.xml
+++ b/examples/android/cukeulator/pom.xml
@@ -6,7 +6,6 @@
     <parent>
         <groupId>io.cucumber.android-examples</groupId>
         <artifactId>android-examples</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/examples/pax-exam/calculator-api/pom.xml
+++ b/examples/pax-exam/calculator-api/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>pax-exam</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/examples/pax-exam/calculator-service/pom.xml
+++ b/examples/pax-exam/calculator-service/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>pax-exam</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/examples/pax-exam/calculator-test/pom.xml
+++ b/examples/pax-exam/calculator-test/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>pax-exam</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/gosu/pom.xml
+++ b/gosu/pom.xml
@@ -6,7 +6,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/jython/pom.xml
+++ b/jython/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/kotlin-java8/pom.xml
+++ b/kotlin-java8/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/needle/pom.xml
+++ b/needle/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/openejb/pom.xml
+++ b/openejb/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/picocontainer/pom.xml
+++ b/picocontainer/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/rhino/pom.xml
+++ b/rhino/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -6,7 +6,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/scala/scala_2.10/pom.xml
+++ b/scala/scala_2.10/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-scala-aggregator</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/scala/scala_2.11/pom.xml
+++ b/scala/scala_2.11/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-scala-aggregator</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/scala/scala_2.12/pom.xml
+++ b/scala/scala_2.12/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-scala-aggregator</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/testng/pom.xml
+++ b/testng/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -4,7 +4,6 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <relativePath>../pom.xml</relativePath>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 


### PR DESCRIPTION
Maven relies on convention over configuration. By convention the
`relativePath` is `../pom.xml` and can be ommited from the pom file[1].

References:
 1. https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#Project_Inheritance