### PR TITLE
Update CHANGELOG.md with link to CONTRIBUTING.md (cucumber/cucumber#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CONTRIBUTING.md) on how to contribute to Cucumber.
+
 ## [2.0.0-SNAPSHOT](https://github.com/cucumber/cucumber-jvm/compare/v1.2.5...master) (In Git)
 
 * [Core] Fix PrettyFormatter exception on nested arguments ([#1200](https://github.com/cucumber/cucumber-jvm/pull/1200) Marit van Dijk, M.P. Korstanje) 


### PR DESCRIPTION
In line with https://github.com/cucumber/cucumber/issues/251: At the top of each CHANGELOG.md, please include a link to the monorepo's CONTRIBUTING.md. 