### PR TITLE
Fix Scenario.isFailed

### DIFF
--- a/core/src/main/java/cucumber/runtime/ScenarioImpl.java
+++ b/core/src/main/java/cucumber/runtime/ScenarioImpl.java
@@ -69,7 +69,7 @@ public class ScenarioImpl implements Scenario {
 
     @Override
     public boolean isFailed() {
-        return "failed".equals(getStatus());
+        return getStatus() == Result.Type.FAILED;
     }
 
     @Override

--- a/core/src/test/java/cucumber/runtime/ScenarioResultTest.java
+++ b/core/src/test/java/cucumber/runtime/ScenarioResultTest.java
@@ -12,8 +12,7 @@ import org.mockito.ArgumentMatcher;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,6 +36,7 @@ public class ScenarioResultTest {
         s.add(new Result(Result.Type.UNDEFINED, 0L, null));
         s.add(new Result(Result.Type.SKIPPED, 0L, null));
         assertEquals(Result.Type.FAILED, s.getStatus());
+        assertTrue(s.isFailed());
     }
 
     @Test
@@ -44,6 +44,7 @@ public class ScenarioResultTest {
         s.add(new Result(Result.Type.PASSED, 0L, null));
         s.add(new Result(Result.Type.SKIPPED, 0L, null));
         assertEquals(Result.Type.SKIPPED, s.getStatus());
+        assertFalse(s.isFailed());
     }
 
     @Test
@@ -53,6 +54,7 @@ public class ScenarioResultTest {
         s.add(new Result(Result.Type.PENDING, 0L, null));
         s.add(new Result(Result.Type.SKIPPED, 0L, null));
         assertEquals(Result.Type.UNDEFINED, s.getStatus());
+        assertFalse(s.isFailed());
     }
 
     @Test
@@ -61,6 +63,7 @@ public class ScenarioResultTest {
         s.add(new Result(Result.Type.UNDEFINED, 0L, null));
         s.add(new Result(Result.Type.SKIPPED, 0L, null));
         assertEquals(Result.Type.UNDEFINED, s.getStatus());
+        assertFalse(s.isFailed());
     }
 
     @Test


### PR DESCRIPTION
Adapt `Scenario.isFailed()` to change in `Scenario.getStatus()`.

Fixes #1215.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
