### PR TITLE
Added extraGlue option to @CucumberOptions

### DIFF
--- a/core/src/main/java/cucumber/api/CucumberOptions.java
+++ b/core/src/main/java/cucumber/api/CucumberOptions.java
@@ -32,6 +32,11 @@ public @interface CucumberOptions {
     String[] glue() default {};
 
     /**
+     * @return where to look for glue code (stepdefs and hooks), in addition to default search path
+     */
+    String[] extraGlue() default {};
+
+    /**
      * @return what tags in the features should be executed
      */
     String[] tags() default {};

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
@@ -150,6 +150,44 @@ public class RuntimeOptionsFactoryTest {
         assertTrue(pluginName + " not found among the plugins", found);
     }
 
+    @Test
+    public void create_with_glue() {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(ClassWithGlue.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+
+        assertEquals(asList("app.features.user.registration", "app.features.hooks"), runtimeOptions.getGlue());
+    }
+
+    @Test
+    public void create_with_extra_glue() {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(ClassWithExtraGlue.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+
+        assertEquals(asList("app.features.hooks", "classpath:cucumber/runtime"), runtimeOptions.getGlue());
+    }
+
+    @Test
+    public void create_with_extra_glue_in_subclass_of_extra_glue() {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(SubClassWithExtraGlueOfExtraGlue.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+
+        assertEquals(asList("app.features.user.hooks", "app.features.hooks", "classpath:cucumber/runtime"), runtimeOptions.getGlue());
+    }
+
+    @Test
+    public void create_with_extra_glue_in_subclass_of_glue() {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(SubClassWithExtraGlueOfGlue.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+
+        assertEquals(asList("app.features.user.hooks", "app.features.user.registration", "app.features.hooks"), runtimeOptions.getGlue());
+    }
+
+    @Test(expected = CucumberException.class)
+    public void cannot_create_with_glue_and_extra_glue() {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(ClassWithGlueAndExtraGlue.class);
+        runtimeOptionsFactory.create();
+    }
+
 
     @CucumberOptions(snippets = SnippetType.CAMELCASE)
     private static class Snippets {
@@ -215,6 +253,31 @@ public class RuntimeOptionsFactoryTest {
 
     @CucumberOptions(junit = {"option1", "option2=value"})
     private static class ClassWithJunitOption {
+        // empty
+    }
+
+    @CucumberOptions(glue = {"app.features.user.registration", "app.features.hooks"})
+    private static class ClassWithGlue {
+        // empty
+    }
+
+    @CucumberOptions(extraGlue = {"app.features.hooks"})
+    private static class ClassWithExtraGlue {
+        // empty
+    }
+
+    @CucumberOptions(extraGlue = {"app.features.user.hooks"})
+    private static class SubClassWithExtraGlueOfExtraGlue extends ClassWithExtraGlue {
+        // empty
+    }
+
+    @CucumberOptions(extraGlue = {"app.features.user.hooks"})
+    private static class SubClassWithExtraGlueOfGlue extends ClassWithGlue {
+        // empty
+    }
+
+    @CucumberOptions(extraGlue = {"app.features.hooks"}, glue = {"app.features.user.registration"})
+    private static class ClassWithGlueAndExtraGlue {
         // empty
     }
 


### PR DESCRIPTION
## Summary

Added extraGlue option to @CucumberOptions

## Details

This option works similarly to glue, specifing packages in which to search for steps and hooks, but the default search path (the current package) is included in the list of glue packages, whereas glue includes only the explicitly listed packages.

## Motivation and Context

Closes #1438.

## How Has This Been Tested?

I've added tests to RuntimeOptionsFactoryTest.java.

`mvn clean install` is successful.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

The only documentation I've found is JavaDocs in CucumberOptions.java; the new option is documented there.