### PR TITLE
[Java] Add repeatable annotations

### DIFF
--- a/java/src/main/groovy/annotation.java.gsp
+++ b/java/src/main/groovy/annotation.java.gsp
@@ -1,12 +1,14 @@
 package io.cucumber.java.api.annotation.${lang};
 
 import io.cucumber.java.StepDefAnnotation;
+import io.cucumber.java.StepDefAnnotations;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.annotation.Documented;
 
 /**
  * To execute steps in a feature file the steps must be
@@ -29,6 +31,7 @@ import java.lang.annotation.Documented;
 @Target(ElementType.METHOD)
 @StepDefAnnotation
 @Documented
+@Repeatable(${kw}.${kw}s.class)
 public @interface ${kw} {
     /**
      * @return a cucumber or regular expression
@@ -40,5 +43,15 @@ public @interface ${kw} {
      */
     long timeout() default 0;
 
+    /**
+     * Allows the use of multiple '${kw}'s on a single method.
+     */
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @StepDefAnnotations
+    @Documented
+    @interface ${kw}s {
+        ${kw}[] value();
+    }
 }
 

--- a/java/src/main/groovy/lambda.java.gsp
+++ b/java/src/main/groovy/lambda.java.gsp
@@ -13,7 +13,7 @@ import io.cucumber.java.api.StepdefBody.A9;
 
 import io.cucumber.java.LambdaGlueRegistry;
 import io.cucumber.java.Java8StepDefinition;
-import io.cucumber.java.LambdaGlueBase;
+import io.cucumber.java.LambdaGlue;
 
 /**
  * ${locale.getDisplayLanguage()}
@@ -34,7 +34,7 @@ import io.cucumber.java.LambdaGlueBase;
  * attempt to transform the data table or doc string to the the
  * type of last argument.
  */
-public interface ${className} extends LambdaGlueBase {
+public interface ${className} extends LambdaGlue {
 <% i18n.stepKeywords.findAll { !it.contains('*') && !it.matches("^\\d.*") }.sort().unique().each { kw -> %>
     /**
      * Creates a new step definition.

--- a/java/src/main/java/io/cucumber/java/Function.java
+++ b/java/src/main/java/io/cucumber/java/Function.java
@@ -1,7 +1,0 @@
-package io.cucumber.java;
-
-public interface Function<T, R> {
-
-    R apply(T t);
-
-}

--- a/java/src/main/java/io/cucumber/java/GlueBase.java
+++ b/java/src/main/java/io/cucumber/java/GlueBase.java
@@ -1,4 +1,0 @@
-package io.cucumber.java;
-
-public interface GlueBase {
-}

--- a/java/src/main/java/io/cucumber/java/JavaBackend.java
+++ b/java/src/main/java/io/cucumber/java/JavaBackend.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 
 import static io.cucumber.core.io.MultiLoader.packageName;
 import static io.cucumber.java.ObjectFactoryLoader.loadObjectFactory;
@@ -41,7 +42,7 @@ public class JavaBackend implements Backend, LambdaGlueRegistry {
 
     private final MethodScanner methodScanner;
     private Glue glue;
-    private List<Class<? extends GlueBase>> glueBaseClasses = new ArrayList<Class<? extends GlueBase>>();
+    private List<Class<? extends LambdaGlue>> lambdaGlueClasses = new ArrayList<>();
 
     /**
      * The constructor called by reflection by default.
@@ -73,14 +74,14 @@ public class JavaBackend implements Backend, LambdaGlueRegistry {
 
         // Scan for Java8 style glue (lambdas)
         for (final String gluePath : gluePaths) {
-            Collection<Class<? extends GlueBase>> glueDefinerClasses = classFinder.getDescendants(GlueBase.class, packageName(gluePath));
-            for (final Class<? extends GlueBase> glueClass : glueDefinerClasses) {
+            Collection<Class<? extends LambdaGlue>> glueDefinerClasses = classFinder.getDescendants(LambdaGlue.class, packageName(gluePath));
+            for (final Class<? extends LambdaGlue> glueClass : glueDefinerClasses) {
                 if (glueClass.isInterface()) {
                     continue;
                 }
 
                 if (objectFactory.addClass(glueClass)) {
-                    glueBaseClasses.add(glueClass);
+                    lambdaGlueClasses.add(glueClass);
                 }
             }
         }
@@ -107,8 +108,8 @@ public class JavaBackend implements Backend, LambdaGlueRegistry {
         // in the constructor.
         try {
             INSTANCE.set(this);
-            for (Class<? extends GlueBase> glueBaseClass : glueBaseClasses) {
-                objectFactory.getInstance(glueBaseClass);
+            for (Class<? extends LambdaGlue> lambdaGlueClass: lambdaGlueClasses) {
+                objectFactory.getInstance(lambdaGlueClass);
             }
         } finally {
             INSTANCE.remove();

--- a/java/src/main/java/io/cucumber/java/JavaBackend.java
+++ b/java/src/main/java/io/cucumber/java/JavaBackend.java
@@ -131,15 +131,14 @@ public class JavaBackend implements Backend, LambdaGlueRegistry {
 
     void addStepDefinition(Annotation annotation, Method method) {
         try {
-            if (objectFactory.addClass(method.getDeclaringClass())) {
-                glue.addStepDefinition(
-                    new JavaStepDefinition(
-                        method,
-                        expression(annotation),
-                        timeoutMillis(annotation),
-                        objectFactory,
-                        typeRegistry));
-            }
+            objectFactory.addClass(method.getDeclaringClass());
+            glue.addStepDefinition(
+                new JavaStepDefinition(
+                    method,
+                    expression(annotation),
+                    timeoutMillis(annotation),
+                    objectFactory,
+                    typeRegistry));
         } catch (CucumberException e) {
             throw e;
         } catch (Throwable e) {

--- a/java/src/main/java/io/cucumber/java/LambdaGlue.java
+++ b/java/src/main/java/io/cucumber/java/LambdaGlue.java
@@ -3,7 +3,7 @@ package io.cucumber.java;
 import io.cucumber.java.api.HookBody;
 import io.cucumber.java.api.HookNoArgsBody;
 
-public interface LambdaGlueBase extends GlueBase {
+public interface LambdaGlue {
 
     String[] EMPTY_TAG_EXPRESSIONS = new String[0];
     long NO_TIMEOUT = 0;

--- a/java/src/main/java/io/cucumber/java/LambdaGlueRegistry.java
+++ b/java/src/main/java/io/cucumber/java/LambdaGlueRegistry.java
@@ -4,8 +4,10 @@ import io.cucumber.core.stepexpression.TypeRegistry;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.StepDefinition;
 
+import java.util.function.Function;
+
 public interface LambdaGlueRegistry {
-    ThreadLocal<LambdaGlueRegistry> INSTANCE = new ThreadLocal<LambdaGlueRegistry>();
+    ThreadLocal<LambdaGlueRegistry> INSTANCE = new ThreadLocal<>();
 
     void addStepDefinition(Function<TypeRegistry, StepDefinition> stepDefinition);
 

--- a/java/src/main/java/io/cucumber/java/StepDefAnnotations.java
+++ b/java/src/main/java/io/cucumber/java/StepDefAnnotations.java
@@ -1,0 +1,11 @@
+package io.cucumber.java;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface StepDefAnnotations {
+}

--- a/java/src/test/java/io/cucumber/java/Java8LambdaStepDefinitionMarksCorrectStackElementTest.java
+++ b/java/src/test/java/io/cucumber/java/Java8LambdaStepDefinitionMarksCorrectStackElementTest.java
@@ -9,6 +9,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.function.Function;
+
 import static java.util.Locale.ENGLISH;
 
 public class Java8LambdaStepDefinitionMarksCorrectStackElementTest {

--- a/java/src/test/java/io/cucumber/java/JavaBackendTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaBackendTest.java
@@ -1,30 +1,48 @@
 package io.cucumber.java;
 
-import io.cucumber.java.api.ObjectFactory;
-import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.backend.Glue;
-import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.StepDefinition;
+import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.io.MultiLoader;
 import io.cucumber.core.io.ResourceLoader;
 import io.cucumber.core.io.ResourceLoaderClassFinder;
-import io.cucumber.java.stepdefs.Stepdefs;
 import io.cucumber.core.stepexpression.TypeRegistry;
+import io.cucumber.java.api.ObjectFactory;
+import io.cucumber.java.stepdefs.Stepdefs;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
+import java.util.List;
 import java.util.Locale;
 
 import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class JavaBackendTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Captor
+    public ArgumentCaptor<StepDefinition> stepDefinition;
+
+    @Mock
+    public Glue glue;
 
     private ObjectFactory factory;
     private JavaBackend backend;
@@ -41,7 +59,6 @@ public class JavaBackendTest {
 
     @Test
     public void finds_step_definitions_by_classpath_url() {
-        GlueStub glue = new GlueStub();
         backend.loadGlue(glue, asList("classpath:cucumber/runtime/java/stepdefs"));
         backend.buildWorld();
         assertEquals(Stepdefs.class, factory.getInstance(Stepdefs.class).getClass());
@@ -49,7 +66,6 @@ public class JavaBackendTest {
 
     @Test
     public void finds_step_definitions_by_package_name() {
-        GlueStub glue = new GlueStub();
         backend.loadGlue(glue, asList("io.cucumber.java.stepdefs"));
         backend.buildWorld();
         assertEquals(Stepdefs.class, factory.getInstance(Stepdefs.class).getClass());
@@ -57,38 +73,21 @@ public class JavaBackendTest {
 
     @Test
     public void detects_subclassed_glue_and_throws_exception() {
-        GlueStub glue = new GlueStub();
         final Executable testMethod = () -> backend.loadGlue(glue, asList("io.cucumber.java.stepdefs", "io.cucumber.java.incorrectlysubclassedstepdefs"));
         final CucumberException expectedThrown = assertThrows(CucumberException.class, testMethod);
         assertThat(expectedThrown.getMessage(), is(equalTo("You're not allowed to extend classes that define Step Definitions or hooks. class io.cucumber.java.incorrectlysubclassedstepdefs.SubclassesStepdefs extends class io.cucumber.java.stepdefs.Stepdefs")));
     }
 
-    private class GlueStub implements Glue {
+    @Test
+    public void detects_repeated_annotations() {
+        backend.loadGlue(glue, asList("io.cucumber.java.repeatable"));
+        verify(glue, times(2)).addStepDefinition(stepDefinition.capture());
 
-        @Override
-        public void addStepDefinition(StepDefinition stepDefinition) {
-            //no-op
-        }
-
-        @Override
-        public void addBeforeStepHook(HookDefinition beforeStepHook) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void addBeforeHook(HookDefinition hookDefinition) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void addAfterStepHook(HookDefinition hookDefinition) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void addAfterHook(HookDefinition hookDefinition) {
-            throw new UnsupportedOperationException();
-        }
+        List<String> patterns = stepDefinition.getAllValues()
+            .stream()
+            .map(StepDefinition::getPattern)
+            .collect(toList());
+        assertThat(patterns, equalTo(asList("test", "test again")));
 
     }
 

--- a/java/src/test/java/io/cucumber/java/lambda/AnonInnerClassStepdefs.java
+++ b/java/src/test/java/io/cucumber/java/lambda/AnonInnerClassStepdefs.java
@@ -3,14 +3,15 @@ package io.cucumber.java.lambda;
 import static org.junit.Assert.assertEquals;
 
 import io.cucumber.core.stepexpression.TypeRegistry;
-import io.cucumber.java.Function;
-import io.cucumber.java.GlueBase;
 import io.cucumber.java.Java8StepDefinition;
 import io.cucumber.java.JavaBackend;
+import io.cucumber.java.LambdaGlue;
 import io.cucumber.java.api.StepdefBody;
 import io.cucumber.core.backend.StepDefinition;
 
-public class AnonInnerClassStepdefs implements GlueBase {
+import java.util.function.Function;
+
+public class AnonInnerClassStepdefs implements LambdaGlue {
 
     public AnonInnerClassStepdefs() {
         JavaBackend.INSTANCE.get().addStepDefinition(new Function<TypeRegistry, StepDefinition>() {

--- a/java/src/test/java/io/cucumber/java/repeatable/Stepdefs.java
+++ b/java/src/test/java/io/cucumber/java/repeatable/Stepdefs.java
@@ -1,0 +1,12 @@
+package io.cucumber.java.repeatable;
+
+import io.cucumber.java.api.annotation.en.Given;
+
+public class Stepdefs {
+
+    @Given("test")
+    @Given("test again")
+    public void test() {
+
+    }
+}


### PR DESCRIPTION
## Summary

Adds the support for repeatable step definition annotations to
the `JavaBackend` e.g.:

```java
    @When("the customer opens his account")
    @When("the account is opened by the customer")
    public void open_account() {

    }
```

Resolves part of #1447.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
