### PR TITLE
Upgrade to Junit 5 and use assertThrows

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,11 +33,6 @@
             <artifactId>datatable</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>xmlunit</groupId>
             <artifactId>xmlunit</artifactId>
             <scope>test</scope>
@@ -50,6 +45,18 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/core/src/test/java/io/cucumber/core/options/RuntimeOptionsFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/options/RuntimeOptionsFactoryTest.java
@@ -3,12 +3,13 @@ package io.cucumber.core.options;
 import cucumber.api.CucumberOptions;
 import cucumber.api.Plugin;
 import cucumber.api.SnippetType;
-import io.cucumber.core.runner.TimeService;
-import io.cucumber.core.runner.TimeServiceEventBus;
 import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.plugin.PluginFactory;
 import io.cucumber.core.plugin.Plugins;
+import io.cucumber.core.runner.TimeService;
+import io.cucumber.core.runner.TimeServiceEventBus;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.Iterator;
 import java.util.List;
@@ -18,12 +19,16 @@ import static io.cucumber.core.options.RuntimeOptionsFactory.packageName;
 import static io.cucumber.core.options.RuntimeOptionsFactory.packagePath;
 import static java.util.Arrays.asList;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RuntimeOptionsFactoryTest {
+
     @Test
     public void create_strict() {
         RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(Strict.class);
@@ -183,10 +188,12 @@ public class RuntimeOptionsFactoryTest {
         assertEquals(asList("app.features.user.hooks", "app.features.user.registration", "app.features.hooks"), runtimeOptions.getGlue());
     }
 
-    @Test(expected = CucumberException.class)
+    @Test
     public void cannot_create_with_glue_and_extra_glue() {
         RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(ClassWithGlueAndExtraGlue.class);
-        runtimeOptionsFactory.create();
+        final Executable testMethod = () -> runtimeOptionsFactory.create();
+        final CucumberException expectedThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("glue and extraGlue cannot be specified at the same time")));
     }
 
 

--- a/core/src/test/java/io/cucumber/core/runner/FailedStepInstantiationMatchTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/FailedStepInstantiationMatchTest.java
@@ -5,12 +5,18 @@ import gherkin.pickles.PickleLocation;
 import gherkin.pickles.PickleStep;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class FailedStepInstantiationMatchTest {
+
     private FailedPickleStepInstantiationMatch match;
 
     @Before
@@ -26,13 +32,18 @@ public class FailedStepInstantiationMatchTest {
         match = new FailedPickleStepInstantiationMatch("uri", step, exception);
     }
 
-    @Test(expected=Exception.class)
-    public void throws_the_exception_passed_to_the_match_when_run() throws Throwable {
-        match.runStep(mock(Scenario.class));
+    @Test
+    public void throws_the_exception_passed_to_the_match_when_run() {
+        final Executable testMethod = () -> match.runStep(mock(Scenario.class));
+        final Exception expectedThrown = assertThrows(Exception.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(nullValue()));
     }
 
-    @Test(expected=Exception.class)
-    public void throws_the_exception_passed_to_the_match_when_dry_run() throws Throwable {
-        match.dryRunStep(mock(Scenario.class));
+    @Test
+    public void throws_the_exception_passed_to_the_match_when_dry_run() {
+        final Executable testMethod = () -> match.dryRunStep(mock(Scenario.class));
+        final Exception expectedThrown = assertThrows(Exception.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(nullValue()));
     }
+
 }

--- a/core/src/test/java/io/cucumber/core/runner/UndefinedStepDefinitionMatchTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/UndefinedStepDefinitionMatchTest.java
@@ -3,22 +3,31 @@ package io.cucumber.core.runner;
 import cucumber.api.Scenario;
 import gherkin.pickles.PickleStep;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 public class UndefinedStepDefinitionMatchTest {
+
     public final UndefinedPickleStepDefinitionMatch match = new UndefinedPickleStepDefinitionMatch(mock(PickleStep.class));
 
-    @Test(expected=UndefinedStepDefinitionException.class)
-    public void throws_ambiguous_step_definitions_exception_when_run() throws Throwable {
-        match.runStep(mock(Scenario.class));
-        fail("UndefinedStepDefinitionsException expected");
+    @Test
+    public void throws_ambiguous_step_definitions_exception_when_run() {
+        final Executable testMethod = () -> match.runStep(mock(Scenario.class));
+        final UndefinedStepDefinitionException expectedThrown = assertThrows(UndefinedStepDefinitionException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("No step definitions found")));
     }
 
-    @Test(expected=UndefinedStepDefinitionException.class)
-    public void throws_ambiguous_step_definitions_exception_when_dry_run() throws Throwable {
-        match.dryRunStep(mock(Scenario.class));
-        fail("UndefinedStepDefinitionsException expected");
+    @Test
+    public void throws_ambiguous_step_definitions_exception_when_dry_run() {
+        final Executable testMethod = () -> match.dryRunStep(mock(Scenario.class));
+        final UndefinedStepDefinitionException expectedThrown = assertThrows(UndefinedStepDefinitionException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("No step definitions found")));
     }
+
 }

--- a/core/src/test/java/io/cucumber/core/runtime/InvokerTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/InvokerTest.java
@@ -1,17 +1,21 @@
 package io.cucumber.core.runtime;
 
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 
 import static java.lang.Thread.sleep;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InvokerTest {
+
     @Test
     public void doesnt_time_out_if_it_doesnt_take_too_long() throws Throwable {
         final Slow slow = new Slow();
@@ -24,55 +28,46 @@ public class InvokerTest {
         assertEquals("slept 10ms", what);
     }
 
-    @Test(expected = TimeoutException.class)
-    public void times_out_if_it_takes_too_long() throws Throwable {
+    @Test
+    public void times_out_if_it_takes_too_long() {
         final Slow slow = new Slow();
-        Invoker.timeout(new Invoker.Callback<String>() {
-            @Override
-            public String call() throws Throwable {
-                return slow.slow(100);
-            }
-        }, 50);
-        fail();
+        final Executable testMethod = () -> Invoker.timeout(() -> slow.slow(100), 50);
+        final TimeoutException expectedThrown = assertThrows(TimeoutException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("Timed out after 50ms.")));
     }
 
-    @Test(expected = TimeoutException.class)
-    public void times_out_infinite_loop_if_it_takes_too_long() throws Throwable {
+    @Test
+    public void times_out_infinite_loop_if_it_takes_too_long() {
         final Slow slow = new Slow();
-        Invoker.timeout(new Invoker.Callback<Void>() {
-            @Override
-            public Void call() throws Throwable {
-                slow.infinite();
-                return null;
-            }
+        final Executable testMethod = () -> Invoker.timeout((Invoker.Callback<Void>) () -> {
+            slow.infinite();
+            return null;
         }, 10);
-        fail();
+        final TimeoutException expectedThrown = assertThrows(TimeoutException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("Timed out after 10ms.")));
     }
 
-    @Test(expected = TimeoutException.class)
-    public void times_out_infinite_latch_wait_if_it_takes_too_long() throws Throwable {
+    @Test
+    public void times_out_infinite_latch_wait_if_it_takes_too_long() {
         final Slow slow = new Slow();
-        Invoker.timeout(new Invoker.Callback<Void>() {
-            @Override
-            public Void call() throws Throwable {
-                slow.infiniteLatchWait();
-                return null;
-            }
+        final Executable testMethod = () -> Invoker.timeout((Invoker.Callback<Void>) () -> {
+            slow.infiniteLatchWait();
+            return null;
         }, 10);
-        fail();
+        final TimeoutException expectedThrown = assertThrows(TimeoutException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("Timed out after 10ms.")));
     }
 
 
-    @Test(expected = TimeoutException.class)
-    public void times_out_busy_wait_if_it_takes_too_long() throws Throwable {
+    @Test
+    public void times_out_busy_wait_if_it_takes_too_long() {
         final Slow slow = new Slow();
-        Invoker.timeout(new Invoker.Callback<Void>() {
-            @Override
-            public Void call() throws Throwable {
-                slow.busyWait();
-                return null;
-            }
+        final Executable testMethod = () -> Invoker.timeout((Invoker.Callback<Void>) () -> {
+            slow.busyWait();
+            return null;
         }, 1);
+        final TimeoutException expectedThrown = assertThrows(TimeoutException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("Timed out after 1ms.")));
     }
 
     @Test
@@ -127,4 +122,5 @@ public class InvokerTest {
             return busyCounter;
         }
     }
+
 }

--- a/core/src/test/java/io/cucumber/core/snippets/FunctionNameGeneratorTest.java
+++ b/core/src/test/java/io/cucumber/core/snippets/FunctionNameGeneratorTest.java
@@ -2,8 +2,13 @@ package io.cucumber.core.snippets;
 
 import cucumber.api.SnippetType;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FunctionNameGeneratorTest {
 
@@ -15,9 +20,11 @@ public class FunctionNameGeneratorTest {
         assertEquals(expectedCamelCase, camelCase.generateFunctionName(sentence));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSanitizeEmptyFunctionName() {
-        underscore.generateFunctionName("");
+        final Executable testMethod = () -> underscore.generateFunctionName("");
+        final IllegalArgumentException expectedThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("Cannot create function name from empty sentence")));
     }
 
     @Test

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -27,9 +27,22 @@
             <artifactId>cucumber-junit</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/guice/src/test/java/io/cucumber/guice/collection/CollectionUtilTest.java
+++ b/guice/src/test/java/io/cucumber/guice/collection/CollectionUtilTest.java
@@ -2,12 +2,15 @@ package io.cucumber.guice.collection;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CollectionUtilTest {
 
@@ -18,14 +21,18 @@ public class CollectionUtilTest {
         list = new ArrayList<String>();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testNullPointerExceptionIsThrownWhenListIsNull() {
-        CollectionUtil.removeAllExceptFirstElement(null);
+        final Executable testMethod = () -> CollectionUtil.removeAllExceptFirstElement(null);
+        final NullPointerException expectedThrown = assertThrows(NullPointerException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("List must not be null.")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIllegalArgumentExceptionIsThrownWhenListIsEmpty() {
-        CollectionUtil.removeAllExceptFirstElement(list);
+        final Executable testMethod = () -> CollectionUtil.removeAllExceptFirstElement(list);
+        final IllegalArgumentException expectedThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("List must contain at least one element.")));
     }
 
     @Test
@@ -56,4 +63,5 @@ public class CollectionUtilTest {
         assertThat(list.size(), equalTo(1));
         assertThat(list.get(0), equalTo(element));
     }
+
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,11 +22,25 @@
             <artifactId>cucumber-junit</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/java/src/test/java/io/cucumber/java/JavaBackendTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaBackendTest.java
@@ -12,12 +12,17 @@ import io.cucumber.java.stepdefs.Stepdefs;
 import io.cucumber.core.stepexpression.TypeRegistry;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.Locale;
 
 import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JavaBackendTest {
 
@@ -50,10 +55,12 @@ public class JavaBackendTest {
         assertEquals(Stepdefs.class, factory.getInstance(Stepdefs.class).getClass());
     }
 
-    @Test(expected = CucumberException.class)
+    @Test
     public void detects_subclassed_glue_and_throws_exception() {
         GlueStub glue = new GlueStub();
-        backend.loadGlue(glue, asList("io.cucumber.java.stepdefs", "io.cucumber.java.incorrectlysubclassedstepdefs"));
+        final Executable testMethod = () -> backend.loadGlue(glue, asList("io.cucumber.java.stepdefs", "io.cucumber.java.incorrectlysubclassedstepdefs"));
+        final CucumberException expectedThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("You're not allowed to extend classes that define Step Definitions or hooks. class io.cucumber.java.incorrectlysubclassedstepdefs.SubclassesStepdefs extends class io.cucumber.java.stepdefs.Stepdefs")));
     }
 
     private class GlueStub implements Glue {
@@ -84,4 +91,5 @@ public class JavaBackendTest {
         }
 
     }
+
 }

--- a/java/src/test/java/io/cucumber/java/JavaStepDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaStepDefinitionTest.java
@@ -33,16 +33,23 @@ import java.util.Collections;
 import java.util.Locale;
 
 import io.cucumber.core.stepexpression.TypeRegistry;
+import org.junit.jupiter.api.function.Executable;
 
 import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 public class JavaStepDefinitionTest {
+
     private static final Method THREE_DISABLED_MICE;
     private static final Method THREE_BLIND_ANIMALS;
     private static final String ENGLISH = "en";
@@ -87,10 +94,12 @@ public class JavaStepDefinitionTest {
         });
     }
 
-    @Test(expected = DuplicateStepDefinitionException.class)
-    public void throws_duplicate_when_two_stepdefs_with_same_regexp_found() throws Throwable {
+    @Test
+    public void throws_duplicate_when_two_stepdefs_with_same_regexp_found() {
         backend.addStepDefinition(THREE_BLIND_ANIMALS.getAnnotation(Given.class), THREE_DISABLED_MICE);
-        backend.addStepDefinition(THREE_BLIND_ANIMALS.getAnnotation(Given.class), THREE_BLIND_ANIMALS);
+        final Executable testMethod = () -> backend.addStepDefinition(THREE_BLIND_ANIMALS.getAnnotation(Given.class), THREE_BLIND_ANIMALS);
+        final DuplicateStepDefinitionException expectedThrown = assertThrows(DuplicateStepDefinitionException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(startsWith("Duplicate step definitions in io.cucumber.java.JavaStepDefinitionTest$Defs.threeDisabledMice(String) in file:")));
     }
 
     @Test
@@ -136,4 +145,5 @@ public class JavaStepDefinitionTest {
             bar = true;
         }
     }
+
 }

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -20,7 +20,18 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/junit/src/test/java/io/cucumber/junit/AssertionsTest.java
+++ b/junit/src/test/java/io/cucumber/junit/AssertionsTest.java
@@ -3,19 +3,25 @@ package io.cucumber.junit;
 import cucumber.api.junit.Cucumber;
 import io.cucumber.core.exception.CucumberException;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.runner.RunWith;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class AssertionsTest {
 
-
-    @Test(expected = CucumberException.class)
+    @Test
     public void should_throw_cucumber_exception_when_annotated() {
-        Assertions.assertNoCucumberAnnotatedMethods(WithCucumberMethod.class);
+        final Executable testMethod = () -> Assertions.assertNoCucumberAnnotatedMethods(WithCucumberMethod.class);
+        final CucumberException expectedThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("\n\nClasses annotated with @RunWith(Cucumber.class) must not define any\nStep Definition or Hook methods. Their sole purpose is to serve as\nan entry point for JUnit. Step Definitions and Hooks should be defined\nin their own classes. This allows them to be reused across features.\nOffending class: class io.cucumber.junit.AssertionsTest$WithCucumberMethod\n")));
     }
-
 
     @RunWith(Cucumber.class)
     public final static class WithCucumberMethod {

--- a/junit/src/test/java/io/cucumber/junit/CucumberTest.java
+++ b/junit/src/test/java/io/cucumber/junit/CucumberTest.java
@@ -8,6 +8,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.ParallelComputer;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.runner.Description;
 import org.junit.runner.Request;
 import org.junit.runner.RunWith;
@@ -22,11 +23,13 @@ import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.argThat;
 
 public class CucumberTest {
@@ -177,9 +180,11 @@ public class CucumberTest {
         Assertions.assertNoCucumberAnnotatedMethods(RunCukesTestValidIgnored.class);
     }
 
-    @Test(expected = CucumberException.class)
+    @Test
     public void no_stepdefs_in_cucumber_runner_invalid() {
-        Assertions.assertNoCucumberAnnotatedMethods(RunCukesTestInvalid.class);
+        final Executable testMethod = () -> Assertions.assertNoCucumberAnnotatedMethods(RunCukesTestInvalid.class);
+        final CucumberException expectedThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("\n\nClasses annotated with @RunWith(Cucumber.class) must not define any\nStep Definition or Hook methods. Their sole purpose is to serve as\nan entry point for JUnit. Step Definitions and Hooks should be defined\nin their own classes. This allows them to be reused across features.\nOffending class: class io.cucumber.junit.CucumberTest$RunCukesTestInvalid\n")));
     }
 
     public class ImplicitFeatureAndGluePath {

--- a/needle/pom.xml
+++ b/needle/pom.xml
@@ -26,8 +26,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/needle/src/test/java/io/cucumber/needle/config/CreateInstanceByDefaultConstructorTest.java
+++ b/needle/src/test/java/io/cucumber/needle/config/CreateInstanceByDefaultConstructorTest.java
@@ -1,8 +1,13 @@
 package io.cucumber.needle.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class CreateInstanceByDefaultConstructorTest {
 
@@ -23,9 +28,11 @@ public class CreateInstanceByDefaultConstructorTest {
         assertNotNull(createInstanceByDefaultConstructor.apply(HasDefaultConstructor.class));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldNotCreateNewInstanceWhenConstructorIsMissing() {
-        createInstanceByDefaultConstructor.apply(DoesNotHaveDefaultConstructor.class);
+        final Executable testMethod = () -> createInstanceByDefaultConstructor.apply(DoesNotHaveDefaultConstructor.class);
+        final IllegalStateException expectedThrown = assertThrows(IllegalStateException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("Can not instantiate Instance by Default Constructor.")));
     }
 
 }

--- a/needle/src/test/java/io/cucumber/needle/config/LoadCucumberNeedleResourceBundleTest.java
+++ b/needle/src/test/java/io/cucumber/needle/config/LoadCucumberNeedleResourceBundleTest.java
@@ -1,15 +1,18 @@
 package io.cucumber.needle.config;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ResourceBundle;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class LoadCucumberNeedleResourceBundleTest {
 
@@ -38,19 +41,25 @@ public class LoadCucumberNeedleResourceBundleTest {
         assertFalse(resourceBundle.getKeys().hasMoreElements());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailWhenResourceNameIsNull() {
-        function.apply(null);
+        final Executable testMethod = () -> function.apply(null);
+        final IllegalArgumentException expectedThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("resourceName must not be null or empty!")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailWhenResourceNameIsEmpty() {
-        function.apply("");
+        final Executable testMethod = () -> function.apply("");
+        final IllegalArgumentException expectedThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("resourceName must not be null or empty!")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldFailWhenResourceNameIsBlank() {
-        function.apply(" ");
+        final Executable testMethod = () -> function.apply(" ");
+        final IllegalArgumentException expectedThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(expectedThrown.getMessage(), is(equalTo("resourceName must not be null or empty!")));
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,21 @@
                 <version>${hamcrest.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.3.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.3.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>5.3.1</version>
+            </dependency>
+            <dependency>
                 <groupId>uk.co.datumedge</groupId>
                 <artifactId>hamcrest-json</artifactId>
                 <version>0.2</version>
@@ -747,6 +762,23 @@
                         <argLine>-Dfile.encoding=UTF-8</argLine>
                         <useFile>false</useFile>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.jupiter</groupId>
+                            <artifactId>junit-jupiter-engine</artifactId>
+                            <version>5.3.1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.junit.platform</groupId>
+                            <artifactId>junit-platform-engine</artifactId>
+                            <version>1.3.1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.junit.vintage</groupId>
+                            <artifactId>junit-vintage-engine</artifactId>
+                            <version>5.3.1</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Upgrade to Junit 5 and use assertThrows for tests checking exception, now branch using Java 8.

## How Has This Been Tested?

Checked test count before matches test count after.
Checked test all still pass

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
