### PR TITLE
Tests for issue with context caching (#1583)

### DIFF
--- a/spring/src/test/java/cucumber/runtime/java/spring/contextcaching/ContextCachingScenarioTest.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/contextcaching/ContextCachingScenarioTest.java
@@ -1,0 +1,8 @@
+package cucumber.runtime.java.spring.contextcaching;
+
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+public class ContextCachingScenarioTest {
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/contextcaching/ContextCachingSteps.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/contextcaching/ContextCachingSteps.java
@@ -1,0 +1,24 @@
+package cucumber.runtime.java.spring.contextcaching;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@ContextConfiguration(classes = {ContextConfig.class})
+public class ContextCachingSteps {
+
+    @Autowired
+    ContextCounter contextCounter;
+
+    @cucumber.api.java.en.When("I run a scenario")
+    public void runningScenario() {
+    }
+
+    @cucumber.api.java.en.Then("there should be only one Spring context")
+    public void oneContext() {
+        assertThat(contextCounter.getContextCount(), is(1));
+    }
+
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/contextcaching/ContextConfig.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/contextcaching/ContextConfig.java
@@ -1,0 +1,9 @@
+package cucumber.runtime.java.spring.contextcaching;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan({"cucumber.runtime.java.spring.contextcaching"})
+public class ContextConfig {
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/contextcaching/ContextCounter.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/contextcaching/ContextCounter.java
@@ -1,0 +1,23 @@
+package cucumber.runtime.java.spring.contextcaching;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Component
+public class ContextCounter implements ApplicationContextAware {
+    private static Set<ApplicationContext> applicationContextSet = new HashSet();
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        applicationContextSet.add(applicationContext);
+    }
+
+    public int getContextCount() {
+        return applicationContextSet.size();
+    }
+}

--- a/spring/src/test/java/cucumber/runtime/java/spring/contextcaching/SomeTest.java
+++ b/spring/src/test/java/cucumber/runtime/java/spring/contextcaching/SomeTest.java
@@ -1,0 +1,25 @@
+package cucumber.runtime.java.spring.contextcaching;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {ContextConfig.class})
+public class SomeTest {
+    @Autowired
+    ContextCounter contextCounter;
+
+    @Test
+    public void contextCountIsOne() {
+        assertThat(contextCounter.getContextCount(), is(1));
+    }
+
+}

--- a/spring/src/test/resources/cucumber/runtime/java/spring/contextcaching/ContextCaching.feature
+++ b/spring/src/test/resources/cucumber/runtime/java/spring/contextcaching/ContextCaching.feature
@@ -1,0 +1,5 @@
+Feature: context caching with JUnit tests
+
+  Scenario:
+    When I run a scenario
+    Then there should be only one Spring context


### PR DESCRIPTION
## Summary

Cucumber doesn't share its spring context with other junit tests using the same context configuration. Added (failing) tests to reproduce this issue.

## Details

Cucumber uses a ThreadLocal to store a ContextCache for each thread. In contrast the spring test runner uses a static default ContextCache in DefaultCacheAwareContextLoaderDelegate. This leads to creating two spring contexts when running cucumber tests together with plain junit tests.

Tests pass when Line 18 in FixBootstrapUtils is changed to 
```CacheAwareContextLoaderDelegate contextLoader = new DefaultCacheAwareContextLoaderDelegate();```
(calling parameterless constructor).

This is probably not a valid solution as it would break functionality added with #1148.