### PR TITLE
Remove helloworld example and point straight to skeleton project

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,9 @@
 # Cucumber-JVM examples
 
-Start with `java-helloworld` - it's the simplest example.
+To start with the simplest example, please use the 
+[cucumber-java-skeleton](https://github.com/cucumber/cucumber-java-skeleton).
+
+Other examples can be found in this directory.
 
 Some example projects depend on the current (unreleased) Cucumber-JVM modules.
 If any of the examples fail to build, just build cucumber-jvm itself once first:

--- a/examples/java-helloworld/README.md
+++ b/examples/java-helloworld/README.md
@@ -1,3 +1,0 @@
-## This example has moved
-
-Please [go here](https://github.com/cucumber/cucumber-java-skeleton).


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Remove helloworld example and point straight to skeleton project

## Details

Current situation: the README in examples folder points to the java-helloworld example, which in turn points to the cucumber-java-skeleton.
New: Point straight to skeleton project from the examples README

## Motivation and Context
Makes it easier & faster to get to the easiest example project.

## How Has This Been Tested?
Text change only.
Visual check on the README locally, including verifying that the link to skeleton project works.


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
