### PR TITLE
Rename and add test for  HTMLFormatter

### DIFF
--- a/core/src/test/java/cucumber/runtime/formatter/HTMLFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/HTMLFormatterTest.java
@@ -12,9 +12,6 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.EcmaError;
-import org.mozilla.javascript.tools.shell.Global;
 
 import java.io.File;
 import java.io.InputStreamReader;
@@ -61,15 +58,38 @@ public class HTMLFormatterTest {
     @Test
     public void writes_valid_report_js() throws Throwable {
         writeReport();
-        URL reportJs = new URL(outputDir, "report.js");
-        Context cx = Context.enter();
-        Global scope = new Global(cx);
-        try {
-            cx.evaluateReader(scope, new InputStreamReader(reportJs.openStream(), "UTF-8"), reportJs.getFile(), 1, null);
-            fail("Should have failed");
-        } catch (EcmaError expected) {
-            assertTrue(expected.getMessage().startsWith("ReferenceError: \"document\" is not defined."));
-        }
+        String reportJs = FixJava.readReader(new InputStreamReader(new URL(outputDir, "report.js").openStream(), "UTF-8"));
+        assertEquals("$(document).ready(function() {var formatter = new CucumberHTML.DOMFormatter($('.cucumber-report'));formatter.uri(\"some\\\\windows\\\\path\\\\some.feature\");\n" +
+            "formatter.feature({\n" +
+            "  \"name\": \"\",\n" +
+            "  \"description\": \"\",\n" +
+            "  \"keyword\": \"Feature\"\n" +
+            "});\n" +
+            "formatter.scenario({\n" +
+            "  \"name\": \"some cukes\",\n" +
+            "  \"description\": \"\",\n" +
+            "  \"keyword\": \"Scenario\"\n" +
+            "});\n" +
+            "formatter.step({\n" +
+            "  \"name\": \"first step\",\n" +
+            "  \"keyword\": \"Given \"\n" +
+            "});\n" +
+            "formatter.match({\n" +
+            "  \"location\": \"path/step_definitions.java:3\"\n" +
+            "});\n" +
+            "formatter.result({\n" +
+            "  \"status\": \"passed\"\n" +
+            "});\n" +
+            "formatter.embedding(\"image/png\", \"embedded0.png\");\n" +
+            "formatter.after({\n" +
+            "  \"status\": \"passed\"\n" +
+            "});\n" +
+            "formatter.embedding(\"text/plain\", \"dodgy stack trace here\");\n" +
+            "formatter.after({\n" +
+            "  \"status\": \"passed\"\n" +
+            "});\n" +
+            "});",
+            reportJs);
     }
 
     @Test


### PR DESCRIPTION
## Summary

<!--- Provide a general summary description of your changes -->
Rename and add test for HTMLFormatter

## Details

<!--- Describe your changes in detail -->
Trying to duplicate / fix https://github.com/cucumber/cucumber-jvm/issues/729 

Cannot reproduce this bug by setting Locale for my laptop, or running the test with VM options: -Duser.language=fr (or nl, for that matter). Only by explicitly setting the Locale in the test (see previous PR).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The original test does not validate that report.js is valid; it validates that an empty report throws a particular exception. I've renamed this test.
As suggested, I've added a test that does check for valid Javascript. I'm not sure this adds a lot of value, as other tests are also checking for valid js.

## How Has This Been Tested?
'mvn clean install' => Build Success

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
