### PR TITLE
[Core] Parse qouted strings from cucumber.options

### DIFF
--- a/core/src/main/java/cucumber/runtime/Shellwords.java
+++ b/core/src/main/java/cucumber/runtime/Shellwords.java
@@ -6,7 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Shellwords {
-    private static final Pattern SHELLWORDS_PATTERN = Pattern.compile("[^\\s']+|'([^']*)'");
+    private static final Pattern SHELLWORDS_PATTERN = Pattern.compile("[^\\s'\"]+|[']([^']*)[']|[\"]([^\"]*)[\"]");
 
     private Shellwords() {
     }
@@ -18,7 +18,13 @@ public class Shellwords {
             if (shellwordsMatcher.group(1) != null) {
                 matchList.add(shellwordsMatcher.group(1));
             } else {
-                matchList.add(shellwordsMatcher.group());
+                String shellword = shellwordsMatcher.group();
+                if (shellword.startsWith("\"")
+                        && shellword.endsWith("\"")
+                        && shellword.length() > 2) {
+                    shellword = shellword.substring(1, shellword.length() - 1);
+                }
+                matchList.add(shellword);
             }
         }
         return matchList;

--- a/core/src/test/java/cucumber/runtime/ShellwordsTest.java
+++ b/core/src/test/java/cucumber/runtime/ShellwordsTest.java
@@ -7,24 +7,22 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
 public class ShellwordsTest {
+
     @Test
     public void parses_single_quoted_strings() {
         assertEquals(asList("--name", "The Fox"), Shellwords.parse("--name 'The Fox'"));
     }
 
-    @Ignore("TODO: fixme")
     @Test
     public void parses_double_quoted_strings() {
         assertEquals(asList("--name", "The Fox"), Shellwords.parse("--name \"The Fox\""));
     }
 
-    @Ignore("TODO: fixme")
     @Test
     public void parses_both_single_and_double_quoted_strings() {
         assertEquals(asList("--name", "The Fox", "--fur", "Brown White"), Shellwords.parse("--name \"The Fox\" --fur 'Brown White'"));
     }
 
-    @Ignore("TODO: fixme")
     @Test
     public void can_quote_both_single_and_double_quotes() {
         assertEquals(asList("'", "\""), Shellwords.parse("\"'\" '\"'"));


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Found `@Ignore("TODO: fixme")` so thought I would solve it.

## Details

Shellwords takes the program arguments and splits them into separate strings but still groups words bound by `"` or `'`

## Motivation and Context

What to help, was looking at helping test code coverage.

## How Has This Been Tested?

`mvn clean install` still passes

458 tests within code pass but now it doesn't have 3 ignored

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
