### PR TITLE
 Fix Java8StepDefinition.isDefinedAt

### DIFF
--- a/java/src/main/java/cucumber/runtime/java/JavaBackend.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaBackend.java
@@ -33,8 +33,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 
-public class JavaBackend implements Backend {
-    public static final ThreadLocal<JavaBackend> INSTANCE = new ThreadLocal<JavaBackend>();
+public class JavaBackend implements Backend, LambdaGlueRegistry {
     private final SnippetGenerator snippetGenerator = new SnippetGenerator(createSnippet());
 
     private Snippet createSnippet() {
@@ -151,6 +150,7 @@ public class JavaBackend implements Backend {
         }
     }
 
+    @Override
     public void addStepDefinition(StepDefinition stepDefinition) {
         glue.addStepDefinition(stepDefinition);
     }
@@ -169,10 +169,12 @@ public class JavaBackend implements Backend {
         }
     }
 
+    @Override
     public void addBeforeHookDefinition(HookDefinition beforeHook) {
         glue.addBeforeHook(beforeHook);
     }
 
+    @Override
     public void addAfterHookDefinition(HookDefinition afterHook) {
         glue.addAfterHook(afterHook);
     }

--- a/java/src/main/java/cucumber/runtime/java/LambdaGlueRegistry.java
+++ b/java/src/main/java/cucumber/runtime/java/LambdaGlueRegistry.java
@@ -1,0 +1,14 @@
+package cucumber.runtime.java;
+
+import cucumber.runtime.HookDefinition;
+import cucumber.runtime.StepDefinition;
+
+public interface LambdaGlueRegistry {
+    ThreadLocal<LambdaGlueRegistry> INSTANCE = new ThreadLocal<LambdaGlueRegistry>();
+
+    void addStepDefinition(StepDefinition stepDefinition);
+
+    void addBeforeHookDefinition(HookDefinition beforeHook);
+
+    void addAfterHookDefinition(HookDefinition afterHook);
+}

--- a/java8/src/main/code_generator/I18n.java8.txt
+++ b/java8/src/main/code_generator/I18n.java8.txt
@@ -1,19 +1,19 @@
 package cucumber.api.java8;
 
-import cucumber.runtime.java.JavaBackend;
+import cucumber.runtime.java.LambdaGlueRegistry;
 import cucumber.runtime.java8.Java8StepDefinition;
 import cucumber.runtime.java8.LambdaGlueBase;
 
 public interface ${className} extends LambdaGlueBase {
 <% i18n.stepKeywords.findAll { !it.contains('*') && !it.matches("^\\d.*") }.sort().unique().each { kw -> %>
     default void ${java.text.Normalizer.normalize(kw.replaceAll("[\\s',!]", ""), java.text.Normalizer.Form.NFC)}(final String regexp, final StepdefBody.A0 body) {
-        JavaBackend.INSTANCE.get().addStepDefinition(
+        LambdaGlueRegistry.INSTANCE.get().addStepDefinition(
             new Java8StepDefinition(regexp, 0, StepdefBody.A0.class, body)
         );
     }
 
     default void ${java.text.Normalizer.normalize(kw.replaceAll("[\\s',!]", ""), java.text.Normalizer.Form.NFC)}(final String regexp, final long timeoutMillis, final StepdefBody.A0 body) {
-        JavaBackend.INSTANCE.get().addStepDefinition(
+        LambdaGlueRegistry.INSTANCE.get().addStepDefinition(
             new Java8StepDefinition(regexp, timeoutMillis, StepdefBody.A0.class, body)
         );
     }
@@ -22,14 +22,14 @@ public interface ${className} extends LambdaGlueBase {
       def genericSignature = ts.join(",") %>
 
     default <${genericSignature}> void ${java.text.Normalizer.normalize(kw.replaceAll("[\\s',!]", ""), java.text.Normalizer.Form.NFC)}(final String regexp, final StepdefBody.A${arity}<${genericSignature}> body) {
-        JavaBackend.INSTANCE.get().addStepDefinition(
+        LambdaGlueRegistry.INSTANCE.get().addStepDefinition(
             new Java8StepDefinition(regexp, 0, StepdefBody.A${arity}.class, body)
         );
 
     }
 
     default <${genericSignature}> void ${java.text.Normalizer.normalize(kw.replaceAll("[\\s',!]", ""), java.text.Normalizer.Form.NFC)}(final String regexp, final long timeoutMillis, final StepdefBody.A${arity}<${genericSignature}> body) {
-        JavaBackend.INSTANCE.get().addStepDefinition(
+        LambdaGlueRegistry.INSTANCE.get().addStepDefinition(
             new Java8StepDefinition(regexp, timeoutMillis, StepdefBody.A${arity}.class, body)
         );
     }

--- a/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
+++ b/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
@@ -38,7 +38,7 @@ public class Java8StepDefinition implements StepDefinition {
         this.body = body;
 
         this.argumentMatcher = new JdkPatternArgumentMatcher(this.pattern);
-        this.location = new Exception().getStackTrace()[3];
+        this.location = new Exception().getStackTrace()[2];
         this.method = getAcceptMethod(body.getClass());
         try {
             Class<?>[] arguments = resolveRawArguments(bodyClass, body.getClass());

--- a/java8/src/test/java/cucumber/runtime/java8/Java8LambdaStepDefinitionMarksCorrectStackElementTest.java
+++ b/java8/src/test/java/cucumber/runtime/java8/Java8LambdaStepDefinitionMarksCorrectStackElementTest.java
@@ -1,0 +1,64 @@
+package cucumber.runtime.java8;
+
+import cucumber.runtime.HookDefinition;
+import cucumber.runtime.StepDefinition;
+import cucumber.runtime.java.LambdaGlueRegistry;
+import org.hamcrest.CustomTypeSafeMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class Java8LambdaStepDefinitionMarksCorrectStackElementTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private final MyLambdaGlueRegistry myLambdaGlueRegistry = new MyLambdaGlueRegistry();
+
+    @Test
+    public void exception_from_step_should_be_defined_at_step_definition_class() throws Throwable {
+        LambdaGlueRegistry.INSTANCE.set(myLambdaGlueRegistry);
+        new SomeLambdaStepDefs();
+        final StepDefinition stepDefinition = myLambdaGlueRegistry.getStepDefinition();
+
+        expectedException.expect(new CustomTypeSafeMatcher<Throwable>("exception with matching stack trace") {
+            @Override
+            protected boolean matchesSafely(Throwable item) {
+                for (StackTraceElement stackTraceElement : item.getStackTrace()) {
+                    if(stepDefinition.isDefinedAt(stackTraceElement)){
+                        return SomeLambdaStepDefs.class.getName().equals(stackTraceElement.getClassName());
+                    }
+
+                }
+                return false;
+            }
+        });
+
+        stepDefinition.execute("en", new Object[0]);
+    }
+
+
+    private class MyLambdaGlueRegistry implements LambdaGlueRegistry {
+
+        private StepDefinition stepDefinition;
+
+        @Override
+        public void addStepDefinition(StepDefinition stepDefinition) {
+            this.stepDefinition = stepDefinition;
+        }
+
+        @Override
+        public void addBeforeHookDefinition(HookDefinition beforeHook) {
+
+        }
+
+        @Override
+        public void addAfterHookDefinition(HookDefinition afterHook) {
+
+        }
+
+        public StepDefinition getStepDefinition() {
+            return stepDefinition;
+        }
+    }
+}

--- a/java8/src/test/java/cucumber/runtime/java8/SomeLambdaStepDefs.java
+++ b/java8/src/test/java/cucumber/runtime/java8/SomeLambdaStepDefs.java
@@ -1,0 +1,13 @@
+package cucumber.runtime.java8;
+
+import cucumber.api.java8.En;
+
+final class SomeLambdaStepDefs implements En {
+
+    SomeLambdaStepDefs() {
+        Given("I have a some step definition", () -> {
+            throw new Exception();
+        });
+    }
+
+}


### PR DESCRIPTION
## Summary

Fixes Java8StepDefinition.isDefinedAt as reported in #1254.

## Details

While replacing ConstantPoolTypeIntrospector with TypeResolver in 657ce3a49304e226da406fe4aa0413898d28747f the creation of the Java8StepDefinition was moved from the JavaBackend to the generated step definition.

This removed one stack element between the invocation of the Lambda (e.g. `Given(....)`) and the creation of the Java8StepDefinition.

## How Has This Been Tested?

Extracted LambdaGlueRegistry to make a unit test possible.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).