### PR TITLE
Fix NullPointerException at Java8StepDefinition.isDefinedAt

### DIFF
--- a/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
+++ b/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
@@ -108,7 +108,7 @@ public class Java8StepDefinition implements StepDefinition {
 
     @Override
     public boolean isDefinedAt(StackTraceElement stackTraceElement) {
-        return location.getFileName().equals(stackTraceElement.getFileName());
+        return location.getFileName() != null && location.getFileName().equals(stackTraceElement.getFileName());
     }
 
     @Override


### PR DESCRIPTION
The api allows `StackTraceElement.getFileName()`[1] to return null. We
were not able to reproduce this problem reliably but it occurred in
production environments anyway.

Fixes #1217

References:
 1. docs.oracle.com/javase/7/docs/api/java/lang/StackTraceElement.html#getFileName()

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
