### PR TITLE
Add missing closing quote

### DIFF
--- a/examples/android/android-studio/Cukeulator/app/build.gradle
+++ b/examples/android/android-studio/Cukeulator/app/build.gradle
@@ -138,7 +138,7 @@ task deleteExistingCucumberReports {
         def files = getCucumberReportFileNames()
         files.each { fileName ->
             def deviceFileName = deviceSourcePath + '/' + fileName
-            def output2 = executeAdb('if [ -d "' + deviceFileName + ' ]; then rm -r "' + deviceFileName + '"; else rm -r "' + deviceFileName + '" ; fi')
+            def output2 = executeAdb('if [ -d "' + deviceFileName + '" ]; then rm -r "' + deviceFileName + '"; else rm -r "' + deviceFileName + '" ; fi')
             println output2
         }
     }


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

There is a missing closing quote in cucumber-jvm/examples/android/android-studio/Cukeulator/app/build.gradle file

## Details

I had added the missing quote to avoid the following error message when I run tests:
```
Task :app:deleteExistingCucumberReports
/system/bin/sh: no closing quote
/system/bin/sh: no closing quote
/system/bin/sh: no closing quote
```
## How Has This Been Tested?

Run tests and there is no more **no closing quote** error

## Types of changes


- [X ] Bug fix (non-breaking change which fixes an issue).
