### PR TITLE
[Java8] Apply identity transform when target type is unknown 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
  * [Core] Reduce plugin memory usage ([#1469](https://github.com/cucumber/cucumber-jvm/pull/1469) M.P. Korstanje) 
 
 ### Changed
- * [Core] Use the docstring content type from pickle in the json formatter ([#1265](https://github.com/cucumber/cucumber-jvm/pull/1265) Robert Wittams, M.P. Korstanje) 
+ * [Core] Use the docstring content type from pickle in the json formatter ([#1265](https://github.com/cucumber/cucumber-jvm/pull/1265) Daryl Piffre, M.P. Korstanje) 
 
 ### Deprecated
    
 ### Removed
 
 ### Fixed
+ * [Java8] Apply identity transform when target type is unknown ([#1475](https://github.com/cucumber/cucumber-jvm/pull/1475) Robert Wittams, M.P. Korstanje) 
 
 ## [4.0.0](https://github.com/cucumber/cucumber-jvm/compare/v3.0.2...v4.0.0) (In Git)
 

--- a/core/src/main/java/io/cucumber/stepexpression/StepExpressionFactory.java
+++ b/core/src/main/java/io/cucumber/stepexpression/StepExpressionFactory.java
@@ -68,16 +68,22 @@ public final class StepExpressionFactory {
         RawTableTransformer<?> tableTransform = new RawTableTransformer<Object>() {
             @Override
             public Object transform(List<List<String>> raw) {
-                return DataTable.create(raw, StepExpressionFactory.this.tableConverter)
-                    .convert(tableOrDocStringType.resolve(), transpose);
+                DataTable dataTable = DataTable.create(raw, StepExpressionFactory.this.tableConverter);
+                Type targetType = tableOrDocStringType.resolve();
+                return dataTable.convert(targetType == null ? DataTable.class : targetType, transpose);
             }
         };
 
         DocStringTransformer<?> docStringTransform = new DocStringTransformer<Object>() {
             @Override
             public Object transform(String docString) {
-                return DataTable.create(singletonList(singletonList(docString)), StepExpressionFactory.this.tableConverter)
-                    .convert(tableOrDocStringType.resolve(), transpose);
+                Type targetType = tableOrDocStringType.resolve();
+                if (targetType == null) {
+                    return docString;
+                }
+
+                List<List<String>> raw = singletonList(singletonList(docString));
+                return DataTable.create(raw, StepExpressionFactory.this.tableConverter).convert(targetType, transpose);
             }
         };
         return new StepExpression(expression, docStringTransform, tableTransform);

--- a/core/src/main/java/io/cucumber/stepexpression/TypeResolver.java
+++ b/core/src/main/java/io/cucumber/stepexpression/TypeResolver.java
@@ -8,7 +8,9 @@ import java.lang.reflect.Type;
 public interface TypeResolver {
 
     /**
-     * A type to data convert the table or doc string to. May not return null.
+     * A type to data convert the table or doc string to.
+     *
+     * May return null if no type could be resolved.
      *
      * @return a type
      */

--- a/core/src/test/java/io/cucumber/stepexpression/StepExpressionFactoryTest.java
+++ b/core/src/test/java/io/cucumber/stepexpression/StepExpressionFactoryTest.java
@@ -14,8 +14,17 @@ import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class StepExpressionFactoryTest {
+
+    private static final TypeResolver UNKNOWN_TYPE = new TypeResolver() {
+        @Override
+        public Type resolve() {
+            return null;
+        }
+    };
+
     static class Ingredient {
         String name;
         Integer amount;
@@ -93,6 +102,22 @@ public class StepExpressionFactoryTest {
         Ingredient ingredient = ingredients.get(0);
         assertEquals(ingredient.name, "chocolate");
     }
+
+    @Test
+    public void unknown_target_type_does_no_transform_data_table() {
+        StepExpression expression = new StepExpressionFactory(registry).createExpression("Given some stuff:", UNKNOWN_TYPE);
+        List<Argument> match = expression.match("Given some stuff:", table);
+        assertEquals(DataTable.create(table), match.get(0).getValue());
+    }
+
+    @Test
+    public void unknown_target_type_does_no_transform_doc_string() {
+        String docString = "A rather long and boring string of documentation";
+        StepExpression expression = new StepExpressionFactory(registry).createExpression("Given some stuff:", UNKNOWN_TYPE);
+        List<Argument> match = expression.match("Given some stuff:", docString);
+        assertEquals(docString, match.get(0).getValue());
+    }
+
 
     private Type getTypeFromStepDefinition() {
         for (Method method : this.getClass().getMethods()) {

--- a/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
+++ b/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
@@ -16,6 +16,7 @@ import io.cucumber.stepexpression.StepExpressionFactory;
 import cucumber.runtime.Utils;
 import gherkin.pickles.PickleStep;
 import io.cucumber.stepexpression.TypeResolver;
+import net.jodah.typetools.TypeResolver.Unknown;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -133,7 +134,12 @@ public class Java8StepDefinition implements StepDefinition {
 
         @Override
         public Type resolve() {
-            return requireNonMapOrListType(parameterInfo.getType());
+            Type type = parameterInfo.getType();
+            if (Object.class.equals(type) || Unknown.class.equals(type)) {
+                return null;
+            }
+
+            return requireNonMapOrListType(type);
         }
 
         private Type requireNonMapOrListType(Type argumentType) {

--- a/java8/src/main/java/cucumber/runtime/java8/ParameterInfo.java
+++ b/java8/src/main/java/cucumber/runtime/java8/ParameterInfo.java
@@ -1,6 +1,5 @@
 package cucumber.runtime.java8;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,11 +10,6 @@ class ParameterInfo {
     static List<ParameterInfo> fromTypes(Type[] genericParameterTypes) {
         List<ParameterInfo> result = new ArrayList<>();
         for (Type genericParameterType : genericParameterTypes) {
-            for (Annotation annotation : genericParameterType.getClass().getAnnotations()) {
-                System.out.println(annotation.toString());
-            }
-
-
             result.add(new ParameterInfo(genericParameterType));
         }
         return result;

--- a/java8/src/test/java/cucumber/runtime/java8/Java8LambdaStepDefinitionTest.java
+++ b/java8/src/test/java/cucumber/runtime/java8/Java8LambdaStepDefinitionTest.java
@@ -1,12 +1,25 @@
 package cucumber.runtime.java8;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
+import gherkin.ast.TableCell;
+import gherkin.ast.TableRow;
+import gherkin.pickles.PickleCell;
+import gherkin.pickles.PickleRow;
+import gherkin.pickles.PickleStep;
+import gherkin.pickles.PickleString;
+import gherkin.pickles.PickleTable;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.stepexpression.Argument;
 import io.cucumber.stepexpression.TypeRegistry;
 import cucumber.api.java8.StepdefBody;
 import cucumber.runtime.CucumberException;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -29,6 +42,27 @@ public class Java8LambdaStepDefinitionTest {
         Java8StepDefinition def = Java8StepDefinition.create("I have some step", StepdefBody.A2.class, body, typeRegistry);
         assertEquals(Integer.valueOf(2), def.getParameterCount());
     }
+
+    @Test
+    public void should_apply_identity_transform_to_doc_string_when_target_type_is_object() {
+        StepdefBody.A1 body = (p1) -> {
+        };
+        Java8StepDefinition def = Java8StepDefinition.create("I have some step", StepdefBody.A1.class, body, typeRegistry);
+        PickleString pickleString = new PickleString(null, "content", "text");
+        List<Argument> arguments = def.matchedArguments(new PickleStep("I have some step", singletonList(pickleString), emptyList()));
+        assertEquals("content", arguments.get(0).getValue());
+    }
+
+    @Test
+    public void should_apply_identity_transform_to_data_table_when_target_type_is_object() {
+        StepdefBody.A1 body = (p1) -> {
+        };
+        Java8StepDefinition def = Java8StepDefinition.create("I have some step", StepdefBody.A1.class, body, typeRegistry);
+        PickleTable table = new PickleTable(singletonList(new PickleRow(singletonList(new PickleCell(null, "content")))));
+        List<Argument> arguments = def.matchedArguments(new PickleStep("I have some step", singletonList(table), emptyList()));
+        assertEquals(DataTable.create(singletonList(singletonList("content"))), arguments.get(0).getValue());
+    }
+
 
     @Test
     public void should_fail_for_param_with_non_generic_list() {


### PR DESCRIPTION
## Summary

Apply identity transform when target type is unknown 

## Motivation and Context 

When using groovy in combination with `cucumber-java8` there is no type information available at all because:

```groovy
public class Stepdefs implements En {
	Stepdefs() {
		Given(/^this docstring:$/, { String s ->
			println s
		} as A1)
	}
}
```

is compiled into:

```java
public class Stepdefs implements En, GroovyObject {
    public Stepdefs() {
        CallSite[] var1 = $getCallSiteArray();
        super();
        MetaClass var2 = this.$getStaticMetaClass();
        this.metaClass = var2;
        var1[0].callCurrent(this, "^this docstring:$", ScriptBytecodeAdapter.createPojoWrapper((A1)ScriptBytecodeAdapter.asType(new Stepdefs._closure1(this, this), A1.class), A1.class));
    }

    public final class _closure1 extends Closure implements GeneratedClosure {
        public _closure1(Object _outerInstance, Object _thisObject) {
            CallSite[] var3 = $getCallSiteArray();
            super(_outerInstance, _thisObject);
        }

        public Object doCall(String s) {
            CallSite[] var2 = $getCallSiteArray();
            return var2[0].callCurrent(this, s);
        }

        public Object call(String s) {
            CallSite[] var2 = $getCallSiteArray();
            return !__$stMC && !BytecodeInterface8.disabledStandardMetaClass() ? this.doCall(s) : var2[1].callCurrent(this, s);
        }
    }
}

```
The `ScriptBytecodeAdapter.asType` forces a conversion of Closure to `A1`. Because `cucumber-java8` applies constant pool inspection to determine `T1` of the generic types of `A1<T1>` this yields an unknown result. There are no generic types to begin with.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
