### PR TITLE
[Build] Fix windows build

### DIFF
--- a/core/src/test/java/cucumber/runner/TestHelper.java
+++ b/core/src/test/java/cucumber/runner/TestHelper.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -421,7 +422,7 @@ public class TestHelper {
 
             @Override
             public InputStream getInputStream() {
-                return new ByteArrayInputStream(source.getBytes());
+                return new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8));
             }
 
         });

--- a/junit/src/test/java/cucumber/runtime/junit/PickleRunnerWithNoStepDescriptionsTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/PickleRunnerWithNoStepDescriptionsTest.java
@@ -48,6 +48,24 @@ public class PickleRunnerWithNoStepDescriptionsTest {
         assertEquals("scenario_name(feature_name)", runner.getDescription().getDisplayName());
     }
 
+    @Test
+    public void shouldConvertTextFromFeatureFileWithRussianLanguage() throws Exception {
+        List<PickleEvent> pickles = TestPickleBuilder.pickleEventsFromFeature("featurePath", "" +
+            "#language:ru\n" +
+            "Функция: имя функции\n" +
+            "  Сценарий: имя сценария\n" +
+            "    Тогда он работает\n");
+
+        PickleRunner runner = PickleRunners.withNoStepDescriptions(
+            "имя функции",
+            mock(ThreadLocalRunnerSupplier.class),
+            pickles.get(0),
+            createJUnitOptions("--filename-compatible-names")
+        );
+
+        assertEquals("____________(___________)", runner.getDescription().getDisplayName());
+    }
+
     private JUnitOptions createJUnitOptions() {
         return new JUnitOptions(true, Collections.<String>emptyList());
     }

--- a/junit/src/test/java/cucumber/runtime/junit/TestPickleBuilder.java
+++ b/junit/src/test/java/cucumber/runtime/junit/TestPickleBuilder.java
@@ -10,6 +10,7 @@ import gherkin.pickles.Pickle;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,7 +44,7 @@ class TestPickleBuilder {
 
             @Override
             public InputStream getInputStream() {
-                return new ByteArrayInputStream(source.getBytes());
+                return new ByteArrayInputStream(source.getBytes(StandardCharsets.UTF_8));
             }
 
         });

--- a/weld/src/main/java/cucumber/runtime/java/weld/WeldFactory.java
+++ b/weld/src/main/java/cucumber/runtime/java/weld/WeldFactory.java
@@ -8,23 +8,35 @@ import org.jboss.weld.environment.se.WeldContainer;
 public class WeldFactory
         implements ObjectFactory {
 
+    protected static final String LINE_SEPARATOR = System.lineSeparator();
+
     protected static final String START_EXCEPTION_MESSAGE = "" +
-        "\n" +
-        "It looks like you're running on a single-core machine, and Weld doesn't like that. See:\n" +
-        "* http://in.relation.to/Bloggers/Weld200Alpha2Released\n" +
-        "* https://issues.jboss.org/browse/WELD-1119\n" +
-        "\n" +
-        "The workaround is to add enabled=false to a org.jboss.weld.executor.properties file on\n" +
-        "your CLASSPATH. Beware that this will trigger another Weld bug - startup will now work,\n" +
-        "but shutdown will fail with a NullPointerException. This exception will be printed and\n" +
-        "not rethrown. It's the best Cucumber-JVM can do until this bug is fixed in Weld.\n" +
-        "\n";
+        LINE_SEPARATOR +
+        "It looks like you're running on a single-core machine, and Weld doesn't like that. See:" +
+        LINE_SEPARATOR +
+        "* http://in.relation.to/Bloggers/Weld200Alpha2Released" +
+        LINE_SEPARATOR +
+        "* https://issues.jboss.org/browse/WELD-1119" +
+        LINE_SEPARATOR +
+        LINE_SEPARATOR +
+        "The workaround is to add enabled=false to a org.jboss.weld.executor.properties file on" +
+        LINE_SEPARATOR +
+        "your CLASSPATH. Beware that this will trigger another Weld bug - startup will now work," +
+        LINE_SEPARATOR +
+        "but shutdown will fail with a NullPointerException. This exception will be printed and" +
+        LINE_SEPARATOR +
+        "not rethrown. It's the best Cucumber-JVM can do until this bug is fixed in Weld." +
+        LINE_SEPARATOR +
+        LINE_SEPARATOR;
 
     protected static final String STOP_EXCEPTION_MESSAGE = "" +
-        "\nIf you have set enabled=false in org.jboss.weld.executor.properties and you are seeing\n" +
-        "this message, it means your weld container didn't shut down properly. It's a Weld bug\n" +
-        "and we can't do much to fix it in Cucumber-JVM.\n" +
-        "";
+        LINE_SEPARATOR +
+        "If you have set enabled=false in org.jboss.weld.executor.properties and you are seeing" +
+        LINE_SEPARATOR +
+        "this message, it means your weld container didn't shut down properly. It's a Weld bug" +
+        LINE_SEPARATOR +
+        "and we can't do much to fix it in Cucumber-JVM." +
+        LINE_SEPARATOR;
 
     private WeldContainer containerInstance;
 

--- a/weld/src/test/java/cucumber/runtime/java/weld/WeldFactoryTest.java
+++ b/weld/src/test/java/cucumber/runtime/java/weld/WeldFactoryTest.java
@@ -87,12 +87,16 @@ public class WeldFactoryTest {
 
         factory.stop();
 
-        final String expectedErrOutput = "\n" +
-            "If you have set enabled=false in org.jboss.weld.executor.properties and you are seeing\n" +
-            "this message, it means your weld container didn't shut down properly. It's a Weld bug\n" +
-            "and we can't do much to fix it in Cucumber-JVM.\n" +
-            "\n" +
-            "java.lang.NullPointerException\n" +
+        final String expectedErrOutput = WeldFactory.LINE_SEPARATOR +
+            "If you have set enabled=false in org.jboss.weld.executor.properties and you are seeing" +
+            WeldFactory.LINE_SEPARATOR +
+            "this message, it means your weld container didn't shut down properly. It's a Weld bug" +
+            WeldFactory.LINE_SEPARATOR +
+            "and we can't do much to fix it in Cucumber-JVM." +
+            WeldFactory.LINE_SEPARATOR +
+            WeldFactory.LINE_SEPARATOR +
+            "java.lang.NullPointerException" +
+            WeldFactory.LINE_SEPARATOR +
             "\tat cucumber.runtime.java.weld.WeldFactory.stop";
 
         assertThat(this.errContent.toString(), is(startsWith(expectedErrOutput)));


### PR DESCRIPTION
## Summary

This PR fixes build on Windows machines #1551  when JVM is started with non-UTF8 as default charset and windows line endings.
## Details

Fixed wrong byte extraction in TestHelper, 
Fixed wrong byte extraction in TestPickleBulder plus added test that covers the change.
Fixed system-independent line ending in WeldFactory + WeldFactoryTest

## Motivation and Context

Fixes: https://github.com/cucumber/cucumber-jvm/issues/1551

## How Has This Been Tested?

Build was run on a local machine.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
