### PR TITLE
[Guice] Replace CucumberModules.SCENARIO with threadsafe factory method

### DIFF
--- a/guice/src/main/java/cucumber/api/guice/CucumberModules.java
+++ b/guice/src/main/java/cucumber/api/guice/CucumberModules.java
@@ -1,6 +1,7 @@
 package cucumber.api.guice;
 
 import com.google.inject.Module;
+import cucumber.runtime.java.guice.ScenarioScope;
 import cucumber.runtime.java.guice.impl.ScenarioModule;
 
 /**
@@ -9,5 +10,17 @@ import cucumber.runtime.java.guice.impl.ScenarioModule;
  * <code>cucumber.runtime.java.guice.ScenarioScope</code>.
  */
 public class CucumberModules {
+    /**
+     * @deprecated please use {@link #createScenarioModule()} instead
+     */
+    @Deprecated
     public static final Module SCENARIO = new ScenarioModule(CucumberScopes.SCENARIO);
+
+    public static Module createScenarioModule() {
+        return new ScenarioModule(CucumberScopes.createScenario());
+    }
+
+    public static Module createScenarioModule(ScenarioScope scenarioScope) {
+        return new ScenarioModule(scenarioScope);
+    }
 }

--- a/guice/src/main/java/cucumber/api/guice/CucumberScopes.java
+++ b/guice/src/main/java/cucumber/api/guice/CucumberScopes.java
@@ -8,5 +8,13 @@ import cucumber.runtime.java.guice.impl.SequentialScenarioScope;
  * in implementations of <code>com.google.inject.Module</code>.
  */
 public class CucumberScopes {
+    /**
+     * @deprecated please use {@link #createScenario()} instead
+     */
     public static final ScenarioScope SCENARIO = new SequentialScenarioScope();
+
+    public static ScenarioScope createScenario() {
+        return new SequentialScenarioScope();
+    }
+
 }

--- a/guice/src/main/java/cucumber/api/guice/package.html
+++ b/guice/src/main/java/cucumber/api/guice/package.html
@@ -121,7 +121,7 @@
     Guice injector and it's Guice modules. The injector must provide a binding for
     <code>cucumber.runtime.java.guice.ScenarioScope</code>. It should also provide a binding for the
     <code>cucumber.runtime.java.guice.ScenarioScoped</code> annotation if your classes are using the annotation. The
-    easiest way to do this it to use <code>CucumberModules.SCENARIO</code>. For example:
+    easiest way to do this it to use <code>CucumberModules.createScenarioModule()</code>. For example:
 </p>
     <pre>
         import com.google.inject.Guice;
@@ -134,7 +134,7 @@
 
             {@literal @}Override
             public Injector getInjector() {
-                return Guice.createInjector(Stage.PRODUCTION, CucumberModules.SCENARIO, new YourModule());
+                return Guice.createInjector(Stage.PRODUCTION, CucumberModules.createScenarioModule(), new YourModule());
             }
         }
     </pre>

--- a/guice/src/test/java/cucumber/runtime/java/guice/impl/GuiceFactoryTest.java
+++ b/guice/src/test/java/cucumber/runtime/java/guice/impl/GuiceFactoryTest.java
@@ -8,7 +8,6 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import com.google.inject.Stage;
 import cucumber.api.guice.CucumberModules;
-import cucumber.api.guice.CucumberScopes;
 import cucumber.api.java.ObjectFactory;
 import cucumber.runtime.java.guice.ScenarioScoped;
 import org.junit.After;
@@ -65,14 +64,14 @@ public class GuiceFactoryTest {
 
     @Test
     public void shouldGiveNewInstancesOfUnscopedClassWithinAScenario() {
-        factory = new GuiceFactory(injector(CucumberModules.SCENARIO));
+        factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromSameScenario = getInstancesFromSameScenario(factory, UnscopedClass.class);
         assertThat(instancesFromSameScenario, elementsAreAllUnique());
     }
 
     @Test
     public void shouldGiveNewInstanceOfUnscopedClassForEachScenario() {
-        factory = new GuiceFactory(injector(CucumberModules.SCENARIO));
+        factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory, UnscopedClass.class);
         assertThat(instancesFromDifferentScenarios, elementsAreAllUnique());
     }
@@ -81,14 +80,14 @@ public class GuiceFactoryTest {
 
     @Test
     public void shouldGiveTheSameInstanceOfAnnotatedScenarioScopedClassWithinAScenario() {
-        factory = new GuiceFactory(injector(CucumberModules.SCENARIO));
+        factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromSameScenario = getInstancesFromSameScenario(factory, AnnotatedScenarioScopedClass.class);
         assertThat(instancesFromSameScenario, elementsAreAllEqual());
     }
 
     @Test
     public void shouldGiveNewInstanceOfAnnotatedScenarioScopedClassForEachScenario() {
-        factory = new GuiceFactory(injector(CucumberModules.SCENARIO));
+        factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory, AnnotatedScenarioScopedClass.class);
         assertThat(instancesFromDifferentScenarios, elementsAreAllUnique());
     }
@@ -97,14 +96,14 @@ public class GuiceFactoryTest {
 
     @Test
     public void shouldGiveTheSameInstanceOfAnnotatedSingletonClassWithinAScenario() {
-        factory = new GuiceFactory(injector(CucumberModules.SCENARIO));
+        factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromSameScenario = getInstancesFromSameScenario(factory, AnnotatedSingletonClass.class);
         assertThat(instancesFromSameScenario, elementsAreAllEqual());
     }
 
     @Test
     public void shouldGiveTheSameInstanceOfAnnotatedSingletonClassForEachScenario() {
-        factory = new GuiceFactory(injector(CucumberModules.SCENARIO));
+        factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory, AnnotatedSingletonClass.class);
         assertThat(instancesFromDifferentScenarios, elementsAreAllEqual());
     }
@@ -113,13 +112,13 @@ public class GuiceFactoryTest {
 
     final AbstractModule boundScenarioScopedClassModule = new AbstractModule() {
         @Override protected void configure() {
-            bind(BoundScenarioScopedClass.class).in(CucumberScopes.SCENARIO);
+            bind(BoundScenarioScopedClass.class).in(ScenarioScoped.class);
         }
     };
 
     @Test
     public void shouldGiveTheSameInstanceOfBoundScenarioScopedClassWithinAScenario() {
-        factory = new GuiceFactory(injector(CucumberModules.SCENARIO, boundScenarioScopedClassModule));
+        factory = new GuiceFactory(injector(CucumberModules.createScenarioModule(), boundScenarioScopedClassModule));
         instancesFromSameScenario = getInstancesFromSameScenario(factory, BoundScenarioScopedClass.class);
         assertThat(instancesFromSameScenario, elementsAreAllEqual());
     }
@@ -148,17 +147,17 @@ public class GuiceFactoryTest {
 
     @Test
     public void shouldGiveTheSameInstanceOfBoundSingletonClassForEachScenario() {
-        factory = new GuiceFactory(injector(CucumberModules.SCENARIO, boundSingletonClassModule));
+        factory = new GuiceFactory(injector(CucumberModules.createScenarioModule(), boundSingletonClassModule));
         instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory, BoundSingletonClass.class);
         assertThat(instancesFromDifferentScenarios, elementsAreAllEqual());
     }
 
     @Test
     public void shouldGiveNewInstanceOfAnnotatedSingletonClassForEachScenarioWhenOverridingModuleBindingIsScenarioScope() {
-        factory = new GuiceFactory(injector(CucumberModules.SCENARIO, new AbstractModule() {
+        factory = new GuiceFactory(injector(CucumberModules.createScenarioModule(), new AbstractModule() {
             @Override
             protected void configure() {
-                bind(AnnotatedSingletonClass.class).in(CucumberScopes.SCENARIO);
+                bind(AnnotatedSingletonClass.class).in(ScenarioScoped.class);
             }
         }));
         instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory, AnnotatedSingletonClass.class);

--- a/guice/src/test/java/cucumber/runtime/java/guice/integration/YourInjectorSource.java
+++ b/guice/src/test/java/cucumber/runtime/java/guice/integration/YourInjectorSource.java
@@ -4,12 +4,14 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Stage;
 import cucumber.api.guice.CucumberModules;
+import cucumber.api.guice.CucumberScopes;
 import cucumber.runtime.java.guice.InjectorSource;
+import cucumber.runtime.java.guice.ScenarioScope;
 
 public class YourInjectorSource implements InjectorSource {
 
     @Override
     public Injector getInjector() {
-        return Guice.createInjector(Stage.PRODUCTION, CucumberModules.SCENARIO, new YourModule());
+        return Guice.createInjector(Stage.PRODUCTION, CucumberModules.createScenarioModule(), new YourModule());
     }
 }

--- a/guice/src/test/java/cucumber/runtime/java/guice/integration/YourModule.java
+++ b/guice/src/test/java/cucumber/runtime/java/guice/integration/YourModule.java
@@ -3,13 +3,14 @@ package cucumber.runtime.java.guice.integration;
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import cucumber.api.guice.CucumberScopes;
+import cucumber.runtime.java.guice.ScenarioScoped;
 
 public class YourModule extends AbstractModule {
 
     @Override
     protected void configure() {
         // UnScopedObject is implicitly bound without scope
-        bind(ScenarioScopedObject.class).in(CucumberScopes.SCENARIO);
+        bind(ScenarioScopedObject.class).in(ScenarioScoped.class);
         bind(SingletonObject.class).in(Scopes.SINGLETON);
     }
 }


### PR DESCRIPTION
## Summary

Updating SequentialScenarioScope to use a threadlocal. This is to prevent issues when running cucumber in parallel mode.

Fixes: https://github.com/cucumber/cucumber-jvm/issues/1485


## Details
Have updated SequentialScenarioScope.class to use ThreadLocal to prevent it from thinking a scoping block is already in progress when running test from surefire with the parallel settings enabled.


## Motivation and Context
This was preventing us from running our test suites with the new parallel running functionality of Cucumber4

## How Has This Been Tested?
Have tested this by using the new scope within our project.
I have also added tests which can be used to reproduce the exception and also prove the change.

Not sure if this is the best solution or has other implications, hoping somebody here can review and let me know if there is a better way.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
