### PR TITLE
Deprecate Spring context configuration by more than one class

### DIFF
--- a/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
+++ b/spring/src/main/java/cucumber/runtime/java/spring/SpringFactory.java
@@ -62,6 +62,7 @@ public class SpringFactory implements ObjectFactory {
 
     private final Collection<Class<?>> stepClasses = new HashSet<Class<?>>();
     private Class<?> stepClassWithSpringContext = null;
+    private boolean deprecationWarningIssued = false;
 
     public SpringFactory() {
     }
@@ -119,6 +120,14 @@ public class SpringFactory implements ObjectFactory {
 
 
     private void checkAnnotationsEqual(Class<?> stepClassWithSpringContext, Class<?> stepClass) {
+        if (!deprecationWarningIssued) {
+            deprecationWarningIssued = true;
+            System.err.println(String.format("" +
+                    "WARNING: Having more than one glue class that configures " +
+                    "the spring context is deprecated. Found both %1$s and %2$s " +
+                    "that attempt to configure the spring context.",
+                    stepClass, stepClassWithSpringContext));
+        }
         Annotation[] annotations1 = stepClassWithSpringContext.getAnnotations();
         Annotation[] annotations2 = stepClass.getAnnotations();
         if (annotations1.length != annotations2.length) {

--- a/spring/src/test/java/cucumber/runtime/java/spring/SpringFactoryTest.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/SpringFactoryTest.java
@@ -16,6 +16,8 @@ import cucumber.runtime.java.spring.contexthierarchyconfig.WithContextHierarchyA
 import cucumber.runtime.java.spring.contexthierarchyconfig.WithDifferentContextHierarchyAnnotation;
 import cucumber.runtime.java.spring.dirtiescontextconfig.DirtiesContextBellyStepDefs;
 import cucumber.runtime.java.spring.metaconfig.dirties.DirtiesContextBellyMetaStepDefs;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -244,8 +246,21 @@ public class SpringFactoryTest {
     @Test
     public void shouldAllowClassesWithSameSpringAnnotations() {
         final ObjectFactory factory = new SpringFactory();
-        factory.addClass(WithSpringAnnotations.class);
-        factory.addClass(BellyStepdefs.class);
+        PrintStream originalErr = System.err;
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            System.setErr(new PrintStream(baos));
+            factory.addClass(WithSpringAnnotations.class);
+            factory.addClass(BellyStepdefs.class);
+            assertEquals("WARNING: Having more than one glue class that configures " +
+                         "the spring context is deprecated. Found both class " +
+                         "cucumber.runtime.java.spring.contextconfig.BellyStepdefs and class " +
+                         "cucumber.runtime.java.spring.contextconfig.WithSpringAnnotations " +
+                         "that attempt to configure the spring context.\n",
+                         baos.toString());
+        } finally {
+            System.setErr(originalErr);
+        }
     }
 
     @Test
@@ -253,8 +268,15 @@ public class SpringFactoryTest {
         expectedException.expect(CucumberException.class);
         expectedException.expectMessage("Annotations differs on glue classes found: cucumber.runtime.java.spring.contexthierarchyconfig.WithContextHierarchyAnnotation, cucumber.runtime.java.spring.contexthierarchyconfig.WithDifferentContextHierarchyAnnotation");
         final ObjectFactory factory = new SpringFactory();
-        factory.addClass(WithContextHierarchyAnnotation.class);
-        factory.addClass(WithDifferentContextHierarchyAnnotation.class);
+        PrintStream originalErr = System.err;
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            System.setErr(new PrintStream(baos));
+            factory.addClass(WithContextHierarchyAnnotation.class);
+            factory.addClass(WithDifferentContextHierarchyAnnotation.class);
+        } finally {
+            System.setErr(originalErr);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Deprecate Spring context configuration by more than one class

## Details

Print a warning if more than one glue class that attempts to configure the Spring context is found (that is have a `@ContextConfiguration` or `@ContextHierarcy` annotation.

## Motivation and Context

We have decided to only allow one glue class to configure the Spring context, as this is a non-backward compatible change, it will be introduced in v3.0.0 (#1246). Until then a deprecation warning should be printed.

## How Has This Been Tested?

The automated test suite has been updated to verify this behavior.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
