### PR TITLE
[Spring] Throw when step definitions have the Component stereotype

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gosu/pom.xml
+++ b/gosu/pom.xml
@@ -53,10 +53,5 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -42,10 +42,5 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -33,7 +33,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jython/pom.xml
+++ b/jython/pom.xml
@@ -36,11 +36,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/needle/pom.xml
+++ b/needle/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -38,11 +38,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <!-- TestNG 6.11 makes the tests of the testng module to fail -->
         <testng.version>6.10</testng.version>
         <junit.version>4.12</junit.version>
+        <hamcrest.version>1.3</hamcrest.version>
         <jython.version>2.7.1</jython.version>
         <mockito.version>1.10.19</mockito.version>
         <selenium.version>3.5.2</selenium.version>
@@ -350,6 +351,11 @@
                 <version>${junit.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${hamcrest.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
@@ -361,13 +367,14 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>${mockito.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>${mockito.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>

--- a/rhino/pom.xml
+++ b/rhino/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -69,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spring/src/test/java/cucumber/runtime/java/spring/SpringFactoryTest.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/SpringFactoryTest.java
@@ -7,6 +7,8 @@ import cucumber.runtime.java.spring.commonglue.AutowiresPlatformTransactionManag
 import cucumber.runtime.java.spring.commonglue.AutowiresThirdStepDef;
 import cucumber.runtime.java.spring.commonglue.OneStepDef;
 import cucumber.runtime.java.spring.commonglue.ThirdStepDef;
+import cucumber.runtime.java.spring.componentannotation.WithComponentAnnotation;
+import cucumber.runtime.java.spring.componentannotation.WithControllerAnnotation;
 import cucumber.runtime.java.spring.metaconfig.general.BellyMetaStepdefs;
 import cucumber.runtime.java.spring.contextconfig.BellyStepdefs;
 import cucumber.runtime.java.spring.contextconfig.WithSpringAnnotations;
@@ -14,7 +16,9 @@ import cucumber.runtime.java.spring.contexthierarchyconfig.WithContextHierarchyA
 import cucumber.runtime.java.spring.contexthierarchyconfig.WithDifferentContextHierarchyAnnotation;
 import cucumber.runtime.java.spring.dirtiescontextconfig.DirtiesContextBellyStepDefs;
 import cucumber.runtime.java.spring.metaconfig.dirties.DirtiesContextBellyMetaStepDefs;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.junit.Assert.assertEquals;
@@ -24,6 +28,9 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class SpringFactoryTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void shouldGiveUsNewStepInstancesForEachScenario() {
@@ -241,10 +248,31 @@ public class SpringFactoryTest {
         factory.addClass(BellyStepdefs.class);
     }
 
-    @Test(expected=CucumberException.class)
+    @Test
     public void shouldFailIfClassesWithDifferentSpringAnnotationsAreFound() {
+        expectedException.expect(CucumberException.class);
+        expectedException.expectMessage("Annotations differs on glue classes found: cucumber.runtime.java.spring.contexthierarchyconfig.WithContextHierarchyAnnotation, cucumber.runtime.java.spring.contexthierarchyconfig.WithDifferentContextHierarchyAnnotation");
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(WithContextHierarchyAnnotation.class);
         factory.addClass(WithDifferentContextHierarchyAnnotation.class);
+    }
+
+    @Test
+    public void shouldFailIfClassWithSpringComponentAnnotationsIsFound() {
+        expectedException.expect(CucumberException.class);
+        expectedException.expectMessage("Glue class cucumber.runtime.java.spring.componentannotation.WithComponentAnnotation was annotated with @Component");
+        expectedException.expectMessage("Please remove the @Component annotation");
+        final ObjectFactory factory = new SpringFactory();
+        factory.addClass(WithComponentAnnotation.class);
+    }
+
+    @Test
+    public void shouldFailIfClassWithAnnotationAnnotatedWithSpringComponentAnnotationsIsFound() {
+        expectedException.expect(CucumberException.class);
+        expectedException.expectMessage("Glue class cucumber.runtime.java.spring.componentannotation.WithControllerAnnotation was annotated with @Controller");
+        expectedException.expectMessage("Please remove the @Controller annotation");
+        final ObjectFactory factory = new SpringFactory();
+        factory.addClass(WithControllerAnnotation.class);
+
     }
 }

--- a/spring/src/test/java/cucumber/runtime/java/spring/componentannotation/WithComponentAnnotation.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/componentannotation/WithComponentAnnotation.java
@@ -1,0 +1,23 @@
+package cucumber.runtime.java.spring.componentannotation;
+
+import cucumber.runtime.java.spring.beans.DummyComponent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+
+@Component
+public class WithComponentAnnotation {
+
+    private boolean autowired;
+
+    @Autowired
+    public void setAutowiredCollaborator(DummyComponent collaborator) {
+        autowired = true;
+    }
+
+    public boolean isAutowired() {
+        return autowired;
+    }
+
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/componentannotation/WithControllerAnnotation.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/componentannotation/WithControllerAnnotation.java
@@ -1,0 +1,22 @@
+package cucumber.runtime.java.spring.componentannotation;
+
+import cucumber.runtime.java.spring.beans.DummyComponent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.stereotype.Repository;
+
+@Controller
+public class WithControllerAnnotation {
+
+    private boolean autowired;
+
+    @Autowired
+    public void setAutowiredCollaborator(DummyComponent collaborator) {
+        autowired = true;
+    }
+
+    public boolean isAutowired() {
+        return autowired;
+    }
+
+}

--- a/testng/pom.xml
+++ b/testng/pom.xml
@@ -22,7 +22,12 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
When step definitions are annotated with `@Component` or other related
annotations they can be picked up by springs class path scanning. This
conflicts with cucumbers class path scanning and may result in
multiple bean definitions for the same class.

This problem is hard to understand and hard to trace. By making the
problem explicit and providing a clear instruction on how to resolve
this we can hopefully avoid future confusion.

The current implementation only checks the a subset of all annotations.
This will hopefully be sufficient.

Closes #1225

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
