### PR TITLE
Add pending tag support to failing scenarios to prevent build fail

### DIFF
--- a/core/src/main/java/cucumber/runner/TestStep.java
+++ b/core/src/main/java/cucumber/runner/TestStep.java
@@ -42,7 +42,7 @@ abstract class TestStep implements cucumber.api.TestStep {
             status = executeStep(language, scenario, skipSteps);
         } catch (Throwable t) {
             error = t;
-            status = mapThrowableToStatus(t);
+            status = mapThrowableToStatus(t, scenario.getSourceTagNames().contains("@pending"));
         }
         Long stopTime = bus.getTime();
         Result result = mapStatusToResult(status, error, stopTime - startTime);
@@ -60,8 +60,8 @@ abstract class TestStep implements cucumber.api.TestStep {
         }
     }
 
-    private Result.Type mapThrowableToStatus(Throwable t) {
-        if (t.getClass().isAnnotationPresent(Pending.class)) {
+    private Result.Type mapThrowableToStatus(Throwable t, boolean isPending) {
+        if (t.getClass().isAnnotationPresent(Pending.class) || isPending) {
             return Result.Type.PENDING;
         }
         if (Arrays.binarySearch(ASSUMPTION_VIOLATED_EXCEPTIONS, t.getClass().getName()) >= 0) {

--- a/core/src/test/java/cucumber/runner/PickleStepTestStepTest.java
+++ b/core/src/test/java/cucumber/runner/PickleStepTestStepTest.java
@@ -183,6 +183,22 @@ public class PickleStepTestStepTest {
     }
 
     @Test
+    public void result_is_passed_when_step_definition_does_not_throw_exception_with_pending_tag() throws Throwable {
+        Collection<String> scenarioTags = new ArrayList<String>();
+        scenarioTags.add("@foo");
+        scenarioTags.add("@pending");
+        scenarioTags.add("@bar");
+
+        when(scenario.getSourceTagNames()).thenReturn(scenarioTags);
+
+        Result result = step.run(bus, language, scenario, false);
+
+        System.out.println(result);
+
+        assertEquals(PASSED, result.getStatus());
+    }
+
+    @Test
     public void step_execution_time_is_measured() throws Throwable {
         Long duration = 1234L;
         TestStep testStep = new PickleStepTestStep("uri", mock(PickleStep.class), definitionMatch);

--- a/core/src/test/java/cucumber/runner/PickleStepTestStepTest.java
+++ b/core/src/test/java/cucumber/runner/PickleStepTestStepTest.java
@@ -12,7 +12,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import static cucumber.api.Result.Type.PASSED;
+import static cucumber.api.Result.Type.PENDING;
 import static cucumber.api.Result.Type.SKIPPED;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -159,6 +163,23 @@ public class PickleStepTestStepTest {
         Result result = step.run(bus, language, scenario, false);
 
         assertEquals(Result.Type.PENDING, result.getStatus());
+    }
+
+    @Test
+    public void result_is_pending_when_step_definition_throws_exception_with_pending_tag() throws Throwable {
+        Collection<String> scenarioTags = new ArrayList<String>();
+        scenarioTags.add("@foo");
+        scenarioTags.add("@pending");
+        scenarioTags.add("@bar");
+
+        when(scenario.getSourceTagNames()).thenReturn(scenarioTags);
+        doThrow(Exception.class).when(definitionMatch).runStep(anyString(), (Scenario) any());
+
+        Result result = step.run(bus, language, scenario, false);
+
+        System.out.println(result);
+
+        assertEquals(PENDING, result.getStatus());
     }
 
     @Test


### PR DESCRIPTION
## Summary



This feature all users to use `@pending` tag to not fail a build.



## Details



Imagine you have a bug in your project. The bug are reported but, you can't fix it imediatly due to roadmap, or anything else.

With this feature, you can add a `@pending` tag before your scenario (or feature, or hook) to continue to pass the build, because `pending` status does not have an effect on exit status, and the failing test continues to appear in your report (to not forget it).



Example:

```gherkin
Feature: Go on moon
	
	@pending
	Scenario: Launch a rocket
	When I click on button launch
	Then The rocket take off
```



Java side:

```java
@When("I click on button launch")
public void I_click_on_button_launch() {
    throw new Exception("Your are not yet ready");
}
```



This example will not fail the test suit, instead, this scenario have a pending result.





## Motivation and Context



This feature is very useful when you work in team on project with built pipeline (automated build, etc.) and you (and other developers) don't have the time to fix the bug quickly.



## How Has This Been Tested?



The tests check if we run a scenario with a `@pending` tag, it returns the `PENDING` status if the a step throws an error, and `PASSED` otherwise.



## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:



- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.