### PR TITLE
[Core] Fix PrettyFormatter exception on nested arguments

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
@@ -224,7 +224,7 @@ class PrettyFormatter implements Formatter, ColorAware {
             // val can be null if the argument isn't there, for example @And("(it )?has something")
             if (argument.getVal() != null) {
                 result.append(argFormat.text(argument.getVal()));
-                // set beginIndex to end of argumentgit
+                // set beginIndex to end of argument
                 beginIndex = argument.getOffset() + argument.getVal().length();
             }
         }

--- a/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
@@ -208,22 +208,28 @@ class PrettyFormatter implements Formatter, ColorAware {
     }
 
     String formatStepText(String keyword, String stepText, Format textFormat, Format argFormat, List<Argument> arguments) {
-        int textStart = 0;
+        int beginIndex = 0;
         StringBuilder result = new StringBuilder(textFormat.text(keyword));
         for (Argument argument : arguments) {
             // can be null if the argument is missing.
             if (argument.getOffset() != null) {
-                String text = stepText.substring(textStart, argument.getOffset());
+                int argumentOffset = argument.getOffset();
+                // a nested argument starts before the enclosing argument ends; ignore it when formatting
+                if (argumentOffset < beginIndex ) {
+                    continue;
+                }
+                String text = stepText.substring(beginIndex, argumentOffset);
                 result.append(textFormat.text(text));
             }
             // val can be null if the argument isn't there, for example @And("(it )?has something")
             if (argument.getVal() != null) {
                 result.append(argFormat.text(argument.getVal()));
-                textStart = argument.getOffset() + argument.getVal().length();
+                // set beginIndex to end of argumentgit
+                beginIndex = argument.getOffset() + argument.getVal().length();
             }
         }
-        if (textStart != stepText.length()) {
-            String text = stepText.substring(textStart, stepText.length());
+        if (beginIndex != stepText.length()) {
+            String text = stepText.substring(beginIndex, stepText.length());
             result.append(textFormat.text(text));
         }
         return result.toString();

--- a/core/src/test/java/cucumber/runtime/JdkPatternArgumentMatcherTest.java
+++ b/core/src/test/java/cucumber/runtime/JdkPatternArgumentMatcherTest.java
@@ -59,6 +59,13 @@ public class JdkPatternArgumentMatcherTest {
         assertNull(matcher.argumentsFrom("I wait for some time").get(0).getVal());
     }
 
+    @Test
+    public void canHandleNestedCaptureGroups() throws UnsupportedEncodingException {
+        assertVariables("the order is placed( and( not yet)? confirmed)?", "the order is placed and not yet confirmed",
+            " and not yet confirmed", 19,
+            " not yet", 23);
+    }
+
     private void assertVariables(String regex, String string, String v1, Integer pos1, String v2, Integer pos2) throws UnsupportedEncodingException {
         List<Argument> args = new JdkPatternArgumentMatcher(Pattern.compile(regex)).argumentsFrom(string);
         assertEquals(2, args.size());

--- a/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
@@ -21,6 +21,7 @@ import static cucumber.runtime.TestHelper.result;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class PrettyFormatterTest {
@@ -50,7 +51,7 @@ public class PrettyFormatterTest {
     }
 
     @Test
-    public void should_handle_backgound() throws Throwable {
+    public void should_handle_background() throws Throwable {
         CucumberFeature feature = feature("path/test.feature", "" +
                 "Feature: feature name\n" +
                 "  Background: background name\n" +
@@ -366,7 +367,7 @@ public class PrettyFormatterTest {
     }
 
     @Test
-    public void should_mark_arguments_in_steps() throws Throwable {
+    public void should_mark_subsequent_arguments_in_steps() throws Throwable {
         Formats formats = new AnsiFormats();
         Argument arg1 = new Argument(5, "arg1");
         Argument arg2 = new Argument(15, "arg2");
@@ -379,6 +380,35 @@ public class PrettyFormatterTest {
                                           AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "arg1"  + AnsiEscapes.RESET +
                                           AnsiEscapes.GREEN + " text " + AnsiEscapes.RESET +
                                           AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "arg2"  + AnsiEscapes.RESET));
+    }
+
+    @Test
+    public void should_mark_nested_argument_as_part_of_full_argument(){
+        Formats formats = new AnsiFormats();
+        Argument enclosingArg = new Argument(20, "and not yet confirmed");
+        Argument nestedArg = new Argument(-17, "not yet ");
+        PrettyFormatter prettyFormatter = new PrettyFormatter(null);
+
+        String formattedText = prettyFormatter.formatStepText("Given ", "the order is placed and not yet confirmed", formats.get("passed"), formats.get("passed_arg"), asList(enclosingArg, nestedArg));
+
+        assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
+            AnsiEscapes.GREEN + "the order is placed " + AnsiEscapes.RESET +
+            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "and not yet confirmed"  + AnsiEscapes.RESET));
+    }
+
+    @Test
+    public void should_mark_nested_arguments_as_part_of_enclosing_argument(){
+        Formats formats = new AnsiFormats();
+        Argument enclosingArg = new Argument(20, "and not yet confirmed");
+        Argument nestedArg = new Argument(-17, "not yet ");
+        Argument nestedNestedArg = new Argument(-5, "yet ");
+        PrettyFormatter prettyFormatter = new PrettyFormatter(null);
+
+        String formattedText = prettyFormatter.formatStepText("Given ", "the order is placed and not yet confirmed", formats.get("passed"), formats.get("passed_arg"), asList(enclosingArg, nestedArg, nestedNestedArg));
+
+        assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
+            AnsiEscapes.GREEN + "the order is placed " + AnsiEscapes.RESET +
+            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "and not yet confirmed"  + AnsiEscapes.RESET));
     }
 
     private String runFeatureWithPrettyFormatter(final CucumberFeature feature, final Map<String, String> stepsToLocation) throws Throwable {

--- a/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/PrettyFormatterTest.java
@@ -385,30 +385,30 @@ public class PrettyFormatterTest {
     @Test
     public void should_mark_nested_argument_as_part_of_full_argument(){
         Formats formats = new AnsiFormats();
-        Argument enclosingArg = new Argument(20, "and not yet confirmed");
-        Argument nestedArg = new Argument(-17, "not yet ");
+        Argument enclosingArg = new Argument(19, " and not yet confirmed");
+        Argument nestedArg = new Argument(23, " not yet ");
         PrettyFormatter prettyFormatter = new PrettyFormatter(null);
 
         String formattedText = prettyFormatter.formatStepText("Given ", "the order is placed and not yet confirmed", formats.get("passed"), formats.get("passed_arg"), asList(enclosingArg, nestedArg));
 
         assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + "the order is placed " + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "and not yet confirmed"  + AnsiEscapes.RESET));
+            AnsiEscapes.GREEN + "the order is placed" + AnsiEscapes.RESET +
+            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + " and not yet confirmed"  + AnsiEscapes.RESET));
     }
 
     @Test
     public void should_mark_nested_arguments_as_part_of_enclosing_argument(){
         Formats formats = new AnsiFormats();
-        Argument enclosingArg = new Argument(20, "and not yet confirmed");
-        Argument nestedArg = new Argument(-17, "not yet ");
-        Argument nestedNestedArg = new Argument(-5, "yet ");
+        Argument enclosingArg = new Argument(19, " and not yet confirmed");
+        Argument nestedArg = new Argument(23, " not yet ");
+        Argument nestedNestedArg = new Argument(27, "yet ");
         PrettyFormatter prettyFormatter = new PrettyFormatter(null);
 
         String formattedText = prettyFormatter.formatStepText("Given ", "the order is placed and not yet confirmed", formats.get("passed"), formats.get("passed_arg"), asList(enclosingArg, nestedArg, nestedNestedArg));
 
         assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + "the order is placed " + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "and not yet confirmed"  + AnsiEscapes.RESET));
+            AnsiEscapes.GREEN + "the order is placed" + AnsiEscapes.RESET +
+            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + " and not yet confirmed"  + AnsiEscapes.RESET));
     }
 
     private String runFeatureWithPrettyFormatter(final CucumberFeature feature, final Map<String, String> stepsToLocation) throws Throwable {


### PR DESCRIPTION
## Summary
Fixed to ignore formatting for nested capture groups (arguments), as they are already formatted as an argument as part of the enclosing capture group (argument), thus no longer throwing StringIndexOutOfBoundsException which prevented additional scenarios/ features from running (#619).

## Details

Added 2 tests to verify formatting of nested capture groups
Added 2 checks on variables passed to substring() to prevent StringIndexOutOfBoundsException (see more below).
Also did a minor refactor (=renamed these variables) for clarity.
Additionally, fixed a typo in PrettyFormatterTest

## Motivation and Context
Nested capture groups could not be handled by the PrettyFormatter. Since each capture groups maps to an argument, this sort of gives an argument in an argument. A nested argument starts before the enclosing argument ends, throwing a StringIndexOutOfBoundsException on stepText.substring().

public String substring(int beginIndex, int endIndex) throws: IndexOutOfBoundsException - if the beginIndex is negative, or endIndex is larger than the length of this String object, or beginIndex is larger than endIndex.

* beginIndex = argument offset + length of argument
* endIndex = argumentOffset

The expected value for argument.offset is always *negative* for nested capture groups, as a nested argument starts before the previous (=enclosing) argument ends. 
This means: 
* beginIndex could be < 0, throwing an Exception  -> Added check to verify beginIndex >= 0 
* beginIndex could be larger than endIndex  -> Added check verify endIndex < beginIndex
** Note: endIndex (argumentOffset) will not be larger than the length of this String object (stepText) -> no check needed

## How Has This Been Tested?

1. Reproduce original bug by creating a test expecting StringIndexOutOfBoundsException. Removed this test once it failed after implementation of the fix.
2. Added 2 tests to test that nested argument(s) is/are formatted as part of the enclosing argument (and no Exception is thrown).
3. Clean/install cucumber-jvm core (i.e. checking all other tests still pass).

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

If necessary, add some documentation about PrettyFormatter (provided by @mpkorstanje ):

The pretty formatter creates a pretty looking text on the command line output.  On windows this is white and plain, but when using a Unix Ansi compatible terminal this output is colored and **has formatting**.

Color and other formatting is enabled by printing a special escape sequence at the start of the part that should be colored. At the end of the markup a reset symbol is printed. 

So the text `Given text arg1 text arg2` is rendered as "Given text **arg1** text **arg2**".

You can see an example of this in `should_mark_arguments_in_steps`.

A nested capture group is a capture group inside a regex that is placed inside another capture group. For example: `the order is placed( and (not yet )? confirmed)?`

This means that all these are valid steps:

```
Given the order is placed
Given the order is placed and confirmed
Given the order is placed and not yet confirmed
```

The step `Given the order is placed and not yet confirmed` has two Arguments.  

```
new Argument(20, "and not yet confirmed")
new Argument(-21, "not yet")
```

And should be formatted as: "Given the order is placed **and not yet confirmed**". It is acceptable to completely skip the nested argument as the enclosing step has already been formatted from end to end.