### PR TITLE
Correct the name of the Json Formatter embeddings node

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
@@ -290,11 +290,11 @@ class JSONFormatter implements Formatter {
     }
 
     private void addEmbeddingToHookMap(byte[] data, String mimeType) {
-        if (!currentStepOrHookMap.containsKey("embedding")) {
-            currentStepOrHookMap.put("embedding", new ArrayList<Map<String, Object>>());
+        if (!currentStepOrHookMap.containsKey("embeddings")) {
+            currentStepOrHookMap.put("embeddings", new ArrayList<Map<String, Object>>());
         }
         Map<String, Object> embedMap = createEmbeddingMap(data, mimeType);
-        ((List<Map<String, Object>>)currentStepOrHookMap.get("embedding")).add(embedMap);
+        ((List<Map<String, Object>>)currentStepOrHookMap.get("embeddings")).add(embedMap);
     }
 
     private Map<String, Object> createEmbeddingMap(byte[] data, String mimeType) {

--- a/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
@@ -584,7 +584,7 @@ public class JSONFormatterTest {
                 "            \"match\": {\n" +
                 "              \"location\": \"Hooks.before_hook_1()\"\n" +
                 "            },\n" +
-                "            \"embedding\": [\n" +
+                "            \"embeddings\": [\n" +
                 "              {\n" +
                 "                \"mime_type\": \"mime-type;base64\",\n" +
                 "                \"data\": \"AQID\"\n" +


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

JSON formatter outputs the embeddings node as "embedding". Version 1.2.5 and earlier had this node as "embeddings"

## Details

`embedding` node changed to `embeddings` in JSONFormatter.java

Fixes #1235.

## Motivation and Context

This is required for `cucumber-reporting` plugin

## How Has This Been Tested?

Existing tests have been updated

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
