### PR TITLE
[Core] Add logger

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-core</artifactId>

--- a/core/src/main/java/cucumber/runner/Runner.java
+++ b/core/src/main/java/cucumber/runner/Runner.java
@@ -5,16 +5,23 @@ import cucumber.api.StepDefinitionReporter;
 import cucumber.api.event.SnippetsSuggestedEvent;
 import cucumber.runtime.Backend;
 import cucumber.runtime.HookDefinition;
+import cucumber.util.FixJava;
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
 import io.cucumber.core.options.RunnerOptions;
 import gherkin.events.PickleEvent;
 import gherkin.pickles.PickleStep;
 import gherkin.pickles.PickleTag;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 public final class Runner {
+
+    private static final Logger log = LoggerFactory.getLogger(Runner.class);
+
     private final Glue glue = new Glue();
     private final EventBus bus;
     private final Collection<? extends Backend> backends;
@@ -24,10 +31,12 @@ public final class Runner {
         this.bus = bus;
         this.runnerOptions = runnerOptions;
         this.backends = backends;
+        List<URI> gluePaths = runnerOptions.getGlue();
+        log.debug("Loading glue from " + FixJava.join(gluePaths, ", "));
         for (Backend backend : backends) {
-            backend.loadGlue(glue, runnerOptions.getGlue());
+            log.debug("Loading glue for backend " + backend.getClass().getName());
+            backend.loadGlue(this.glue, gluePaths);
         }
-
     }
 
     public EventBus getBus() {

--- a/core/src/main/java/cucumber/runtime/FeaturePathFeatureSupplier.java
+++ b/core/src/main/java/cucumber/runtime/FeaturePathFeatureSupplier.java
@@ -2,6 +2,7 @@ package cucumber.runtime;
 
 import cucumber.runtime.model.CucumberFeature;
 import cucumber.runtime.model.FeatureLoader;
+import cucumber.util.FixJava;
 import io.cucumber.core.logging.Logger;
 import io.cucumber.core.logging.LoggerFactory;
 import io.cucumber.core.options.FeatureOptions;
@@ -27,13 +28,15 @@ public class FeaturePathFeatureSupplier implements FeatureSupplier {
     @Override
     public List<CucumberFeature> get() {
         List<URI> featurePaths = featureOptions.getFeaturePaths();
+
+        log.debug("Loading features from " + FixJava.join(featurePaths, ", "));
         List<CucumberFeature> cucumberFeatures = featureLoader.load(featurePaths);
 
         if (cucumberFeatures.isEmpty()) {
             if (featurePaths.isEmpty()) {
                 log.warn("Got no path to feature directory or feature file");
             } else {
-                log.warn(String.format("No features found at %s", featurePaths));
+                log.warn("No features found at " + FixJava.join(featurePaths, ", "));
             }
         }
 

--- a/core/src/main/java/cucumber/runtime/FeaturePathFeatureSupplier.java
+++ b/core/src/main/java/cucumber/runtime/FeaturePathFeatureSupplier.java
@@ -2,14 +2,20 @@ package cucumber.runtime;
 
 import cucumber.runtime.model.CucumberFeature;
 import cucumber.runtime.model.FeatureLoader;
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
 import io.cucumber.core.options.FeatureOptions;
 
+import java.net.URI;
 import java.util.List;
 
 /**
  * Supplies a list of features found on the the feature path provided to RuntimeOptions.
  */
 public class FeaturePathFeatureSupplier implements FeatureSupplier {
+
+    private static final Logger log = LoggerFactory.getLogger(FeaturePathFeatureSupplier.class);
+
     private final FeatureLoader featureLoader;
     private final FeatureOptions featureOptions;
 
@@ -20,6 +26,17 @@ public class FeaturePathFeatureSupplier implements FeatureSupplier {
 
     @Override
     public List<CucumberFeature> get() {
-        return featureLoader.load(featureOptions.getFeaturePaths(), System.out);
+        List<URI> featurePaths = featureOptions.getFeaturePaths();
+        List<CucumberFeature> cucumberFeatures = featureLoader.load(featurePaths);
+
+        if (cucumberFeatures.isEmpty()) {
+            if (featurePaths.isEmpty()) {
+                log.warn("Got no path to feature directory or feature file");
+            } else {
+                log.warn(String.format("No features found at %s", featurePaths));
+            }
+        }
+
+        return cucumberFeatures;
     }
 }

--- a/core/src/main/java/cucumber/runtime/filter/TagExpressionOld.java
+++ b/core/src/main/java/cucumber/runtime/filter/TagExpressionOld.java
@@ -1,6 +1,8 @@
 package cucumber.runtime.filter;
 
 import gherkin.pickles.PickleTag;
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -9,6 +11,9 @@ import java.util.List;
 import java.util.Map;
 
 class TagExpressionOld {
+
+    private static final Logger logger = LoggerFactory.getLogger(TagExpressionOld.class);
+
     private final Map<String, Integer> limits = new HashMap<String, Integer>();
     private And and = new And();
 
@@ -17,10 +22,10 @@ class TagExpressionOld {
             return false;
         }
         if (tagExpression.contains(",")) {
-            System.err.println("WARNING: Found tags option '" + tagExpression + "'. Support for '@tag1,@tag2' will be removed from the next release of Cucumber-JVM. Please use '@tag or @tag2' instead");
+            logger.warn("Found tags option '" + tagExpression + "'. Support for '@tag1,@tag2' will be removed from the next release of Cucumber-JVM. Please use '@tag or @tag2' instead");
         }
         if (tagExpression.contains("~")) {
-            System.err.println("WARNING: Found tags option '" + tagExpression + "'. Support for '~@tag' will be removed from the next release of Cucumber-JVM. Please use 'not @tag' instead.");
+            logger.warn("Found tags option '" + tagExpression + "'. Support for '~@tag' will be removed from the next release of Cucumber-JVM. Please use 'not @tag' instead.");
         }
         return tagExpression.contains(",") || tagExpression.contains("~");
     }

--- a/core/src/main/java/cucumber/runtime/model/FeatureLoader.java
+++ b/core/src/main/java/cucumber/runtime/model/FeatureLoader.java
@@ -4,7 +4,6 @@ import cucumber.runtime.io.Resource;
 import cucumber.runtime.io.ResourceLoader;
 import io.cucumber.core.model.FeatureIdentifier;
 
-import java.io.PrintStream;
 import java.net.URI;
 import java.util.Iterator;
 import java.util.List;
@@ -16,18 +15,6 @@ public final class FeatureLoader {
 
     public FeatureLoader(ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
-    }
-
-    public List<CucumberFeature> load(List<URI> featurePaths, PrintStream out) {
-        final List<CucumberFeature> cucumberFeatures = load(featurePaths);
-        if (cucumberFeatures.isEmpty()) {
-            if (featurePaths.isEmpty()) {
-                out.println("Got no path to feature directory or feature file");
-            } else {
-                out.println(String.format("No features found at %s", featurePaths));
-            }
-        }
-        return cucumberFeatures;
     }
 
     public List<CucumberFeature> load(List<URI> featurePaths) {

--- a/core/src/main/java/cucumber/util/FixJava.java
+++ b/core/src/main/java/cucumber/util/FixJava.java
@@ -7,10 +7,14 @@ import java.util.List;
 
 public class FixJava {
 
-    public static String join(List<String> strings, String separator) {
+    private FixJava() {
+
+    }
+
+    public static String join(List<? extends Object> objects, String separator) {
         StringBuilder sb = new StringBuilder();
         int i = 0;
-        for (String s : strings) {
+        for (Object s : objects) {
             if (i != 0) sb.append(separator);
             sb.append(s);
             i++;

--- a/core/src/main/java/io/cucumber/core/logging/LogRecordListener.java
+++ b/core/src/main/java/io/cucumber/core/logging/LogRecordListener.java
@@ -1,0 +1,19 @@
+package io.cucumber.core.logging;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.logging.LogRecord;
+
+public final class LogRecordListener {
+
+    private final ConcurrentLinkedDeque<LogRecord> logRecords = new ConcurrentLinkedDeque<>();
+
+    void logRecordSubmitted(LogRecord logRecord) {
+        logRecords.add(logRecord);
+    }
+
+    public List<LogRecord> getLogRecords() {
+        return Arrays.asList(logRecords.toArray(new LogRecord[0]));
+    }
+}

--- a/core/src/main/java/io/cucumber/core/logging/Logger.java
+++ b/core/src/main/java/io/cucumber/core/logging/Logger.java
@@ -1,0 +1,78 @@
+package io.cucumber.core.logging;
+
+/**
+ * Logs messages to {@link java.util.logging.Logger}.
+ * <p>
+ * The methods correspond to {@link java.util.logging.Level} in JUL:
+ * <ul>
+ * <li>{@code error} maps to {@link java.util.logging.Level#SEVERE}</li>
+ * <li>{@code warn} maps to {@link java.util.logging.Level#WARNING}</li>
+ * <li>{@code info} maps to {@link java.util.logging.Level#INFO}</li>
+ * <li>{@code config} maps to {@link java.util.logging.Level#CONFIG}</li>
+ * <li>{@code debug} maps to {@link java.util.logging.Level#FINE}</li>
+ * <li>{@code trace} maps to {@link java.util.logging.Level#FINER}</li>
+ * </ul>
+ */
+public interface Logger {
+
+    /**
+     * Log the {@code message} at error level.
+     */
+    void error(String message);
+
+    /**
+     * Log the {@code message} and {@code throwable} at error level.
+     */
+    void error(String message, Throwable throwable);
+
+    /**
+     * Log the {@code message} at warning level.
+     */
+    void warn(String message);
+
+    /**
+     * Log the {@code message} and {@code throwable} at warning level.
+     */
+    void warn(String message, Throwable throwable);
+
+    /**
+     * Log the {@code message} at info level.
+     */
+    void info(String message);
+
+    /**
+     * Log the {@code message} and {@code throwable} at info level.
+     */
+    void info(String message, Throwable throwable);
+
+    /**
+     * Log the {@code message} at config level.
+     */
+    void config(String message);
+
+    /**
+     * Log the {@code message} and {@code throwable} at config level.
+     */
+    void config(String message, Throwable throwable);
+
+    /**
+     * Log the {@code message} at debug level.
+     */
+    void debug(String message);
+
+    /**
+     * Log {@code message} and {@code throwable} at debug level.
+     */
+    void debug(String message, Throwable throwable);
+
+    /**
+     * Log the {@code message} at trace level.
+     */
+    void trace(String message);
+
+    /**
+     * Log the {@code message} and {@code throwable} at trace level.
+     */
+    void trace(String message, Throwable throwable);
+
+}

--- a/core/src/main/java/io/cucumber/core/logging/LoggerFactory.java
+++ b/core/src/main/java/io/cucumber/core/logging/LoggerFactory.java
@@ -1,0 +1,139 @@
+package io.cucumber.core.logging;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Cucumber uses the Java Logging APIs from {@link java.util.logging} (JUL).
+ * <p>
+ * See the {@link java.util.logging.LogManager} for configuration options or use
+ * the <a href="https://www.slf4j.org/legacy.html#jul-to-slf4j">JUL to SLF4J Bridge</a>
+ */
+public final class LoggerFactory {
+
+    private LoggerFactory() {
+
+    }
+
+    /**
+     * Get a {@link Logger}
+     *
+     * @param clazz the class for which to get the logger
+     * @return the logger
+     */
+    public static Logger getLogger(Class<?> clazz) {
+        requireNonNull(clazz, "Class must not be null");
+        return new DelegatingLogger(clazz.getName());
+    }
+
+    private static final class DelegatingLogger implements Logger {
+
+        private static final String THIS_LOGGER_CLASS = DelegatingLogger.class.getName();
+
+        private final String name;
+
+        private final java.util.logging.Logger julLogger;
+
+        DelegatingLogger(String name) {
+            this.name = name;
+            this.julLogger = java.util.logging.Logger.getLogger(name);
+        }
+
+        @Override
+        public void error(String message) {
+            log(Level.SEVERE, null, message);
+        }
+
+        @Override
+        public void error(String message, Throwable throwable) {
+            log(Level.SEVERE, throwable, message);
+        }
+
+        @Override
+        public void warn(String message) {
+            log(Level.WARNING, null, message);
+        }
+
+        @Override
+        public void warn(String message, Throwable throwable) {
+            log(Level.WARNING, throwable, message);
+        }
+
+        @Override
+        public void info(String message) {
+            log(Level.INFO, null, message);
+        }
+
+        @Override
+        public void info(String message, Throwable throwable) {
+            log(Level.INFO, throwable, message);
+        }
+
+        @Override
+        public void config(String message) {
+            log(Level.CONFIG, null, message);
+        }
+
+        @Override
+        public void config(String message, Throwable throwable) {
+            log(Level.CONFIG, throwable, message);
+        }
+
+        @Override
+        public void debug(String message) {
+            log(Level.FINE, null, message);
+        }
+
+        @Override
+        public void debug(String message, Throwable throwable) {
+            log(Level.FINE, throwable, message);
+        }
+
+        @Override
+        public void trace(String message) {
+            log(Level.FINER, null, message);
+        }
+
+        @Override
+        public void trace(String message, Throwable throwable) {
+            log(Level.FINER, throwable, message);
+        }
+
+        private void log(Level level, Throwable throwable, String message) {
+            boolean loggable = julLogger.isLoggable(level);
+            if (loggable) {
+                LogRecord logRecord = createLogRecord(level, throwable, message);
+                julLogger.log(logRecord);
+            }
+        }
+
+        private LogRecord createLogRecord(Level level, Throwable throwable, String message) {
+            StackTraceElement[] stack = new Throwable().getStackTrace();
+            String sourceClassName = null;
+            String sourceMethodName = null;
+            boolean found = false;
+            for (StackTraceElement element : stack) {
+                String className = element.getClassName();
+                if (THIS_LOGGER_CLASS.equals(className)) {
+                    found = true; // Next element is calling this logger
+                } else if (found) {
+                    sourceClassName = className;
+                    sourceMethodName = element.getMethodName();
+                    break;
+                }
+            }
+
+            LogRecord logRecord = new LogRecord(level, message);
+            logRecord.setLoggerName(name);
+            logRecord.setThrown(throwable);
+            logRecord.setSourceClassName(sourceClassName);
+            logRecord.setSourceMethodName(sourceMethodName);
+            logRecord.setResourceBundleName(julLogger.getResourceBundleName());
+            logRecord.setResourceBundle(julLogger.getResourceBundle());
+
+            return logRecord;
+        }
+    }
+}

--- a/core/src/test/java/cucumber/runtime/FeaturePathFeatureSupplierTest.java
+++ b/core/src/test/java/cucumber/runtime/FeaturePathFeatureSupplierTest.java
@@ -1,0 +1,69 @@
+package cucumber.runtime;
+
+import cucumber.runtime.io.Resource;
+import cucumber.runtime.io.ResourceLoader;
+import cucumber.runtime.model.FeatureLoader;
+import io.cucumber.core.logging.LogRecordListener;
+import io.cucumber.core.logging.LoggerFactory;
+import io.cucumber.core.model.FeaturePath;
+import io.cucumber.core.options.FeatureOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FeaturePathFeatureSupplierTest {
+
+    private LogRecordListener logRecordListener;
+
+    @Before
+    public void setup() {
+        logRecordListener = new LogRecordListener();
+        LoggerFactory.addListener(logRecordListener);
+    }
+
+    @After
+    public void tearDown(){
+        LoggerFactory.removeListener(logRecordListener);
+    }
+
+    @Test
+    public void logs_message_if_no_features_are_found() {
+        ResourceLoader resourceLoader = mock(ResourceLoader.class);
+        when(resourceLoader.resources(URI.create("file:does/not/exist"), ".feature")).thenReturn(Collections.<Resource>emptyList());
+        FeatureOptions featureOptions = new FeatureOptions() {
+            @Override
+            public List<URI> getFeaturePaths() {
+                return Collections.singletonList(FeaturePath.parse("does/not/exist"));
+            }
+        };
+
+        FeaturePathFeatureSupplier supplier = new FeaturePathFeatureSupplier(new FeatureLoader(resourceLoader), featureOptions);
+        supplier.get();
+        assertThat(logRecordListener.getLogRecords().get(0).getMessage(), containsString("No features found at [file:does/not/exist]"));
+    }
+
+    @Test
+    public void logs_message_if_no_feature_paths_are_given() {
+        ResourceLoader resourceLoader = mock(ResourceLoader.class);
+        FeatureOptions featureOptions = new FeatureOptions() {
+            @Override
+            public List<URI> getFeaturePaths() {
+                return Collections.emptyList();
+            }
+        };
+
+        FeaturePathFeatureSupplier supplier = new FeaturePathFeatureSupplier(new FeatureLoader(resourceLoader), featureOptions);
+        supplier.get();
+        assertThat(logRecordListener.getLogRecords().get(0).getMessage(), containsString("Got no path to feature directory or feature file"));
+    }
+
+}

--- a/core/src/test/java/cucumber/runtime/FeaturePathFeatureSupplierTest.java
+++ b/core/src/test/java/cucumber/runtime/FeaturePathFeatureSupplierTest.java
@@ -48,7 +48,7 @@ public class FeaturePathFeatureSupplierTest {
 
         FeaturePathFeatureSupplier supplier = new FeaturePathFeatureSupplier(new FeatureLoader(resourceLoader), featureOptions);
         supplier.get();
-        assertThat(logRecordListener.getLogRecords().get(0).getMessage(), containsString("No features found at [file:does/not/exist]"));
+        assertThat(logRecordListener.getLogRecords().get(1).getMessage(), containsString("No features found at file:does/not/exist"));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class FeaturePathFeatureSupplierTest {
 
         FeaturePathFeatureSupplier supplier = new FeaturePathFeatureSupplier(new FeatureLoader(resourceLoader), featureOptions);
         supplier.get();
-        assertThat(logRecordListener.getLogRecords().get(0).getMessage(), containsString("Got no path to feature directory or feature file"));
+        assertThat(logRecordListener.getLogRecords().get(1).getMessage(), containsString("Got no path to feature directory or feature file"));
     }
 
 }

--- a/core/src/test/java/cucumber/runtime/model/CucumberFeatureTest.java
+++ b/core/src/test/java/cucumber/runtime/model/CucumberFeatureTest.java
@@ -25,42 +25,20 @@ public class CucumberFeatureTest {
     public void succeeds_if_no_features_are_found() {
         ResourceLoader resourceLoader = mock(ResourceLoader.class);
         mockNonExistingResource(resourceLoader);
-
-        PrintStream baos = new PrintStream(new ByteArrayOutputStream());
-        new FeatureLoader(resourceLoader).load(feature("does/not/exist"), baos);
+        new FeatureLoader(resourceLoader).load(feature("does/not/exist"));
     }
 
     private void mockNonExistingResource(ResourceLoader resourceLoader) {
         when(resourceLoader.resources(URI.create(DOES_NOT_EXIST), ".feature")).thenReturn(Collections.<Resource>emptyList());
     }
 
-    @Test
-    public void logs_message_if_no_features_are_found() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ResourceLoader resourceLoader = mock(ResourceLoader.class);
-        mockNonExistingResource(resourceLoader);
-
-        new FeatureLoader(resourceLoader).load(feature("does/not/exist"), new PrintStream(baos));
-
-        assertEquals(String.format("No features found at [does/not/exist]%n"), baos.toString());
-    }
-
-    @Test
-    public void logs_message_if_no_feature_paths_are_given() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ResourceLoader resourceLoader = mock(ResourceLoader.class);
-
-        new FeatureLoader(resourceLoader).load(Collections.<URI>emptyList(), new PrintStream(baos));
-
-        assertEquals(String.format("Got no path to feature directory or feature file%n"), baos.toString());
-    }
 
     @Test
     public void gives_error_message_if_path_does_not_exist() {
         ResourceLoader resourceLoader = mock(ResourceLoader.class);
         mockFeaturePathToNotExist(resourceLoader, "path/bar.feature");
         try {
-            new FeatureLoader(resourceLoader).load(feature("path/bar.feature"), new PrintStream(new ByteArrayOutputStream()));
+            new FeatureLoader(resourceLoader).load(feature("path/bar.feature"));
             fail("IllegalArgumentException was expected");
         } catch (IllegalArgumentException exception) {
             assertEquals("Not a file or directory: path/bar.feature", exception.getMessage());
@@ -76,7 +54,7 @@ public class CucumberFeatureTest {
         ResourceLoader resourceLoader = mock(ResourceLoader.class);
         mockFeaturePathToNotExist(resourceLoader, "classpath:path/bar.feature");
         try {
-            new FeatureLoader(resourceLoader).load(feature("classpath:path/bar.feature"), new PrintStream(new ByteArrayOutputStream()));
+            new FeatureLoader(resourceLoader).load(feature("classpath:path/bar.feature"));
             fail("IllegalArgumentException was expected");
         } catch (IllegalArgumentException exception) {
             assertEquals("Feature not found: classpath:path/bar.feature", exception.getMessage());

--- a/core/src/test/java/io/cucumber/core/logging/LoggerFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/logging/LoggerFactoryTest.java
@@ -1,0 +1,128 @@
+package io.cucumber.core.logging;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.junit.Assert.assertThat;
+
+
+public class LoggerFactoryTest {
+
+    private final Exception exception = new Exception();
+    private LogRecord logged;
+    private Logger logger = LoggerFactory.getLogger(LoggerFactoryTest.class);
+
+    private static Matcher<LogRecord> logRecord(final String message, final Level level, final Throwable throwable) {
+        return new TypeSafeDiagnosingMatcher<LogRecord>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("error=");
+                description.appendValue(message);
+                description.appendText(" level=");
+                description.appendValue(level);
+                description.appendText(" throwable=");
+                description.appendValue(throwable);
+            }
+
+
+            @Override
+            protected boolean matchesSafely(LogRecord logRecord, Description description) {
+                description.appendText("error=");
+                description.appendValue(logRecord.getMessage());
+                description.appendText(" level=");
+                description.appendValue(logRecord.getLevel());
+                description.appendText(" throwable=");
+                description.appendValue(logRecord.getThrown());
+
+                return Objects.equals(logRecord.getMessage(), message)
+                    && Objects.equals(logRecord.getLevel(), level)
+                    && Objects.equals(logRecord.getThrown(), throwable);
+            }
+        };
+    }
+
+    @Before
+    public void setup() {
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logged = record;
+            }
+
+            @Override
+            public void flush() {
+
+            }
+
+            @Override
+            public void close() throws SecurityException {
+
+            }
+        };
+        handler.setLevel(Level.ALL);
+
+        java.util.logging.Logger julLogger = java.util.logging.Logger.getLogger(LoggerFactoryTest.class.getName());
+        julLogger.setLevel(Level.ALL);
+        julLogger.addHandler(handler);
+        // Suppress out put
+        julLogger.setUseParentHandlers(false);
+    }
+
+    @Test
+    public void error() {
+        logger.error("Error");
+        assertThat(logged, logRecord("Error", Level.SEVERE, null));
+        logger.error("Error", exception);
+        assertThat(logged, logRecord("Error", Level.SEVERE, exception));
+    }
+
+    @Test
+    public void warn() {
+        logger.warn("Warn");
+        assertThat(logged, logRecord("Warn", Level.WARNING, null));
+        logger.warn("Warn", exception);
+        assertThat(logged, logRecord("Warn", Level.WARNING, exception));
+    }
+
+    @Test
+    public void info() {
+        logger.info("Info");
+        assertThat(logged, logRecord("Info", Level.INFO, null));
+        logger.info("Info", exception);
+        assertThat(logged, logRecord("Info", Level.INFO, exception));
+    }
+
+    @Test
+    public void config() {
+        logger.config("Config");
+        assertThat(logged, logRecord("Config", Level.CONFIG, null));
+        logger.config("Config", exception);
+        assertThat(logged, logRecord("Config", Level.CONFIG, exception));
+    }
+
+
+    @Test
+    public void debug() {
+        logger.debug("Debug");
+        assertThat(logged, logRecord("Debug", Level.FINE, null));
+        logger.debug("Debug", exception);
+        assertThat(logged, logRecord("Debug", Level.FINE, exception));
+    }
+
+    @Test
+    public void trace() {
+        logger.trace("Trace");
+        assertThat(logged, logRecord("Trace", Level.FINER, null));
+        logger.trace("Trace", exception);
+        assertThat(logged, logRecord("Trace", Level.FINER, exception));
+    }
+
+}

--- a/examples/java-calculator-testng/pom.xml
+++ b/examples/java-calculator-testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-calculator-testng</artifactId>

--- a/examples/java-calculator/pom.xml
+++ b/examples/java-calculator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-calculator</artifactId>

--- a/examples/java-wicket/java-wicket-main/pom.xml
+++ b/examples/java-wicket/java-wicket-main/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>java-wicket</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket-main</artifactId>
     <name>Examples: Wicket application</name>

--- a/examples/java-wicket/java-wicket-test/pom.xml
+++ b/examples/java-wicket/java-wicket-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>java-wicket</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket-test</artifactId>
     <name>Examples: Wicket application tested with Selenium</name>

--- a/examples/java-wicket/pom.xml
+++ b/examples/java-wicket/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket</artifactId>
     <packaging>pom</packaging>

--- a/examples/java8-calculator/pom.xml
+++ b/examples/java8-calculator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java8-calculator</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-examples</artifactId>

--- a/examples/spring-txn/pom.xml
+++ b/examples/spring-txn/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-txn</artifactId>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-guice</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-java</artifactId>

--- a/java/src/main/java/cucumber/runtime/java/ObjectFactoryLoader.java
+++ b/java/src/main/java/cucumber/runtime/java/ObjectFactoryLoader.java
@@ -6,6 +6,8 @@ import cucumber.runtime.CucumberException;
 import cucumber.runtime.NoInstancesException;
 import cucumber.runtime.Reflections;
 import cucumber.runtime.TooManyInstancesException;
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
 
 import java.net.URI;
 import java.util.List;
@@ -13,6 +15,9 @@ import java.util.List;
 import static java.util.Arrays.asList;
 
 public class ObjectFactoryLoader {
+
+    private static final Logger log = LoggerFactory.getLogger(ObjectFactoryLoader.class);
+
     private ObjectFactoryLoader() {
     }
 
@@ -20,7 +25,7 @@ public class ObjectFactoryLoader {
      * Loads an instance of {@link ObjectFactory}. The class name can be explicit, or it can be null.
      * When it's null, the implementation is searched for in the <pre>cucumber.runtime</pre> packahe.
      *
-     * @param classFinder where to load classes from
+     * @param classFinder            where to load classes from
      * @param objectFactoryClassName specific class name of {@link ObjectFactory} implementation. May be null.
      * @return an instance of {@link ObjectFactory}
      */
@@ -29,7 +34,7 @@ public class ObjectFactoryLoader {
         try {
             Reflections reflections = new Reflections(classFinder);
 
-            if(objectFactoryClassName != null) {
+            if (objectFactoryClassName != null) {
                 Class<ObjectFactory> objectFactoryClass = (Class<ObjectFactory>) classFinder.loadClass(objectFactoryClassName);
                 objectFactory = reflections.newInstance(new Class[0], new Object[0], objectFactoryClass);
             } else {
@@ -37,8 +42,8 @@ public class ObjectFactoryLoader {
                 objectFactory = reflections.instantiateExactlyOneSubclass(ObjectFactory.class, packages, new Class[0], new Object[0], null);
             }
         } catch (TooManyInstancesException e) {
-            System.out.println(e.getMessage());
-            System.out.println(getMultipleObjectFactoryLogMessage());
+            log.warn(e.getMessage());
+            log.warn(getMultipleObjectFactoryLogMessage());
             objectFactory = new DefaultJavaObjectFactory();
         } catch (NoInstancesException e) {
             objectFactory = new DefaultJavaObjectFactory();

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-java8</artifactId>

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-junit</artifactId>

--- a/kotlin-java8/pom.xml
+++ b/kotlin-java8/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-kotlin-java8</artifactId>

--- a/needle/pom.xml
+++ b/needle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-needle</artifactId>

--- a/openejb/pom.xml
+++ b/openejb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-openejb</artifactId>

--- a/picocontainer/pom.xml
+++ b/picocontainer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-picocontainer</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <version>1.0.3</version>
     </parent>
     <artifactId>cucumber-jvm</artifactId>
-    <version>4.2.7-SNAPSHOT</version>
+    <version>4.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Cucumber-JVM</name>
     <description>Cucumber for the JVM</description>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-spring</artifactId>

--- a/testng/pom.xml
+++ b/testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-testng</artifactId>

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.2.7-SNAPSHOT</version>
+        <version>4.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-weld</artifactId>

--- a/weld/src/main/java/cucumber/runtime/java/weld/WeldFactory.java
+++ b/weld/src/main/java/cucumber/runtime/java/weld/WeldFactory.java
@@ -2,10 +2,14 @@ package cucumber.runtime.java.weld;
 
 import cucumber.runtime.CucumberException;
 import cucumber.api.java.ObjectFactory;
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 
 public class WeldFactory implements ObjectFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(WeldFactory.class);
 
     static final String START_EXCEPTION_MESSAGE = "\n" +
         "It looks like you're running on a single-core machine, and Weld doesn't like that. See:\n" +
@@ -48,8 +52,7 @@ public class WeldFactory implements ObjectFactory {
                 containerInstance.close();
             }
         } catch (NullPointerException npe) {
-            System.err.println(STOP_EXCEPTION_MESSAGE);
-            npe.printStackTrace(System.err);
+            log.error(STOP_EXCEPTION_MESSAGE, npe);
         }
     }
 

--- a/weld/src/test/java/cucumber/runtime/java/weld/WeldFactoryTest.java
+++ b/weld/src/test/java/cucumber/runtime/java/weld/WeldFactoryTest.java
@@ -2,20 +2,21 @@ package cucumber.runtime.java.weld;
 
 import cucumber.api.java.ObjectFactory;
 import cucumber.runtime.CucumberException;
+import io.cucumber.core.logging.LogRecordListener;
+import io.cucumber.core.logging.LoggerFactory;
 import org.jboss.weld.environment.se.Weld;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,6 +24,19 @@ public class WeldFactoryTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    private LogRecordListener logRecordListener;
+
+    @Before
+    public void setup() {
+        logRecordListener = new LogRecordListener();
+        LoggerFactory.addListener(logRecordListener);
+    }
+
+    @After
+    public void tearDown(){
+        LoggerFactory.removeListener(logRecordListener);
+    }
 
     @Test
     public void shouldGiveUsNewInstancesForEachScenario() {
@@ -61,15 +75,8 @@ public class WeldFactoryTest {
 
     @Test
     public void stopCalledWithoutStart() {
-        PrintStream originalErr = System.err;
-        try {
-            ByteArrayOutputStream errContent = new ByteArrayOutputStream();
-            System.setErr(new PrintStream(errContent));
-            ObjectFactory factory = new WeldFactory();
-            factory.stop();
-            assertThat(errContent.toString(), startsWith(WeldFactory.STOP_EXCEPTION_MESSAGE));
-        } finally {
-            System.setErr(originalErr);
-        }
+        ObjectFactory factory = new WeldFactory();
+        factory.stop();
+        assertThat(logRecordListener.getLogRecords().get(0).getMessage(), containsString(WeldFactory.STOP_EXCEPTION_MESSAGE));
     }
 }


### PR DESCRIPTION
## Summary

Add logger. 

The logger is based on [`java.util.logger`](https://docs.oracle.com/javase/7/docs/api/java/util/logging/Logger.html). This logger can be by configured using [`java.util.logging.LogManager`](https://docs.oracle.com/javase/7/docs/api/java/util/logging/LogManager.html) or the <a href="https://www.slf4j.org/legacy.html#jul-to-slf4j">JUL to SLF4J Bridge</a>.

## Details
  
Rather then using `System.out` or `System.err` to print errors  warnings these should be printed via a logger. This allows end users  control over what is logged when and where. The exception to this is `RuntimeOptions`. These outputs are part of the CLI and should always go to `System.out`.

## Motivation and Context

To assist debugging and provide more clarity about the internal state of cucumber some form of output is needed. In #147 a `--verbose` option is suggested but given the highly integrated nature of `RuntimeOptions` this is not feasible.

Only when `RuntimeOptions` is used a part of a standalone program (i.e. the CLI) it can assume control over the `LogManager`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
