### PR TITLE
[Core] Clean up step definition

### DIFF
--- a/core/src/main/java/cucumber/api/Plugin.java
+++ b/core/src/main/java/cucumber/api/Plugin.java
@@ -36,7 +36,6 @@ import java.net.URL;
  * <li>{@link cucumber.api.formatter.StrictAware}</li>
  * <li>{@link cucumber.api.event.EventListener}</li>
  * </ul>
- * <p>
  */
 public interface Plugin {
 }

--- a/core/src/main/java/cucumber/api/Transpose.java
+++ b/core/src/main/java/cucumber/api/Transpose.java
@@ -8,8 +8,8 @@ import java.lang.annotation.Target;
 /**
  * <p>
  * This annotation can be specified on step definition method parameters to give Cucumber a hint
- * to transpose a DataTable into an object or list of objects. 
- * 
+ * to transpose a DataTable.
+ * <p>
  * For example, if you have the following Gherkin step with a table
  * </p>
  * <pre>
@@ -19,6 +19,22 @@ import java.lang.annotation.Target;
  *    | nationality	| Italian	|
  * </pre>
  * <p>
+ * And a data table type to create a User
+ *
+ * <pre>
+ * typeRegistry.defineDataTableType(new DataTableType(
+ *    Author.class,
+ *    new TableEntryTransformer<User>() {
+ *    @Override
+ *    public Author transform(Map<String, String> entry) {
+ *       return new User(
+ *          entry.get("firstName"),
+ *          entry.get("lastName"),
+ *          entry.get("nationality"));
+ *    }
+ * }));
+ *
+ * </pre>
  * Then the following Java Step Definition would convert that into an User object:
  * </p>
  * <pre>
@@ -27,13 +43,10 @@ import java.lang.annotation.Target;
  *     this.user = user;
  * }
  * </pre>
- * <p>
- * 
- * This annotation also works for data tables that are transformed to a list of beans.
  * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.PARAMETER)
+@Target({ElementType.PARAMETER})
 public @interface Transpose {
     boolean value() default true;
 }

--- a/core/src/main/java/cucumber/api/Transpose.java
+++ b/core/src/main/java/cucumber/api/Transpose.java
@@ -11,7 +11,6 @@ import java.lang.annotation.Target;
  * to transpose a DataTable.
  * <p>
  * For example, if you have the following Gherkin step with a table
- * </p>
  * <pre>
  * Given the user is
  *    | firstname	| Roberto	|
@@ -24,9 +23,9 @@ import java.lang.annotation.Target;
  * <pre>
  * typeRegistry.defineDataTableType(new DataTableType(
  *    Author.class,
- *    new TableEntryTransformer<User>() {
- *    @Override
- *    public Author transform(Map<String, String> entry) {
+ *    new TableEntryTransformer&lt;User&gt;() {
+ *    &#064;Override
+ *    public Author transform(Map&lt;String, String&gt; entry) {
  *       return new User(
  *          entry.get("firstName"),
  *          entry.get("lastName"),
@@ -36,14 +35,12 @@ import java.lang.annotation.Target;
  *
  * </pre>
  * Then the following Java Step Definition would convert that into an User object:
- * </p>
  * <pre>
  * &#064;Given("^the user is$")
- * public void the_user_is(@Transpose User user) {
+ * public void the_user_is(&#064;Transpose User user) {
  *     this.user = user;
  * }
  * </pre>
- * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PARAMETER})

--- a/core/src/main/java/cucumber/api/event/TestStepFinished.java
+++ b/core/src/main/java/cucumber/api/event/TestStepFinished.java
@@ -14,7 +14,6 @@ import cucumber.api.TestStep;
  * Each test step finished event is followed by an matching
  * {@link TestStepStarted} event for the same step.The order in which
  * these events may be expected is:
- * <p>
  * <pre>
  *     [before hook,]* [[before step hook,]* test step, [after step hook,]*]+, [after hook,]*
  * </pre>

--- a/core/src/main/java/cucumber/runtime/NoStepDefinition.java
+++ b/core/src/main/java/cucumber/runtime/NoStepDefinition.java
@@ -3,7 +3,6 @@ package cucumber.runtime;
 import io.cucumber.stepexpression.Argument;
 import gherkin.pickles.PickleStep;
 
-import java.lang.reflect.Type;
 import java.util.List;
 
 class NoStepDefinition implements StepDefinition {
@@ -21,11 +20,6 @@ class NoStepDefinition implements StepDefinition {
     @Override
     public Integer getParameterCount() {
         return 0;
-    }
-
-    @Override
-    public ParameterInfo getParameterType(int n, Type argumentType) {
-        return null;
     }
 
     @Override

--- a/core/src/main/java/cucumber/runtime/StepDefinition.java
+++ b/core/src/main/java/cucumber/runtime/StepDefinition.java
@@ -3,7 +3,6 @@ package cucumber.runtime;
 import io.cucumber.stepexpression.Argument;
 import gherkin.pickles.PickleStep;
 
-import java.lang.reflect.Type;
 import java.util.List;
 
 public interface StepDefinition {
@@ -23,18 +22,9 @@ public interface StepDefinition {
     String getLocation(boolean detail);
 
     /**
-     * How many declared parameters this stepdefinition has. Returns null if unknown.
+     * How many declared parameters this step definition has. Returns null if unknown.
      */
     Integer getParameterCount();
-
-    /**
-     * The parameter type at index n. A hint about the raw parameter type is passed to make
-     * it easier for the implementation to make a guess based on runtime information.
-     * <p/>
-     * Statically typed languages will typically ignore the {@code argumentType} while dynamically
-     * typed ones will use it to infer a "good type". It's also ok to return null.
-     */
-    ParameterInfo getParameterType(int n, Type argumentType) throws IndexOutOfBoundsException;
 
     /**
      * Invokes the step definition. The method should raise a Throwable

--- a/core/src/test/java/cucumber/runtime/StubStepDefinition.java
+++ b/core/src/test/java/cucumber/runtime/StubStepDefinition.java
@@ -9,21 +9,22 @@ import io.cucumber.stepexpression.StepExpression;
 import io.cucumber.stepexpression.StepExpressionFactory;
 
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class StubStepDefinition implements StepDefinition {
     private final StepExpression expression;
-    private List<ParameterInfo> parameterInfos;
+    private List<Type> parameters;
 
     StubStepDefinition(String pattern, TypeRegistry typeRegistry, Type... types) {
-        this.parameterInfos = ParameterInfo.fromTypes(types);
-        if (parameterInfos.isEmpty()) {
+        this.parameters = Arrays.asList(types);
+        if (parameters.isEmpty()) {
             this.expression = new StepExpressionFactory(typeRegistry).createExpression(pattern);
         } else {
-            ParameterInfo lastParameter = parameterInfos.get(parameterInfos.size() - 1);
-            this.expression = new StepExpressionFactory(typeRegistry).createExpression(pattern, lastParameter.getType());
+            Type lastParameter = parameters.get(parameters.size() - 1);
+            this.expression = new StepExpressionFactory(typeRegistry).createExpression(pattern, lastParameter);
         }
     }
 
@@ -40,19 +41,14 @@ public class StubStepDefinition implements StepDefinition {
 
     @Override
     public Integer getParameterCount() {
-        return parameterInfos.size();
-    }
-
-    @Override
-    public ParameterInfo getParameterType(int n, Type argumentType) {
-        return parameterInfos.get(n);
+        return parameters.size();
     }
 
     @Override
     public void execute(String language, Object[] args) {
-        assertEquals(parameterInfos.size(), args.length);
+        assertEquals(parameters.size(), args.length);
         for (int i = 0; i < args.length; i++) {
-            assertEquals(parameterInfos.get(i).getType(), args[i].getClass());
+            assertEquals(parameters.get(i), args[i].getClass());
         }
     }
 

--- a/java/src/main/java/cucumber/runtime/java/JavaStepDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaStepDefinition.java
@@ -6,7 +6,6 @@ import io.cucumber.stepexpression.Argument;
 import io.cucumber.stepexpression.ArgumentMatcher;
 import io.cucumber.stepexpression.ExpressionArgumentMatcher;
 import cucumber.runtime.MethodFormat;
-import cucumber.runtime.ParameterInfo;
 import cucumber.runtime.StepDefinition;
 import io.cucumber.stepexpression.StepExpression;
 import io.cucumber.stepexpression.StepExpressionFactory;
@@ -14,7 +13,6 @@ import cucumber.runtime.Utils;
 import gherkin.pickles.PickleStep;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.util.List;
 
 class JavaStepDefinition implements StepDefinition {
@@ -63,11 +61,6 @@ class JavaStepDefinition implements StepDefinition {
     @Override
     public Integer getParameterCount() {
         return parameterInfos.size();
-    }
-
-    @Override
-    public ParameterInfo getParameterType(int n, Type argumentType) {
-        return parameterInfos.get(n);
     }
 
     public boolean isDefinedAt(StackTraceElement e) {

--- a/java/src/main/java/cucumber/runtime/java/ParameterInfo.java
+++ b/java/src/main/java/cucumber/runtime/java/ParameterInfo.java
@@ -1,4 +1,4 @@
-package cucumber.runtime;
+package cucumber.runtime.java;
 
 import cucumber.api.Transpose;
 
@@ -11,11 +11,11 @@ import java.util.List;
 /**
  * This class composes all interesting parameter information into one object.
  */
-public class ParameterInfo {
+class ParameterInfo {
     private final Type type;
     private final boolean transposed;
 
-    public static List<ParameterInfo> fromMethod(Method method) {
+    static List<ParameterInfo> fromMethod(Method method) {
         List<ParameterInfo> result = new ArrayList<ParameterInfo>();
         Type[] genericParameterTypes = method.getGenericParameterTypes();
         Annotation[][] annotations = method.getParameterAnnotations();
@@ -31,28 +31,16 @@ public class ParameterInfo {
         return result;
     }
 
-    public static List<ParameterInfo> fromTypes(Type[] genericParameterTypes) {
-        List<ParameterInfo> result = new ArrayList<ParameterInfo>();
-        for (Type genericParameterType : genericParameterTypes) {
-            result.add(new ParameterInfo(genericParameterType, false));
-        }
-        return result;
-    }
-
-    ParameterInfo(Type type) {
-        this(type, false);
-    }
-
     private ParameterInfo(Type type, boolean transposed) {
         this.type = type;
         this.transposed = transposed;
     }
 
-    public Type getType() {
+    Type getType() {
         return type;
     }
 
-    public boolean isTransposed() {
+    boolean isTransposed() {
         return transposed;
     }
 

--- a/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
+++ b/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
@@ -1,6 +1,6 @@
 package cucumber.runtime.java8;
 
-import static cucumber.runtime.ParameterInfo.fromTypes;
+import static cucumber.runtime.java8.ParameterInfo.fromTypes;
 import static java.lang.String.format;
 import static net.jodah.typetools.TypeResolver.resolveRawArguments;
 
@@ -10,7 +10,6 @@ import cucumber.api.java8.StepdefBody;
 import io.cucumber.stepexpression.ArgumentMatcher;
 import cucumber.runtime.CucumberException;
 import io.cucumber.stepexpression.ExpressionArgumentMatcher;
-import cucumber.runtime.ParameterInfo;
 import cucumber.runtime.StepDefinition;
 import io.cucumber.stepexpression.StepExpression;
 import io.cucumber.stepexpression.StepExpressionFactory;
@@ -101,11 +100,6 @@ public class Java8StepDefinition implements StepDefinition {
     @Override
     public Integer getParameterCount() {
         return parameterInfos.size();
-    }
-
-    @Override
-    public ParameterInfo getParameterType(int n, Type argumentType) throws IndexOutOfBoundsException {
-        return parameterInfos.get(n);
     }
 
     @Override

--- a/java8/src/main/java/cucumber/runtime/java8/ParameterInfo.java
+++ b/java8/src/main/java/cucumber/runtime/java8/ParameterInfo.java
@@ -1,0 +1,37 @@
+package cucumber.runtime.java8;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+class ParameterInfo {
+    private final Type type;
+
+    static List<ParameterInfo> fromTypes(Type[] genericParameterTypes) {
+        List<ParameterInfo> result = new ArrayList<>();
+        for (Type genericParameterType : genericParameterTypes) {
+            for (Annotation annotation : genericParameterType.getClass().getAnnotations()) {
+                System.out.println(annotation.toString());
+            }
+
+
+            result.add(new ParameterInfo(genericParameterType));
+        }
+        return result;
+    }
+
+    private ParameterInfo(Type type) {
+        this.type = type;
+    }
+
+    Type getType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return type.toString();
+    }
+
+}

--- a/junit/src/main/java/cucumber/api/junit/Cucumber.java
+++ b/junit/src/main/java/cucumber/api/junit/Cucumber.java
@@ -33,7 +33,6 @@ import java.util.List;
  * Classes annotated with {@code @RunWith(Cucumber.class)} will run a Cucumber Feature.
  * In general, the runner class should be empty without any fields or methods.
  * For example:
- * <p>
  * <blockquote><pre>
  * &#64;RunWith(Cucumber.class)
  * &#64;CucumberOptions(plugin = "pretty")

--- a/pom.xml
+++ b/pom.xml
@@ -882,6 +882,14 @@
                             </revapi.semver.ignore>
                             <revapi.java>
                                 <filter>
+                                    <classes>
+                                        <regex>true</regex>
+                                        <exclude>
+                                            <item>cucumber\.runner\..*</item>
+                                            <item>cucumber\.runtime\..*</item>
+                                            <item>cucumber\.util\..*</item>
+                                        </exclude>
+                                    </classes>
                                     <packages>
                                         <regex>true</regex>
                                         <exclude>


### PR DESCRIPTION
## Summary

Clean up unused methods in step definition. Split up parameter type determination into java and java8 specific parts and fix java documentation related to `@Transpose`.