### PR TITLE
[Core] Json Formatter: include the content type of doc strings

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
@@ -16,6 +16,7 @@ import cucumber.api.event.WriteEvent;
 import cucumber.api.formatter.Formatter;
 import cucumber.api.formatter.NiceAppendable;
 import gherkin.ast.Background;
+import gherkin.ast.DocString;
 import gherkin.ast.Feature;
 import gherkin.ast.ScenarioDefinition;
 import gherkin.ast.Step;
@@ -231,15 +232,15 @@ final class JSONFormatter implements Formatter {
         Map<String, Object> stepMap = new HashMap<String, Object>();
         stepMap.put("name", testStep.getStepText());
         stepMap.put("line", testStep.getStepLine());
+        TestSourcesModel.AstNode astNode = testSources.getAstNode(currentFeatureFile, testStep.getStepLine());
         if (!testStep.getStepArgument().isEmpty()) {
             Argument argument = testStep.getStepArgument().get(0);
             if (argument instanceof PickleString) {
-                stepMap.put("doc_string", createDocStringMap(argument));
+                stepMap.put("doc_string", createDocStringMap(argument, astNode));
             } else if (argument instanceof PickleTable) {
                 stepMap.put("rows", createDataTableList(argument));
             }
         }
-        TestSourcesModel.AstNode astNode = testSources.getAstNode(currentFeatureFile, testStep.getStepLine());
         if (astNode != null) {
             Step step = (Step) astNode.node;
             stepMap.put("keyword", step.getKeyword());
@@ -248,11 +249,14 @@ final class JSONFormatter implements Formatter {
         return stepMap;
     }
 
-    private Map<String, Object> createDocStringMap(Argument argument) {
+    private Map<String, Object> createDocStringMap(Argument argument, TestSourcesModel.AstNode astNode) {
         Map<String, Object> docStringMap = new HashMap<String, Object>();
         PickleString docString = ((PickleString)argument);
         docStringMap.put("value", docString.getContent());
         docStringMap.put("line", docString.getLocation().getLine());
+        if (astNode != null) {
+            docStringMap.put("content_type", ((DocString)((Step)astNode.node).getArgument()).getContentType());
+        }
         return docStringMap;
     }
 

--- a/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
@@ -770,6 +770,69 @@ public class JSONFormatterTest {
     }
 
     @Test
+    public void should_format_scenario_with_a_step_with_a_doc_string_and_content_type() throws Throwable {
+        CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
+            "Feature: Banana party\n" +
+            "\n" +
+            "  Scenario: Monkey eats bananas\n" +
+            "    Given there are bananas\n" +
+            "    \"\"\"doc\n" +
+            "    doc string content\n" +
+            "    \"\"\"\n");
+        Map<String, Result> stepsToResult = new HashMap<String, Result>();
+        stepsToResult.put("there are bananas", result("passed"));
+        Map<String, String> stepsToLocation = new HashMap<String, String>();
+        stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
+        Long stepDuration = milliSeconds(1);
+
+        String formatterOutput = runFeatureWithJSONPrettyFormatter(feature, stepsToResult, stepsToLocation, stepDuration);
+
+        String expected = "" +
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"doc_string\": {\n" +
+                "              \"content_type\": \"doc\",\n" +
+                "              \"value\": \"doc string content\",\n" +
+                "              \"line\": 5\n" +
+                "            },\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
+        assertPrettyJsonEquals(expected, formatterOutput);
+    }
+
+
+    @Test
     public void should_format_scenario_with_a_step_with_a_data_table() throws Throwable {
         CucumberFeature feature = TestHelper.feature("path/test.feature", "" +
                 "Feature: Banana party\n" +


### PR DESCRIPTION
## Summary

Include the content type of a doc string in the Json Formatter output (if the content type of the doc string is defined in the feature file).

## Details

The content type of the doc strings (if defined in the feature file) is not defined in the Pickles, so the Json Formatter need to fetch in based on the feature file AST.

## Motivation and Context

In Cucumber-JVM v1.x.x the content type of doc strings were included in the Json Formatter output (if defined in the feature file).

## How Has This Been Tested?

The automated test suite has been updated to verify this behavior.

## Types of changes

- [X] Bug fix, regression from v1.x.x (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
