### PR TITLE
Partial Java 9 clean up

### DIFF
--- a/core/src/main/java/cucumber/runtime/HookComparator.java
+++ b/core/src/main/java/cucumber/runtime/HookComparator.java
@@ -11,7 +11,10 @@ class HookComparator implements Comparator<HookDefinition> {
 
     @Override
     public int compare(HookDefinition hook1, HookDefinition hook2) {
-        int comparison = Integer.compare(hook1.getOrder(), hook2.getOrder());
+        int x = hook1.getOrder();
+        int y = hook2.getOrder();
+        // TODO Java7 PR #1147: Inlined Integer.compare. Not available in java 6 yet.
+        int comparison = (x < y) ? -1 : ((x == y) ? 0 : 1);
         return ascending ? comparison : -comparison;
     }
 }

--- a/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JUnitFormatter.java
@@ -325,7 +325,9 @@ final class JUnitFormatter implements Formatter, StrictAware {
             // the createCDATASection method seems to convert "\n" to "\r\n" on Windows, in case
             // data originally contains "\r\n" line separators the result becomes "\r\r\n", which
             // are displayed as double line breaks.
-            child.appendChild(doc.createCDATASection(sb.toString().replace(System.lineSeparator(), "\n")));
+            // TODO Java 7 PR #1147: Inlined System.lineSeparator()
+            String systemLineSeperator = System.getProperty("line.separator");
+            child.appendChild(doc.createCDATASection(sb.toString().replace(systemLineSeperator, "\n")));
             return child;
         }
 

--- a/examples/spring-txn/pom.xml
+++ b/examples/spring-txn/pom.xml
@@ -17,6 +17,10 @@
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.freemarker</groupId>

--- a/guice/src/test/java/cucumber/runtime/java/guice/impl/GuiceFactoryTest.java
+++ b/guice/src/test/java/cucumber/runtime/java/guice/impl/GuiceFactoryTest.java
@@ -1,6 +1,12 @@
 package cucumber.runtime.java.guice.impl;
 
-import com.google.inject.*;
+import com.google.inject.AbstractModule;
+import com.google.inject.ConfigurationException;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.Stage;
 import cucumber.api.guice.CucumberModules;
 import cucumber.api.guice.CucumberScopes;
 import cucumber.api.java.ObjectFactory;

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <needle.version>2.2</needle.version>
         <javaee-api.version>7.0</javaee-api.version>
         <javax.inject.version>1</javax.inject.version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
         <dbunit.version>2.5.4</dbunit.version>
         <logback.version>1.2.3</logback.version>
@@ -320,7 +321,11 @@
                 <artifactId>javax.servlet-api</artifactId>
                 <version>${javax.servlet-api.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>


### PR DESCRIPTION
This is a partial fix for #1311 and addresses a few minor issues that occur when trying to build and run with Java 9.

### Guice  ###

Don't use wildcard imports

The wildcard import of `com.google.inject.Module` clashes with `java.lang.Module` in Java 9.

### Core ###

Inline `@since 1.7` methods

JDK9 strictly checks if the byte code target and api usage are consistent. `Integer.compare` and `System.lineSeperator()` are not available at 1.6.

### Spring ###

Add explicit dependency on `jaxb-api`

Java 9 added the Jigsaw module system and moved java.xml.bind into a module. This module is not active by default. It can be be activated by running with --add-modules java.xml.bind however as it is scheduled to be removed in Java 10 it is prudent to migrate away from it now.