### PR TITLE
Fix for HTMLFormatterTest fails on Locale

### DIFF
--- a/core/src/test/java/cucumber/runtime/formatter/HTMLFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/HTMLFormatterTest.java
@@ -19,13 +19,8 @@ import org.mozilla.javascript.tools.shell.Global;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.util.*;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -60,6 +55,8 @@ public class HTMLFormatterTest {
 
     @Test
     public void writes_valid_report_js() throws Throwable {
+        Locale original = Locale.getDefault();
+        Locale.setDefault(new Locale("en", "US"));
         writeReport();
         URL reportJs = new URL(outputDir, "report.js");
         Context cx = Context.enter();
@@ -69,6 +66,8 @@ public class HTMLFormatterTest {
             fail("Should have failed");
         } catch (EcmaError expected) {
             assertTrue(expected.getMessage().startsWith("ReferenceError: \"document\" is not defined."));
+        } finally {
+            Locale.setDefault(original);
         }
     }
 


### PR DESCRIPTION

## Summary

Fix for #729 HTMLFormatterTest#writes_valid_report_js

## Details

The test fails because the expected error message is in English. If Locale is set to different language (using Locale.setDefault()), the actual error message is in the language set as default.

## Motivation and Context

See comment on #729 

## How Has This Been Tested?

Set a different Locale at the beginning of the test.
run maven clean install on root to see no other unit tests fail
on OSX, Cucumber version: Current master branch (commit a6dff1d)

## Screenshots (if appropriate):
N/A
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Contains test code only
No update to documentation needed
