### PR TITLE
cucumber-core: Use the docstring content type in the json formatter.

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
@@ -250,6 +250,7 @@ final class JSONFormatter implements Formatter {
         PickleString docString = ((PickleString)argument);
         docStringMap.put("value", docString.getContent());
         docStringMap.put("line", docString.getLocation().getLine());
+        docStringMap.put("content_type", docString.getContentType());
         return docStringMap;
     }
 

--- a/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
@@ -678,7 +678,7 @@ public class JSONFormatterTest {
     }
 
     @Test
-    public void should_format_scenario_with_a_step_with_a_doc_string2() throws Throwable {
+    public void should_format_scenario_with_a_step_with_a_doc_string_and_content_type() throws Throwable {
         CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
             "Feature: Banana party\n" +
             "\n" +

--- a/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
@@ -678,6 +678,68 @@ public class JSONFormatterTest {
     }
 
     @Test
+    public void should_format_scenario_with_a_step_with_a_doc_string2() throws Throwable {
+        CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
+            "Feature: Banana party\n" +
+            "\n" +
+            "  Scenario: Monkey eats bananas\n" +
+            "    Given there are bananas\n" +
+            "    \"\"\"doc\n" +
+            "    doc string content\n" +
+            "    \"\"\"\n");
+        Map<String, Result> stepsToResult = new HashMap<String, Result>();
+        stepsToResult.put("there are bananas", result("passed"));
+        Map<String, String> stepsToLocation = new HashMap<String, String>();
+        stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
+        Long stepDuration = milliSeconds(1);
+
+        String formatterOutput = runFeatureWithJSONPrettyFormatter(feature, stepsToResult, stepsToLocation, stepDuration);
+
+        String expected = "[\n" +
+            "  {\n" +
+            "    \"line\": 1,\n" +
+            "    \"elements\": [\n" +
+            "      {\n" +
+            "        \"line\": 3,\n" +
+            "        \"name\": \"Monkey eats bananas\",\n" +
+            "        \"description\": \"\",\n" +
+            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+            "        \"type\": \"scenario\",\n" +
+            "        \"keyword\": \"Scenario\",\n" +
+            "        \"steps\": [\n" +
+            "          {\n" +
+            "            \"result\": {\n" +
+            "              \"duration\": 1000000,\n" +
+            "              \"status\": \"passed\"\n" +
+            "            },\n" +
+            "            \"line\": 4,\n" +
+            "            \"name\": \"there are bananas\",\n" +
+            "            \"match\": {\n" +
+            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+            "            },\n" +
+            "            \"keyword\": \"Given \",\n" +
+            "            \"doc_string\": {\n" +
+            "              \"content_type\": \"doc\",\n" +
+            "              \"line\": 5,\n" +
+            "              \"value\": \"doc string content\"\n" +
+            "            }\n" +
+            "          }\n" +
+            "        ]\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"name\": \"Banana party\",\n" +
+            "    \"description\": \"\",\n" +
+            "    \"id\": \"banana-party\",\n" +
+            "    \"keyword\": \"Feature\",\n" +
+            "    \"uri\": \"path/test.feature\"\n" +
+            "  }\n" +
+            "]";
+
+        assertPrettyJsonEquals(expected, formatterOutput);
+    }
+
+
+    @Test
     public void should_format_scenario_with_a_step_with_a_data_table() throws Throwable {
         CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
                 "Feature: Banana party\n" +


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Docstring content type is currently not carried down into the json formatter. 
This worked in 1.2.5.
PickleString did not have the corresponding field, so I added that in:
https://github.com/cucumber/cucumber/pull/292
(*The mono repo PR is required for this one to compile, so this will fail CI*). 

https://github.com/cucumber/cucumber-jvm/issues/1263
Fixing this bug. 

<!--- Provide a general summary description of your changes -->

Passes the contentType field down into the map that gets json serialized.
Uses the content_type name to match 1.2.5 and other language reports.

<!--- Describe your changes in detail -->

## Motivation and Context

https://github.com/cucumber/cucumber-jvm/issues/1263

## How Has This Been Tested?

Unit test added. 
All tests run, Pax Exam Calculator Test appears to be broken before this change, due to a deployment issue?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

I do not know if any docs need changing. I expect not as this is a regression from 1.2.5