### PR TITLE
Use gherkin 5.0.0

### DIFF
--- a/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
@@ -502,8 +502,7 @@ public class JUnitFormatterTest {
     @Test
     public void should_add_dummy_testcase_if_no_scenarios_are_run_to_aviod_failed_jenkins_jobs() throws Throwable {
         CucumberFeature feature = TestHelper.feature("path/test.feature",
-                "Feature: feature name\n" +
-                        "  Scenario: scenario name\n");
+                "Feature: feature name\n");
 
         String formatterOutput = runFeatureWithJUnitFormatter(feature);
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <minimum.maven.version>3.3</minimum.maven.version>
         <outputDirectory>${project.build.directory}</outputDirectory>
-        <gherkin.version>4.1.3</gherkin.version>
+        <gherkin.version>5.0.0</gherkin.version>
         <groovy.version>2.4.12</groovy.version>
         <picocontainer.version>2.15</picocontainer.version>
         <spring.version>4.3.10.RELEASE</spring.version>


### PR DESCRIPTION
## Summary

Use gherkin 5.0.0

## Details

Gherkin 5.0.0 will create an empty pickle for an empty scenario. See: https://github.com/cucumber/gherkin-java/commit/f9a0ef04e109b5afd30436b579896e2e8558ba72 However a feature without scenario's still doesn't run any thing. The JUnit test has been updated accordingly.

## Motivation and Context

With the release of gherkin 5.0.0 the build broke. Due to some black magic in pax-exam the osgi maven bundles will always try to resolve the latest version unless specific version numbers are used. Upgrading gherkin was the easiest way out.

## How Has This Been Tested?

Ran the tests. Fixed the tests.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
