### PR TITLE
Clean up public API

### DIFF
--- a/core/src/main/java/cucumber/api/DataTable.java
+++ b/core/src/main/java/cucumber/api/DataTable.java
@@ -3,7 +3,6 @@ package cucumber.api;
 import cucumber.runtime.CucumberException;
 import cucumber.runtime.ParameterInfo;
 import cucumber.runtime.table.DiffableRow;
-import cucumber.runtime.table.TableConverter;
 import cucumber.runtime.table.TableDiffException;
 import cucumber.runtime.table.TableDiffer;
 import cucumber.runtime.table.TablePrinter;
@@ -42,7 +41,7 @@ public class DataTable {
 
     private static DataTable create(List<?> raw, Locale locale, String format, String... columnNames) {
         ParameterInfo parameterInfo = new ParameterInfo(null, format, null, null);
-        TableConverter tableConverter = new TableConverter(new LocalizedXStreams(Thread.currentThread().getContextClassLoader()).get(locale), parameterInfo);
+        TableConverter tableConverter = new cucumber.runtime.table.TableConverter(new LocalizedXStreams(Thread.currentThread().getContextClassLoader()).get(locale), parameterInfo);
         return tableConverter.toTable(raw, columnNames);
     }
 

--- a/core/src/main/java/cucumber/api/TableConverter.java
+++ b/core/src/main/java/cucumber/api/TableConverter.java
@@ -1,0 +1,19 @@
+package cucumber.api;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+public interface TableConverter {
+    <T> T convert(DataTable dataTable, Type type, boolean transposed);
+
+    <T> List<T> toList(DataTable dataTable, Type itemType);
+
+    <T> List<List<T>> toLists(DataTable dataTable, Type itemType);
+
+    <K, V> Map<K, V> toMap(DataTable dataTable, Type keyType, Type valueType);
+
+    <K, V> List<Map<K, V>> toMaps(DataTable dataTable, Type keyType, Type valueType);
+
+    DataTable toTable(List<?> objects, String... columnNames);
+}

--- a/core/src/main/java/cucumber/api/TestCase.java
+++ b/core/src/main/java/cucumber/api/TestCase.java
@@ -15,12 +15,40 @@ public class TestCase {
     private final List<TestStep> testSteps;
     private final boolean dryRun;
 
+    /**
+     * Creates a new instance of a test case.
+     *
+     * @param testSteps   of the test case
+     * @param pickleEvent the pickle executed by this test case
+     * @deprecated not part of the public api
+     */
+    @Deprecated
+    public TestCase(List<TestStep> testSteps, PickleEvent pickleEvent) {
+        this(testSteps, pickleEvent, false);
+    }
+
+    /**
+     * Creates a new instance of a test case.
+     *
+     * @param testSteps   of the test case
+     * @param pickleEvent the pickle executed by this test case
+     * @param dryRun      skip execution of the test steps
+     * @deprecated not part of the public api
+     */
+    @Deprecated
     public TestCase(List<TestStep> testSteps, PickleEvent pickleEvent, boolean dryRun) {
         this.testSteps = testSteps;
         this.pickleEvent = pickleEvent;
         this.dryRun = dryRun;
     }
 
+    /**
+     * Executes the test case.
+     *
+     * @param bus to which events should be broadcast
+     * @deprecated not part of the public api
+     */
+    @Deprecated
     public void run(EventBus bus) {
         boolean skipNextStep = this.dryRun;
         Long startTime = bus.getTime();

--- a/core/src/main/java/cucumber/api/TestStep.java
+++ b/core/src/main/java/cucumber/api/TestStep.java
@@ -17,11 +17,24 @@ public abstract class TestStep {
             "org.junit.AssumptionViolatedException",
             "org.junit.internal.AssumptionViolatedException"
     };
+
     static {
         Arrays.sort(ASSUMPTION_VIOLATED_EXCEPTIONS);
     }
+
+    /**
+     * @deprecated not part of the public api
+     */
+    @Deprecated
     protected final DefinitionMatch definitionMatch;
 
+    /**
+     * Creates a new test step from the matching step definition
+     *
+     * @param definitionMatch the matching step definition
+     * @deprecated not part of the public api
+     */
+    @Deprecated
     public TestStep(DefinitionMatch definitionMatch) {
         this.definitionMatch = definitionMatch;
     }
@@ -52,6 +65,15 @@ public abstract class TestStep {
 
     public abstract HookType getHookType();
 
+    /**
+     * @param bus       to which events should be broadcast
+     * @param language  in which the step is defined
+     * @param scenario  of which this step is part
+     * @param skipSteps if this step should be skipped
+     * @return result of running this step
+     * @deprecated not part of the public api
+     */
+    @Deprecated
     public Result run(EventBus bus, String language, Scenario scenario, boolean skipSteps) {
         Long startTime = bus.getTime();
         bus.send(new TestStepStarted(startTime, this));
@@ -69,10 +91,12 @@ public abstract class TestStep {
         return result;
     }
 
+    @Deprecated
     protected Result.Type nonExceptionStatus(boolean skipSteps) {
         return skipSteps ? Result.Type.SKIPPED : Result.Type.PASSED;
     }
 
+    @Deprecated
     protected Result.Type executeStep(String language, Scenario scenario, boolean skipSteps) throws Throwable {
         if (!skipSteps) {
             definitionMatch.runStep(language, scenario);

--- a/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
@@ -2,7 +2,7 @@ package cucumber.runtime;
 
 import cucumber.api.DataTable;
 import cucumber.api.Scenario;
-import cucumber.runtime.table.TableConverter;
+import cucumber.api.TableConverter;
 import cucumber.runtime.xstream.LocalizedXStreams;
 import cucumber.util.Mapper;
 import gherkin.pickles.PickleCell;
@@ -100,7 +100,7 @@ public class StepDefinitionMatch extends Match implements DefinitionMatch {
 
     private Object tableArgument(PickleTable stepArgument, int argIndex, LocalizedXStreams.LocalizedXStream xStream) {
         ParameterInfo parameterInfo = getParameterType(argIndex, DataTable.class);
-        TableConverter tableConverter = new TableConverter(xStream, parameterInfo);
+        TableConverter tableConverter = new cucumber.runtime.table.TableConverter(xStream, parameterInfo);
         DataTable table = new DataTable(stepArgument, tableConverter);
         Type type = parameterInfo.getType();
         return tableConverter.convert(table, type, parameterInfo.isTransposed());

--- a/core/src/main/java/cucumber/runtime/table/DataTableDiff.java
+++ b/core/src/main/java/cucumber/runtime/table/DataTableDiff.java
@@ -1,6 +1,7 @@
 package cucumber.runtime.table;
 
 import cucumber.api.DataTable;
+import cucumber.api.TableConverter;
 import gherkin.pickles.PickleRow;
 import gherkin.pickles.PickleTable;
 

--- a/core/src/main/java/cucumber/runtime/table/TableConverter.java
+++ b/core/src/main/java/cucumber/runtime/table/TableConverter.java
@@ -34,7 +34,7 @@ import static java.util.Arrays.asList;
 /**
  * This class converts a {@link cucumber.api.DataTable} to various other types.
  */
-public class TableConverter {
+public class TableConverter implements cucumber.api.TableConverter {
     private final LocalizedXStreams.LocalizedXStream xStream;
     private final ParameterInfo parameterInfo;
 
@@ -55,6 +55,7 @@ public class TableConverter {
      * @param transposed whether the table should be transposed first.
      * @return the transformed object.
      */
+    @Override
     public <T> T convert(DataTable dataTable, Type type, boolean transposed) {
         if (transposed) {
             dataTable = dataTable.transpose();
@@ -117,6 +118,7 @@ public class TableConverter {
         }
     }
 
+    @Override
     public <T> List<T> toList(DataTable dataTable, Type itemType) {
         SingleValueConverter itemConverter = xStream.getSingleValueConverter(itemType);
         if (itemConverter != null) {
@@ -141,6 +143,7 @@ public class TableConverter {
         return Collections.unmodifiableList(result);
     }
 
+    @Override
     public <T> List<List<T>> toLists(DataTable dataTable, Type itemType) {
         try {
             xStream.setParameterInfo(parameterInfo);
@@ -163,6 +166,7 @@ public class TableConverter {
         }
     }
 
+    @Override
     public <K, V> Map<K, V> toMap(DataTable dataTable, Type keyType, Type valueType) {
         try {
             xStream.setParameterInfo(parameterInfo);
@@ -188,6 +192,7 @@ public class TableConverter {
         }
     }
 
+    @Override
     public <K, V> List<Map<K, V>> toMaps(DataTable dataTable, Type keyType, Type valueType) {
         try {
             xStream.setParameterInfo(parameterInfo);
@@ -227,6 +232,7 @@ public class TableConverter {
      * @param columnNames an explicit list of column names
      * @return a DataTable
      */
+    @Override
     public DataTable toTable(List<?> objects, String... columnNames) {
         try {
             xStream.setParameterInfo(parameterInfo);


### PR DESCRIPTION
## Summary

Deprecate constructors and run methods of TestCase and TestStep and extract an interface for DataTable.

## Details

Test(Case|Step) is exposed because it is part of the event bus protocol. However its constructors and run method have no general public use. As such they should not be part of the public api. In the long run Test(Case|Step) should be replaced with an interface.

TableConverter is not part of the public api but is used by DataTable.
By extracting the interface we can hide the details of how a data table
converts its data.

This will also be usefull once we start moving away from xstream as we
can introduce an XStreamTableConverter and SomeOtherTableConverter.

## Motivation and Context

Keeping the public API neat, focused and clean will make it easier to maintain it in the future.