### PR TITLE
cache matched steps definitions in RuntimeGlue

### DIFF
--- a/core/src/main/java/cucumber/runtime/RuntimeGlue.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeGlue.java
@@ -74,16 +74,14 @@ public class RuntimeGlue implements Glue {
         }
         if (matches.size() == 1) {
             StepDefinitionMatch match = matches.get(0);
-            matchedStepDefinitionsCache.put(stepText, new CacheEntry(match.getStepDefinition(),match.getArguments()));
+            matchedStepDefinitionsCache.put(stepText, new CacheEntry(match.getStepDefinition(), match.getArguments()));
             return match;
-        } else {
-            throw new AmbiguousStepDefinitionsException(step, matches);
         }
+        throw new AmbiguousStepDefinitionsException(step, matches);
     }
 
     private List<StepDefinitionMatch> stepDefinitionMatches(String featurePath, PickleStep step) {
         List<StepDefinitionMatch> result = new ArrayList<StepDefinitionMatch>();
-
         for (StepDefinition stepDefinition : stepDefinitionsByPattern.values()) {
             List<Argument> arguments = stepDefinition.matchedArguments(step);
             if (arguments != null) {
@@ -109,9 +107,9 @@ public class RuntimeGlue implements Glue {
 
     private void removeScenarioScopedHooks(List<HookDefinition> beforeHooks1) {
         Iterator<HookDefinition> hookIterator = beforeHooks1.iterator();
-        while(hookIterator.hasNext()) {
+        while (hookIterator.hasNext()) {
             HookDefinition hook = hookIterator.next();
-            if(hook.isScenarioScoped()) {
+            if (hook.isScenarioScoped()) {
                 hookIterator.remove();
             }
         }
@@ -119,15 +117,16 @@ public class RuntimeGlue implements Glue {
 
     private void removeScenarioScopedStepdefs() {
         Iterator<Map.Entry<String, StepDefinition>> stepdefs = stepDefinitionsByPattern.entrySet().iterator();
-        while(stepdefs.hasNext()) {
+        while (stepdefs.hasNext()) {
             StepDefinition stepDefinition = stepdefs.next().getValue();
-            if(stepDefinition.isScenarioScoped()) {
+            if (stepDefinition.isScenarioScoped()) {
                 stepdefs.remove();
             }
         }
     }
 
     static final class CacheEntry {
+
         StepDefinition stepDefinition;
         List<Argument> arguments;
 
@@ -136,5 +135,4 @@ public class RuntimeGlue implements Glue {
             this.arguments = arguments;
         }
     }
-
 }

--- a/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
+++ b/core/src/main/java/cucumber/runtime/StepDefinitionMatch.java
@@ -183,6 +183,10 @@ public class StepDefinitionMatch extends Match implements DefinitionMatch {
         return this;
     }
 
+    StepDefinition getStepDefinition() {
+        return stepDefinition;
+    }
+
     @Override
     public String getCodeLocation() {
         return stepDefinition.getLocation(false);

--- a/core/src/test/java/cucumber/runtime/RuntimeGlueTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeGlueTest.java
@@ -1,17 +1,36 @@
 package cucumber.runtime;
 
 import cucumber.runtime.xstream.LocalizedXStreams;
+import gherkin.pickles.Argument;
+import gherkin.pickles.PickleLocation;
+import gherkin.pickles.PickleStep;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Collections;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class RuntimeGlueTest {
+
+    private RuntimeGlue glue;
+
+    @Before
+    public void setUp() throws Exception {
+        glue = new RuntimeGlue(new LocalizedXStreams(Thread.currentThread().getContextClassLoader()));
+    }
+
     @Test
     public void throws_duplicate_error_on_dupe_stepdefs() {
-        RuntimeGlue glue = new RuntimeGlue(new LocalizedXStreams(Thread.currentThread().getContextClassLoader()));
 
         StepDefinition a = mock(StepDefinition.class);
         when(a.getPattern()).thenReturn("hello");
@@ -35,7 +54,6 @@ public class RuntimeGlueTest {
         // But it was too much hassle creating a better test without refactoring RuntimeGlue
         // and probably some of its immediate collaborators... Aslak.
 
-        RuntimeGlue glue = new RuntimeGlue(new LocalizedXStreams(Thread.currentThread().getContextClassLoader()));
 
         StepDefinition sd = mock(StepDefinition.class);
         when(sd.isScenarioScoped()).thenReturn(true);
@@ -59,5 +77,64 @@ public class RuntimeGlueTest {
         assertEquals(0, glue.stepDefinitionsByPattern.size());
         assertEquals(0, glue.beforeHooks.size());
         assertEquals(0, glue.afterHooks.size());
+    }
+
+    @Test
+    public void step_definition_match() {
+
+        StepDefinition stepDefinition1 = getStepDefinitionMockWithPattern("pattern1");
+        StepDefinition stepDefinition2 = getStepDefinitionMockWithPattern("^pattern2");
+        StepDefinition stepDefinition3 = getStepDefinitionMockWithPattern("^pattern[1,3]");
+
+        glue.addStepDefinition(stepDefinition1);
+        glue.addStepDefinition(stepDefinition2);
+        glue.addStepDefinition(stepDefinition3);
+
+        String featurePath = "someFeature.feature";
+        assertNull(glue.stepDefinitionMatch(featurePath, getPickleStep("pattern")));
+
+        assertEquals("^pattern2",glue.stepDefinitionMatch(featurePath, getPickleStep("pattern2")).getPattern());
+        assertEquals("^pattern2",glue.matchedStepDefinitionsCache.get("pattern2").stepDefinition.getPattern());
+        assertTrue(glue.matchedStepDefinitionsCache.get("pattern2").arguments.isEmpty());
+        assertEquals("^pattern2",glue.stepDefinitionMatch(featurePath, getPickleStep("pattern2")).getPattern());
+
+        assertEquals("^pattern[1,3]",glue.stepDefinitionMatch(featurePath, getPickleStep("pattern3")).getPattern());
+
+        boolean ambiguousCalled = false;
+        try {
+
+            glue.stepDefinitionMatch(featurePath, getPickleStep("pattern1"));
+        } catch (AmbiguousStepDefinitionsException e) {
+            assertEquals(2,e.getMatches().size());
+            ambiguousCalled = true;
+        }
+        assertTrue(ambiguousCalled);
+        ambiguousCalled = false;
+        //try again to verify if we don't cache when there is duplicate step
+        try {
+
+            glue.stepDefinitionMatch(featurePath, getPickleStep("pattern1"));
+        } catch (AmbiguousStepDefinitionsException e) {
+            assertEquals(2,e.getMatches().size());
+            ambiguousCalled = true;
+        }
+        assertTrue(ambiguousCalled);
+    }
+
+    private PickleStep getPickleStep(String text) {
+        return new PickleStep(text, Collections.<Argument>emptyList(), Collections.<PickleLocation>emptyList());
+    }
+
+    private StepDefinition getStepDefinitionMockWithPattern(String pattern) {
+        final JdkPatternArgumentMatcher jdkPatternArgumentMatcher = new JdkPatternArgumentMatcher(Pattern.compile(pattern));
+        StepDefinition stepDefinition = mock(StepDefinition.class);
+        when(stepDefinition.getPattern()).thenReturn(pattern);
+        when(stepDefinition.matchedArguments(any(PickleStep.class))).then(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return jdkPatternArgumentMatcher.argumentsFrom(invocationOnMock.getArgumentAt(0,PickleStep.class).getText());
+            }
+        });
+        return stepDefinition;
     }
 }


### PR DESCRIPTION
## Summary

This is a performance improvement in `RuntimeGlue.stepDefinitionMatches` method which is very slow on Android < 8.0 and with large test base

## Details

`stepDefinitionMatches` iterates through all steps definitions to find all definitions that match current `PickleStep` (by testing if step text matches regular expression of step definition) - lots of steps doesn't have arguments or have only table argument or are used with same arguments - this implies that matching `StepDefinition` for them can be safely cached to avoid repeating of iteration through all definitions and receiving the same results.
I've added simple cache where step text is a key and `StepDefinition` and `List<Argument>` are value. When a step with the same text is being processed then its definition is taken from cache.

E.g. in my project I have 5730 steps invocations and 813 steps definitions which normally causes 4 658 490 regular expression checks.  After adding cache 4218 invocations was processed by cache which saves lots of time.

## Motivation and Context

Cucumber should perform as quickly as possible and dryRun should complete very fast because it executes only Cucumber code. In fact on my project (653 executed unique scenarios) dryRun on Nexus 7 Android 6.0 takes 5 minutes and on Emulator Android 8.0 it takes 40 s.

After adding cache  dryRun on Nexus 7 takes 2 mins and on Emulator it takes 20 s

## How Has This Been Tested?

I've tested it on my project with 653 scenarios.
I've added unit test for `RuntimeGlue.stepDefinitionMatches`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
