### PR TITLE
[Core] Add feature list to TestRunStarted event

### DIFF
--- a/core/src/main/java/cucumber/api/event/TestRunStarted.java
+++ b/core/src/main/java/cucumber/api/event/TestRunStarted.java
@@ -1,8 +1,14 @@
 package cucumber.api.event;
 
-public final class TestRunStarted extends TimeStampedEvent {
+import cucumber.runtime.model.CucumberFeature;
 
-    public TestRunStarted(Long timeStamp) {
+import java.util.List;
+
+public final class TestRunStarted extends TimeStampedEvent {
+    public final List<CucumberFeature> features;
+
+    public TestRunStarted(Long timeStamp, List<CucumberFeature> features) {
         super(timeStamp);
+        this.features = features;
     }
 }

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -307,7 +307,7 @@ public class RuntimeOptions {
     public List<CucumberFeature> cucumberFeatures(ResourceLoader resourceLoader, EventBus bus) {
         List<CucumberFeature> features = load(resourceLoader, featurePaths, System.out);
         getPlugins(); // to create the formatter objects
-        bus.send(new TestRunStarted(bus.getTime()));
+        bus.send(new TestRunStarted(bus.getTime(), features));
         for (CucumberFeature feature : features) {
             feature.sendTestSourceRead(bus);
         }


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Extended the TestRunStarted event to take in the list of CucumberFeatures that is scheduled to be executed.

## Details

I have extended the TestRunStarted event to accept additional property of List<CucumberFeature>. Which is the list of features that will be executed by the run.

## Motivation and Context

In terms of creating customised plugins to monitor and report on execution. It would be a great addition to the TestRunStarted event to share the list of features that are scheduled to be executed in the run.

It would facilitate run progression tracking(Since the TestCaseStarted & TestCaseFinished events both declare what test case has been executed.)


## How Has This Been Tested?
Executing the existing suite of tests to ensure no regressions.

I have also stepped through execution using a custom plugin that I have created which analyses the events.

Additional statement/Question:
I had a look around the source - there does not appear to be specific tests that check any events? Is this an oversight?


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
