### PR TITLE
Allow RuntimeOptions to be created by subclasses

### DIFF
--- a/junit/src/main/java/cucumber/api/junit/Cucumber.java
+++ b/junit/src/main/java/cucumber/api/junit/Cucumber.java
@@ -56,8 +56,7 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
         ClassLoader classLoader = clazz.getClassLoader();
         Assertions.assertNoCucumberAnnotatedMethods(clazz);
 
-        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(clazz);
-        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+        RuntimeOptions runtimeOptions = createRuntimeOptions(clazz);
 
         ResourceLoader resourceLoader = new MultiLoader(classLoader);
         runtime = createRuntime(resourceLoader, classLoader, runtimeOptions);
@@ -66,6 +65,17 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
         final List<CucumberFeature> cucumberFeatures = runtimeOptions.cucumberFeatures(resourceLoader, runtime.getEventBus());
         jUnitReporter = new JUnitReporter(runtime.getEventBus(), runtimeOptions.isStrict(), junitOptions);
         addChildren(cucumberFeatures);
+    }
+
+    /**
+     * Create the runtime options. Can be overridden to customize the runtime options.
+     * 
+     * @param clazz
+     *            the class with the @RunWith annotation.
+     * @return runtime options
+     */
+    protected RuntimeOptions createRuntimeOptions(Class clazz) {
+        return new RuntimeOptionsFactory(clazz).create();
     }
 
     /**


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Allow creation of `RuntimeOptions` without use of the `CucumberOptions` annotation.

## Details

Having tried to configure plugins in an overridden `createRuntime` method, these plugins did not get applied.  This plugin extracts the existing logic into a method, and allows for it to be overridden.

## Motivation and Context

To allow `RuntimeOptions` to be overridden by subclasses of `Cucumber` allowing programatic configuration.

## How Has This Been Tested?

Existing test suite passes.

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.