### PR TITLE
[Core] Running empty Pickles should yield the result undefined.

### DIFF
--- a/core/src/main/java/cucumber/runner/Runner.java
+++ b/core/src/main/java/cucumber/runner/Runner.java
@@ -92,12 +92,14 @@ public class Runner implements UnreportedStepExecutor {
 
     private TestCase createTestCaseForPickle(PickleEvent pickleEvent) {
         List<TestStep> testSteps = new ArrayList<TestStep>();
-        if (!runtimeOptions.isDryRun()) {
-            addTestStepsForBeforeHooks(testSteps, pickleEvent.pickle.getTags());
-        }
-        addTestStepsForPickleSteps(testSteps, pickleEvent);
-        if (!runtimeOptions.isDryRun()) {
-            addTestStepsForAfterHooks(testSteps, pickleEvent.pickle.getTags());
+        if (!pickleEvent.pickle.getSteps().isEmpty()) {
+            if (!runtimeOptions.isDryRun()) {
+                addTestStepsForBeforeHooks(testSteps, pickleEvent.pickle.getTags());
+            }
+            addTestStepsForPickleSteps(testSteps, pickleEvent);
+            if (!runtimeOptions.isDryRun()) {
+                addTestStepsForAfterHooks(testSteps, pickleEvent.pickle.getTags());
+            }
         }
         return new TestCase(testSteps, pickleEvent, runtimeOptions.isDryRun());
     }

--- a/core/src/main/java/cucumber/runtime/ScenarioImpl.java
+++ b/core/src/main/java/cucumber/runtime/ScenarioImpl.java
@@ -60,6 +60,9 @@ public class ScenarioImpl implements Scenario {
 
     @Override
     public Result.Type getStatus() {
+        if (stepResults.isEmpty()) {
+            return Result.Type.UNDEFINED;
+        }
         int pos = 0;
         for (Result stepResult : stepResults) {
             pos = Math.max(pos, SEVERITY.indexOf(stepResult.getStatus()));

--- a/core/src/test/java/cucumber/runtime/HookOrderTest.java
+++ b/core/src/test/java/cucumber/runtime/HookOrderTest.java
@@ -38,7 +38,8 @@ public class HookOrderTest {
         Runtime runtime = new Runtime(mock(ResourceLoader.class), classLoader, asList(mock(Backend.class)), runtimeOptions);
         runner = runtime.getRunner();
         glue = runtime.getGlue();
-        pickleEvent = new PickleEvent("uri", new Pickle("name", ENGLISH, Collections.<PickleStep>emptyList(), Collections.<PickleTag>emptyList(), asList(mock(PickleLocation.class))));
+        PickleStep step = mock(PickleStep.class);
+        pickleEvent = new PickleEvent("uri", new Pickle("name", ENGLISH, asList(step), Collections.<PickleTag>emptyList(), asList(mock(PickleLocation.class))));
     }
 
     @Test

--- a/core/src/test/java/cucumber/runtime/HookTest.java
+++ b/core/src/test/java/cucumber/runtime/HookTest.java
@@ -39,7 +39,8 @@ public class HookTest {
         Runtime runtime = new Runtime(new ClasspathResourceLoader(classLoader), classLoader, asList(backend), runtimeOptions);
         runtime.getGlue().addAfterHook(hook);
         Runner runner = runtime.getRunner();
-        PickleEvent pickleEvent = new PickleEvent("uri", new Pickle("name", ENGLISH, Collections.<PickleStep>emptyList(), Collections.<PickleTag>emptyList(), asList(mock(PickleLocation.class))));
+        PickleStep step = mock(PickleStep.class);
+        PickleEvent pickleEvent = new PickleEvent("uri", new Pickle("name", ENGLISH, asList(step), Collections.<PickleTag>emptyList(), asList(mock(PickleLocation.class))));
 
         runner.runPickle(pickleEvent);
 

--- a/core/src/test/java/cucumber/runtime/ScenarioResultTest.java
+++ b/core/src/test/java/cucumber/runtime/ScenarioResultTest.java
@@ -24,7 +24,13 @@ public class ScenarioResultTest {
     private ScenarioImpl s = new ScenarioImpl(bus, pickleEvent());
 
     @Test
-    public void no_steps_is_passed() throws Exception {
+    public void no_steps_is_undefined() throws Exception {
+        assertEquals(Result.Type.UNDEFINED, s.getStatus());
+    }
+
+    @Test
+    public void one_passed_step_is_passed() throws Exception {
+        s.add(new Result(Result.Type.PASSED, 0L, null));
         assertEquals(Result.Type.PASSED, s.getStatus());
     }
 


### PR DESCRIPTION
## Summary

 Running empty Pickles should yield the result undefined.

## Details

Gherkin v5 does create empty Pickles for Scenarios with no steps. Running these empty Pickles should yield the result undefined, and no test steps should be executed.

## Motivation and Context

See cucumber/cucumber#249 and https://github.com/cucumber/cucumber-ruby-core/pull/144#issuecomment-323510760 for background

## How Has This Been Tested?

The automated test suite has been updated to verify this behavior.

I have also manually/locally added an empty scenario to the Java calculator example to check that it indeed yielded an undefined scenario in the summary count.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
