### PR TITLE
[Core] Apply identity transform to Argument when type is Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 ### Removed
 
 ### Fixed
+ * [Java8] Apply identity transform to argument when target type is object ([#1477](https://github.com/cucumber/cucumber-jvm/pull/1477) M.P. Korstanje) 
 
 ## [4.0.1-SNAPSHOT](https://github.com/cucumber/cucumber-jvm/compare/v4.0.1...v4.0.2) 
 

--- a/core/src/main/java/io/cucumber/stepexpression/StepExpressionFactory.java
+++ b/core/src/main/java/io/cucumber/stepexpression/StepExpressionFactory.java
@@ -70,7 +70,7 @@ public final class StepExpressionFactory {
             public Object transform(List<List<String>> raw) {
                 DataTable dataTable = DataTable.create(raw, StepExpressionFactory.this.tableConverter);
                 Type targetType = tableOrDocStringType.resolve();
-                return dataTable.convert(targetType == null ? DataTable.class : targetType, transpose);
+                return dataTable.convert(Object.class.equals(targetType) ? DataTable.class : targetType, transpose);
             }
         };
 
@@ -78,7 +78,7 @@ public final class StepExpressionFactory {
             @Override
             public Object transform(String docString) {
                 Type targetType = tableOrDocStringType.resolve();
-                if (targetType == null) {
+                if (Object.class.equals(targetType)) {
                     return docString;
                 }
 

--- a/core/src/main/java/io/cucumber/stepexpression/TypeResolver.java
+++ b/core/src/main/java/io/cucumber/stepexpression/TypeResolver.java
@@ -8,9 +8,9 @@ import java.lang.reflect.Type;
 public interface TypeResolver {
 
     /**
-     * A type to data convert the table or doc string to.
-     *
-     * May return null if no type could be resolved.
+     * A type to data convert the table or doc string to. May not return null.
+     * <p>
+     * When the {@link Object} type is returned no transform will be applied.
      *
      * @return a type
      */

--- a/core/src/test/java/io/cucumber/stepexpression/StepExpressionFactoryTest.java
+++ b/core/src/test/java/io/cucumber/stepexpression/StepExpressionFactoryTest.java
@@ -21,7 +21,7 @@ public class StepExpressionFactoryTest {
     private static final TypeResolver UNKNOWN_TYPE = new TypeResolver() {
         @Override
         public Type resolve() {
-            return null;
+            return Object.class;
         }
     };
 

--- a/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
+++ b/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
@@ -135,8 +135,8 @@ public class Java8StepDefinition implements StepDefinition {
         @Override
         public Type resolve() {
             Type type = parameterInfo.getType();
-            if (Object.class.equals(type) || Unknown.class.equals(type)) {
-                return null;
+            if (Unknown.class.equals(type)) {
+                return Object.class;
             }
 
             return requireNonMapOrListType(type);


### PR DESCRIPTION
## Summary

```java
@Given("a doc string:")
public void given_a_doc_string(Object docString){

}

@Given("a data table:")
public void given_a_data_table(Object table){

}
```

Results in an error telling us that Cucumber doesn't know how to transform an instance of `String` or `Datatable` to `Object`. This is a bit silly. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
