### PR TITLE
Remove scenario scoped step definitions from step definition cache

### DIFF
--- a/core/src/main/java/cucumber/runtime/RuntimeGlue.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeGlue.java
@@ -123,6 +123,14 @@ public class RuntimeGlue implements Glue {
                 stepdefs.remove();
             }
         }
+
+        Iterator<Map.Entry<String, CacheEntry>> cachedStepDefs = matchedStepDefinitionsCache.entrySet().iterator();
+        while(cachedStepDefs.hasNext()){
+            StepDefinition stepDefinition = cachedStepDefs.next().getValue().stepDefinition;
+            if(stepDefinition.isScenarioScoped()){
+                cachedStepDefs.remove();
+            }
+        }
     }
 
     static final class CacheEntry {

--- a/core/src/test/java/cucumber/runtime/RuntimeGlueTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeGlueTest.java
@@ -81,6 +81,24 @@ public class RuntimeGlueTest {
     }
 
     @Test
+    public void removes_scenario_scoped_cache_entries() {
+        StepDefinition sd = getStepDefinitionMockWithPattern("pattern");
+        when(sd.isScenarioScoped()).thenReturn(true);
+        glue.addStepDefinition(sd);
+        String featurePath = "someFeature.feature";
+
+        String stepText = "pattern1";
+        PickleStep pickleStep1 = getPickleStep(stepText);
+        assertEquals(sd, glue.stepDefinitionMatch(featurePath, pickleStep1).getStepDefinition());
+
+        assertEquals(1, glue.matchedStepDefinitionsCache.size());
+
+        glue.removeScenarioScopedGlue();
+
+        assertEquals(0, glue.matchedStepDefinitionsCache.size());
+    }
+
+    @Test
     public void returns_null_if_no_matching_steps_found() {
         StepDefinition stepDefinition = getStepDefinitionMockWithPattern("pattern1");
         glue.addStepDefinition(stepDefinition);

--- a/examples/java-calculator-testng/pom.xml
+++ b/examples/java-calculator-testng/pom.xml
@@ -14,11 +14,6 @@
     <dependencies>
         <dependency>
             <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-jvm-deps</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
             <scope>test</scope>
         </dependency>
@@ -26,12 +21,6 @@
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-testng</artifactId>
             <scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-				</exclusion>
-			</exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/examples/java-calculator/pom.xml
+++ b/examples/java-calculator/pom.xml
@@ -14,11 +14,6 @@
     <dependencies>
         <dependency>
             <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-jvm-deps</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
             <scope>test</scope>
         </dependency>

--- a/examples/java8-calculator/pom.xml
+++ b/examples/java8-calculator/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.cucumber</groupId>
+        <artifactId>cucumber-examples</artifactId>
+        <version>2.3.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>java8-calculator</artifactId>
+    <packaging>jar</packaging>
+    <name>Examples: Java8 Calculator</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java8</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <fork>true</fork>
+                    <encoding>UTF-8</encoding>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <compilerArgument>-XDignore.symbol.file=true</compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/java8-calculator/src/main/java/cucumber/examples/java/calculator/RpnCalculator.java
+++ b/examples/java8-calculator/src/main/java/cucumber/examples/java/calculator/RpnCalculator.java
@@ -1,0 +1,40 @@
+package cucumber.examples.java.calculator;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+public class RpnCalculator {
+    private final Deque<Number> stack = new LinkedList<Number>();
+    private static final List<String> OPS = asList("-", "+", "*", "/");
+
+    public void push(Object arg) {
+        if (OPS.contains(arg)) {
+            Number y = stack.removeLast();
+            Number x = stack.isEmpty() ? 0 : stack.removeLast();
+            Double val = null;
+            if (arg.equals("-")) {
+                val = x.doubleValue() - y.doubleValue();
+            } else if (arg.equals("+")) {
+                val = x.doubleValue() + y.doubleValue();
+            } else if (arg.equals("*")) {
+                val = x.doubleValue() * y.doubleValue();
+            } else if (arg.equals("/")) {
+                val = x.doubleValue() / y.doubleValue();
+            }
+            push(val);
+        } else {
+            stack.add((Number) arg);
+        }
+    }
+
+    public void PI() {
+        push(Math.PI);
+    }
+
+    public Number value() {
+        return stack.getLast();
+    }
+}

--- a/examples/java8-calculator/src/test/java/cucumber/examples/java/calculator/RpnCalculatorStepdefs.java
+++ b/examples/java8-calculator/src/test/java/cucumber/examples/java/calculator/RpnCalculatorStepdefs.java
@@ -1,0 +1,56 @@
+package cucumber.examples.java.calculator;
+
+import cucumber.api.DataTable;
+import cucumber.api.Scenario;
+import cucumber.api.java8.En;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class RpnCalculatorStepdefs implements En {
+    private RpnCalculator calc;
+
+    public RpnCalculatorStepdefs() {
+        Given("^a calculator I just turned on$", () -> {
+            calc = new RpnCalculator();
+        });
+
+        When("^I add (\\d+) and (\\d+)$", (Integer arg1, Integer arg2) -> {
+            calc.push(arg1);
+            calc.push(arg2);
+            calc.push("+");
+        });
+
+
+        Given("^I press (.+)$", (String what) -> calc.push(what));
+
+        Then("^the result is (\\d+)$", (Double expected) -> assertEquals(expected, calc.value()));
+
+
+        Before(new String[]{"not @foo"}, (Scenario scenario) -> {
+            scenario.write("Runs before scenarios *not* tagged with @foo");
+        });
+
+        After((Scenario scenario) -> {
+            // result.write("HELLLLOO");
+        });
+
+
+        Given("^the previous entries:$", (DataTable dataTable) -> {
+            List<Entry> entries = dataTable.asList(Entry.class);
+            for (Entry entry : entries) {
+                calc.push(entry.first);
+                calc.push(entry.second);
+                calc.push(entry.operation);
+            }
+        });
+
+    }
+
+    public class Entry {
+        Integer first;
+        Integer second;
+        String operation;
+    }
+}

--- a/examples/java8-calculator/src/test/java/cucumber/examples/java/calculator/RunCukesTest.java
+++ b/examples/java8-calculator/src/test/java/cucumber/examples/java/calculator/RunCukesTest.java
@@ -1,0 +1,10 @@
+package cucumber.examples.java.calculator;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(plugin = "json:target/cucumber-report.json")
+public class RunCukesTest {
+}

--- a/examples/java8-calculator/src/test/java/cucumber/examples/java/calculator/ShoppingStepdefs.java
+++ b/examples/java8-calculator/src/test/java/cucumber/examples/java/calculator/ShoppingStepdefs.java
@@ -1,0 +1,63 @@
+package cucumber.examples.java.calculator;
+
+import cucumber.api.DataTable;
+import cucumber.api.Transformer;
+import cucumber.api.java8.En;
+import cucumber.deps.com.thoughtworks.xstream.annotations.XStreamConverter;
+
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ShoppingStepdefs implements En {
+
+    private RpnCalculator calc = new RpnCalculator();
+
+    public ShoppingStepdefs() {
+
+
+        Given("^the following groceries:$", (DataTable dataTable) -> {
+            List<Grocery> groceries = dataTable.asList(Grocery.class);
+            for (Grocery grocery : groceries) {
+                calc.push(grocery.price.value);
+                calc.push("+");
+            }
+        });
+
+        When("^I pay (\\d+)$", (Integer amount) -> {
+            calc.push(amount);
+            calc.push("-");
+        });
+
+        Then("^my change should be (\\d+)$", (Integer change) -> {
+            assertEquals(-calc.value().intValue(), change.intValue());
+        });
+    }
+
+
+    static class Grocery {
+        public String name;
+        @XStreamConverter(Price.Converter.class)
+        public Price price;
+
+        public Grocery() {
+            super();
+        }
+    }
+
+    static class Price {
+        public int value;
+
+        public Price(int value) {
+            this.value = value;
+        }
+
+        public static class Converter extends Transformer<Price> {
+            @Override
+            public Price transform(String value) {
+                return new Price(Integer.parseInt(value));
+            }
+        }
+    }
+}

--- a/examples/java8-calculator/src/test/resources/cucumber/examples/java/calculator/basic_arithmetic.feature
+++ b/examples/java8-calculator/src/test/resources/cucumber/examples/java/calculator/basic_arithmetic.feature
@@ -1,0 +1,35 @@
+@foo
+Feature: Basic Arithmetic
+
+  Background: A Calculator
+    Given a calculator I just turned on
+
+  Scenario: Addition
+  # Try to change one of the values below to provoke a failure
+    When I add 4 and 5
+    Then the result is 9
+
+  Scenario: Another Addition
+  # Try to change one of the values below to provoke a failure
+    When I add 4 and 7
+    Then the result is 11
+
+  Scenario Outline: Many additions
+    Given the previous entries:
+      | first | second | operation |
+      | 1     | 1      | +         |
+      | 2     | 1      | +         |
+    When I press +
+    And I add <a> and <b>
+    And I press +
+    Then the result is <c>
+
+  Examples: Single digits
+    | a | b | c  |
+    | 1 | 2 | 8  |
+    | 2 | 3 | 10 |
+
+  Examples: Double digits
+    | a  | b  | c  |
+    | 10 | 20 | 35 |
+    | 20 | 30 | 55 |

--- a/examples/java8-calculator/src/test/resources/cucumber/examples/java/calculator/shopping.feature
+++ b/examples/java8-calculator/src/test/resources/cucumber/examples/java/calculator/shopping.feature
@@ -1,0 +1,10 @@
+Feature: Shopping
+
+  Scenario: Give correct change
+    Given the following groceries:
+      | name  | price |
+      | milk  | 9     |
+      | bread | 7     |
+      | soap  | 5     |
+    When I pay 25
+    Then my change should be 4

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -14,6 +14,7 @@
     <modules>
         <module>spring-txn</module>
         <module>java-calculator</module>
+        <module>java8-calculator</module>
         <module>java-calculator-testng</module>
         <module>pax-exam</module>
         <module>java-wicket</module>

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -91,7 +91,6 @@ GherkinDialectProvider.DIALECTS.keySet().each { language ->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.2</version>
                 <configuration>
                     <fork>true</fork>
                     <encoding>UTF-8</encoding>


### PR DESCRIPTION
## Summary

Remove scenario scoped step definitions from step definition cache This fixes a bug in cucumber 2.3.0 where the cache would serve up a lambda step definition from a previous step.

## How Has This Been Tested?

Added a unit test and java8 examples. Features used by cucumber-java8, specifically glue coded step
definitions, were not used in integration tests. Adding these should allow us to discover java8 related problems quicker.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
