### PR TITLE
Fix the gradle dependencies group

### DIFF
--- a/examples/android/android-studio/Cukeulator/README.md
+++ b/examples/android/android-studio/Cukeulator/README.md
@@ -9,7 +9,7 @@ The rest of the dependencies are added automatically in `app/build.gradle`.
 The cucumber-android dependency is added as (see `app/build.gradle`):
 
 ```
-androidTestCompile 'info.cukes:cucumber-android:<version>'
+androidTestCompile 'io.cucumber:cucumber-android:<version>'
 ```
 
 ### Using gradle

--- a/examples/android/android-studio/Cukeulator/app/build.gradle
+++ b/examples/android/android-studio/Cukeulator/app/build.gradle
@@ -36,6 +36,6 @@ android {
 dependencies {
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.0'
     androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
-    androidTestCompile 'info.cukes:cucumber-android:2.0.1'
-    androidTestCompile 'info.cukes:cucumber-picocontainer:2.0.1'
+    androidTestCompile 'io.cucumber:cucumber-android:2.0.1'
+    androidTestCompile 'io.cucumber:cucumber-picocontainer:2.0.1'
 }


### PR DESCRIPTION
## Summary
The Gradle dependencies group is outdated on the Android Studio sample

## Details
I updated it following the @mpkorstanje feedback

## Motivation and Context
This sample project does not compile today. This fixes the problem

## How Has This Been Tested?
Tested on Mac with the current project's configuration. The host platform should not imply a different behaviour.

## Checklist:

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.