### PR TITLE
Reformatted usage.txt for easier readability

### DIFF
--- a/core/src/main/resources/cucumber/api/cli/USAGE.txt
+++ b/core/src/main/resources/cucumber/api/cli/USAGE.txt
@@ -2,50 +2,68 @@ Usage: java cucumber.api.cli.Main [options] [ [DIR|DIR URI] | [ [FILE|FILE URI][
 
 Options:
 
-  --threads COUNT                        Number of threads to run tests under. 
-                                         Defaults to 1.
-  -g, --glue PATH                        Package to load glue code (step definitions,
-                                         hooks and plugins) from. E.g: com.example.app
-  -p, --[add-]plugin PLUGIN[:PATH_OR_URL]
-                                         Register a plugin.
-                                         Built-in formatter PLUGIN types: junit,
-                                         html, pretty, progress, json, usage, rerun,
-                                         testng. Built-in summary PLUGIN types:
-                                         default_summary, null_summary. PLUGIN can
-                                         also be a fully qualified class name, allowing
-                                         registration of 3rd party plugins.
-                                         --add-plugin does not clobber plugins of that 
-                                         type defined from a different source.
-  -t, --tags TAG_EXPRESSION              Only run scenarios tagged with tags matching
-                                         TAG_EXPRESSION.
-  -n, --name REGEXP                      Only run scenarios whose names match REGEXP.
-  -d, --[no-]dry-run                    Skip execution of glue code.
-  -m, --[no-]monochrome                 Don't colour terminal output.
-  -s, --[no-]strict                     Treat undefined and pending steps as errors.
-      --snippets [underscore|camelcase]  Naming convention for generated snippets.
-                                         Defaults to underscore.
-  -v, --version                          Print version.
-  -h, --help                             You're looking at it.
-  --i18n LANG                            List keywords for in a particular language
-                                         Run with "--i18n help" to see all languages
-  --junit,OPTION[,OPTION]*               Pass the OPTION(s) to the JUnit module.
-                                         Use --junit,-h or --junit,--help to print the
-                                         options of the JUnit module.
-  -w, --wip                              Fail if there are any passing scenarios.
+      --threads COUNT                      Number of threads to run tests under.
+                                           Defaults to 1.
+
+  -g, --glue PATH                          Package to load glue code (step definitions,
+                                           hooks and plugins) from. E.g: com.example.app
+
+  -p, --[add-]plugin PLUGIN[:PATH_OR_URL]  Register a plugin.
+                                           Built-in formatter PLUGIN types: junit,
+                                           html, pretty, progress, json, usage, rerun,
+                                           testng. Built-in summary PLUGIN types:
+                                           default_summary, null_summary. PLUGIN can
+                                           also be a fully qualified class name, allowing
+                                           registration of 3rd party plugins.
+                                           --add-plugin does not clobber plugins of that
+                                           type defined from a different source.
+
+  -t, --tags TAG_EXPRESSION                Only run scenarios tagged with tags matching
+                                           TAG_EXPRESSION.
+
+  -n, --name REGEXP                        Only run scenarios whose names match REGEXP.
+
+  -d, --[no-]dry-run                       Skip execution of glue code.
+
+  -m, --[no-]monochrome                    Don't colour terminal output.
+
+  -s, --[no-]strict                        Treat undefined and pending steps as errors.
+
+      --snippets [underscore|camelcase]    Naming convention for generated snippets.
+                                           Defaults to underscore.
+
+  -v, --version                            Print version.
+
+  -h, --help                               You're looking at it.
+
+      --i18n LANG                          List keywords for in a particular language
+                                           Run with "--i18n help" to see all languages
+
+      --junit,OPTION[,OPTION]*             Pass the OPTION(s) to the JUnit module.
+                                           Use --junit,-h or --junit,--help to print the
+                                           options of the JUnit module.
+
+  -w, --wip                                Fail if there are any passing scenarios.
 
 Feature path examples:
-  <path>                                 Load the files with the extension ".feature"
-                                         for the directory <path>
-                                         and its sub directories.
-  <path>/<name>.feature                  Load the feature file <path>/<name>.feature
-                                         from the file system.
-  classpath:<path>/<name>.feature        Load the feature file <path>/<name>.feature
-                                         from the classpath.
-  <path>/<name>.feature:3:9              Load the scenarios on line 3 and line 9 in
-                                         the file <path>/<name>.feature.
-  @<path>/<file>                         Load <path>/<file> from the file system and
-                                         parse feature paths generated by the rerun
-                                         formatter.
-  @classpath:<path>/<file>               Load <path>/<file> from the classpath and
-                                         parse feature paths generated by the rerun
-                                         formatter.
+
+  <path>                                   Load the files with the extension ".feature"
+                                           for the directory <path>
+                                           and its sub directories.
+
+  <path>/<name>.feature                    Load the feature file <path>/<name>.feature
+                                           from the file system.
+
+  classpath:<path>/<name>.feature          Load the feature file <path>/<name>.feature
+                                           from the classpath.
+
+  <path>/<name>.feature:3:9                Load the scenarios on line 3 and line 9 in
+                                           the file <path>/<name>.feature.
+
+  @<path>/<file>                           Load <path>/<file> from the file system and
+                                           parse feature paths generated by the rerun
+                                           formatter.
+
+  @classpath:<path>/<file>                 Load <path>/<file> from the classpath and
+                                           parse feature paths generated by the rerun
+                                           formatter.


### PR DESCRIPTION
## Summary

White space changes

## Details

Added blank lines between each option the make it easier to read the description for that particular option.

Indented the descriptions so they form a straight column.

Indented the options with two leading dashes so they are all in the same column.

## Motivation and Context

When looking at the usage.txt when running the command line implementation with `--help` I was irritated about the indentation. It wasn't nice and unnecessary hard to read.

I reformatted the file and hope that it became easier to read.

## How Has This Been Tested?

Nope, it is a formatting change of the help text.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
