### PR TITLE
Fix a small typo: handeTestCaseFinished -> handleTestCaseFinished

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/RerunFormatter.java
@@ -27,7 +27,7 @@ final class RerunFormatter implements Formatter, StrictAware {
     private EventHandler<TestCaseFinished> testCaseFinishedHandler = new EventHandler<TestCaseFinished>() {
         @Override
         public void receive(TestCaseFinished event) {
-            handeTestCaseFinished(event);
+            handleTestCaseFinished(event);
         }
     };
     private EventHandler<TestRunFinished> runFinishHandler = new EventHandler<TestRunFinished>() {
@@ -53,7 +53,7 @@ final class RerunFormatter implements Formatter, StrictAware {
         isStrict = strict;
     }
 
-    private void handeTestCaseFinished(TestCaseFinished event) {
+    private void handleTestCaseFinished(TestCaseFinished event) {
         if (!event.result.isOk(isStrict)) {
             recordTestFailed(event.testCase);
         }


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Fixed typo in cucumber.runtime.formatter.RerunFormatter: missing 'l' in  handeTestCaseFinished 

## Motivation and Context

Just don't want to see warnings in IDE

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
I just checked that all test are still green
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
