### PR TITLE
Add feature tags in the JSON output

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
@@ -170,6 +170,8 @@ final class JSONFormatter implements Formatter {
             featureMap.put("description", feature.getDescription() != null ? feature.getDescription() : "");
             featureMap.put("line", feature.getLocation().getLine());
             featureMap.put("id", TestSourcesModel.convertToId(feature.getName()));
+            featureMap.put("tags", feature.getTags());
+
         }
         return featureMap;
     }

--- a/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
@@ -91,7 +91,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  }\n" +
                 "]";
         assertPrettyJsonEquals(expected, formatterOutput);
@@ -144,7 +145,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  }\n" +
                 "]";
         assertPrettyJsonEquals(expected, formatterOutput);
@@ -198,7 +200,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  }\n" +
                 "]";
         assertPrettyJsonEquals(expected, formatterOutput);
@@ -254,7 +257,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  }\n" +
                 "]";
         assertPrettyJsonEquals(expected, formatterOutput);
@@ -381,7 +385,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  }\n" +
                 "]";
         assertPrettyJsonEquals(expected, formatterOutput);
@@ -462,7 +467,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  }\n" +
                 "]";
         assertPrettyJsonEquals(expected, formatterOutput);
@@ -535,7 +541,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  }\n" +
                 "]";
         assertPrettyJsonEquals(expected, formatterOutput);
@@ -611,7 +618,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  }\n" +
                 "]";
         assertPrettyJsonEquals(expected, formatterOutput);
@@ -671,7 +679,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  }\n" +
                 "]";
         assertPrettyJsonEquals(expected, formatterOutput);
@@ -740,7 +749,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  }\n" +
                 "]";
         assertPrettyJsonEquals(expected, formatterOutput);
@@ -800,7 +810,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  },\n" +
                 "  {\n" +
                 "    \"id\": \"orange-party\",\n" +
@@ -832,7 +843,8 @@ public class JSONFormatterTest {
                 "          }\n" +
                 "        ]\n" +
                 "      }\n" +
-                "    ]\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
                 "  }\n" +
                 "]";
         assertPrettyJsonEquals(expected, formatterOutput);

--- a/core/src/test/resources/cucumber/runtime/formatter/JSONPrettyFormatterTest.json
+++ b/core/src/test/resources/cucumber/runtime/formatter/JSONPrettyFormatterTest.json
@@ -344,6 +344,7 @@
         "type": "scenario"
       }
     ],
-    "uri": "cucumber/runtime/formatter/JSONPrettyFormatterTest.feature"
+    "uri": "cucumber/runtime/formatter/JSONPrettyFormatterTest.feature",
+    "tags": []
   }
 ]


### PR DESCRIPTION
## Summary

Add feature tags in the JSON result of the JSON Formatter

## Details

New JSON field named "tags" in feature section

## Motivation and Context

Cucumber 1.x JSON reports contain feature tags.
We use feature tags to keep our features organized.

## How Has This Been Tested?

Updated JSON Formatter unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
