### PR TITLE
[Core Bug Fix] Fixed runtime exit status for ambiguous scenarios

### DIFF
--- a/core/src/main/java/cucumber/runtime/Stats.java
+++ b/core/src/main/java/cucumber/runtime/Stats.java
@@ -94,7 +94,7 @@ class Stats implements EventListener {
 
     public byte exitStatus(boolean isStrict) {
         byte result = 0x0;
-        if (!failedScenarios.isEmpty() || (isStrict && (!pendingScenarios.isEmpty() || !undefinedScenarios.isEmpty() || !ambiguousScenarios.isEmpty()))) {
+        if (!failedScenarios.isEmpty() || !ambiguousScenarios.isEmpty() || (isStrict && (!pendingScenarios.isEmpty() || !undefinedScenarios.isEmpty()))) {
             result |= ERRORS;
         }
         return result;

--- a/core/src/main/java/cucumber/runtime/Stats.java
+++ b/core/src/main/java/cucumber/runtime/Stats.java
@@ -94,7 +94,7 @@ class Stats implements EventListener {
 
     public byte exitStatus(boolean isStrict) {
         byte result = 0x0;
-        if (!failedScenarios.isEmpty() || (isStrict && (!pendingScenarios.isEmpty() || !undefinedScenarios.isEmpty()))) {
+        if (!failedScenarios.isEmpty() || (isStrict && (!pendingScenarios.isEmpty() || !undefinedScenarios.isEmpty() || !ambiguousScenarios.isEmpty()))) {
             result |= ERRORS;
         }
         return result;

--- a/core/src/main/resources/cucumber/api/cli/USAGE.txt
+++ b/core/src/main/resources/cucumber/api/cli/USAGE.txt
@@ -19,7 +19,7 @@ Options:
   -n, --name REGEXP                      Only run scenarios whose names match REGEXP.
   -d, --[no-]-dry-run                    Skip execution of glue code.
   -m, --[no-]-monochrome                 Don't colour terminal output.
-  -s, --[no-]-strict                     Treat undefined, pending and ambiguous steps as errors.
+  -s, --[no-]-strict                     Treat undefined and pending steps as errors.
       --snippets [underscore|camelcase]  Naming convention for generated snippets.
                                          Defaults to underscore.
   -v, --version                          Print version.

--- a/core/src/main/resources/cucumber/api/cli/USAGE.txt
+++ b/core/src/main/resources/cucumber/api/cli/USAGE.txt
@@ -19,7 +19,7 @@ Options:
   -n, --name REGEXP                      Only run scenarios whose names match REGEXP.
   -d, --[no-]-dry-run                    Skip execution of glue code.
   -m, --[no-]-monochrome                 Don't colour terminal output.
-  -s, --[no-]-strict                     Treat undefined and pending steps as errors.
+  -s, --[no-]-strict                     Treat undefined, pending and ambiguous steps as errors.
       --snippets [underscore|camelcase]  Naming convention for generated snippets.
                                          Defaults to underscore.
   -v, --version                          Print version.

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -204,6 +204,22 @@ public class RuntimeTest {
     }
 
     @Test
+    public void non_strict_with_ambiguous_scenarios() {
+        Runtime runtime = createNonStrictRuntime();
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.AMBIGUOUS));
+
+        assertEquals(0x0, runtime.exitStatus());
+    }
+
+    @Test
+    public void strict_with_ambiguous_scenarios() {
+        Runtime runtime = createStrictRuntime();
+        runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.AMBIGUOUS));
+
+        assertEquals(0x1, runtime.exitStatus());
+    }
+
+    @Test
     public void should_pass_if_no_features_are_found() throws IOException {
         ResourceLoader resourceLoader = createResourceLoaderThatFindsNoFeatures();
         Runtime runtime = createStrictRuntime(resourceLoader);

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -208,7 +208,7 @@ public class RuntimeTest {
         Runtime runtime = createNonStrictRuntime();
         runtime.getEventBus().send(testCaseFinishedWithStatus(Result.Type.AMBIGUOUS));
 
-        assertEquals(0x0, runtime.exitStatus());
+        assertEquals(0x1, runtime.exitStatus());
     }
 
     @Test


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
Fixed an issue where a successful runtime **exit status (0x0)** is returned for ambiguous scenarios when runtime option '**strict**' is set to true.
<!--- Provide a general summary description of your changes -->

## Details
When using the Cucumber CLI and an **AmbiguousStepDefinitionsException** is raised, the runtime exit status is **0x0** even though runtime option '**strict**' is set to true.

The runtime exit status should be **0x1** when **isStrict**
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Yes - 2 new tests added.
<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
