### PR TITLE
Update contribution guidlines

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,17 +1,43 @@
-<!-- Please use the [support](https://cucumber.io/support) forums for questions 
-and discussions which are not related to bug reports or feature requests -->
+<!-- 
 
-<!-- Please search for related issues and check the [documentation](https://docs.cucumber.io/support)
-before opening a new issue -->
 
-<!-- If your issue is related to other tools (Serenity, Selenium, etc),
-please open an issue on the related tool. Only open an issue here once
-you have confirmed the issue is with Cucumber -->
 
-<!-- If you are reporting a bug, please provide as much information as you can to help us solving your problem.
-The sections below are meant as guidance, to help you give the kind of information we'll need to help with your issue. 
-If a section  doesn't seem to fit, just skip it.-->
+Hi,
 
+
+
+you are about to create an issue. Great.
+
+
+
+Please read this first. You'll be more successfull.
+
+
+
+Before you do so please consider the following:
+
+ * Use the [support](https://cucumber.io/support) forums for questions 
+   and discussions which are not related to bug reports or feature requests 
+
+ * Search for related issues and check the documentation before opening a 
+   new issue. https://docs.cucumber.io/support
+
+ * If your issue is related to other tools (Serenity, Selenium, etc),
+   please open an issue on the related tool. Only open an issue here once
+   you have confirmed the issue is with Cucumber 
+
+  * If you are reporting a bug, please provide as much information as you 
+    can to help us solving your problem. 
+    
+
+Finally the sections below are meant as guidance, to help you give the kind of 
+information we'll need to help with your issue. Please try your best. 
+
+If a section  doesn't seem to fit, just delete it.
+
+
+-->    
+    
 ## Summary
 
 <!--- Provide a general summary description of the issue -->
@@ -28,9 +54,10 @@ If a section  doesn't seem to fit, just skip it.-->
 <!--- If suggesting a change/improvement, explain the difference from current behavior -->
 
 <!--- If you have got some output place it in the code block below. Otherwise remove it. -->
-~~~
-~~~
+```
 
+
+```
 ## Possible Solution
 
 <!--- Not obligatory, but suggest a fix/reason for the bug, -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,26 @@
-## About to create a new Github Issue?
+## About to contribute?
 
 We appreciate that. But before you do, please learn our basic rules:
 
-* This is not a support or discussion forum. If you have a question, please ask it on [The Cukes Google Group](http://groups.google.com/group/cukes).
-* Do you have a feature request? Then don't expect it to be implemented unless you or someone else sends a [pull request](https://help.github.com/articles/using-pull-requests).
-* Reporting a bug? We need to know what java/ruby/node.js etc. runtime you have, and what jar/gem/npm package versions you are using. Bugs with [pull requests](https://help.github.com/articles/using-pull-requests) get fixed quicker. Some bugs may never be fixed.
-* You have to tell us how to reproduce a bug. Bonus point for a [pull request](https://help.github.com/articles/using-pull-requests) with a failing test that reproduces the bug.
-* Want to paste some code or output? Put \`\`\` on a line above and below your code/output. See [Github Flavored Markdown](https://help.github.com/articles/github-flavored-markdown)'s *Fenced Code Blocks* for details.
-* We love [pull requests](https://help.github.com/articles/using-pull-requests), but if you don't have a test to go with it we probably won't merge it.
+* This is not a support or discussion forum. If you have a question, please ask
+  it on [The Cukes Google Group](http://groups.google.com/group/cukes).
+* Do you have a feature request? Then don't expect it to be implemented unless
+  you or someone else sends a [pull request](https://help.github.com/articles/using-pull-requests).
+* Reporting a bug? We need to know what java/ruby/node.js etc. runtime you have,
+  and what jar/gem/npm package versions you are using. Bugs with 
+  [pull requests](https://help.github.com/articles/using-pull-requests) get
+  fixed quicker. Some bugs may never be fixed.
+* You have to tell us how to reproduce a bug. Bonus point for a 
+  [pull request](https://help.github.com/articles/using-pull-requests) with a
+  failing test that reproduces the bug.
+* Want to paste some code or output? Put \`\`\` on a line above and below your 
+  code/output. See 
+  [Github Flavored Markdown](https://help.github.com/articles/github-flavored-markdown)'s 
+  *Fenced Code Blocks* for details.
+* We love [pull requests](https://help.github.com/articles/using-pull-requests), 
+  but if you don't have a test to go with it we probably won't merge it.
+* Before making significant contribution consider discussing the outline of 
+  your solution first. This may avoid a duplication of efforts.
 
 ## Building Cucumber-JVM
 
@@ -25,13 +38,16 @@ mvn clean install
 File -> Open Project -> path/to/cucumber-jvm/pom.xml
 ```
 
-Your `.feature` files must be in a folder that IDEA recognises as *source* or *test*. You must also tell IDEA to copy your `.feature` files to your output directory:
+Your `.feature` files must be in a folder that IDEA recognises as *source* or 
+*test*. You must also tell IDEA to copy your `.feature` files to your output 
+directory:
 
 ```
 Preferences -> Compiler -> Resource Patterns -> Add `;?*.feature`
 ```
 
-If you are writing step definitions in a scripting language you must also add the appropriate file extension for that language as well.
+If you are writing step definitions in a scripting language you must also add 
+the appropriate file extension for that language as well.
 
 ### Eclipse
 
@@ -39,7 +55,8 @@ Just load the root `pom.xml`
 
 ## Contributing
 
-To contribute to Cucumber-JVM you need a JDK, Maven and Git to get the code. You also need to set your IDE/text editor to use:
+To contribute to Cucumber-JVM you need a JDK, Maven and Git to get the code. You
+also need to set your IDE/text editor to use:
 
 * UTF-8 file encoding <sup>+</sup>
 * LF (UNIX) line endings <sup>+</sup>
@@ -51,9 +68,12 @@ To contribute to Cucumber-JVM you need a JDK, Maven and Git to get the code. You
 * 2 Space indent (no tabs) <sup>+</sup>
   * Gherkin
 
-`+` These are set automatically if you use an editor/IDE that supports [EditorConfig](http://editorconfig.org/#download).
+`+` These are set automatically if you use an editor/IDE that supports 
+[EditorConfig](http://editorconfig.org/#download).
 
-Please do *not* add @author tags - this project embraces collective code ownership. If you want to know who wrote some
-code, look in git. When you are done, send a [pull request](http://help.github.com/send-pull-requests/).
-If we get a pull request where an entire file is changed because of insignificant whitespace changes we cannot see what
-you have changed, and your contribution might get rejected.
+Please do *not* add @author tags - this project embraces collective code 
+ownership. If you want to know who wrote some code, look in git. When you are
+done, send a [pull request](http://help.github.com/send-pull-requests/).
+If we get a pull request where an entire file is changed because of 
+insignificant whitespace changes we cannot see what you have changed, and your
+contribution might get rejected.

--- a/README.md
+++ b/README.md
@@ -8,64 +8,35 @@
 [![Coverage Status](https://coveralls.io/repos/github/cucumber/cucumber-jvm/badge.svg?branch=master)](https://coveralls.io/github/cucumber/cucumber-jvm?branch=master)
 
 Cucumber-JVM is a pure Java implementation of Cucumber. 
-You can [run](https://docs.cucumber.io/cucumber/api/#running-cucumber) it with the tool of your choice.
-Cucumber-JVM also integrates with all the popular [Dependency Injection containers](https://docs.cucumber.io/installation/java/#dependency-injection).
+You can [run](https://docs.cucumber.io/cucumber/api/#running-cucumber) it with 
+the tool of your choice.
 
-## Documentation
+Cucumber-JVM also integrates with all the popular 
+[Dependency Injection containers](https://docs.cucumber.io/installation/java/#dependency-injection).
 
-[Start Here](https://cucumber.io/docs).
+## Getting started
+ * [Installation](https://docs.cucumber.io/installation/java/)
+ * [Documentation](https://cucumber.io/docs)
+ * [Hello World project](https://github.com/cucumber/cucumber-java-skeleton)
 
-If you'd like to contribute to the documentation, go [here](https://github.com/cucumber/docs.cucumber.io).
+## Questions, Problems, Help needed?
 
-## Hello World
-
-Check out the simple [cucumber-java-skeleton](https://github.com/cucumber/cucumber-java-skeleton) starter project.
-
-## Downloading / Installation
-
-[Install](https://docs.cucumber.io/installation/java/)
+Please ask on 
+[The Cukes Google Group](http://groups.google.com/group/cukes).
 
 ## Bugs and Feature requests
 
-You can register bugs and feature requests in the [Github Issue Tracker](https://github.com/cucumber/cucumber-jvm/issues).
+You can register bugs and feature requests in the 
+[Github Issue Tracker](https://github.com/cucumber/cucumber-jvm/issues). 
 
-You're most likely going to paste code and output, so familiarise yourself with
-[Github Flavored Markdown](https://help.github.com/articles/github-flavored-markdown) to make sure it remains readable.
+Please bear in mind that this project is almost entirely developed by 
+volunteers. If you do not provided the implementation yourself (or pay someone 
+to do it for you), the bug might never get fixed. If it is a serious bug, other 
+people than you might care enough to provide a fix.
 
-*At the very least - use triple backticks*:
+## Contributing 
 
-<pre>
-```java
-// Why doesn't this work?
-@Given("I have {int} cukes in my {string}")
-public void some_cukes(int howMany, String what) {
-    // HALP!
-}
-```
-</pre>
-
-Please consider including the following information if you register a ticket:
-
-* What cucumber-jvm version you're using
-* What modules you're using (`cucumber-java`, `cucumber-spring`, `cucumber-groovy` etc)
-* What command you ran
-* What output you saw
-* How it can be reproduced
-
-### How soon will my ticket be fixed?
-
-The best way to have a bug fixed or feature request implemented is to
-[fork the cucumber-jvm repo](http://help.github.com/fork-a-repo/) and send a
-[pull request](http://help.github.com/send-pull-requests/).
-If the pull request has good tests and follows the coding conventions (see below) it has a good chance of
-making it into the next release.
-
-If you don't fix the bug yourself (or pay someone to do it for you), the bug might never get fixed. If it is a serious
-bug, other people than you might care enough to provide a fix.
-
-In other words, there is no guarantee that a bug or feature request gets fixed. Tickets that are more than 6 months old
-are likely to be closed to keep the backlog manageable.
-
-## Contributing fixes
-
-See [CONTRIBUTING.md](https://github.com/cucumber/cucumber-jvm/blob/master/CONTRIBUTING.md)
+If you'd like to contribute to the documentation, checkout 
+[cucumber/docs.cucumber.io](https://github.com/cucumber/docs.cucumber.io) 
+otherwise see our
+[CONTRIBUTING.md](https://github.com/cucumber/cucumber-jvm/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

Updated the issue template to draw more attention to the fact that there are instructions written in it. This will hopefully reduce the frequency of questions and redirect people to the google groups.

Updated the readme to include a section about questions and where to ask them. Also changed the getting started section to be less verbose. Removed most of the guidance on creating an issue. It's already in the issue template and the contributing guidelines.

Added a line about discussing major changes first to the contribution guide.

Also formatted everything at 80 width.