### PR TITLE
Fix PrettyFormatter Exception for nested capture groups

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
@@ -214,10 +214,13 @@ class PrettyFormatter implements Formatter, ColorAware {
             // can be null if the argument is missing.
             if (argument.getOffset() != null) {
                 int textEnd = argument.getOffset();
-                if (textStart <= textEnd ) { // textStart can be > textEnd with nested capture groups
+                if (textStart > textEnd ) { // textStart can be > textEnd with nested capture groups
+                    continue;
+                } else {
                     String text = stepText.substring(textStart, textEnd);
                     result.append(textFormat.text(text));
                 }
+
             }
             // val can be null if the argument isn't there, for example @And("(it )?has something")
             if (argument.getVal() != null) {
@@ -225,7 +228,7 @@ class PrettyFormatter implements Formatter, ColorAware {
                 textStart = argument.getOffset() + argument.getVal().length();
             }
         }
-        if (textStart != stepText.length() && textStart >= 0) { // textStart can be < 0 with nested capture groups
+        if (textStart != stepText.length() && textStart >= 0 && textStart < stepText.length()) { // textStart can be < 0 with nested capture groups
             String text = stepText.substring(textStart, stepText.length());
             result.append(textFormat.text(text));
         }

--- a/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
@@ -213,8 +213,11 @@ class PrettyFormatter implements Formatter, ColorAware {
         for (Argument argument : arguments) {
             // can be null if the argument is missing.
             if (argument.getOffset() != null) {
-                String text = stepText.substring(textStart, argument.getOffset());
-                result.append(textFormat.text(text));
+                int textEnd = argument.getOffset();
+                if (textStart <= textEnd ) { // textStart can be > textEnd with nested capture groups
+                    String text = stepText.substring(textStart, textEnd);
+                    result.append(textFormat.text(text));
+                }
             }
             // val can be null if the argument isn't there, for example @And("(it )?has something")
             if (argument.getVal() != null) {
@@ -222,7 +225,7 @@ class PrettyFormatter implements Formatter, ColorAware {
                 textStart = argument.getOffset() + argument.getVal().length();
             }
         }
-        if (textStart != stepText.length()) {
+        if (textStart != stepText.length() && textStart >= 0) { // textStart can be < 0 with nested capture groups
             String text = stepText.substring(textStart, stepText.length());
             result.append(textFormat.text(text));
         }

--- a/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
@@ -208,28 +208,27 @@ class PrettyFormatter implements Formatter, ColorAware {
     }
 
     String formatStepText(String keyword, String stepText, Format textFormat, Format argFormat, List<Argument> arguments) {
-        int textStart = 0;
+        int beginIndex = 0;
         StringBuilder result = new StringBuilder(textFormat.text(keyword));
         for (Argument argument : arguments) {
             // can be null if the argument is missing.
             if (argument.getOffset() != null) {
-                int textEnd = argument.getOffset();
-                if (textStart > textEnd ) { // textStart can be > textEnd with nested capture groups
+                int argumentOffset = argument.getOffset();
+                if (argumentOffset < beginIndex ) { // a nested argument starts before the enclosing argument ends; ignore it when formatting
                     continue;
-                } else {
-                    String text = stepText.substring(textStart, textEnd);
-                    result.append(textFormat.text(text));
                 }
-
+                String text = stepText.substring(beginIndex, argumentOffset);
+                result.append(textFormat.text(text));
             }
             // val can be null if the argument isn't there, for example @And("(it )?has something")
             if (argument.getVal() != null) {
                 result.append(argFormat.text(argument.getVal()));
-                textStart = argument.getOffset() + argument.getVal().length();
+                int argumentEnd = argument.getOffset() + argument.getVal().length(); // end of current argument; can be < 0 for nested argument
+                beginIndex = argumentEnd;
             }
         }
-        if (textStart != stepText.length() && textStart >= 0 && textStart < stepText.length()) { // textStart can be < 0 with nested capture groups
-            String text = stepText.substring(textStart, stepText.length());
+        if (beginIndex != stepText.length() && beginIndex >= 0) {
+            String text = stepText.substring(beginIndex, stepText.length());
             result.append(textFormat.text(text));
         }
         return result.toString();

--- a/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
@@ -21,6 +21,7 @@ import static cucumber.runtime.TestHelper.result;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class PrettyFormatterTest {
@@ -50,7 +51,7 @@ public class PrettyFormatterTest {
     }
 
     @Test
-    public void should_handle_backgound() throws Throwable {
+    public void should_handle_background() throws Throwable {
         CucumberFeature feature = feature("path/test.feature", "" +
                 "Feature: feature name\n" +
                 "  Background: background name\n" +
@@ -379,6 +380,37 @@ public class PrettyFormatterTest {
                                           AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "arg1"  + AnsiEscapes.RESET +
                                           AnsiEscapes.GREEN + " text " + AnsiEscapes.RESET +
                                           AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "arg2"  + AnsiEscapes.RESET));
+    }
+
+    // Reproduce issue #619: This test should now fail!
+    @Test(expected = StringIndexOutOfBoundsException.class)
+    public void nested_capture_groups_cannot_be_handled(){
+        Formats formats = new AnsiFormats();
+        Argument fullArg = new Argument(0, "this is the nested argument full argument");
+        Argument nestedArg = new Argument(-29, "nested argument");
+        PrettyFormatter prettyFormatter = new PrettyFormatter(null);
+
+        try {
+            String formattedText = prettyFormatter.formatStepText("Given ", "this is the (nested argument) full argument", formats.get("passed"), formats.get("passed_arg"), asList(fullArg, nestedArg));
+        } catch (StringIndexOutOfBoundsException e) {
+            assertEquals("String index out of range: -70", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Test
+    public void nested_capture_groups_cannot_be_formatted(){
+        Formats formats = new AnsiFormats();
+        Argument fullArg = new Argument(0, "this is the nested argument full argument");
+        Argument nestedArg = new Argument(-29, "nested argument");
+        PrettyFormatter prettyFormatter = new PrettyFormatter(null);
+
+        try {
+            String formattedText = prettyFormatter.formatStepText("Given ", "this is the (nested argument) full argument", formats.get("passed"), formats.get("passed_arg"), asList(fullArg, nestedArg));
+        } catch (StringIndexOutOfBoundsException e) {
+            assertEquals("String index out of range: -70", e.getMessage());
+            throw e;
+        }
     }
 
     private String runFeatureWithPrettyFormatter(final CucumberFeature feature, final Map<String, String> stepsToLocation) throws Throwable {

--- a/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
@@ -382,35 +382,18 @@ public class PrettyFormatterTest {
                                           AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "arg2"  + AnsiEscapes.RESET));
     }
 
-    // Reproduce issue #619: This test should now fail!
-    @Test(expected = StringIndexOutOfBoundsException.class)
-    public void nested_capture_groups_cannot_be_handled(){
-        Formats formats = new AnsiFormats();
-        Argument fullArg = new Argument(0, "this is the nested argument full argument");
-        Argument nestedArg = new Argument(-29, "nested argument");
-        PrettyFormatter prettyFormatter = new PrettyFormatter(null);
-
-        try {
-            String formattedText = prettyFormatter.formatStepText("Given ", "this is the (nested argument) full argument", formats.get("passed"), formats.get("passed_arg"), asList(fullArg, nestedArg));
-        } catch (StringIndexOutOfBoundsException e) {
-            assertEquals("String index out of range: -70", e.getMessage());
-            throw e;
-        }
-    }
-
     @Test
-    public void nested_capture_groups_cannot_be_formatted(){
+    public void should_mark_nested_argument_as_part_of_full_argument(){
         Formats formats = new AnsiFormats();
-        Argument fullArg = new Argument(0, "this is the nested argument full argument");
-        Argument nestedArg = new Argument(-29, "nested argument");
+        Argument fullArg = new Argument(20, "and not yet confirmed");
+        Argument nestedArg = new Argument(-21, "not yet ");
         PrettyFormatter prettyFormatter = new PrettyFormatter(null);
 
-        try {
-            String formattedText = prettyFormatter.formatStepText("Given ", "this is the (nested argument) full argument", formats.get("passed"), formats.get("passed_arg"), asList(fullArg, nestedArg));
-        } catch (StringIndexOutOfBoundsException e) {
-            assertEquals("String index out of range: -70", e.getMessage());
-            throw e;
-        }
+        String formattedText = prettyFormatter.formatStepText("Given ", "the order is placed and not yet confirmed", formats.get("passed"), formats.get("passed_arg"), asList(fullArg, nestedArg));
+
+        assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
+            AnsiEscapes.GREEN + "the order is placed " + AnsiEscapes.RESET +
+            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "and not yet confirmed"  + AnsiEscapes.RESET));
     }
 
     private String runFeatureWithPrettyFormatter(final CucumberFeature feature, final Map<String, String> stepsToLocation) throws Throwable {

--- a/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
@@ -385,47 +385,26 @@ public class PrettyFormatterTest {
     @Test
     public void should_mark_nested_argument_as_part_of_full_argument(){
         Formats formats = new AnsiFormats();
-        Argument fullArg = new Argument(20, "and not yet confirmed");
+        Argument enclosingArg = new Argument(20, "and not yet confirmed");
         Argument nestedArg = new Argument(-17, "not yet ");
         PrettyFormatter prettyFormatter = new PrettyFormatter(null);
 
-        String formattedText = prettyFormatter.formatStepText("Given ", "the order is placed and not yet confirmed", formats.get("passed"), formats.get("passed_arg"), asList(fullArg, nestedArg));
+        String formattedText = prettyFormatter.formatStepText("Given ", "the order is placed and not yet confirmed", formats.get("passed"), formats.get("passed_arg"), asList(enclosingArg, nestedArg));
 
         assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
             AnsiEscapes.GREEN + "the order is placed " + AnsiEscapes.RESET +
             AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "and not yet confirmed"  + AnsiEscapes.RESET));
     }
-    /* @Dado("^a empresa (\\d+) (não )?possui esse NCM( e (não )?tem mesmo enquadramento tributário)?$")
-               01234567890     1 2345  678901234567890 123 4567  8901234567890123456789012345678901
-                                                          -38 (tov einde van enclosing argument)
-    Since each capture groups maps to an argument, this sort of gives an argument in an argument,
-    the third argument (e não tem mesmo enquadramento tributário), will end at a position after the forth argument starts (não).
-    Exactly 38 positions before the end the third argument thereby the String index out of range: -38
-
-subString(from, to)
-IndexOutOfBoundsException -
-if the beginIndex is negative,
-57or endIndex is larger than the length of this String object,
-or beginIndex is larger than endIndex.
-
-
-    *  What is the expected range of offset values for nested capture groups? negative
-    *
-    *  Can you explain (or even better write a test) for the scenario where textStart becomes less then zero or longer
-    *  then the stepText now that we are skipping nested arguments?
-    *
-    *  Or alternatively, if you can't find such a scenario, can you proof that it can't happen?
-    */
 
     @Test
     public void should_mark_nested_arguments_as_part_of_enclosing_argument(){
         Formats formats = new AnsiFormats();
-        Argument fullArg = new Argument(20, "and not yet confirmed");
+        Argument enclosingArg = new Argument(20, "and not yet confirmed");
         Argument nestedArg = new Argument(-17, "not yet ");
-        Argument nestedInNestedArg = new Argument(-5, "yet ");
+        Argument nestedNestedArg = new Argument(-5, "yet ");
         PrettyFormatter prettyFormatter = new PrettyFormatter(null);
 
-        String formattedText = prettyFormatter.formatStepText("Given ", "the order is placed and not yet confirmed", formats.get("passed"), formats.get("passed_arg"), asList(fullArg, nestedArg, nestedInNestedArg));
+        String formattedText = prettyFormatter.formatStepText("Given ", "the order is placed and not yet confirmed", formats.get("passed"), formats.get("passed_arg"), asList(enclosingArg, nestedArg, nestedNestedArg));
 
         assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
             AnsiEscapes.GREEN + "the order is placed " + AnsiEscapes.RESET +

--- a/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
@@ -367,7 +367,7 @@ public class PrettyFormatterTest {
     }
 
     @Test
-    public void should_mark_arguments_in_steps() throws Throwable {
+    public void should_mark_subsequent_arguments_in_steps() throws Throwable {
         Formats formats = new AnsiFormats();
         Argument arg1 = new Argument(5, "arg1");
         Argument arg2 = new Argument(15, "arg2");
@@ -386,10 +386,46 @@ public class PrettyFormatterTest {
     public void should_mark_nested_argument_as_part_of_full_argument(){
         Formats formats = new AnsiFormats();
         Argument fullArg = new Argument(20, "and not yet confirmed");
-        Argument nestedArg = new Argument(-21, "not yet ");
+        Argument nestedArg = new Argument(-17, "not yet ");
         PrettyFormatter prettyFormatter = new PrettyFormatter(null);
 
         String formattedText = prettyFormatter.formatStepText("Given ", "the order is placed and not yet confirmed", formats.get("passed"), formats.get("passed_arg"), asList(fullArg, nestedArg));
+
+        assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
+            AnsiEscapes.GREEN + "the order is placed " + AnsiEscapes.RESET +
+            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "and not yet confirmed"  + AnsiEscapes.RESET));
+    }
+    /* @Dado("^a empresa (\\d+) (não )?possui esse NCM( e (não )?tem mesmo enquadramento tributário)?$")
+               01234567890     1 2345  678901234567890 123 4567  8901234567890123456789012345678901
+                                                          -38 (tov einde van enclosing argument)
+    Since each capture groups maps to an argument, this sort of gives an argument in an argument,
+    the third argument (e não tem mesmo enquadramento tributário), will end at a position after the forth argument starts (não).
+    Exactly 38 positions before the end the third argument thereby the String index out of range: -38
+
+subString(from, to)
+IndexOutOfBoundsException -
+if the beginIndex is negative,
+57or endIndex is larger than the length of this String object,
+or beginIndex is larger than endIndex.
+
+
+    *  What is the expected range of offset values for nested capture groups? negative
+    *
+    *  Can you explain (or even better write a test) for the scenario where textStart becomes less then zero or longer
+    *  then the stepText now that we are skipping nested arguments?
+    *
+    *  Or alternatively, if you can't find such a scenario, can you proof that it can't happen?
+    */
+
+    @Test
+    public void should_mark_nested_arguments_as_part_of_enclosing_argument(){
+        Formats formats = new AnsiFormats();
+        Argument fullArg = new Argument(20, "and not yet confirmed");
+        Argument nestedArg = new Argument(-17, "not yet ");
+        Argument nestedInNestedArg = new Argument(-5, "yet ");
+        PrettyFormatter prettyFormatter = new PrettyFormatter(null);
+
+        String formattedText = prettyFormatter.formatStepText("Given ", "the order is placed and not yet confirmed", formats.get("passed"), formats.get("passed_arg"), asList(fullArg, nestedArg, nestedInNestedArg));
 
         assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
             AnsiEscapes.GREEN + "the order is placed " + AnsiEscapes.RESET +


### PR DESCRIPTION
## Summary

Do not throw StringIndexoutOfBoundsException in PrettyFormatter for nested capture groups.
Format nested arguments as part of already formatted enclosing argument.

## Details

Reproduced issue #619 with (now removed) test that expects a StringIndexOutOfBoundsException.
Added 2 tests to verify formatting of nested capture groups and added some checks on variables passed to substring() to prevent StringIndexOutOfBoundsException.
Additionally, minor refactor (renamed these variables) for clarity.
(Additionally, fixed a typo in PrettyFormatterTest)

## Motivation and Context
Nested capture groups could not be handled by the PrettyFormatter. Since each capture groups maps to an argument, this sort of gives an argument in an argument. A nested argument starts before the enclosing argument ends, throwing a StringIndexOutOfBoundsException on stepText.substring() - thus preventing additional features from running.

Detailed explanation:
public String substring(int beginIndex, int endIndex)
throws: IndexOutOfBoundsException - if the beginIndex is negative, or endIndex is larger than the length of this String object, or beginIndex is larger than endIndex.

The expected value of argument.offset is negative for nested capture groups, since a nested argument starts before the previous (=enclosing) argument ends. Therefore:
ad 1. beginIndex is negative => when using a nested argument, as the end of the nested argument (argument offset + length of argument) is before the end of the previous (=enclosing) argument -> Added check to see if beginIndex >= 0
ad 2. endIndex is larger than the length of this String object => should not happen, as endIndex = argument offset + length of argument, which should always be inside the String stepText.
ad 3. beginIndex is larger than endIndex => for a nested argument, the nested argument starts before the previous (=enclosing) argument ends, and the endIndex (=value of argument.offset) is negative -> Added check check if argumentOffset < beginIndex
Fixed to ignore formatting for nested capture groups (arguments), as they are already formatted as an argument as part of the enclosing capture group (argument), thus no longer throwing StringIndexOutOfBoundsException.

## How Has This Been Tested?
1. Reproduce original bug (expect Exception)
2. Test current function with nested argument(s) -> nested argument is formatted as part of the enclosing argument (and no Exception is thrown
3. Clean/install cucumber-jvm core (i.e. checking all other tests still pass)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

May need update to documentation, which I have not yet made. I suggest using explanation of pretty formatter by @mpkorstanje 