### PR TITLE
[Core, TestNG] Support the TestNG SkipException

### DIFF
--- a/core/src/main/java/cucumber/api/TestStep.java
+++ b/core/src/main/java/cucumber/api/TestStep.java
@@ -15,7 +15,8 @@ import java.util.List;
 public abstract class TestStep {
     private static final String[] ASSUMPTION_VIOLATED_EXCEPTIONS = {
             "org.junit.AssumptionViolatedException",
-            "org.junit.internal.AssumptionViolatedException"
+            "org.junit.internal.AssumptionViolatedException",
+            "org.testng.SkipException"
     };
 
     static {

--- a/testng/src/test/java/cucumber/api/testng/TestCaseResultListenerTest.java
+++ b/testng/src/test/java/cucumber/api/testng/TestCaseResultListenerTest.java
@@ -1,0 +1,151 @@
+package cucumber.api.testng;
+
+import cucumber.api.PendingException;
+import cucumber.api.Result;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestCaseResultListenerTest {
+
+    @Test
+    public void should_be_passed_for_passed_result() throws Exception {
+        TestCaseResultListener resultListener = new TestCaseResultListener(false);
+
+        resultListener.receiveResult(mockPassedResult());
+
+        assertTrue(resultListener.isPassed());
+        assertNull(resultListener.getError());
+    }
+
+    @Test
+    public void should_not_be_passed_for_failed_result() throws Exception {
+        Result result = mockFailedResult();
+        TestCaseResultListener resultListener = new TestCaseResultListener(false);
+
+        resultListener.receiveResult(result);
+
+        assertFalse(resultListener.isPassed());
+        assertEquals(resultListener.getError(), result.getError());
+    }
+
+    @Test
+    public void should_not_be_passed_for_ambiguous_result() throws Exception {
+        Result result = mockAmbiguousResult();
+        TestCaseResultListener resultListener = new TestCaseResultListener(false);
+
+        resultListener.receiveResult(result);
+
+        assertFalse(resultListener.isPassed());
+        assertEquals(resultListener.getError(), result.getError());
+    }
+
+    @Test
+    public void should_be_skipped_for_undefined_result() throws Exception {
+        TestCaseResultListener resultListener = new TestCaseResultListener(false);
+
+        resultListener.receiveResult(mockUndefinedResult());
+
+        assertFalse(resultListener.isPassed());
+        assertTrue(resultListener.getError() instanceof SkipException);
+    }
+
+    @Test
+    public void should_not_be_skipped_for_undefined_result_in_strict_mode() throws Exception {
+        TestCaseResultListener resultListener = new TestCaseResultListener(true);
+
+        resultListener.receiveResult(mockUndefinedResult());
+
+        assertFalse(resultListener.isPassed());
+        assertEquals(resultListener.getError().getMessage(), TestCaseResultListener.UNDEFINED_MESSAGE);
+    }
+
+    @Test
+    public void should_be_skipped_for_pending_result() throws Exception {
+        TestCaseResultListener resultListener = new TestCaseResultListener(false);
+
+        resultListener.receiveResult(mockPendingResult());
+
+        assertFalse(resultListener.isPassed());
+        assertTrue(resultListener.getError() instanceof SkipException);
+    }
+
+    @Test
+    public void should_not_be_skipped_for_pending_result_in_strict_mode() throws Exception {
+        TestCaseResultListener resultListener = new TestCaseResultListener(true);
+
+        resultListener.receiveResult(mockPendingResult());
+
+        assertFalse(resultListener.isPassed());
+        assertTrue(resultListener.getError() instanceof PendingException);
+    }
+
+    @Test
+    public void should_be_skipped_for_skipped_result() throws Exception {
+        TestCaseResultListener resultListener = new TestCaseResultListener(false);
+
+        resultListener.receiveResult(mockSkippedResult());
+
+        assertFalse(resultListener.isPassed());
+        assertTrue(resultListener.getError() instanceof SkipException);
+    }
+
+    @Test
+    public void should_reset_errors() throws Exception {
+        TestCaseResultListener resultListener = new TestCaseResultListener(false);
+        resultListener.receiveResult(mockFailedResult());
+
+        resultListener.startPickle();
+
+        assertTrue(resultListener.isPassed());
+        assertNull(resultListener.getError());
+    }
+
+    private Result mockPassedResult() {
+        Result result = mockResult(Result.Type.PASSED);
+        return result;
+    }
+
+    private Result mockSkippedResult() {
+        Result result = mockResult(Result.Type.SKIPPED);
+        return result;
+    }
+
+    private Result mockUndefinedResult() {
+        Result result = mockResult(Result.Type.UNDEFINED);
+        return result;
+    }
+
+    private Result mockFailedResult() {
+        Result result = mockResult(Result.Type.FAILED);
+        when(result.getError()).thenReturn(mock(Throwable.class));
+        return result;
+    }
+
+    private Result mockAmbiguousResult() {
+        Result result = mockResult(Result.Type.AMBIGUOUS);
+        when(result.getError()).thenReturn(mock(Throwable.class));
+        return result;
+    }
+
+    private Result mockPendingResult() {
+        Result result = mockResult(Result.Type.PENDING);
+        when(result.getError()).thenReturn(new PendingException());
+        return result;
+    }
+
+    private Result mockResult(Result.Type status) {
+        Result result = mock(Result.class);
+        when(result.getStatus()).thenReturn(status);
+        for (Result.Type type : Result.Type.values()) {
+            when(result.is(type)).thenReturn(type == status);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary

Let a `org.testng.SkipException` thrown from a test step make the result of that test step skipped.

## Details

Let a `org.testng.SkipException` thrown from a test step make the result of that test step skipped.

Also use the `SkipException` to signal to the TestNG runner that the test should be considered as skipped, for instance Pending and Undefined test cases in non-strict-mode.

## Motivation and Context

The JUnit exception (`org.junit.AssumptionViolatedException`) has been supported by Cucumber-JVM for some time. Cucumber-JVM should also support the corresponding TestNG exception ([`org.testng.SkipException`](https://jitpack.io/com/github/cbeust/testng/master/javadoc/org/testng/SkipException.html)).

## How Has This Been Tested?

In addition to the updated in the automated test suite, the changes has been manually tested using the `java-calcualator-testng` example in the repository.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
