### PR TITLE
Reduce Throwable to Exception in JavaSnippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 
 ## [2.0.0-SNAPSHOT](https://github.com/cucumber/cucumber-jvm/compare/v1.2.5...master) (In Git)
 
+* [Java] Reduce Throwable to Exception in JavaSnippet ([#1207](https://github.com/cucumber/cucumber-jvm/issues/1207), [#1208](https://github.com/cucumber/cucumber-jvm/pull/1208) M.P. Korstanje)
 * [Core] Update the cucumber-html dependency to version 0.2.6 (Björn Rasmusson)
 * [Core] Fix PrettyFormatter exception on nested arguments ([#1200](https://github.com/cucumber/cucumber-jvm/pull/1200) Marit van Dijk, M.P. Korstanje) 
 * [Core] Added tests for diffing with empty table and list ([#1194](https://github.com/cucumber/cucumber-jvm/pull/1194) Marit van Dijk, M.P. Korstanje) 

--- a/java/src/main/java/cucumber/runtime/java/JavaSnippet.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaSnippet.java
@@ -10,7 +10,7 @@ class JavaSnippet extends AbstractJavaSnippet {
     @Override
     public String template() {
         return "@{0}(\"{1}\")\n" +
-                "public void {2}({3}) throws Throwable '{'\n" +
+                "public void {2}({3}) throws Exception '{'\n" +
                 "    // {4}\n" +
                 "{5}    throw new PendingException();\n" +
                 "'}'\n";

--- a/java/src/test/java/cucumber/runtime/java/JavaSnippetTest.java
+++ b/java/src/test/java/cucumber/runtime/java/JavaSnippetTest.java
@@ -27,7 +27,7 @@ public class JavaSnippetTest {
     public void generatesPlainSnippet() {
         String expected = "" +
                 "@Given(\"^I have (\\\\d+) cukes in my \\\"([^\\\"]*)\\\" belly$\")\n" +
-                "public void i_have_cukes_in_my_belly(int arg1, String arg2) throws Throwable {\n" +
+                "public void i_have_cukes_in_my_belly(int arg1, String arg2) throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException();\n" +
                 "}\n";
@@ -38,7 +38,7 @@ public class JavaSnippetTest {
     public void generatesCopyPasteReadyStepSnippetForNumberParameters() throws Exception {
         String expected = "" +
                 "@Given(\"^before (\\\\d+) after$\")\n" +
-                "public void before_after(int arg1) throws Throwable {\n" +
+                "public void before_after(int arg1) throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException();\n" +
                 "}\n";
@@ -50,7 +50,7 @@ public class JavaSnippetTest {
     public void generatesCopyPasteReadySnippetWhenStepHasIllegalJavaIdentifierChars() {
         String expected = "" +
                 "@Given(\"^I have (\\\\d+) cukes in: my \\\"([^\\\"]*)\\\" red-belly!$\")\n" +
-                "public void i_have_cukes_in_my_red_belly(int arg1, String arg2) throws Throwable {\n" +
+                "public void i_have_cukes_in_my_red_belly(int arg1, String arg2) throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException();\n" +
                 "}\n";
@@ -61,7 +61,7 @@ public class JavaSnippetTest {
     public void generatesCopyPasteReadySnippetWhenStepHasIntegersInsideStringParameter() {
         String expected = "" +
                 "@Given(\"^the DI system receives a message saying \\\"([^\\\"]*)\\\"$\")\n" +
-                "public void the_DI_system_receives_a_message_saying(String arg1) throws Throwable {\n" +
+                "public void the_DI_system_receives_a_message_saying(String arg1) throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException();\n" +
                 "}\n";
@@ -72,7 +72,7 @@ public class JavaSnippetTest {
     public void generatesSnippetWithEscapedDollarSigns() {
         String expected = "" +
                 "@Given(\"^I have \\\\$(\\\\d+)$\")\n" +
-                "public void i_have_$(int arg1) throws Throwable {\n" +
+                "public void i_have_$(int arg1) throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException();\n" +
                 "}\n";
@@ -83,7 +83,7 @@ public class JavaSnippetTest {
     public void generatesSnippetWithEscapedQuestionMarks() {
         String expected = "" +
                 "@Given(\"^is there an error\\\\?:$\")\n" +
-                "public void is_there_an_error() throws Throwable {\n" +
+                "public void is_there_an_error() throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException();\n" +
                 "}\n";
@@ -94,7 +94,7 @@ public class JavaSnippetTest {
     public void generatesSnippetWithLotsOfEscapes() {
         String expected = "" +
                 "@Given(\"^\\\\^\\\\(\\\\[a-z\\\\]\\\\*\\\\)\\\\?\\\\.\\\\+\\\\$$\")\n" +
-                "public void a_z_$() throws Throwable {\n" +
+                "public void a_z_$() throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException();\n" +
                 "}\n";
@@ -105,7 +105,7 @@ public class JavaSnippetTest {
     public void generatesSnippetWithEscapedParentheses() {
         String expected = "" +
                 "@Given(\"^I have (\\\\d+) cukes \\\\(maybe more\\\\)$\")\n" +
-                "public void i_have_cukes_maybe_more(int arg1) throws Throwable {\n" +
+                "public void i_have_cukes_maybe_more(int arg1) throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException();\n" +
                 "}\n";
@@ -116,7 +116,7 @@ public class JavaSnippetTest {
     public void generatesSnippetWithEscapedBrackets() {
         String expected = "" +
                 "@Given(\"^I have (\\\\d+) cukes \\\\[maybe more\\\\]$\")\n" +
-                "public void i_have_cukes_maybe_more(int arg1) throws Throwable {\n" +
+                "public void i_have_cukes_maybe_more(int arg1) throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException();\n" +
                 "}\n";
@@ -127,7 +127,7 @@ public class JavaSnippetTest {
     public void generatesSnippetWithDocString() {
         String expected = "" +
                 "@Given(\"^I have:$\")\n" +
-                "public void i_have(String arg1) throws Throwable {\n" +
+                "public void i_have(String arg1) throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException();\n" +
                 "}\n";
@@ -139,7 +139,7 @@ public class JavaSnippetTest {
     public void recognisesWordWithNumbers() {
         String expected = "" +
                 "@Given(\"^Then it responds ([^\\\"]*)$\")\n" +
-                "public void Then_it_responds(String arg1) throws Throwable {\n" +
+                "public void Then_it_responds(String arg1) throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "}\n";
         assertEquals(expected, snippetFor("Then it responds UTF-8"));
@@ -149,7 +149,7 @@ public class JavaSnippetTest {
     public void generatesSnippetWithDataTable() {
         String expected = "" +
                 "@Given(\"^I have:$\")\n" +
-                "public void i_have(DataTable arg1) throws Throwable {\n" +
+                "public void i_have(DataTable arg1) throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    // For automatic transformation, change DataTable to one of\n" +
                 "    // List<YourType>, List<List<E>>, List<Map<K,V>> or Map<K,V>.\n" +
@@ -164,7 +164,7 @@ public class JavaSnippetTest {
     public void generateSnippetWithOutlineParam() {
         String expected = "" +
                 "@Given(\"^Then it responds (.*)$\")\n" +
-                "public void then_it_responds(String arg1) throws Throwable {\n" +
+                "public void then_it_responds(String arg1) throws Exception {\n" +
                 "    // Write code here that turns the phrase above into concrete actions\n" +
                 "    throw new PendingException();\n" +
                 "}\n";


### PR DESCRIPTION
## Summary

Tests are allowed to fail by throwing an(y) exception. As such #318
added `throws Throwable` to the JavaSnippet. Aside from being a bad
practice this results in unnecessary checkstyle warnings. As such the
generated snippet should not explicitly declare `Throwable`.

Reducing `Throwable` to `Exception` should be sufficient.

Fixes #1207
## How Has This Been Tested?

Updated the Unit Tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
