### PR TITLE
Update Plugin documentation

### DIFF
--- a/core/src/main/java/cucumber/api/Plugin.java
+++ b/core/src/main/java/cucumber/api/Plugin.java
@@ -5,22 +5,30 @@ import java.net.URI;
 import java.net.URL;
 
 /**
- * Interface for all plugins.
+ * Marker interface for all plugins.
  * <p>
- * A plugin must have a constructor that is either empty
- * or takes a single argument of one of the following types:
- * <ul>
- * <li>{@link Appendable}</li>
- * <li>{@link File}</li>
- * <li>{@link URL}</li>
- * <li>{@link URI}</li>
- * </ul>
+ * A plugin can be added to the runtime to listen in on step definition, summary printing and test
+ * execution.
+ * <p>
  * Plugins must implement one of the following interfaces:
  * <ul>
  * <li>{@link cucumber.api.StepDefinitionReporter}</li>
  * <li>{@link cucumber.api.SummaryPrinter}</li>
  * <li>{@link cucumber.api.formatter.Formatter}</li>
  * </ul>
+ * <p>
+ * Plugins are added to the runtime from the command line or @{@link CucumberOptions} and may be provided with a
+ * parameter. To accept this parameter the plugin must have a public constructor that accepts one of the following
+ * arguments:
+ * <ul>
+ * <li>{@link String}</li>
+ * <li>{@link Appendable}</li>
+ * <li>{@link URI}</li>
+ * <li>{@link URL}</li>
+ * <li>{@link File}</li>
+ * </ul>
+ * <p>
+ * To make the parameter optional the plugin must also have a public default constructor.
  */
 public interface Plugin {
 }

--- a/core/src/main/java/cucumber/api/SummaryPrinter.java
+++ b/core/src/main/java/cucumber/api/SummaryPrinter.java
@@ -2,6 +2,11 @@ package cucumber.api;
 
 import cucumber.runtime.Runtime;
 
+/**
+ * Interface for plugins that print a summary after test execution.
+ *
+ * @see Plugin
+ */
 public interface SummaryPrinter extends Plugin {
     void print(Runtime runtime);
 }

--- a/core/src/main/java/cucumber/api/formatter/ColorAware.java
+++ b/core/src/main/java/cucumber/api/formatter/ColorAware.java
@@ -1,5 +1,15 @@
 package cucumber.api.formatter;
 
+/**
+ * Interface for Formatters that use ANSI escape codes to print coloured output.
+ */
 public interface ColorAware extends Formatter {
+    /**
+     * When set to monochrome the formatter should not use colored output.
+     * <p>
+     * For the benefit of systems that do not support ANSI escape codes.
+     *
+     * @param monochrome true iff monochrome output should be used
+     */
     void setMonochrome(boolean monochrome);
 }

--- a/core/src/main/java/cucumber/api/formatter/Formatter.java
+++ b/core/src/main/java/cucumber/api/formatter/Formatter.java
@@ -6,6 +6,9 @@ import cucumber.api.event.EventListener;
 /**
  * This is the interface you should implement if you want your own custom
  * formatter.
+ *
+ * @see EventListener
+ * @see Plugin
  */
 public interface Formatter extends EventListener, Plugin {
 }

--- a/core/src/main/java/cucumber/api/formatter/StrictAware.java
+++ b/core/src/main/java/cucumber/api/formatter/StrictAware.java
@@ -1,5 +1,13 @@
 package cucumber.api.formatter;
 
+/**
+ * Interface for Formatters that need to know if the Runtime is strict.
+ */
 public interface StrictAware extends Formatter {
+    /**
+     * When set to strict the formatter should indicate failure for undefined and pending steps
+     *
+     * @param strict true iff the runtime is in strict mode
+     */
     void setStrict(boolean strict);
 }

--- a/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
@@ -89,6 +89,7 @@ final class JSONFormatter implements Formatter {
         }
     };
 
+    @SuppressWarnings("WeakerAccess") // Used by PluginFactory
     public JSONFormatter(Appendable out) {
         this.out = new NiceAppendable(out);
     }

--- a/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
@@ -29,18 +29,10 @@ import static java.util.Arrays.asList;
  * This class creates plugin instances from a String.
  * <p>
  * The String is of the form name[:output] where name is either a fully qualified class name or one of the built-in
- * short names. The output is optional for some plugins (and mandatory for some) and must have a single argument constructor
- * with one of the following types:
- * <p>
- * <ul>
- * <li>{@link String}</li>
- * <li>{@link Appendable}</li>
- * <li>{@link URI}</li>
- * <li>{@link URL}</li>
- * <li>{@link File}</li>
+ * short names. The output is optional for some plugins (and mandatory for some).
  * </ul>
  *
- * @see Plugin
+ * @see Plugin for specific requirements
  */
 public final class PluginFactory {
     private final Class[] CTOR_PARAMETERS = new Class[]{String.class, Appendable.class, URI.class, URL.class, File.class};

--- a/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PrettyFormatter.java
@@ -90,6 +90,7 @@ final class PrettyFormatter implements Formatter, ColorAware {
         }
     };
 
+    @SuppressWarnings("WeakerAccess") // Used by PluginFactory
     public PrettyFormatter(Appendable out) {
         this.out = new NiceAppendable(out);
         this.formats = new AnsiFormats();

--- a/core/src/main/java/cucumber/runtime/formatter/ProgressFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/ProgressFormatter.java
@@ -53,6 +53,7 @@ final class ProgressFormatter implements Formatter, ColorAware {
         }
     };
 
+    @SuppressWarnings("WeakerAccess") // Used by PluginFactory
     public ProgressFormatter(Appendable appendable) {
         out = new NiceAppendable(appendable);
     }

--- a/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
@@ -37,6 +37,7 @@ final class RerunFormatter implements Formatter, StrictAware {
         }
     };
 
+    @SuppressWarnings("WeakerAccess") // Used by PluginFactory
     public RerunFormatter(Appendable out) {
         this.out = new NiceAppendable(out);
     }

--- a/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
@@ -84,6 +84,7 @@ class TestNGFormatter implements Formatter, StrictAware {
         }
     };
 
+    @SuppressWarnings("WeakerAccess") // Used by PluginFactory
     public TestNGFormatter(URL url) throws IOException {
         this.writer = new UTF8OutputStreamWriter(new URLOutputStream(url));
         TestMethod.treatSkippedAsFailure = false;

--- a/core/src/main/java/cucumber/runtime/formatter/UsageFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/UsageFormatter.java
@@ -46,6 +46,7 @@ final class UsageFormatter implements Formatter {
      *
      * @param out {@link Appendable} to print the result
      */
+    @SuppressWarnings("WeakerAccess") // Used by PluginFactory
     public UsageFormatter(Appendable out) {
         this.out = new NiceAppendable(out);
 


### PR DESCRIPTION
## Summary

Update Plugin documentation

## Details

Moved the Plugin specifications from the PluginFactory to the interface. Requirements imposed on a class should be documented on its interface rather then the factory that creates it.