### PR TITLE
Adding new timestamp field to event and json report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
     * Allow parameter-types in escaped optional groups ([#cucumber/572](https://github.com/cucumber/cucumber/pull/572), [#cucumber/561](https://github.com/cucumber/cucumber/pull/561) Luke Hill, Jayson Smith, M.P. Korstanje)
     * Prefer expression with the longest non-empty match ([#cucumber/580](https://github.com/cucumber/cucumber/pull/580) M.P. Korstanje)
     * Improve heuristics for creating Cucumber/Regular Expressions from strings ([#cucumber/518](https://github.com/cucumber/cucumber/pull/518) Aslak Hellesøy)
+ *  [Kotlin-Java8] Upgrade Kotlin to v1.3.0 and more idiomatic Kotlin ([#1590](https://github.com/cucumber/cucumber-jvm/pull/1590) Marit van Dijk)
 
 ### Deprecated
    
@@ -42,7 +43,7 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
 ### Fixed
  * [Core] Disambiguate between Windows drive letter and uri scheme ([#1568](https://github.com/cucumber/cucumber-jvm/issues/1568), [#1564](https://github.com/cucumber/cucumber-jvm/issues/1564) jsa34)
 
-## [4.2.3-SNAPSHOT](https://github.com/cucumber/cucumber-jvm/compare/v4.2.2...v4.2.3) (2019-02-08)
+## [4.2.3](https://github.com/cucumber/cucumber-jvm/compare/v4.2.2...v4.2.3) (2019-02-08)
 
 ### Fixed
  * [Build] Fix windows build ([#1552](https://github.com/cucumber/cucumber-jvm/pull/1552), [#1551](https://github.com/cucumber/cucumber-jvm/issues/1551) Alexey Mozhenin) 

--- a/core/src/main/java/io/cucumber/core/api/event/TestCaseStarted.java
+++ b/core/src/main/java/io/cucumber/core/api/event/TestCaseStarted.java
@@ -2,10 +2,16 @@ package io.cucumber.core.api.event;
 
 public final class TestCaseStarted extends TestCaseEvent {
     public final TestCase testCase;
+    private final long elapsedTimiMillis; 
 
-    public TestCaseStarted(Long timeStamp, TestCase testCase) {
+    public TestCaseStarted(Long timeStamp, Long elapsedTimiMillis, TestCase testCase) {
         super(timeStamp, testCase);
         this.testCase = testCase;
+        this.elapsedTimiMillis = elapsedTimiMillis;
+    }
+
+    public long getElapsedTimiMillis() {
+        return elapsedTimiMillis;
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/event/EventBus.java
+++ b/core/src/main/java/io/cucumber/core/event/EventBus.java
@@ -7,6 +7,8 @@ public interface EventBus extends EventPublisher {
 
     Long getTime();
 
+    Long getElapsedTimeMillis();
+    
     void send(Event event);
 
     void sendAll(Iterable<Event> queue);

--- a/core/src/main/java/io/cucumber/core/plugin/JSONFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/JSONFormatter.java
@@ -394,8 +394,7 @@ public final class JSONFormatter implements EventListener {
         return resultMap;
     }
 
-    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter)
-    {
+    public void setDateTimeFormatter(DateTimeFormatter dateTimeFormatter) {
         this.dateTimeFormatter = dateTimeFormatter;
     }
 

--- a/core/src/main/java/io/cucumber/core/runner/TestCase.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCase.java
@@ -1,17 +1,17 @@
 package io.cucumber.core.runner;
 
-import io.cucumber.core.api.event.Result;
-import io.cucumber.core.api.event.TestStep;
-import io.cucumber.core.api.event.TestCaseFinished;
-import io.cucumber.core.api.event.TestCaseStarted;
-import gherkin.events.PickleEvent;
-import gherkin.pickles.PickleLocation;
-import gherkin.pickles.PickleTag;
-import io.cucumber.core.event.EventBus;
-
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+
+import gherkin.events.PickleEvent;
+import gherkin.pickles.PickleLocation;
+import gherkin.pickles.PickleTag;
+import io.cucumber.core.api.event.Result;
+import io.cucumber.core.api.event.TestCaseFinished;
+import io.cucumber.core.api.event.TestCaseStarted;
+import io.cucumber.core.api.event.TestStep;
+import io.cucumber.core.event.EventBus;
 
 final class TestCase implements io.cucumber.core.api.event.TestCase {
     private final PickleEvent pickleEvent;
@@ -35,7 +35,9 @@ final class TestCase implements io.cucumber.core.api.event.TestCase {
     void run(EventBus bus) {
         boolean skipNextStep = this.dryRun;
         Long startTime = bus.getTime();
-        bus.send(new TestCaseStarted(startTime, this));
+        Long startTimeMillis = bus.getElapsedTimeMillis();
+        
+        bus.send(new TestCaseStarted(startTime, startTimeMillis, this));
         Scenario scenario = new Scenario(bus, this);
 
         for (HookTestStep before : beforeHooks) {

--- a/core/src/main/java/io/cucumber/core/runner/TimeService.java
+++ b/core/src/main/java/io/cucumber/core/runner/TimeService.java
@@ -11,8 +11,7 @@ public interface TimeService {
         }
 
         @Override
-        public long elapsedTimeMillis()
-        {
+        public long elapsedTimeMillis() {
             return System.currentTimeMillis();
         }
     };

--- a/core/src/main/java/io/cucumber/core/runner/TimeService.java
+++ b/core/src/main/java/io/cucumber/core/runner/TimeService.java
@@ -2,11 +2,18 @@ package io.cucumber.core.runner;
 
 public interface TimeService {
     long time();
+    long elapsedTimeMillis();
 
     TimeService SYSTEM = new TimeService() {
         @Override
         public long time() {
             return System.nanoTime();
+        }
+
+        @Override
+        public long elapsedTimeMillis()
+        {
+            return System.currentTimeMillis();
         }
     };
 

--- a/core/src/main/java/io/cucumber/core/runner/TimeServiceEventBus.java
+++ b/core/src/main/java/io/cucumber/core/runner/TimeServiceEventBus.java
@@ -8,9 +8,13 @@ public final class TimeServiceEventBus extends AbstractEventBus {
     public TimeServiceEventBus(TimeService stopWatch) {
         this.stopWatch = stopWatch;
     }
-
+    
     @Override
     public Long getTime() {
         return stopWatch.time();
+    }
+    
+    public Long getElapsedTimeMillis() {
+        return stopWatch.elapsedTimeMillis();
     }
 }

--- a/core/src/main/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplier.java
+++ b/core/src/main/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplier.java
@@ -111,8 +111,7 @@ public final class ThreadLocalRunnerSupplier implements RunnerSupplier {
         }
 
         @Override
-        public Long getElapsedTimeMillis()
-        {
+        public Long getElapsedTimeMillis() {
             return delegate.getElapsedTimeMillis();
         }
     }

--- a/core/src/main/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplier.java
+++ b/core/src/main/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplier.java
@@ -3,7 +3,6 @@ package io.cucumber.core.runtime;
 import io.cucumber.core.api.event.Event;
 import io.cucumber.core.api.event.EventHandler;
 import io.cucumber.core.backend.BackendSupplier;
-import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.backend.ObjectFactorySupplier;
 import io.cucumber.core.event.AbstractEventBus;
 import io.cucumber.core.event.EventBus;
@@ -62,6 +61,12 @@ public final class ThreadLocalRunnerSupplier implements RunnerSupplier {
             super.send(event);
             parent.send(event);
         }
+
+        @Override
+        public Long getElapsedTimeMillis()
+        {
+            return parent.getElapsedTimeMillis();
+        }
     }
 
     private static final class SynchronizedEventBus implements EventBus {
@@ -103,6 +108,12 @@ public final class ThreadLocalRunnerSupplier implements RunnerSupplier {
         @Override
         public synchronized <T extends Event> void removeHandlerFor(Class<T> eventType, EventHandler<T> handler) {
             delegate.removeHandlerFor(eventType, handler);
+        }
+
+        @Override
+        public Long getElapsedTimeMillis()
+        {
+            return delegate.getElapsedTimeMillis();
         }
     }
 }

--- a/core/src/test/java/io/cucumber/core/api/event/CanonicalEventOrderTest.java
+++ b/core/src/test/java/io/cucumber/core/api/event/CanonicalEventOrderTest.java
@@ -32,12 +32,18 @@ public class CanonicalEventOrderTest {
         return new Date().getTime();
     }
 
+    private static long getTimeInMillis()
+    {
+        return System.currentTimeMillis();
+    }
+
     static Event createTestCaseEvent(final String uri, final int line) {
         final TestCase testCase = mock(TestCase.class);
         given(testCase.getUri()).willReturn(uri);
         given(testCase.getLine()).willReturn(line);
-        return new TestCaseStarted(getTime(), testCase);
+        return new TestCaseStarted(getTime(), getTimeInMillis(), testCase);
     }
+
 
     private Event runStarted = new TestRunStarted(getTime());
     private Event testRead = new TestSourceRead(getTime(), "uri", "source");

--- a/core/src/test/java/io/cucumber/core/api/event/CanonicalEventOrderTest.java
+++ b/core/src/test/java/io/cucumber/core/api/event/CanonicalEventOrderTest.java
@@ -32,8 +32,7 @@ public class CanonicalEventOrderTest {
         return new Date().getTime();
     }
 
-    private static long getTimeInMillis()
-    {
+    private static long getTimeInMillis() {
         return System.currentTimeMillis();
     }
 

--- a/core/src/test/java/io/cucumber/core/plugin/JSONFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/JSONFormatterTest.java
@@ -92,6 +92,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -142,6 +143,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -195,6 +197,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -252,6 +255,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"fruit-party;monkey-eats-fruits;fruit-table;2\",\n" +
             "        \"keyword\": \"Scenario Outline\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats fruits\",\n" +
             "        \"line\": 7,\n" +
             "        \"description\": \"\",\n" +
@@ -336,6 +340,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 6,\n" +
             "        \"description\": \"\",\n" +
@@ -379,6 +384,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-more-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats more bananas\",\n" +
             "        \"line\": 9,\n" +
             "        \"description\": \"\",\n" +
@@ -432,6 +438,7 @@ public class JSONFormatterTest {
             "        \"id\": \"banana-party;monkey-eats-more-bananas\",\n" +
             "        \"type\": \"scenario\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"steps\": [\n" +
             "          {\n" +
             "            \"result\": {\n" +
@@ -518,6 +525,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -601,6 +609,7 @@ public class JSONFormatterTest {
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"type\": \"scenario\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"steps\": [\n" +
             "          {\n" +
             "            \"result\": {\n" +
@@ -732,6 +741,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -802,6 +812,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -875,6 +886,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -935,6 +947,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -995,6 +1008,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -1070,6 +1084,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -1103,6 +1118,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"orange-party;monkey-eats-oranges\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T05:30:00\",\n" +
             "        \"name\": \"Monkey eats oranges\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -1195,6 +1211,7 @@ public class JSONFormatterTest {
         final EventBus bus = new TimeServiceEventBus(new TimeServiceStub(1234));
 
         Appendable stringBuilder = new StringBuilder();
+        
         Runtime.builder()
             .withClassLoader(classLoader)
             .withResourceLoader(resourceLoader)

--- a/core/src/test/java/io/cucumber/core/plugin/JsonParallelRuntimeTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/JsonParallelRuntimeTest.java
@@ -1,10 +1,13 @@
 package io.cucumber.core.plugin;
 
-import io.cucumber.core.runtime.Runtime;
-import org.junit.Test;
-
 import static org.junit.Assert.assertThat;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
+
+import java.time.format.DateTimeFormatter;
+
+import org.junit.Test;
+
+import io.cucumber.core.runtime.Runtime;
 
 //TODO: Merge with the existing test
 public class JsonParallelRuntimeTest {
@@ -12,18 +15,26 @@ public class JsonParallelRuntimeTest {
     @Test
     public void testSingleFeature() {
         StringBuilder parallel = new StringBuilder();
+        
+        JSONFormatter jsonFormatterParallel = new JSONFormatter(parallel);
+        jsonFormatterParallel.setDateTimeFormatter(DateTimeFormatter.ISO_DATE);
+        
         Runtime.builder()
             .withArgs("--threads", "3",
                 "src/test/resources/io/cucumber/core/plugin/JSONPrettyFormatterTest.feature")
-            .withAdditionalPlugins(new JSONFormatter(parallel))
+            .withAdditionalPlugins(jsonFormatterParallel)
             .build()
             .run();
-
+        
+       
         StringBuilder serial = new StringBuilder();
+        JSONFormatter jsonFormatterSerial = new JSONFormatter(serial);
+        jsonFormatterSerial.setDateTimeFormatter(DateTimeFormatter.ISO_DATE);
+       
         Runtime.builder()
             .withArgs("--threads", "1",
                 "src/test/resources/io/cucumber/core/plugin/JSONPrettyFormatterTest.feature")
-            .withAdditionalPlugins(new JSONFormatter(serial))
+            .withAdditionalPlugins(jsonFormatterSerial)
             .build()
             .run();
 
@@ -33,21 +44,29 @@ public class JsonParallelRuntimeTest {
     @Test
     public void testMultipleFeatures() {
         StringBuilder parallel = new StringBuilder();
+
+        JSONFormatter jsonFormatterParallel = new JSONFormatter(parallel);
+        jsonFormatterParallel.setDateTimeFormatter(DateTimeFormatter.ISO_DATE);
+        
         Runtime.builder()
             .withArgs("--threads", "3",
                 "src/test/resources/io/cucumber/core/plugin/JSONPrettyFormatterTest.feature",
                 "src/test/resources/io/cucumber/core/plugin/FormatterInParallel.feature")
-            .withAdditionalPlugins(new JSONFormatter(parallel))
+            .withAdditionalPlugins(jsonFormatterParallel)
             .build()
             .run();
 
 
         StringBuilder serial = new StringBuilder();
+        
+        JSONFormatter jsonFormatterSerial = new JSONFormatter(serial);
+        jsonFormatterSerial.setDateTimeFormatter(DateTimeFormatter.ISO_DATE);
+        
         Runtime.builder()
             .withArgs("--threads", "1",
                 "src/test/resources/io/cucumber/core/plugin/JSONPrettyFormatterTest.feature",
                 "src/test/resources/io/cucumber/core/plugin/FormatterInParallel.feature")
-            .withAdditionalPlugins(new JSONFormatter(serial))
+            .withAdditionalPlugins(jsonFormatterSerial)
             .build()
             .run();
 

--- a/core/src/test/java/io/cucumber/core/runner/StepDurationTimeService.java
+++ b/core/src/test/java/io/cucumber/core/runner/StepDurationTimeService.java
@@ -35,4 +35,10 @@ public class StepDurationTimeService implements TimeService, EventListener {
         long time = time();
         currentTime.set(time + stepDuration);
     }
+
+    @Override
+    public long elapsedTimeMillis()
+    {
+        return 0L;
+    }
 }

--- a/core/src/test/java/io/cucumber/core/runner/StepDurationTimeService.java
+++ b/core/src/test/java/io/cucumber/core/runner/StepDurationTimeService.java
@@ -37,8 +37,7 @@ public class StepDurationTimeService implements TimeService, EventListener {
     }
 
     @Override
-    public long elapsedTimeMillis()
-    {
+    public long elapsedTimeMillis() {
         return 0L;
     }
 }

--- a/core/src/test/java/io/cucumber/core/runner/TimeServiceStub.java
+++ b/core/src/test/java/io/cucumber/core/runner/TimeServiceStub.java
@@ -17,8 +17,7 @@ public class TimeServiceStub implements TimeService {
     }
 
     @Override
-    public long elapsedTimeMillis()
-    {
+    public long elapsedTimeMillis() {
         return 0L;
     }
 }

--- a/core/src/test/java/io/cucumber/core/runner/TimeServiceStub.java
+++ b/core/src/test/java/io/cucumber/core/runner/TimeServiceStub.java
@@ -15,4 +15,10 @@ public class TimeServiceStub implements TimeService {
         currentTime.set(result + duration);
         return result;
     }
+
+    @Override
+    public long elapsedTimeMillis()
+    {
+        return 0L;
+    }
 }

--- a/core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,7 +35,6 @@ import io.cucumber.core.api.event.HookType;
 import io.cucumber.core.api.event.Result;
 import io.cucumber.core.api.event.TestCase;
 import io.cucumber.core.api.event.TestCaseFinished;
-import io.cucumber.core.api.plugin.Plugin;
 import io.cucumber.core.api.plugin.StepDefinitionReporter;
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.BackendSupplier;
@@ -48,6 +48,7 @@ import io.cucumber.core.io.TestClasspathResourceLoader;
 import io.cucumber.core.model.CucumberFeature;
 import io.cucumber.core.plugin.FormatterBuilder;
 import io.cucumber.core.plugin.FormatterSpy;
+import io.cucumber.core.plugin.JSONFormatter;
 import io.cucumber.core.runner.TestBackendSupplier;
 import io.cucumber.core.runner.TestHelper;
 import io.cucumber.core.runner.TimeService;
@@ -73,7 +74,9 @@ public class RuntimeTest {
             "    When s\n");
         StringBuilder out = new StringBuilder();
 
-        Plugin jsonFormatter = FormatterBuilder.jsonFormatter(out);
+        JSONFormatter jsonFormatter = FormatterBuilder.jsonFormatter(out);
+        jsonFormatter.setDateTimeFormatter(DateTimeFormatter.ofPattern(""));
+        
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         BackendSupplier backendSupplier = new BackendSupplier() {
             @Override
@@ -81,6 +84,7 @@ public class RuntimeTest {
                 return singletonList(mock(Backend.class));
             }
         };
+        
         FeatureSupplier featureSupplier = new TestFeatureSupplier(bus, feature);
         Runtime.builder()
             .withBackendSupplier(backendSupplier)
@@ -114,6 +118,7 @@ public class RuntimeTest {
             "        ]\n" +
             "      },\n" +
             "      {\n" +
+            "        \"start_timestamp\": \"\",\n" +
             "        \"line\": 4,\n" +
             "        \"name\": \"scenario name\",\n" +
             "        \"description\": \"\",\n" +

--- a/core/src/test/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplierTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplierTest.java
@@ -98,6 +98,6 @@ public class ThreadLocalRunnerSupplierTest {
                 fail();
             }
         });
-        eventBus.send(new TestCaseStarted(0L, null));
+        eventBus.send(new TestCaseStarted(0L, 0L, null));
     }
 }

--- a/core/src/test/resources/io/cucumber/core/plugin/JSONPrettyFormatterTest.json
+++ b/core/src/test/resources/io/cucumber/core/plugin/JSONPrettyFormatterTest.json
@@ -44,6 +44,7 @@
       },
       {
         "id": "feature-3;scenario-1",
+		"start_timestamp": "1970-01-01T05:30:00",
         "before": [
           {
             "result": {
@@ -135,6 +136,7 @@
       },
       {
         "id": "feature-3;scenariooutline-1;;2",
+		"start_timestamp": "1970-01-01T05:30:00",
         "before": [
           {
             "result": {
@@ -217,6 +219,7 @@
       },
       {
         "id": "feature-3;scenariooutline-1;;3",
+		"start_timestamp": "1970-01-01T05:30:00",
         "before": [
           {
             "result": {
@@ -299,6 +302,7 @@
       },
       {
         "id": "feature-3;scenario-2",
+		"start_timestamp": "1970-01-01T05:30:00",
         "before": [
           {
             "result": {

--- a/junit/src/test/java/io/cucumber/junit/api/FeatureRunnerTest.java
+++ b/junit/src/test/java/io/cucumber/junit/api/FeatureRunnerTest.java
@@ -170,8 +170,7 @@ public class FeatureRunnerTest {
             }
 
             @Override
-            public long elapsedTimeMillis()
-            {
+            public long elapsedTimeMillis() {
                 return 0L;
             }
         };

--- a/junit/src/test/java/io/cucumber/junit/api/FeatureRunnerTest.java
+++ b/junit/src/test/java/io/cucumber/junit/api/FeatureRunnerTest.java
@@ -1,35 +1,5 @@
 package io.cucumber.junit.api;
 
-import io.cucumber.core.backend.ObjectFactory;
-import io.cucumber.core.backend.ObjectFactorySupplier;
-import io.cucumber.core.backend.SingletonObjectFactorySupplier;
-import io.cucumber.core.io.MultiLoader;
-import io.cucumber.core.io.Resource;
-import io.cucumber.core.io.ResourceLoader;
-import io.cucumber.core.options.Env;
-import io.cucumber.core.runner.TimeServiceEventBus;
-import io.cucumber.core.event.EventBus;
-import io.cucumber.core.runner.TimeService;
-import io.cucumber.core.backend.Backend;
-import io.cucumber.core.backend.BackendSupplier;
-import io.cucumber.core.options.RuntimeOptions;
-import io.cucumber.core.runtime.ThreadLocalRunnerSupplier;
-import io.cucumber.core.filter.Filters;
-import io.cucumber.core.model.CucumberFeature;
-import io.cucumber.core.model.FeatureLoader;
-import org.junit.Test;
-import org.junit.runner.Description;
-import org.junit.runner.notification.RunNotifier;
-import org.junit.runners.model.InitializationError;
-import org.mockito.InOrder;
-
-import java.net.URI;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
-import static io.cucumber.core.backend.ObjectFactoryLoader.loadObjectFactory;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
@@ -38,6 +8,35 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+import org.mockito.InOrder;
+
+import io.cucumber.core.backend.Backend;
+import io.cucumber.core.backend.BackendSupplier;
+import io.cucumber.core.backend.ObjectFactorySupplier;
+import io.cucumber.core.backend.SingletonObjectFactorySupplier;
+import io.cucumber.core.event.EventBus;
+import io.cucumber.core.filter.Filters;
+import io.cucumber.core.io.MultiLoader;
+import io.cucumber.core.io.Resource;
+import io.cucumber.core.io.ResourceLoader;
+import io.cucumber.core.model.CucumberFeature;
+import io.cucumber.core.model.FeatureLoader;
+import io.cucumber.core.options.Env;
+import io.cucumber.core.options.RuntimeOptions;
+import io.cucumber.core.runner.TimeService;
+import io.cucumber.core.runner.TimeServiceEventBus;
+import io.cucumber.core.runtime.ThreadLocalRunnerSupplier;
 
 public class FeatureRunnerTest {
 
@@ -167,6 +166,12 @@ public class FeatureRunnerTest {
         final TimeService timeServiceStub = new TimeService() {
             @Override
             public long time() {
+                return 0L;
+            }
+
+            @Override
+            public long elapsedTimeMillis()
+            {
                 return 0L;
             }
         };

--- a/kotlin-java8/pom.xml
+++ b/kotlin-java8/pom.xml
@@ -12,7 +12,7 @@
     <name>Cucumber-JVM: Kotlin Java8</name>
 
     <properties>
-        <kotlin.version>1.2.51</kotlin.version>
+        <kotlin.version>1.2.41</kotlin.version>
     </properties>
 
     <dependencies>

--- a/kotlin-java8/src/test/kotlin/io/cucumber/kotlin/LambdaStepdefs.kt
+++ b/kotlin-java8/src/test/kotlin/io/cucumber/kotlin/LambdaStepdefs.kt
@@ -50,7 +50,7 @@ class LambdaStepdefs : En {
 
         Given("A statement with a body expression$") { assertTrue(true) }
 
-        Given("A statement with a simple match$", { -> assertTrue(true) })
+        Given("A statement with a simple match$", { assertTrue(true) })
 
         val localInt = 1
         Given("A statement with a scoped argument$", { assertEquals(2, localInt + 1) })
@@ -62,9 +62,6 @@ class LambdaStepdefs : En {
             assertEquals(4, d)
         }
     }
-
-    class Person {
-        var first: String? = null
-        var last: String? = null
-    }
 }
+
+data class Person(val first: String?, val last: String?)

--- a/kotlin-java8/src/test/kotlin/io/cucumber/kotlin/RunCukesTest.kt
+++ b/kotlin-java8/src/test/kotlin/io/cucumber/kotlin/RunCukesTest.kt
@@ -4,5 +4,4 @@ import io.cucumber.junit.api.Cucumber
 import org.junit.runner.RunWith
 
 @RunWith(Cucumber::class)
-class RunCukesTest {
-}
+class RunCukesTest

--- a/kotlin-java8/src/test/kotlin/io/cucumber/kotlin/TypeRegistryConfiguration.kt
+++ b/kotlin-java8/src/test/kotlin/io/cucumber/kotlin/TypeRegistryConfiguration.kt
@@ -16,13 +16,10 @@ class TypeRegistryConfiguration : TypeRegistryConfigurer {
 
     override fun configureTypeRegistry(typeRegistry: TypeRegistry) {
         typeRegistry.defineDataTableType(DataTableType(
-                LambdaStepdefs.Person::class.java,
-                TableEntryTransformer<LambdaStepdefs.Person>
+                Person::class.java,
+                TableEntryTransformer<Person>
                 { map: Map<String, String> ->
-                    val person = LambdaStepdefs.Person()
-                    person.first = map.get("first")
-                    person.last = map.get("last")
-                    person
+                    Person(map["first"], map["last"])
                 }))
     }
 }


### PR DESCRIPTION
**Summary**
Adding new timestamp field to event and json report

**Detail**
New elapsedTimeInMillis field added to the eventBus as well as the TimeService (and its stub).

This calculates the system time elapsed in millis and is later used in the jsonformatter as a time stamp (after conversion).

This field can be used in all the events for timestamp usages if required (unlike nanos this is an accurate representation of the current timestamp), right now its only being used in TestCaseStarted.

I also updated the JUnits accordinly since the date is calculated dynamically. The JSON formatter takes a DateTimeFormatter input to change how the time will be formatted to string format.
<!--- Describe your changes in detail -->

**Motivation and Context**
The timestamp field in the json report allows plugins to correctly calculate the time a TestSuite takes when the TCs are run in parallel. The scenario startTime (which is what i currently added to the report) will be useful in a number of ways both for reporting and getting correct duration of parallel TC execution.

**How Has This Been Tested?**
The current JUnits have been updated to reflect the new timestamp field that is passed on to the report.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

**Checklist:**
I have updated the current TCs but not sure if i need to add new ones solely for testing the addition of this new field. please let me know if i do.

A documentation update is probably not needed for this, but if it is, please let me know and i ll update it.