### PR TITLE
Improve plugin and formatter structure

### DIFF
--- a/android/src/main/java/cucumber/runtime/android/AndroidObjectFactory.java
+++ b/android/src/main/java/cucumber/runtime/android/AndroidObjectFactory.java
@@ -12,7 +12,7 @@ import cucumber.api.java.ObjectFactory;
  * make sure that created test classes have all necessary references to the executing {@link android.app.Instrumentation}
  * and the associated {@link android.content.Context}.
  */
-public class AndroidObjectFactory implements ObjectFactory {
+final class AndroidObjectFactory implements ObjectFactory {
 
     /**
      * The actual {@link ObjectFactory} responsible for creating instances.
@@ -32,7 +32,7 @@ public class AndroidObjectFactory implements ObjectFactory {
      * @param delegate the {@link ObjectFactory} to delegate to
      * @param instrumentation the {@link android.app.Instrumentation} to set to the tests
      */
-    public AndroidObjectFactory(final ObjectFactory delegate, final Instrumentation instrumentation) {
+    AndroidObjectFactory(final ObjectFactory delegate, final Instrumentation instrumentation) {
         this.delegate = delegate;
         this.instrumentation = instrumentation;
     }

--- a/android/src/main/java/cucumber/runtime/android/AndroidResource.java
+++ b/android/src/main/java/cucumber/runtime/android/AndroidResource.java
@@ -11,7 +11,7 @@ import java.io.InputStream;
  * Android specific implementation of {@link cucumber.runtime.io.Resource} which is apple
  * to create {@link java.io.InputStream}s for android assets.
  */
-public class AndroidResource implements Resource {
+public final class AndroidResource implements Resource {
 
     /**
      * The {@link android.content.Context} to get the {@link java.io.InputStream} from
@@ -29,7 +29,7 @@ public class AndroidResource implements Resource {
      * @param context the {@link android.content.Context} to create the {@link java.io.InputStream} from
      * @param path the path to the ressource
      */
-    public AndroidResource(final Context context, final String path) {
+    AndroidResource(final Context context, final String path) {
         this.context = context;
         this.path = path;
     }

--- a/android/src/main/java/cucumber/runtime/android/AndroidResourceLoader.java
+++ b/android/src/main/java/cucumber/runtime/android/AndroidResourceLoader.java
@@ -13,12 +13,12 @@ import java.util.List;
 /**
  * Android specific implementation of {@link cucumber.runtime.io.ResourceLoader} which loads non-class resources such as .feature files.
  */
-public class AndroidResourceLoader implements ResourceLoader {
+final class AndroidResourceLoader implements ResourceLoader {
 
     /**
      * The format of the resource path.
      */
-    public static final String RESOURCE_PATH_FORMAT = "%s/%s";
+    private static final String RESOURCE_PATH_FORMAT = "%s/%s";
 
     /**
      * The {@link android.content.Context} to get the resources from.
@@ -30,7 +30,7 @@ public class AndroidResourceLoader implements ResourceLoader {
      *
      * @param context the {@link android.content.Context} to get resources from
      */
-    public AndroidResourceLoader(final Context context) {
+    AndroidResourceLoader(final Context context) {
         this.context = context;
     }
 

--- a/android/src/main/java/cucumber/runtime/android/Arguments.java
+++ b/android/src/main/java/cucumber/runtime/android/Arguments.java
@@ -7,23 +7,23 @@ import android.os.Bundle;
  */
 public class Arguments {
 
-    public static final String VALUE_SEPARATOR = "--";
+    private static final String VALUE_SEPARATOR = "--";
 
     /**
      * Keys of supported arguments.
      */
-    public static class KEY {
-        public static final String COUNT_ENABLED = "count";
-        public static final String DEBUG_ENABLED = "debug";
-        public static final String COVERAGE_ENABLED = "coverage";
-        public static final String COVERAGE_DATA_FILE_PATH = "coverageFile";
+    static class KEY {
+        static final String COUNT_ENABLED = "count";
+        static final String DEBUG_ENABLED = "debug";
+        static final String COVERAGE_ENABLED = "coverage";
+        static final String COVERAGE_DATA_FILE_PATH = "coverageFile";
     }
 
     /**
      * Default values of supported arguments.
      */
-    public static class DEFAULT {
-        public static final String COVERAGE_DATA_FILE_PATH = "coverage.ec";
+    static class DEFAULT {
+        static final String COVERAGE_DATA_FILE_PATH = "coverage.ec";
     }
 
     private final boolean countEnabled;

--- a/android/src/main/java/cucumber/runtime/android/CucumberExecutor.java
+++ b/android/src/main/java/cucumber/runtime/android/CucumberExecutor.java
@@ -14,6 +14,8 @@ import cucumber.runtime.Env;
 import cucumber.runtime.Runtime;
 import cucumber.runtime.RuntimeOptions;
 import cucumber.runtime.RuntimeOptionsFactory;
+import cucumber.runtime.formatter.AndroidInstrumentationReporter;
+import cucumber.runtime.formatter.AndroidLogcatReporter;
 import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.java.JavaBackend;
 import cucumber.runtime.java.ObjectFactoryLoader;
@@ -27,19 +29,19 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Executes the cucumber scnearios.
+ * Executes the cucumber scenarios.
  */
-public class CucumberExecutor {
+public final class CucumberExecutor {
 
     /**
      * The logcat tag to log all cucumber related information to.
      */
-    public static final String TAG = "cucumber-android";
+    static final String TAG = "cucumber-android";
 
     /**
      * The system property name of the cucumber options.
      */
-    public static final String CUCUMBER_OPTIONS_SYSTEM_PROPERTY = "cucumber.options";
+    private static final String CUCUMBER_OPTIONS_SYSTEM_PROPERTY = "cucumber.options";
 
     /**
      * The instrumentation to report to.

--- a/android/src/main/java/cucumber/runtime/android/DexClassFinder.java
+++ b/android/src/main/java/cucumber/runtime/android/DexClassFinder.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * Android specific implementation of {@link cucumber.runtime.ClassFinder} which loads classes contained in the provided {@link dalvik.system.DexFile}.
  */
-public class DexClassFinder implements ClassFinder {
+final class DexClassFinder implements ClassFinder {
 
     /**
      * Symbol name of the manifest class.
@@ -53,7 +53,7 @@ public class DexClassFinder implements ClassFinder {
      *
      * @param dexFile the {@link dalvik.system.DexFile} to load classes from
      */
-    public DexClassFinder(final DexFile dexFile) {
+    DexClassFinder(final DexFile dexFile) {
         this.dexFile = dexFile;
     }
 

--- a/android/src/main/java/cucumber/runtime/android/FeatureCompiler.java
+++ b/android/src/main/java/cucumber/runtime/android/FeatureCompiler.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * Utility class to count scenarios, including outlined.
  */
-public class FeatureCompiler {
+final class FeatureCompiler {
 
     /**
      * Compilers the given {@code cucumberFeatures} to {@link PickleEvent}s.
@@ -18,7 +18,7 @@ public class FeatureCompiler {
      * @param cucumberFeatures the list of {@link CucumberFeature} to compile
      * @return the compiled pickles in {@link PickleEvent}s
      */
-    public static List<PickleEvent> compile(final List<CucumberFeature> cucumberFeatures, final Runtime runtime) {
+    static List<PickleEvent> compile(final List<CucumberFeature> cucumberFeatures, final Runtime runtime) {
         List<PickleEvent> pickles = new ArrayList<PickleEvent>();
         for (final CucumberFeature feature : cucumberFeatures) {
             for (final PickleEvent pickleEvent : runtime.compileFeature(feature)) {

--- a/android/src/main/java/cucumber/runtime/formatter/AndroidInstrumentationReporter.java
+++ b/android/src/main/java/cucumber/runtime/formatter/AndroidInstrumentationReporter.java
@@ -1,4 +1,4 @@
-package cucumber.runtime.android;
+package cucumber.runtime.formatter;
 
 import android.app.Instrumentation;
 import android.os.Bundle;
@@ -12,7 +12,6 @@ import cucumber.api.event.TestSourceRead;
 import cucumber.api.event.TestStepFinished;
 import cucumber.api.formatter.Formatter;
 import cucumber.runtime.Runtime;
-import cucumber.runtime.formatter.TestSourcesModel;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -36,26 +35,26 @@ import java.io.StringWriter;
  *     hook threw an exception other than an {@link AssertionError}</li>
  * </ul>
  */
-public class AndroidInstrumentationReporter implements Formatter {
+public final class AndroidInstrumentationReporter implements Formatter {
 
     /**
      * Tests status keys.
      */
-    public static class StatusKeys {
-        public static final String TEST = "test";
-        public static final String CLASS = "class";
-        public static final String STACK = "stack";
-        public static final String NUMTESTS = "numtests";
+    static class StatusKeys {
+        static final String TEST = "test";
+        static final String CLASS = "class";
+        static final String STACK = "stack";
+        static final String NUMTESTS = "numtests";
     }
 
     /**
      * Test result status codes.
      */
-    public static class StatusCodes {
-        public static final int FAILURE = -2;
-        public static final int START = 1;
-        public static final int ERROR = -1;
-        public static final int OK = 0;
+    static class StatusCodes {
+        static final int FAILURE = -2;
+        static final int START = 1;
+        static final int ERROR = -1;
+        static final int OK = 0;
     }
 
     /**

--- a/android/src/main/java/cucumber/runtime/formatter/AndroidLogcatReporter.java
+++ b/android/src/main/java/cucumber/runtime/formatter/AndroidLogcatReporter.java
@@ -1,4 +1,4 @@
-package cucumber.runtime.android;
+package cucumber.runtime.formatter;
 
 import android.util.Log;
 import cucumber.api.event.EventHandler;
@@ -12,7 +12,7 @@ import cucumber.runtime.Runtime;
 /**
  * Logs information about the currently executed statements to androids logcat.
  */
-public class  AndroidLogcatReporter implements Formatter {
+public final class  AndroidLogcatReporter implements Formatter {
 
     /**
      * The {@link cucumber.runtime.Runtime} to get the errors and snippets from for writing them to the logcat at the end of the execution.

--- a/android/src/main/java/cucumber/runtime/formatter/MissingStepDefinitionError.java
+++ b/android/src/main/java/cucumber/runtime/formatter/MissingStepDefinitionError.java
@@ -1,16 +1,16 @@
-package cucumber.runtime.android;
+package cucumber.runtime.formatter;
 
 /**
  * Indicates that there was a missing step in the execution of the scenario lifecycle.
  */
-public class MissingStepDefinitionError extends AssertionError {
+final class MissingStepDefinitionError extends AssertionError {
 
     /**
      * Creates a new instance for the given snippet.
      *
      * @param snippet the suggested snippet which could be implemented to avoid this exception
      */
-    public MissingStepDefinitionError(final String snippet) {
+    MissingStepDefinitionError(final String snippet) {
         super(String.format("\n\n%s", snippet));
     }
 }

--- a/android/src/test/java/cucumber/runtime/formatter/AndroidInstrumentationReporterTest.java
+++ b/android/src/test/java/cucumber/runtime/formatter/AndroidInstrumentationReporterTest.java
@@ -1,6 +1,5 @@
-package cucumber.runtime.android;
+package cucumber.runtime.formatter;
 
-import static cucumber.runtime.android.AndroidInstrumentationReporter.StatusCodes;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
@@ -17,6 +16,7 @@ import cucumber.api.Result;
 import cucumber.api.TestCase;
 import cucumber.api.event.TestSourceRead;
 import cucumber.runtime.Runtime;
+import cucumber.runtime.formatter.AndroidInstrumentationReporter.StatusCodes;
 import edu.emory.mathcs.backport.java.util.Collections;
 import org.junit.Before;
 import org.junit.Rule;

--- a/android/src/test/java/cucumber/runtime/formatter/MissingStepDefinitionErrorTest.java
+++ b/android/src/test/java/cucumber/runtime/formatter/MissingStepDefinitionErrorTest.java
@@ -1,4 +1,4 @@
-package cucumber.runtime.android;
+package cucumber.runtime.formatter;
 
 import org.junit.Test;
 import static org.hamcrest.core.Is.is;

--- a/core/src/main/java/cucumber/api/Plugin.java
+++ b/core/src/main/java/cucumber/api/Plugin.java
@@ -1,4 +1,26 @@
 package cucumber.api;
 
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+
+/**
+ * Interface for all plugins.
+ * <p>
+ * A plugin must have a constructor that is either empty
+ * or takes a single argument of one of the following types:
+ * <ul>
+ * <li>{@link Appendable}</li>
+ * <li>{@link File}</li>
+ * <li>{@link URL}</li>
+ * <li>{@link URI}</li>
+ * </ul>
+ * Plugins must implement one of the following interfaces:
+ * <ul>
+ * <li>{@link cucumber.api.StepDefinitionReporter}</li>
+ * <li>{@link cucumber.api.SummaryPrinter}</li>
+ * <li>{@link cucumber.api.formatter.Formatter}</li>
+ * </ul>
+ */
 public interface Plugin {
 }

--- a/core/src/main/java/cucumber/api/StepDefinitionReporter.java
+++ b/core/src/main/java/cucumber/api/StepDefinitionReporter.java
@@ -2,7 +2,7 @@ package cucumber.api;
 
 import cucumber.runtime.StepDefinition;
 
-public interface StepDefinitionReporter {
+public interface StepDefinitionReporter extends Plugin {
     /**
      * Called when a step definition is defined
      *

--- a/core/src/main/java/cucumber/api/SummaryPrinter.java
+++ b/core/src/main/java/cucumber/api/SummaryPrinter.java
@@ -1,5 +1,7 @@
 package cucumber.api;
 
-public interface SummaryPrinter {
-    public void print(cucumber.runtime.Runtime runtime);
+import cucumber.runtime.Runtime;
+
+public interface SummaryPrinter extends Plugin {
+    void print(Runtime runtime);
 }

--- a/core/src/main/java/cucumber/api/formatter/ColorAware.java
+++ b/core/src/main/java/cucumber/api/formatter/ColorAware.java
@@ -1,5 +1,5 @@
 package cucumber.api.formatter;
 
-public interface ColorAware {
+public interface ColorAware extends Formatter {
     void setMonochrome(boolean monochrome);
 }

--- a/core/src/main/java/cucumber/api/formatter/Formatter.java
+++ b/core/src/main/java/cucumber/api/formatter/Formatter.java
@@ -1,10 +1,11 @@
 package cucumber.api.formatter;
 
+import cucumber.api.Plugin;
 import cucumber.api.event.EventListener;
 
 /**
  * This is the interface you should implement if you want your own custom
  * formatter.
  */
-public interface Formatter extends EventListener {
+public interface Formatter extends EventListener, Plugin {
 }

--- a/core/src/main/java/cucumber/api/formatter/StrictAware.java
+++ b/core/src/main/java/cucumber/api/formatter/StrictAware.java
@@ -1,5 +1,5 @@
 package cucumber.api.formatter;
 
-public interface StrictAware {
+public interface StrictAware extends Formatter {
     void setStrict(boolean strict);
 }

--- a/core/src/main/java/cucumber/runtime/DefaultSummaryPrinter.java
+++ b/core/src/main/java/cucumber/runtime/DefaultSummaryPrinter.java
@@ -13,7 +13,7 @@ public class DefaultSummaryPrinter implements SummaryPrinter {
     }
 
     @Override
-    public void print(cucumber.runtime.Runtime runtime) {
+    public void print(Runtime runtime) {
         out.println();
         printStats(runtime);
         out.println();
@@ -21,18 +21,18 @@ public class DefaultSummaryPrinter implements SummaryPrinter {
         printSnippets(runtime);
     }
 
-    private void printStats(cucumber.runtime.Runtime runtime) {
+    private void printStats(Runtime runtime) {
         runtime.printStats(out);
     }
 
-    private void printErrors(cucumber.runtime.Runtime runtime) {
+    private void printErrors(Runtime runtime) {
         for (Throwable error : runtime.getErrors()) {
             error.printStackTrace(out);
             out.println();
         }
     }
 
-    private void printSnippets(cucumber.runtime.Runtime runtime) {
+    private void printSnippets(Runtime runtime) {
         List<String> snippets = runtime.getSnippets();
         if (!snippets.isEmpty()) {
             out.append("\n");

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -1,5 +1,6 @@
 package cucumber.runtime;
 
+import cucumber.api.Plugin;
 import cucumber.api.SnippetType;
 import cucumber.api.StepDefinitionReporter;
 import cucumber.api.SummaryPrinter;
@@ -68,7 +69,7 @@ public class RuntimeOptions {
     private final List<String> pluginSummaryPrinterNames = new ArrayList<String>();
     private final List<String> junitOptions = new ArrayList<String>();
     private final PluginFactory pluginFactory;
-    private final List<Object> plugins = new ArrayList<Object>();
+    private final List<Plugin> plugins = new ArrayList<Plugin>();
     private final List<XStreamConverter> converters = new ArrayList<XStreamConverter>();
     private boolean dryRun;
     private boolean strict = false;
@@ -316,21 +317,21 @@ public class RuntimeOptions {
         return features;
     }
 
-    public List<Object> getPlugins() {
+    public List<Plugin> getPlugins() {
         if (!pluginNamesInstantiated) {
             for (String pluginName : pluginFormatterNames) {
-                Object plugin = pluginFactory.create(pluginName);
+                Plugin plugin = pluginFactory.create(pluginName);
                 plugins.add(plugin);
                 setMonochromeOnColorAwarePlugins(plugin);
                 setStrictOnStrictAwarePlugins(plugin);
                 setEventBusFormatterPlugins(plugin);
             }
             for (String pluginName : pluginStepDefinitionReporterNames) {
-                Object plugin = pluginFactory.create(pluginName);
+                Plugin plugin = pluginFactory.create(pluginName);
                 plugins.add(plugin);
             }
             for (String pluginName : pluginSummaryPrinterNames) {
-                Object plugin = pluginFactory.create(pluginName);
+                Plugin plugin = pluginFactory.create(pluginName);
                 plugins.add(plugin);
             }
             pluginNamesInstantiated = true;
@@ -362,7 +363,7 @@ public class RuntimeOptions {
      * @param <T>         generic proxy type
      * @return a proxy
      */
-    public <T> T pluginProxy(ClassLoader classLoader, final Class<T> type) {
+    private <T> T pluginProxy(ClassLoader classLoader, final Class<T> type) {
         Object proxy = Proxy.newProxyInstance(classLoader, new Class<?>[]{type}, new InvocationHandler() {
             @Override
             public Object invoke(Object target, Method method, Object[] args) throws Throwable {
@@ -421,11 +422,9 @@ public class RuntimeOptions {
         return featurePaths;
     }
 
-    public void addPlugin(Object plugin) {
+    public void addPlugin(Formatter plugin) {
         plugins.add(plugin);
-        if (plugin instanceof Formatter) {
-            setEventBusFormatterPlugins(plugin);
-        }
+        setEventBusFormatterPlugins(plugin);
     }
 
     public List<Pattern> getNameFilters() {

--- a/core/src/main/java/cucumber/runtime/formatter/AnsiFormats.java
+++ b/core/src/main/java/cucumber/runtime/formatter/AnsiFormats.java
@@ -5,7 +5,7 @@ import cucumber.api.formatter.AnsiEscapes;
 import java.util.HashMap;
 import java.util.Map;
 
-public class AnsiFormats implements Formats {
+public final class AnsiFormats implements Formats {
     private static final Map<String, Format> formats = new HashMap<String, Format>() {{
         put("undefined", new ColorFormat(AnsiEscapes.YELLOW));
         put("undefined_arg", new ColorFormat(AnsiEscapes.YELLOW, AnsiEscapes.INTENSITY_BOLD)); // Never used, but avoids NPE in formatters.
@@ -28,10 +28,10 @@ public class AnsiFormats implements Formats {
         put("output", new ColorFormat(AnsiEscapes.BLUE));
     }};
 
-    public static class ColorFormat implements Format {
+    private static final class ColorFormat implements Format {
         private final AnsiEscapes[] escapes;
 
-        public ColorFormat(AnsiEscapes... escapes) {
+        ColorFormat(AnsiEscapes... escapes) {
             this.escapes = escapes;
         }
 

--- a/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
@@ -49,7 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-class HTMLFormatter implements Formatter {
+final class HTMLFormatter implements Formatter {
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
     private static final String JS_FORMATTER_VAR = "formatter";
     private static final String JS_REPORT_FILENAME = "report.js";
@@ -356,7 +356,7 @@ class HTMLFormatter implements Formatter {
     private Map<String, Object> createBackground(TestCase testCase) {
         TestSourcesModel.AstNode astNode = testSources.getAstNode(currentFeatureFile, testCase.getLine());
         if (astNode != null) {
-            Background background = TestSourcesModel.getBackgoundForTestCase(astNode);
+            Background background = TestSourcesModel.getBackgroundForTestCase(astNode);
             Map<String, Object> testCaseMap = new HashMap<String, Object>();
             testCaseMap.put("name", background.getName());
             testCaseMap.put("keyword", background.getKeyword());

--- a/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
@@ -34,7 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-class JSONFormatter implements Formatter {
+final class JSONFormatter implements Formatter {
     private String currentFeatureFile;
     private List<Map<String, Object>> featureMaps = new ArrayList<Map<String, Object>>();
     private List<Map<String, Object>> currentElementsList;
@@ -201,7 +201,7 @@ class JSONFormatter implements Formatter {
     private Map<String, Object> createBackground(TestCase testCase) {
         TestSourcesModel.AstNode astNode = testSources.getAstNode(currentFeatureFile, testCase.getLine());
         if (astNode != null) {
-            Background background = TestSourcesModel.getBackgoundForTestCase(astNode);
+            Background background = TestSourcesModel.getBackgroundForTestCase(astNode);
             Map<String, Object> testCaseMap = new HashMap<String, Object>();
             testCaseMap.put("name", background.getName());
             testCaseMap.put("line", background.getLocation().getLine());

--- a/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
@@ -42,7 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-class JUnitFormatter implements Formatter, StrictAware {
+final class JUnitFormatter implements Formatter, StrictAware {
     private final Writer out;
     private final Document doc;
     private final Element rootElement;

--- a/core/src/main/java/cucumber/runtime/formatter/MonochromeFormats.java
+++ b/core/src/main/java/cucumber/runtime/formatter/MonochromeFormats.java
@@ -1,6 +1,6 @@
 package cucumber.runtime.formatter;
 
-public class MonochromeFormats implements Formats {
+public final class MonochromeFormats implements Formats {
     private static final Format FORMAT = new Format() {
         public String text(String text) {
             return text;

--- a/core/src/main/java/cucumber/runtime/formatter/NullFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/NullFormatter.java
@@ -3,7 +3,7 @@ package cucumber.runtime.formatter;
 import cucumber.api.event.EventPublisher;
 import cucumber.api.formatter.Formatter;
 
-class NullFormatter implements Formatter {
+final class NullFormatter implements Formatter {
     public NullFormatter() {
     }
 

--- a/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
@@ -28,7 +28,7 @@ import gherkin.pickles.PickleTag;
 
 import java.util.List;
 
-class PrettyFormatter implements Formatter, ColorAware {
+final class PrettyFormatter implements Formatter, ColorAware {
     private static final String SCENARIO_INDENT = "  ";
     private static final String STEP_INDENT = "    ";
     private static final String EXAMPLES_INDENT = "    ";
@@ -305,7 +305,7 @@ class PrettyFormatter implements Formatter, ColorAware {
     private void printBackground(TestCase testCase) {
         TestSourcesModel.AstNode astNode = testSources.getAstNode(currentFeatureFile, testCase.getLine());
         if (astNode != null) {
-            Background background = TestSourcesModel.getBackgoundForTestCase(astNode);
+            Background background = TestSourcesModel.getBackgroundForTestCase(astNode);
             String backgroundText = getScenarioDefinitionText(background);
             boolean useBackgroundSteps = true;
             calculateLocationIndentation(SCENARIO_INDENT + backgroundText, testCase.getTestSteps(), useBackgroundSteps);

--- a/core/src/main/java/cucumber/runtime/formatter/ProgressFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/ProgressFormatter.java
@@ -14,7 +14,7 @@ import cucumber.api.formatter.NiceAppendable;
 import java.util.HashMap;
 import java.util.Map;
 
-class ProgressFormatter implements Formatter, ColorAware {
+final class ProgressFormatter implements Formatter, ColorAware {
     private static final Map<Result.Type, Character> CHARS = new HashMap<Result.Type, Character>() {{
         put(Result.Type.PASSED, '.');
         put(Result.Type.UNDEFINED, 'U');

--- a/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
@@ -19,7 +19,7 @@ import java.util.Set;
  * Formatter for reporting all failed test cases and print their locations
  * Failed means: results that make the exit code non-zero.
  */
-class RerunFormatter implements Formatter, StrictAware {
+final class RerunFormatter implements Formatter, StrictAware {
     private final NiceAppendable out;
     private Map<String, ArrayList<Integer>> featureAndFailedLinesMapping = new HashMap<String, ArrayList<Integer>>();
     private boolean isStrict = false;

--- a/core/src/main/java/cucumber/runtime/formatter/TestSourcesModel.java
+++ b/core/src/main/java/cucumber/runtime/formatter/TestSourcesModel.java
@@ -20,19 +20,19 @@ import gherkin.ast.TableRow;
 import java.util.HashMap;
 import java.util.Map;
 
-public class TestSourcesModel {
+final class TestSourcesModel {
     private final Map<String, TestSourceRead> pathToReadEventMap = new HashMap<String, TestSourceRead>();
     private final Map<String, GherkinDocument> pathToAstMap = new HashMap<String, GherkinDocument>();
     private final Map<String, Map<Integer, AstNode>> pathToNodeMap = new HashMap<String, Map<Integer, AstNode>>();
 
-    public static Feature getFeatureForTestCase(AstNode astNode) {
+    static Feature getFeatureForTestCase(AstNode astNode) {
         while (astNode.parent != null) {
             astNode = astNode.parent;
         }
-        return (Feature)astNode.node;
+        return (Feature) astNode.node;
     }
 
-    public static Background getBackgoundForTestCase(AstNode astNode) {
+    static Background getBackgroundForTestCase(AstNode astNode) {
         Feature feature = getFeatureForTestCase(astNode);
         ScenarioDefinition backgound = feature.getChildren().get(0);
         if (backgound instanceof Background) {
@@ -42,47 +42,47 @@ public class TestSourcesModel {
         }
     }
 
-    public static ScenarioDefinition getScenarioDefinition(AstNode astNode) {
-        return astNode.node instanceof ScenarioDefinition ? (ScenarioDefinition)astNode.node : (ScenarioDefinition)astNode.parent.parent.node;
+    static ScenarioDefinition getScenarioDefinition(AstNode astNode) {
+        return astNode.node instanceof ScenarioDefinition ? (ScenarioDefinition) astNode.node : (ScenarioDefinition) astNode.parent.parent.node;
     }
 
-    public static boolean isScenarioOutlineScenario(AstNode astNode) {
+    static boolean isScenarioOutlineScenario(AstNode astNode) {
         return !(astNode.node instanceof ScenarioDefinition);
     }
 
-    public static boolean isBackgroundStep(AstNode astNode) {
+    static boolean isBackgroundStep(AstNode astNode) {
         return astNode.parent.node instanceof Background;
     }
 
-    public static String calculateId(AstNode astNode) {
+    static String calculateId(AstNode astNode) {
         Node node = astNode.node;
         if (node instanceof ScenarioDefinition) {
-            return calculateId(astNode.parent) + ";" + convertToId(((ScenarioDefinition)node).getName());
+            return calculateId(astNode.parent) + ";" + convertToId(((ScenarioDefinition) node).getName());
         }
         if (node instanceof ExamplesRowWrapperNode) {
-            return calculateId(astNode.parent) + ";" + Integer.toString(((ExamplesRowWrapperNode)node).bodyRowIndex + 2);
+            return calculateId(astNode.parent) + ";" + Integer.toString(((ExamplesRowWrapperNode) node).bodyRowIndex + 2);
         }
         if (node instanceof TableRow) {
             return calculateId(astNode.parent) + ";" + Integer.toString(1);
         }
         if (node instanceof Examples) {
-            return calculateId(astNode.parent) + ";" + convertToId(((Examples)node).getName());
+            return calculateId(astNode.parent) + ";" + convertToId(((Examples) node).getName());
         }
         if (node instanceof Feature) {
-            return convertToId(((Feature)node).getName());
+            return convertToId(((Feature) node).getName());
         }
         return "";
     }
 
-    public static String convertToId(String name) {
+    static String convertToId(String name) {
         return name.replaceAll("[\\s'_,!]", "-").toLowerCase();
     }
 
-    public void addTestSourceReadEvent(String path, TestSourceRead event) {
+    void addTestSourceReadEvent(String path, TestSourceRead event) {
         pathToReadEventMap.put(path, event);
     }
 
-    public Feature getFeature(String path) {
+    Feature getFeature(String path) {
         if (!pathToAstMap.containsKey(path)) {
             parseGherkinSource(path);
         }
@@ -92,11 +92,11 @@ public class TestSourcesModel {
         return null;
     }
 
-    public ScenarioDefinition getScenarioDefinition(String path, int line) {
+    ScenarioDefinition getScenarioDefinition(String path, int line) {
         return getScenarioDefinition(getAstNode(path, line));
     }
 
-    public AstNode getAstNode(String path, int line) {
+    AstNode getAstNode(String path, int line) {
         if (!pathToNodeMap.containsKey(path)) {
             parseGherkinSource(path);
         }
@@ -106,18 +106,18 @@ public class TestSourcesModel {
         return null;
     }
 
-    public boolean hasBackground(String path, int line) {
+    boolean hasBackground(String path, int line) {
         if (!pathToNodeMap.containsKey(path)) {
             parseGherkinSource(path);
         }
         if (pathToNodeMap.containsKey(path)) {
             AstNode astNode = pathToNodeMap.get(path).get(line);
-            return getBackgoundForTestCase(astNode) != null;
+            return getBackgroundForTestCase(astNode) != null;
         }
         return false;
     }
 
-    public String getKeywordFromSource(String uri, int stepLine) {
+    String getKeywordFromSource(String uri, int stepLine) {
         Feature feature = getFeature(uri);
         if (feature != null) {
             TestSourceRead event = getTestSourceReadEvent(uri);
@@ -132,14 +132,14 @@ public class TestSourcesModel {
         return "";
     }
 
-    public TestSourceRead getTestSourceReadEvent(String uri) {
+    private TestSourceRead getTestSourceReadEvent(String uri) {
         if (pathToReadEventMap.containsKey(uri)) {
             return pathToReadEventMap.get(uri);
         }
         return null;
     }
 
-    public String getFeatureName(String uri) {
+    String getFeatureName(String uri) {
         Feature feature = getFeature(uri);
         if (feature != null) {
             return feature.getName();
@@ -174,7 +174,7 @@ public class TestSourcesModel {
             nodeMap.put(step.getLocation().getLine(), new AstNode(step, childNode));
         }
         if (child instanceof ScenarioOutline) {
-            processScenarioOutlineExamples(nodeMap, (ScenarioOutline)child, childNode);
+            processScenarioOutlineExamples(nodeMap, (ScenarioOutline) child, childNode);
         }
     }
 
@@ -194,19 +194,19 @@ public class TestSourcesModel {
     }
 
     class ExamplesRowWrapperNode extends Node {
-        public final int bodyRowIndex;
+        final int bodyRowIndex;
 
-        protected ExamplesRowWrapperNode(Node examplesRow, int bodyRowIndex) {
+        ExamplesRowWrapperNode(Node examplesRow, int bodyRowIndex) {
             super(examplesRow.getLocation());
             this.bodyRowIndex = bodyRowIndex;
         }
     }
 
     class AstNode {
-        public final Node node;
-        public final AstNode parent;
+        final Node node;
+        final AstNode parent;
 
-        public AstNode(Node node, AstNode parent) {
+        AstNode(Node node, AstNode parent) {
             this.node = node;
             this.parent = parent;
         }

--- a/core/src/main/java/cucumber/runtime/formatter/UsageFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/UsageFormatter.java
@@ -21,7 +21,7 @@ import java.util.Map;
  * Formatter to measure performance of steps. Aggregated results for all steps can be computed
  * by adding {@link UsageStatisticStrategy} to the usageFormatter
  */
-class UsageFormatter implements Formatter {
+final class UsageFormatter implements Formatter {
     private static final BigDecimal NANOS_PER_SECOND = BigDecimal.valueOf(1000000000);
     final Map<String, List<StepContainer>> usageMap = new HashMap<String, List<StepContainer>>();
     private final Map<String, UsageStatisticStrategy> statisticStrategies = new HashMap<String, UsageStatisticStrategy>();

--- a/core/src/test/java/cucumber/runtime/BackgroundTest.java
+++ b/core/src/test/java/cucumber/runtime/BackgroundTest.java
@@ -2,7 +2,6 @@ package cucumber.runtime;
 
 import cucumber.runtime.io.ClasspathResourceLoader;
 import cucumber.runtime.model.CucumberFeature;
-//import gherkin.formatter.PrettyFormatter;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
@@ -1,7 +1,9 @@
 package cucumber.runtime;
 
 import cucumber.api.CucumberOptions;
+import cucumber.api.Plugin;
 import cucumber.api.SnippetType;
+import cucumber.api.formatter.Formatter;
 import cucumber.runtime.io.ResourceLoader;
 import cucumber.deps.com.thoughtworks.xstream.annotations.XStreamConverter;
 import cucumber.deps.com.thoughtworks.xstream.annotations.XStreamConverters;
@@ -118,7 +120,7 @@ public class RuntimeOptionsFactoryTest {
         RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(SubClassWithFormatter.class);
         RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
 
-        List<Object> plugins = runtimeOptions.getPlugins();
+        List<Plugin> plugins = runtimeOptions.getPlugins();
         assertPluginExists(plugins, "cucumber.runtime.formatter.JSONFormatter");
         assertPluginExists(plugins, "cucumber.runtime.formatter.PrettyFormatter");
     }
@@ -174,10 +176,10 @@ public class RuntimeOptionsFactoryTest {
         assertEquals(DummyConverter.class, converters.get(1).value());
     }
 
-    private void assertPluginExists(List<Object> plugins, String pluginName) {
+    private void assertPluginExists(List<Plugin> plugins, String pluginName) {
         boolean found = false;
-        for (Object plugin : plugins) {
-            if (plugin.getClass().getName() == pluginName) {
+        for (Plugin plugin : plugins) {
+            if (plugin.getClass().getName().equals(pluginName)) {
                 found = true;
             }
         }


### PR DESCRIPTION
## Summary

The following improvements have been made

1. All plugin interfaces (Formatter, StepDefinitionReporter,
   SummaryPrinter) now extend the Plugin interface.

2. Updated documentation to make it clear what each plugin does.

3. All plugins have been made final. They are not designed for
   extension.

4. Moved android formatters into formatter package to limit visibility
   of TestSourcesModel.

5. Classes in runtime/android have been made final and have had their
   visibility reduced. They are not designed for extension.

## Motivation and Context

Discussion on Slack showed that TestSourcesModel was still available for use. TestSourcesModel is not part of the API so its use should be discouraged. While doing so the fact that none of the plugins actually implemented the plugin interface bugged me to no end.

## How Has This Been Tested?

Ran the tests, fixed the tests.

## Types of changes

The changes to the api should be backwards compatible as an interface has been added to the interfaces that were already used. It is possible that plugin used none of these interfaces, but such a plugin would have no effect.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).