### PR TITLE
[Core] Remove the deprecated -f/--format option.

### DIFF
--- a/core/src/main/java/cucumber/api/CucumberOptions.java
+++ b/core/src/main/java/cucumber/api/CucumberOptions.java
@@ -37,13 +37,6 @@ public @interface CucumberOptions {
     String[] tags() default {};
 
     /**
-     * @return what formatter(s) to use
-     * @deprecated use {@link #plugin()}
-     */
-    @Deprecated
-    String[] format() default {};
-
-    /**
      * @return what plugins(s) to use
      */
     String[] plugin() default {};

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -155,9 +155,6 @@ public class RuntimeOptions {
                 parsedTagFilters.add(args.remove(0));
             } else if (arg.equals("--plugin") || arg.equals("--add-plugin") || arg.equals("-p")) {
                 parsedPluginData.addPluginName(args.remove(0), arg.equals("--add-plugin"));
-            } else if (arg.equals("--format") || arg.equals("-f")) {
-                System.err.println("WARNING: Cucumber-JVM's --format option is deprecated. Please use --plugin instead.");
-                parsedPluginData.addPluginName(args.remove(0), true);
             } else if (arg.equals("--no-dry-run") || arg.equals("--dry-run") || arg.equals("-d")) {
                 dryRun = !arg.startsWith("--no-");
             } else if (arg.equals("--no-strict") || arg.equals("--strict") || arg.equals("-s")) {

--- a/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
@@ -87,7 +87,6 @@ public class RuntimeOptionsFactory {
     private void addPlugins(CucumberOptions options, List<String> args) {
         List<String> plugins = new ArrayList<String>();
         plugins.addAll(asList(options.plugin()));
-        plugins.addAll(asList(options.format()));
         for (String plugin : plugins) {
             args.add("--plugin");
             args.add(plugin);

--- a/core/src/main/resources/cucumber/api/cli/USAGE.txt
+++ b/core/src/main/resources/cucumber/api/cli/USAGE.txt
@@ -14,7 +14,6 @@ Options:
                                          registration of 3rd party plugins.
                                          --add-plugin does not clobber plugins of that 
                                          type defined from a different source.
-  -f, --format FORMAT[:PATH_OR_URL]      Deprecated. Use --plugin instead.
   -t, --tags TAG_EXPRESSION              Only run scenarios tagged with tags matching
                                          TAG_EXPRESSION.
   -n, --name REGEXP                      Only run scenarios whose names match REGEXP.

--- a/examples/java-calculator-testng/src/test/java/cucumber/examples/java/calculator/RunCukesByCompositionTest.java
+++ b/examples/java-calculator-testng/src/test/java/cucumber/examples/java/calculator/RunCukesByCompositionTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
  * AbstractTestNGCucumberTests but still executes each scenario as a separate
  * TestNG test.
  */
-@CucumberOptions(strict = true, format = "json:target/cucumber-report-feature-composite.json")
+@CucumberOptions(strict = true, plugin = "json:target/cucumber-report-feature-composite.json")
 public class RunCukesByCompositionTest extends RunCukesByCompositionBase {
     private TestNGCucumberRunner testNGCucumberRunner;
 


### PR DESCRIPTION
## Summary

Remove the deprecated `-f`/`--format` option.

## Details

Remove the deprecated `-f`/`--format` option.

## Motivation and Context

The `-f`/`--format` option has been deprecated in favor of the `-p`/`--plugin` option since v1.2.0. Since it was not removed in v2.0.0, it should be removed in v3.0.0.

## How Has This Been Tested?

Manually tested that `-Dcucumber.options="-f pretty"` to the Java calculator example resulted in expected error message.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
