### PR TITLE
Include javadoc in the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,14 @@ jobs:
       script: mvn -q install
       after_success:
         - mvn clean cobertura:cobertura coveralls:report -P coveralls.io
-    # Stage Test - Job 3: Build Android Examples.
+    # Stage Test - Job 3: Build java and scala doc
+    - jdk: oraclejdk8
+      env: JAVADOC=true
+      script:
+        - mvn clean install -DskipTests=true
+        - mvn javadoc:aggregate
+        - mvn scala:doc
+    # Stage Test - Job 4: Build Android Examples.
     - jdk: oraclejdk8
       env: ANDROID_EXAMPLES=true
       language: android

--- a/core/src/main/java/cucumber/api/Result.java
+++ b/core/src/main/java/cucumber/api/Result.java
@@ -11,7 +11,7 @@ public class Result {
     private final Throwable error;
     public static final Result SKIPPED = new Result(Result.Type.SKIPPED, null, null);
     public static final Result UNDEFINED = new Result(Result.Type.UNDEFINED, null, null);
-    public static enum Type {
+    public enum Type {
         PASSED,
         SKIPPED,
         PENDING,
@@ -35,11 +35,11 @@ public class Result {
     }
 
     /**
-     * Used at runtime
+     * The result of a step or scenario
      *
-     * @param status
-     * @param duration
-     * @param error
+     * @param status status of the step or scenario
+     * @param duration the duration in nanoseconds
+     * @param error the error that caused the failure if any
      */
     public Result(Result.Type status, Long duration, Throwable error) {
         this.status = status;

--- a/core/src/main/java/cucumber/api/event/EventListener.java
+++ b/core/src/main/java/cucumber/api/event/EventListener.java
@@ -7,7 +7,9 @@ package cucumber.api.event;
 public interface EventListener {
 
     /**
-     * Set the event bus that the formatter can register event listeners in.
+     * Set the event publisher. The formatter can register event listeners with the publisher.
+     *
+     * @param publisher the event publisher
      */
     void setEventPublisher(EventPublisher publisher);
 

--- a/core/src/main/java/cucumber/api/event/EventPublisher.java
+++ b/core/src/main/java/cucumber/api/event/EventPublisher.java
@@ -1,5 +1,28 @@
 package cucumber.api.event;
 
 public interface EventPublisher {
+
+    /**
+     * Registers an event handler for a specific event.
+     *
+     * The available events types are:
+     * <ul>
+     * <li>{@link TestRunStarted} - the first event sent.
+     * <li>{@link TestSourceRead} - sent for each feature file read, contains the feature file source.
+     * <li>{@link SnippetsSuggestedEvent} - sent for each step that could not be matched to a step definition, contains the raw snippets for the step.
+     * <li> {@link TestCaseStarted} - sent before starting the execution of a Test Case(/Pickle/Scenario), contains the Test Case
+     * <li>{@link TestStepStarted} - sent before starting the execution of a Test Step, contains the Test Step
+     * <li>{@link EmbedEvent} - calling scenario.embed in a hook triggers this event.
+     * <li>{@link WriteEvent} - calling scenario.write in a hook triggers this event.
+     * <li>{@link TestStepFinished} - sent after the execution of a Test Step, contains the Test Step and its Result.
+     * <li>{@link TestCaseFinished} - sent after the execution of a Test Case(/Pickle/Scenario), contains the Test Case and its Result.
+     * <li>{@link TestRunFinished} - the last event sent.
+     * </ul>
+     *
+     *
+     * @param eventType the event type for which the handler is being registered
+     * @param handler the event handler
+     * @param <T> the event type
+     */
     <T extends Event> void registerHandlerFor(Class<T> eventType, EventHandler<T> handler);
 }

--- a/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
+++ b/testng/src/main/java/cucumber/api/testng/AbstractTestNGCucumberTests.java
@@ -23,8 +23,9 @@ public abstract class AbstractTestNGCucumberTests {
     }
 
     /**
-     * @return returns a two dimensional array of {@link PickleEventWrapper} scenarios
-     * with their associated {@link CucumberFeatureWrapper) feature.
+     * Returns two dimensional array of PickleEventWrapper scenarios with their associated CucumberFeatureWrapper feature.
+     *
+     * @return a two dimensional array of scenarios features.
      */
     @DataProvider
     public Object[][] scenarios() {


### PR DESCRIPTION
Generating javadoc using command 'mvn javadoc:aggregate' under java 8
fails if the javadoc tags are incomplete. To ensure the javadoc remains
complete we include it in the build.

Fixes #1209