### PR TITLE
[CLI] Remove excess hyphens in USAGE.txt

### DIFF
--- a/core/src/main/resources/cucumber/api/cli/USAGE.txt
+++ b/core/src/main/resources/cucumber/api/cli/USAGE.txt
@@ -17,9 +17,9 @@ Options:
   -t, --tags TAG_EXPRESSION              Only run scenarios tagged with tags matching
                                          TAG_EXPRESSION.
   -n, --name REGEXP                      Only run scenarios whose names match REGEXP.
-  -d, --[no-]-dry-run                    Skip execution of glue code.
-  -m, --[no-]-monochrome                 Don't colour terminal output.
-  -s, --[no-]-strict                     Treat undefined and pending steps as errors.
+  -d, --[no-]dry-run                    Skip execution of glue code.
+  -m, --[no-]monochrome                 Don't colour terminal output.
+  -s, --[no-]strict                     Treat undefined and pending steps as errors.
       --snippets [underscore|camelcase]  Naming convention for generated snippets.
                                          Defaults to underscore.
   -v, --version                          Print version.


### PR DESCRIPTION
## Summary

Some of the options in the USAGE.txt have description in format --[no-]-something.
Last hyphen should not be there: the correct format is --[no-]something

Note: https://cucumber.io/docs/reference/jvm#configuration needs update as well

## How Has This Been Tested?

No tests, it's a small docs typo fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
