### PR TITLE
[Core] Disambiguate between drive letter and uri scheme

### DIFF
--- a/core/src/main/java/io/cucumber/core/model/FeaturePath.java
+++ b/core/src/main/java/io/cucumber/core/model/FeaturePath.java
@@ -3,6 +3,7 @@ package io.cucumber.core.model;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 
 
 /**
@@ -48,7 +49,10 @@ public class FeaturePath {
         return URI.create(featureIdentifier);
     }
     
-    private static boolean isWindowsOS() { return System.getProperty("os.name").contains("Windows");}
+    private static boolean isWindowsOS() { 
+        String osName = System.getProperty("os.name");
+        return normalize(osName).contains("windows");
+    }
     
     private static boolean pathContainsWindowsDrivePattern(String featureIdentifier) {
         return featureIdentifier.matches("^(?:[a-zA-Z]:.*)$");
@@ -81,4 +85,12 @@ public class FeaturePath {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
     }
+    
+    private static String normalize(final String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.toLowerCase(Locale.US).replaceAll("[^a-z0-9]+", "");
+    }
+    
 }

--- a/core/src/main/java/io/cucumber/core/model/FeaturePath.java
+++ b/core/src/main/java/io/cucumber/core/model/FeaturePath.java
@@ -32,6 +32,10 @@ public class FeaturePath {
             String standardized = replaceNonStandardPathSeparator(featureIdentifier);
             return parseAssumeFileScheme(standardized);
         }
+        
+        if (isWindowsOS() && pathContainsWindowsDrivePattern(featureIdentifier)) {
+            return parseAssumeFileScheme(featureIdentifier);
+        }
 
         if (probablyURI(featureIdentifier)) {
             return parseProbableURI(featureIdentifier);
@@ -43,11 +47,16 @@ public class FeaturePath {
     private static URI parseProbableURI(String featureIdentifier) {
         return URI.create(featureIdentifier);
     }
-
+    
+    private static boolean isWindowsOS() { return System.getProperty("os.name").contains("Windows");}
+    
+    private static boolean pathContainsWindowsDrivePattern(String featureIdentifier) {
+        return featureIdentifier.matches("^(?:[a-zA-Z]:.*)$");
+    }
+    
     private static boolean probablyURI(String featureIdentifier) {
         return featureIdentifier.matches("^\\w+:.*$");
     }
-
 
     private static String replaceNonStandardPathSeparator(String featureIdentifier) {
         return featureIdentifier.replace(File.separatorChar, '/');

--- a/core/src/main/java/io/cucumber/core/model/FeaturePath.java
+++ b/core/src/main/java/io/cucumber/core/model/FeaturePath.java
@@ -59,7 +59,7 @@ public class FeaturePath {
     }
     
     private static boolean probablyURI(String featureIdentifier) {
-        return featureIdentifier.matches("^\\w+:.*$");
+        return featureIdentifier.matches("^[a-zA-Z+.\\-]+:.*$");
     }
 
     private static String replaceNonStandardPathSeparator(String featureIdentifier) {

--- a/core/src/main/java/io/cucumber/core/model/FeaturePath.java
+++ b/core/src/main/java/io/cucumber/core/model/FeaturePath.java
@@ -55,7 +55,7 @@ public class FeaturePath {
     }
     
     private static boolean pathContainsWindowsDrivePattern(String featureIdentifier) {
-        return featureIdentifier.matches("^(?:[a-zA-Z]:.*)$");
+        return featureIdentifier.matches("^[a-zA-Z]:.*$");
     }
     
     private static boolean probablyURI(String featureIdentifier) {

--- a/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.io.File;
 import java.net.URI;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeThat;

--- a/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
@@ -1,12 +1,13 @@
 package io.cucumber.core.model;
 
+import org.hamcrest.CustomTypeSafeMatcher;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 
 import java.io.File;
 import java.net.URI;
 import java.util.Locale;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeThat;
@@ -79,9 +80,7 @@ public class FeaturePathTest {
         assumeThat(File.separatorChar, is('\\')); //Requires windows
         URI uri = FeaturePath.parse("C:\\path\\to\\file.feature");
         assertEquals("file", uri.getScheme());
-        // Use File to work out the drive letter
-        File file = new File("/path/to/file.feature");
-        assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
+        assertEquals("C:/path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
     @Test
@@ -97,6 +96,7 @@ public class FeaturePathTest {
         assumeThat(normalize(osName), containsString("windows")); //Requires windows
         URI uri = FeaturePath.parse("C:/path/to/the/file.feature");
         assertEquals("file", uri.getScheme());
+        assertEquals("C:/path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
     @Test

--- a/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
@@ -94,7 +94,7 @@ public class FeaturePathTest {
     public void can_parse_windows_file_path_with_standard_file_separator(){
         assumeThat(System.getProperty("os.name"), isWindows());
 
-        URI uri = FeaturePath.parse("C:/path/to/the/file.feature");
+        URI uri = FeaturePath.parse("C:/path/to/file.feature");
         assertEquals("file", uri.getScheme());
         assertEquals("C:/path/to/file.feature", uri.getSchemeSpecificPart());
     }

--- a/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
@@ -80,7 +80,7 @@ public class FeaturePathTest {
         assumeThat(File.separatorChar, is('\\')); //Requires windows
         URI uri = FeaturePath.parse("C:\\path\\to\\file.feature");
         assertEquals("file", uri.getScheme());
-        assertEquals("C:/path/to/file.feature", uri.getSchemeSpecificPart());
+        assertEquals("/C:/path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class FeaturePathTest {
 
         URI uri = FeaturePath.parse("C:/path/to/file.feature");
         assertEquals("file", uri.getScheme());
-        assertEquals("C:/path/to/file.feature", uri.getSchemeSpecificPart());
+        assertEquals("/C:/path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
     private static Matcher<String> isWindows() {

--- a/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
@@ -94,9 +94,6 @@ public class FeaturePathTest {
         assumeThat(System.getProperty("os.name"), containsString("Windows")); //Requires windows
         URI uri = FeaturePath.parse("C:/path/to/the/file.feature");
         assertEquals("file", uri.getScheme());
-        // Use File to work out the drive letter
-        File file = new File("/path/to/the/file.feature");
-        assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
     }
 
     @Test
@@ -104,9 +101,6 @@ public class FeaturePathTest {
         assumeThat(System.getProperty("os.name"), containsString("Windows")); //Requires windows
         URI uri = FeaturePath.parse("C:/path-to/the_file.feature");
         assertEquals("file", uri.getScheme());
-        // Use File to work out the drive letter
-        File file = new File("/path-to/the_file.feature");
-        assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
@@ -90,20 +90,29 @@ public class FeaturePathTest {
     
     @Test
     public void can_parse_windows_file_path_with_standard_file_separator(){
-        URI uri = FeaturePath.parse("C:/path/to/the/file.feature");
-        assertEquals("file", uri.getScheme());
-        // Use File to work out the drive letter
-        File file = new File("/path/to/the/file.feature");
-        assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
+        String originalOSName = System.getProperty("os.name");
+        try {
+            URI uri = FeaturePath.parse("C:/path/to/the/file.feature");
+            assertEquals("file", uri.getScheme());
+            // Use File to work out the drive letter
+            File file = new File("/path/to/the/file.feature");
+            assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
+        } finally {
+            System.setProperty("os.name", originalOSName);
+        }
     }
     
     @Test
     public void can_parse_windows_file_path_with_standard_file_separator_and_non_alpanumeric_chars(){
-        URI uri = FeaturePath.parse("C:/path-to/the_file.feature");
-        assertEquals("file", uri.getScheme());
-        // Use File to work out the drive letter
-        File file = new File("/path-to/the_file.feature");
-        assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
-    }
-    
+        String originalOSName = System.getProperty("os.name");
+        try {
+            URI uri = FeaturePath.parse("C:/path-to/the_file.feature");
+            assertEquals("file", uri.getScheme());
+            // Use File to work out the drive letter
+            File file = new File("/path-to/the_file.feature");
+            assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
+        } finally {
+            System.setProperty("os.name", originalOSName);
+        }
+
 }

--- a/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
@@ -114,5 +114,6 @@ public class FeaturePathTest {
         } finally {
             System.setProperty("os.name", originalOSName);
         }
+    }
 
 }

--- a/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
@@ -4,11 +4,13 @@ import org.junit.Test;
 
 import java.io.File;
 import java.net.URI;
+import java.util.Locale;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeThat;
+
 
 public class FeaturePathTest {
 
@@ -91,16 +93,25 @@ public class FeaturePathTest {
     
     @Test
     public void can_parse_windows_file_path_with_standard_file_separator(){
-        assumeThat(System.getProperty("os.name"), containsString("Windows")); //Requires windows
+        String osName = System.getProperty("os.name");
+        assumeThat(normalize(osName), containsString("windows")); //Requires windows
         URI uri = FeaturePath.parse("C:/path/to/the/file.feature");
         assertEquals("file", uri.getScheme());
     }
 
     @Test
     public void can_parse_windows_file_path_with_standard_file_separator_and_non_alpanumeric_chars(){
-        assumeThat(System.getProperty("os.name"), containsString("Windows")); //Requires windows
+        String osName = System.getProperty("os.name");
+        assumeThat(normalize(osName), containsString("windows")); //Requires windows
         URI uri = FeaturePath.parse("C:/path-to/the_file.feature");
         assertEquals("file", uri.getScheme());
     }
+    
+    private static String normalize(final String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.toLowerCase(Locale.US).replaceAll("[^a-z0-9]+", "");
+    }        
 
 }

--- a/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
@@ -92,26 +92,25 @@ public class FeaturePathTest {
     
     @Test
     public void can_parse_windows_file_path_with_standard_file_separator(){
-        String osName = System.getProperty("os.name");
-        assumeThat(normalize(osName), containsString("windows")); //Requires windows
+        assumeThat(System.getProperty("os.name"), isWindows());
+
         URI uri = FeaturePath.parse("C:/path/to/the/file.feature");
         assertEquals("file", uri.getScheme());
         assertEquals("C:/path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
-    @Test
-    public void can_parse_windows_file_path_with_standard_file_separator_and_non_alpanumeric_chars(){
-        String osName = System.getProperty("os.name");
-        assumeThat(normalize(osName), containsString("windows")); //Requires windows
-        URI uri = FeaturePath.parse("C:/path-to/the_file.feature");
-        assertEquals("file", uri.getScheme());
+    private static Matcher<String> isWindows() {
+        return new CustomTypeSafeMatcher<String>("windows") {
+            @Override
+            protected boolean matchesSafely(String value) {
+                if (value == null) {
+                    return false;
+                }
+                return value
+                    .toLowerCase(Locale.US)
+                    .replaceAll("[^a-z0-9]+", "")
+                    .contains("windows");
+            }
+        };
     }
-    
-    private static String normalize(final String value) {
-        if (value == null) {
-            return "";
-        }
-        return value.toLowerCase(Locale.US).replaceAll("[^a-z0-9]+", "");
-    }        
-
 }

--- a/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
@@ -90,30 +90,22 @@ public class FeaturePathTest {
     
     @Test
     public void can_parse_windows_file_path_with_standard_file_separator(){
-        String originalOSName = System.getProperty("os.name");
-        try {
-            URI uri = FeaturePath.parse("C:/path/to/the/file.feature");
-            assertEquals("file", uri.getScheme());
-            // Use File to work out the drive letter
-            File file = new File("/path/to/the/file.feature");
-            assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
-        } finally {
-            System.setProperty("os.name", originalOSName);
-        }
+        assumeThat(System.getProperty("os.name"), containsString("Windows")); //Requires windows
+        URI uri = FeaturePath.parse("C:/path/to/the/file.feature");
+        assertEquals("file", uri.getScheme());
+        // Use File to work out the drive letter
+        File file = new File("/path/to/the/file.feature");
+        assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
     }
-    
+
     @Test
     public void can_parse_windows_file_path_with_standard_file_separator_and_non_alpanumeric_chars(){
-        String originalOSName = System.getProperty("os.name");
-        try {
-            URI uri = FeaturePath.parse("C:/path-to/the_file.feature");
-            assertEquals("file", uri.getScheme());
-            // Use File to work out the drive letter
-            File file = new File("/path-to/the_file.feature");
-            assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
-        } finally {
-            System.setProperty("os.name", originalOSName);
-        }
+        assumeThat(System.getProperty("os.name"), containsString("Windows")); //Requires windows
+        URI uri = FeaturePath.parse("C:/path-to/the_file.feature");
+        assertEquals("file", uri.getScheme());
+        // Use File to work out the drive letter
+        File file = new File("/path-to/the_file.feature");
+        assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/model/FeaturePathTest.java
@@ -71,7 +71,6 @@ public class FeaturePathTest {
         assertEquals("path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
-
     @Test
     public void can_parse_windows_absolute_path_form(){
         assumeThat(File.separatorChar, is('\\')); //Requires windows
@@ -82,12 +81,29 @@ public class FeaturePathTest {
         assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
     }
 
-
     @Test
     public void can_parse_whitespace_in_path(){
         URI uri = FeaturePath.parse("path/to the/file.feature");
         assertEquals("file", uri.getScheme());
         assertEquals("path/to the/file.feature", uri.getSchemeSpecificPart());
     }
-
+    
+    @Test
+    public void can_parse_windows_file_path_with_standard_file_separator(){
+        URI uri = FeaturePath.parse("C:/path/to/the/file.feature");
+        assertEquals("file", uri.getScheme());
+        // Use File to work out the drive letter
+        File file = new File("/path/to/the/file.feature");
+        assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
+    }
+    
+    @Test
+    public void can_parse_windows_file_path_with_standard_file_separator_and_non_alpanumeric_chars(){
+        URI uri = FeaturePath.parse("C:/path-to/the_file.feature");
+        assertEquals("file", uri.getScheme());
+        // Use File to work out the drive letter
+        File file = new File("/path-to/the_file.feature");
+        assertEquals(file.toURI().getSchemeSpecificPart(), uri.getSchemeSpecificPart());
+    }
+    
 }


### PR DESCRIPTION
Added windows case where path is being passed with standard file separator in the file location passed.

Fixes: #1564 

## Summary

Update for path in case it is being passed in Windows with the standard file separator, as Intellij appears to do.
