### PR TITLE
[Core] Cache all matched step defintions 

### DIFF
--- a/core/src/main/java/cucumber/runner/Glue.java
+++ b/core/src/main/java/cucumber/runner/Glue.java
@@ -81,9 +81,7 @@ final class Glue implements cucumber.runtime.Glue {
             // the step text. As such the step definition arguments can not be cached and
             // must be recreated each time.
             List<Argument> arguments = stepDefinition.matchedArguments(step);
-            if(arguments != null){
-                return new PickleStepDefinitionMatch(arguments, stepDefinition, featurePath, step);
-            }
+            return new PickleStepDefinitionMatch(arguments, stepDefinition, featurePath, step);
         }
 
         List<PickleStepDefinitionMatch> matches = stepDefinitionMatches(featurePath, step);

--- a/core/src/main/java/cucumber/runtime/MethodFormat.java
+++ b/core/src/main/java/cucumber/runtime/MethodFormat.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
 public class MethodFormat {
     private static final Pattern METHOD_PATTERN = Pattern.compile("((?:static\\s|public\\s)+)([^\\s]*)\\s\\.?(.*)\\.([^\\(]*)\\(([^\\)]*)\\)(?: throws )?(.*)");
     private static final String PACKAGE_PATTERN = "[^,]*\\.";
+    private static final Pattern COMPILED_PACKAGE_PATTERN = Pattern.compile(PACKAGE_PATTERN);
     private final MessageFormat format;
 
     public static final MethodFormat SHORT = new MethodFormat("%c.%m(%a)");
@@ -58,9 +59,9 @@ public class MethodFormat {
             String m = matcher.group(4);
             String qa = matcher.group(5);
             String qe = matcher.group(6);
-            String c = qc.replaceAll(PACKAGE_PATTERN, "");
-            String a = qa.replaceAll(PACKAGE_PATTERN, "");
-            String e = qe.replaceAll(PACKAGE_PATTERN, "");
+            String c = removePackage(qc);
+            String a = removePackage(qa);
+            String e = removePackage(qe);
             String s = getCodeSource(method);
 
             return format.format(new Object[]{
@@ -78,6 +79,10 @@ public class MethodFormat {
         } else {
             throw new CucumberException("Cucumber bug: Couldn't format " + signature);
         }
+    }
+
+    private static String removePackage(String qc) {
+        return COMPILED_PACKAGE_PATTERN.matcher(qc).replaceAll("");
     }
 
     private String getCodeSource(Method method) {

--- a/core/src/main/java/cucumber/runtime/MethodFormat.java
+++ b/core/src/main/java/cucumber/runtime/MethodFormat.java
@@ -11,8 +11,7 @@ import java.util.regex.Pattern;
  */
 public class MethodFormat {
     private static final Pattern METHOD_PATTERN = Pattern.compile("((?:static\\s|public\\s)+)([^\\s]*)\\s\\.?(.*)\\.([^\\(]*)\\(([^\\)]*)\\)(?: throws )?(.*)");
-    private static final String PACKAGE_PATTERN = "[^,]*\\.";
-    private static final Pattern COMPILED_PACKAGE_PATTERN = Pattern.compile(PACKAGE_PATTERN);
+    private static final Pattern PACKAGE_PATTERN = Pattern.compile("[^,]*\\.");
     private final MessageFormat format;
 
     public static final MethodFormat SHORT = new MethodFormat("%c.%m(%a)");
@@ -82,7 +81,7 @@ public class MethodFormat {
     }
 
     private static String removePackage(String qc) {
-        return COMPILED_PACKAGE_PATTERN.matcher(qc).replaceAll("");
+        return PACKAGE_PATTERN.matcher(qc).replaceAll("");
     }
 
     private String getCodeSource(Method method) {

--- a/core/src/test/java/cucumber/runner/GlueTest.java
+++ b/core/src/test/java/cucumber/runner/GlueTest.java
@@ -99,11 +99,11 @@ public class GlueTest {
         PickleStep pickleStep1 = getPickleStep(stepText);
         assertEquals(sd, glue.stepDefinitionMatch(featurePath, pickleStep1).getStepDefinition());
 
-        assertEquals(1, glue.matchedStepDefinitionsCache.size());
+        assertEquals(1, glue.stepDefinitionsByStepText.size());
 
         glue.removeScenarioScopedGlue();
 
-        assertEquals(0, glue.matchedStepDefinitionsCache.size());
+        assertEquals(0, glue.stepDefinitionsByStepText.size());
     }
 
     @Test
@@ -133,7 +133,7 @@ public class GlueTest {
         verify(stepDefinition2).matchedArguments(pickleStep1);
 
         //check cache
-        StepDefinition entry = glue.matchedStepDefinitionsCache.get(stepText);
+        StepDefinition entry = glue.stepDefinitionsByStepText.get(stepText);
         assertEquals(stepDefinition1,entry);
 
         PickleStep pickleStep2 = getPickleStep(stepText);

--- a/core/src/test/java/cucumber/runner/GlueTest.java
+++ b/core/src/test/java/cucumber/runner/GlueTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -132,13 +133,13 @@ public class GlueTest {
         verify(stepDefinition2).matchedArguments(pickleStep1);
 
         //check cache
-        Glue.CacheEntry entry = glue.matchedStepDefinitionsCache.get(stepText);
-        assertEquals(stepDefinition1,entry.stepDefinition);
+        StepDefinition entry = glue.matchedStepDefinitionsCache.get(stepText);
+        assertEquals(stepDefinition1,entry);
 
         PickleStep pickleStep2 = getPickleStep(stepText);
         assertEquals(stepDefinition1, glue.stepDefinitionMatch(featurePath, pickleStep2).getStepDefinition());
-        //verify that match wasn't called again
-        verify(stepDefinition1).matchedArguments(any(PickleStep.class));
+        //verify that only cached step definition has called matchedArguments again
+        verify(stepDefinition1,times(2)).matchedArguments(any(PickleStep.class));
         verify(stepDefinition2).matchedArguments(any(PickleStep.class));
 
     }

--- a/java/src/main/java/cucumber/runtime/java/JavaStepDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaStepDefinition.java
@@ -36,11 +36,11 @@ class JavaStepDefinition implements StepDefinition {
         this.timeoutMillis = timeoutMillis;
         this.objectFactory = objectFactory;
         List<ParameterInfo> parameterInfos = ParameterInfo.fromMethod(method);
-        parameterTypes = getTypes(parameterInfos);
+        this.parameterTypes = getTypes(parameterInfos);
         this.expression = createExpression(parameterInfos, expression, typeRegistry);
-        argumentMatcher = new ExpressionArgumentMatcher(this.expression);
-        shortFormat = MethodFormat.SHORT.format(method);
-        fullFormat = MethodFormat.FULL.format(method);
+        this.argumentMatcher = new ExpressionArgumentMatcher(this.expression);
+        this.shortFormat = MethodFormat.SHORT.format(method);
+        this.fullFormat = MethodFormat.FULL.format(method);
     }
 
     private StepExpression createExpression(List<ParameterInfo> parameterInfos, String expression, TypeRegistry typeRegistry) {


### PR DESCRIPTION
## Summary

Performance improvements in step definitions searching

## Details

- Allow caching of step definitions with arguments. It was previously disabled because of DocString and Table arguments. I've change it in such way to always create new arguments list from PickleStep but do not search for definition if step text is the same
- create some objects once in `JavaStepDefinition`

## Motivation and Context

Improve performance of most often executed operations - `Glue.stepDefinitionMatches` is executed `step_definitions_count * average_steps_count_per_scenario * scenarios_count`

## How Has This Been Tested?
Tested on my Android project with 800 scenarios

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
