### PR TITLE
Highlight arguments in html report

### DIFF
--- a/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
@@ -381,7 +381,7 @@ final class HTMLFormatter implements EventListener {
         return false;
     }
 
-    private Map<String, Object> createTestStep(PickleStepTestStep testStep) {
+    Map<String, Object> createTestStep(PickleStepTestStep testStep) {
         Map<String, Object> stepMap = new HashMap<String, Object>();
         stepMap.put("name", testStep.getStepText());
         if (!testStep.getStepArgument().isEmpty()) {
@@ -396,6 +396,9 @@ final class HTMLFormatter implements EventListener {
         if (astNode != null) {
             Step step = (Step) astNode.node;
             stepMap.put("keyword", step.getKeyword());
+        }
+        if (!testStep.getDefinitionArgument().isEmpty()) {
+            stepMap.put("arguments", createArgumentsMap(testStep.getDefinitionArgument()));
         }
 
         return stepMap;
@@ -413,6 +416,18 @@ final class HTMLFormatter implements EventListener {
             rowList.add(createRowMap(row));
         }
         return rowList;
+    }
+
+    private List<Map<String, Object>> createArgumentsMap(List<cucumber.api.Argument> arguments) {
+        List<Map<String, Object>> argList = new ArrayList<Map<String, Object>>();
+        for (cucumber.api.Argument argument : arguments) {
+            Map<String, Object> argMap = new HashMap<String, Object>();
+            argMap.put("value", argument.getValue());
+            argMap.put("start", argument.getStart());
+            argMap.put("end", argument.getEnd());
+            argList.add(argMap);
+        }
+        return argList;
     }
 
     private Map<String, Object> createRowMap(PickleRow row) {


### PR DESCRIPTION
## Summary

This highlights the arguments of the steps in the HTML report, displaying them in bold.

## Details

The changes here add details about arguments to the .js file with the report data. A pull request against cucumber-html (https://github.com/cucumber/cucumber-html/pull/51) uses that information to display them in bold.

## How Has This Been Tested?

I've added a unit test. Unfortunately, I had to deviate a little from the style of the other tests. It seems the test harness used in other tests does not allow expressions with arguments and capturing them. So I tested the relevant function individually (which required making it package-protected). I've modelled the new test based on a similar one in `PrettyFormatterTest.java`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
