### PR TITLE
[Core] Use Locale.ROOT when transforming case of identifiers

### DIFF
--- a/core/src/main/java/cucumber/api/HookType.java
+++ b/core/src/main/java/cucumber/api/HookType.java
@@ -1,10 +1,12 @@
 package cucumber.api;
 
+import static java.util.Locale.ROOT;
+
 public enum HookType {
     Before, After, BeforeStep, AfterStep;
 
     @Override
     public String toString() {
-        return super.toString().toLowerCase();
+        return super.toString().toLowerCase(ROOT);
     }
 }

--- a/core/src/main/java/cucumber/api/Result.java
+++ b/core/src/main/java/cucumber/api/Result.java
@@ -5,6 +5,7 @@ import java.io.StringWriter;
 import java.util.Comparator;
 import java.util.Objects;
 
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 public final class Result {
@@ -30,15 +31,15 @@ public final class Result {
         FAILED;
 
         public static Type fromLowerCaseName(String lowerCaseName) {
-            return valueOf(lowerCaseName.toUpperCase());
+            return valueOf(lowerCaseName.toUpperCase(ROOT));
         }
 
         public String lowerCaseName() {
-            return name().toLowerCase();
+            return name().toLowerCase(ROOT);
         }
 
         public String firstLetterCapitalizedName() {
-            return name().substring(0, 1) + name().substring(1).toLowerCase();
+            return name().substring(0, 1) + name().substring(1).toLowerCase(ROOT);
         }
 
 

--- a/core/src/main/java/cucumber/runtime/Env.java
+++ b/core/src/main/java/cucumber/runtime/Env.java
@@ -6,6 +6,8 @@ import java.util.MissingResourceException;
 import java.util.Properties;
 import java.util.ResourceBundle;
 
+import static java.util.Locale.ROOT;
+
 /**
  * Looks up values in the following order:
  * <ol>
@@ -56,8 +58,8 @@ public class Env {
     private void put(String key, String string) {
         map.put(key, string);
         // Support old skool
-        map.put(key.replace('.', '_').toUpperCase(), string);
-        map.put(key.replace('_', '.').toLowerCase(), string);
+        map.put(key.replace('.', '_').toUpperCase(ROOT), string);
+        map.put(key.replace('_', '.').toLowerCase(ROOT), string);
     }
 
     public String get(String key) {

--- a/core/src/main/java/cucumber/util/Encoding.java
+++ b/core/src/main/java/cucumber/util/Encoding.java
@@ -7,6 +7,8 @@ import java.io.InputStreamReader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.Locale.ROOT;
+
 /**
  * Utilities for reading the encoding of a file.
  */
@@ -36,6 +38,6 @@ public class Encoding {
                 break;
             }
         }
-        return encoding.toUpperCase();
+        return encoding.toUpperCase(ROOT);
     }
 }

--- a/junit/src/main/java/cucumber/runtime/junit/NotificationLevel.java
+++ b/junit/src/main/java/cucumber/runtime/junit/NotificationLevel.java
@@ -1,10 +1,12 @@
 package cucumber.runtime.junit;
 
+import static java.util.Locale.ROOT;
+
 public enum NotificationLevel {
     SCENARIO,
     STEP;
 
     String lowerCaseName() {
-        return name().toLowerCase();
+        return name().toLowerCase(ROOT);
     }
 }


### PR DESCRIPTION
## Summary

Several plugins use lowercased string representations of enum
values. Doing this without an explicit locale results in the
default locale being used. This may lead to surprising errors.

Fixes: https://github.com/cucumber/cucumber-java-skeleton/issues/33
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).