### PR TITLE
[Core] Fix race condition in Timeout

### DIFF
--- a/core/src/main/java/cucumber/runtime/Timeout.java
+++ b/core/src/main/java/cucumber/runtime/Timeout.java
@@ -1,8 +1,8 @@
 package cucumber.runtime;
 
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -14,29 +14,46 @@ public class Timeout {
     public static <T> T timeout(Callback<T> callback, long timeoutMillis) throws Throwable {
         if (timeoutMillis == 0) {
             return callback.call();
-        } else {
-            final Thread executionThread = Thread.currentThread();
-            final AtomicBoolean done = new AtomicBoolean();
+        }
 
-            ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
-            ScheduledFuture<?> timer = executorService.schedule(new Runnable() {
-                @Override
-                public void run() {
+        /* We need to ensure a happens before relation exists between these events;
+         *   a. the timer setting the interrupt flag on the execution thread.
+         *   b. terminating and cleaning up the timer
+         * To do this we synchronize on monitor. The atomic boolean is merely a convenient container.
+         */
+        final Thread executionThread = Thread.currentThread();
+        final Object monitor = new Object();
+        final AtomicBoolean done = new AtomicBoolean();
+
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        ScheduledFuture<?> timer = executorService.schedule(new Runnable() {
+            @Override
+            public void run() {
+                synchronized (monitor) {
                     if (!done.get()) {
                         executionThread.interrupt();
                     }
                 }
-            }, timeoutMillis, TimeUnit.MILLISECONDS);
-            try {
-                return callback.call();
-            } catch (InterruptedException timeout) {
+            }
+        }, timeoutMillis, TimeUnit.MILLISECONDS);
+
+        try {
+            T result = callback.call();
+            // The callback may have been busy waiting.
+            if (Thread.interrupted()) {
                 throw new TimeoutException("Timed out after " + timeoutMillis + "ms.");
-            } finally {
+            }
+            return result;
+        } catch (InterruptedException timeout) {
+            throw new TimeoutException("Timed out after " + timeoutMillis + "ms.");
+        } finally {
+            synchronized (monitor) {
                 done.set(true);
                 timer.cancel(true);
                 executorService.shutdownNow();
+                // Clear the interrupted flag. It may have been set by the timer just before we returned the result.
+                Thread.interrupted();
             }
-
         }
     }
 


### PR DESCRIPTION
## Summary

We need to ensure a happens before relation exists between these events;
  a. the timer setting the interrupt flag on the execution thread.
  b. terminating and cleaning up the timer
To do this we synchronize on monitor. The atomic boolean is merely a
convenient container.

Additionally Timeout did not throw any exceptions when the callback
was busy waiting but did set the interrupted flag. To resolve this
we check and throw after the completion of the callback.

This fixes #1241

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
