### PR TITLE
[JUnit] Invoke @BeforeClass before TestRunStarted event

### DIFF
--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -26,5 +26,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/junit/src/test/java/cucumber/runtime/junit/CucumberTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/CucumberTest.java
@@ -78,7 +78,7 @@ public class CucumberTest {
             new Cucumber(FormatterWithLexerErrorFeature.class);
             fail("Expecting error");
         } catch (CucumberException e){
-            assertFalse("File is created despite Lexor Error", new File("lexor_error_feature.json").exists());
+            assertFalse("File is created despite Lexor Error", new File("target/lexor_error_feature.json").exists());
         }
     }
 
@@ -199,7 +199,7 @@ public class CucumberTest {
 
     }
 
-    @CucumberOptions(features = {"classpath:cucumber/runtime/error/lexer_error.feature"}, plugin = {"json:lexor_error_feature.json"})
+    @CucumberOptions(features = {"classpath:cucumber/runtime/error/lexer_error.feature"}, plugin = {"json:target/lexor_error_feature.json"})
     public class FormatterWithLexerErrorFeature {
 
     }

--- a/junit/src/test/java/cucumber/runtime/junit/InvokeMethodsAroundEventsTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/InvokeMethodsAroundEventsTest.java
@@ -1,0 +1,76 @@
+package cucumber.runtime.junit;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.event.ConcurrentEventListener;
+import cucumber.api.event.EventHandler;
+import cucumber.api.event.EventPublisher;
+import cucumber.api.event.TestRunFinished;
+import cucumber.api.event.TestRunStarted;
+import cucumber.api.junit.Cucumber;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.Assert.assertThat;
+
+public class InvokeMethodsAroundEventsTest {
+
+    private static final List<String> events = new ArrayList<>();
+
+    private static EventHandler<TestRunStarted> testRunStartedEventHandler = new EventHandler<TestRunStarted>() {
+        @Override
+        public void receive(TestRunStarted event) {
+            events.add("TestRunStarted");
+        }
+    };
+    private static EventHandler<TestRunFinished> testRunFinishedEventHandler = new EventHandler<TestRunFinished>() {
+        @Override
+        public void receive(TestRunFinished event) {
+            events.add("TestRunFinished");
+        }
+    };
+
+    @AfterClass
+    public static void afterClass() {
+        events.clear();
+    }
+
+    @Test
+    public void finds_features_based_on_implicit_package() throws InitializationError {
+        Cucumber cucumber = new Cucumber(BeforeAfterClass.class);
+        cucumber.run(new RunNotifier());
+        assertThat(events, contains("BeforeClass", "TestRunStarted", "TestRunFinished", "AfterClass"));
+    }
+
+    @CucumberOptions(plugin = {"cucumber.runtime.junit.InvokeMethodsAroundEventsTest$TestRunStartedFinishedListener"})
+    public static class BeforeAfterClass {
+
+        @BeforeClass
+        public static void beforeClass() {
+            events.add("BeforeClass");
+
+        }
+
+        @AfterClass
+        public static void afterClass() {
+            events.add("AfterClass");
+        }
+    }
+
+    @SuppressWarnings("unused") // Used as a plugin by BeforeAfterClass
+    public static class TestRunStartedFinishedListener implements ConcurrentEventListener {
+
+        @Override
+        public void setEventPublisher(EventPublisher publisher) {
+            publisher.registerHandlerFor(TestRunStarted.class, testRunStartedEventHandler);
+            publisher.registerHandlerFor(TestRunFinished.class, testRunFinishedEventHandler);
+        }
+
+    }
+}


### PR DESCRIPTION
## Summary

Invoke @BeforeClass before TestRunStarted event

JUnit is running Cucumber so the expectation is that JUnit's
`@BeforeClass` and `@AfterClass` methods are invoked respectively before
and after all events emitted by Cucumber. However because the
`TestRunStarted` event was emitted in the constructor of `Cucumber` it
would precede the the invocation of `@BeforeClass`.

In older versions of Cucumber sending the `TestSourceRead` events was
coupled to reading the test sources. This made it impossible to read the
features ahead of time -required to to create the test description
tree and fail on lexer errors- and send `TestRunStarted` after
`@BeforeClass`.

This is no longer case since #1367 and so this problem can be resolved.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
