### PR TITLE
correct method RuntimeOptionsFactory.addDefaultFeaturePathIfNoFeature…

### DIFF
--- a/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptionsFactory.java
@@ -10,6 +10,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 
 public class RuntimeOptionsFactory {
+    private static final String FEATURE_SUFFIX = "feature";
     private final Class clazz;
     private boolean featuresSpecified = false;
     private boolean overridingGlueSpecified = false;
@@ -78,8 +79,7 @@ public class RuntimeOptionsFactory {
     }
 
     private void addPlugins(CucumberOptions options, List<String> args) {
-        List<String> plugins = new ArrayList<>();
-        plugins.addAll(asList(options.plugin()));
+        List<String> plugins = new ArrayList<>(asList(options.plugin()));
         for (String plugin : plugins) {
             args.add("--plugin");
             args.add(plugin);
@@ -95,8 +95,18 @@ public class RuntimeOptionsFactory {
 
     private void addDefaultFeaturePathIfNoFeaturePathIsSpecified(List<String> args, Class clazz) {
         if (!featuresSpecified) {
-            args.add(MultiLoader.CLASSPATH_SCHEME + packagePath(clazz));
+            final String path = MultiLoader.CLASSPATH_SCHEME + packagePath(clazz);
+            if (containsFeatures(path)) {
+                args.add(path);
+            } else {
+                args.add("src/test/resources/features/");
+            }
         }
+    }
+
+    private boolean containsFeatures(String path) {
+        MultiLoader loader = new MultiLoader(this.getClass().getClassLoader());
+        return loader.resources(path, FEATURE_SUFFIX).iterator().hasNext();
     }
 
     private void addGlue(CucumberOptions options, List<String> args) {

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsFactoryTest.java
@@ -188,6 +188,24 @@ public class RuntimeOptionsFactoryTest {
         runtimeOptionsFactory.create();
     }
 
+    @Test
+    public void with_defined_features_path() {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(ClassWithFeatures.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+        assertFalse(runtimeOptions.getFeaturePaths().isEmpty());
+        assertEquals(runtimeOptions.getFeaturePaths().size(),1);
+        assertEquals(runtimeOptions.getFeaturePaths().get(0),"/path/to/features/");
+    }
+
+    @Test
+    public void without_defined_features_path() {
+        RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(String.class);
+        RuntimeOptions runtimeOptions = runtimeOptionsFactory.create();
+        assertFalse(runtimeOptions.getFeaturePaths().isEmpty());
+        assertEquals(runtimeOptions.getFeaturePaths().size(),1);
+        assertEquals(runtimeOptions.getFeaturePaths().get(0),"src/test/resources/features/");
+    }
+
 
     @CucumberOptions(snippets = SnippetType.CAMELCASE)
     private static class Snippets {
@@ -279,6 +297,16 @@ public class RuntimeOptionsFactoryTest {
     @CucumberOptions(extraGlue = {"app.features.hooks"}, glue = {"app.features.user.registration"})
     private static class ClassWithGlueAndExtraGlue {
         // empty
+    }
+
+    @CucumberOptions(features = "/path/to/features/")
+    private static class ClassWithFeatures {
+        //empty
+    }
+
+    @CucumberOptions
+    private static class ClassWithOutFeatures {
+        //empty
     }
 
 }

--- a/testng/src/test/java/cucumber/api/testng/AbstractTestNGCucumberTestsTest.java
+++ b/testng/src/test/java/cucumber/api/testng/AbstractTestNGCucumberTestsTest.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import cucumber.runtime.testng.RunFeatureWithThreeScenariosTest;
 import org.testng.Assert;
+import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -18,14 +19,14 @@ public final class AbstractTestNGCucumberTestsTest {
 
     @BeforeClass(alwaysRun = true)
     public void setUp() {
-        InvokedMethodListener icml = new InvokedMethodListener();
+        ITestNGListener testNGListener = new InvokedMethodListener();
         TestNG testNG = new TestNG();
-        testNG.addListener(icml);
+        testNG.addListener(testNGListener);
         testNG.setGroups("cucumber");
         testNG.setTestClasses(new Class[]{RunFeatureWithThreeScenariosTest.class});
         testNG.run();
-        invokedConfigurationMethodNames = icml.getInvokedConfigurationMethodNames();
-        invokedTestMethodNames = icml.getInvokedTestMethodNames();
+        invokedConfigurationMethodNames = ((InvokedMethodListener) testNGListener).getInvokedConfigurationMethodNames();
+        invokedTestMethodNames = ((InvokedMethodListener) testNGListener).getInvokedTestMethodNames();
     }
     
     @Test

--- a/weld/src/test/java/cucumber/runtime/java/weld/WeldFactoryTest.java
+++ b/weld/src/test/java/cucumber/runtime/java/weld/WeldFactoryTest.java
@@ -91,8 +91,9 @@ public class WeldFactoryTest {
             "If you have set enabled=false in org.jboss.weld.executor.properties and you are seeing\n" +
             "this message, it means your weld container didn't shut down properly. It's a Weld bug\n" +
             "and we can't do much to fix it in Cucumber-JVM.\n" +
-            "\n" +
-            "java.lang.NullPointerException\n" +
+            System.lineSeparator() +
+            "java.lang.NullPointerException" +
+            System.lineSeparator()+
             "\tat cucumber.runtime.java.weld.WeldFactory.stop";
 
         assertThat(this.errContent.toString(), is(startsWith(expectedErrOutput)));


### PR DESCRIPTION
…PathIsSpecified - if not defined feature path set package path or absolute src/test/resources/features/ if feature files not found

correct AbstractTestNGCucumberTestsTest.setUp method - replace deprecated use method testNG.addListener
correct test WeldFactoryTest.stopCalledWithoutStart - replaced line wrapping with the default in the OS

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
issue #1507
<!--- Provide a general summary description of your changes -->
Make the directory src/test/resources/features/ the fallback default location for cucumber-jvm to search for feature files in case the current default location has no feature files.
## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
