### PR TITLE
[Core] Add TimeStampMillis to TimeStampedEvent

### DIFF
--- a/core/src/main/java/cucumber/api/Result.java
+++ b/core/src/main/java/cucumber/api/Result.java
@@ -10,7 +10,7 @@ import static java.util.Objects.requireNonNull;
 
 public final class Result {
 
-    public final static Comparator<Result> SEVERITY = new Comparator<Result>() {
+    public static final Comparator<Result> SEVERITY = new Comparator<Result>() {
 
         @Override
         public int compare(Result a, Result b) {

--- a/core/src/main/java/cucumber/api/event/CanonicalEventOrder.java
+++ b/core/src/main/java/cucumber/api/event/CanonicalEventOrder.java
@@ -62,12 +62,12 @@ final class CanonicalEventOrder implements Comparator<Event> {
 
         @Override
         public int compare(TestCaseEvent a, TestCaseEvent b) {
-            int uri = a.testCase.getUri().compareTo(b.testCase.getUri());
+            int uri = a.getTestCase().getUri().compareTo(b.getTestCase().getUri());
             if (uri != 0) {
                 return uri;
             }
 
-            int line = Integer.compare(a.testCase.getLine(), b.testCase.getLine());
+            int line = Integer.compare(a.getTestCase().getLine(), b.getTestCase().getLine());
             if(line != 0){
                 return line;
             }

--- a/core/src/main/java/cucumber/api/event/EmbedEvent.java
+++ b/core/src/main/java/cucumber/api/event/EmbedEvent.java
@@ -6,8 +6,13 @@ public final class EmbedEvent extends TestCaseEvent {
     public final byte[] data;
     public final String mimeType;
 
+    @Deprecated
     public EmbedEvent(Long timeStamp, TestCase testCase, byte[] data, String mimeType) {
-        super(timeStamp, testCase);
+        this(timeStamp, 0, testCase, data, mimeType);
+    }
+
+    public EmbedEvent(Long timeStamp, long timeStampMillis, TestCase testCase, byte[] data, String mimeType) {
+        super(timeStamp, timeStampMillis, testCase);
         this.data = data;
         this.mimeType = mimeType;
     }

--- a/core/src/main/java/cucumber/api/event/Event.java
+++ b/core/src/main/java/cucumber/api/event/Event.java
@@ -30,6 +30,14 @@ public interface Event {
      */
     Comparator<Event> CANONICAL_ORDER = new CanonicalEventOrder();
 
+    /**
+     * Returns timestamp in nano seconds since an arbitrary start time.
+     *
+     * @return timestamp in nano seconds
+     * @see System#nanoTime()
+     * @deprecated prefer {@link TimeStampedEvent#getTimeStampMillis()}
+     */
+    @Deprecated
     Long getTimeStamp();
 
 }

--- a/core/src/main/java/cucumber/api/event/SnippetsSuggestedEvent.java
+++ b/core/src/main/java/cucumber/api/event/SnippetsSuggestedEvent.java
@@ -10,8 +10,13 @@ public class SnippetsSuggestedEvent extends TimeStampedEvent {
     public final List<PickleLocation> stepLocations;
     public final List<String> snippets;
 
+    @Deprecated
     public SnippetsSuggestedEvent(Long timeStamp, String uri, List<PickleLocation> stepLocations, List<String> snippets) {
-        super(timeStamp);
+        this(timeStamp, 0, uri, stepLocations, snippets);
+    }
+
+    public SnippetsSuggestedEvent(Long timeStamp, long timeStampMillis, String uri, List<PickleLocation> stepLocations, List<String> snippets) {
+        super(timeStamp, timeStampMillis);
         this.uri = uri;
         this.stepLocations = stepLocations;
         this.snippets = Collections.unmodifiableList(snippets);

--- a/core/src/main/java/cucumber/api/event/TestCaseEvent.java
+++ b/core/src/main/java/cucumber/api/event/TestCaseEvent.java
@@ -4,10 +4,10 @@ import cucumber.api.TestCase;
 
 public abstract class TestCaseEvent extends TimeStampedEvent {
 
-    final TestCase testCase;
+    private final TestCase testCase;
 
-    TestCaseEvent(Long timeStamp, TestCase testCase) {
-        super(timeStamp);
+    TestCaseEvent(Long timeStamp, long timeStampMillis, TestCase testCase) {
+        super(timeStamp, timeStampMillis);
         this.testCase = testCase;
     }
 

--- a/core/src/main/java/cucumber/api/event/TestCaseFinished.java
+++ b/core/src/main/java/cucumber/api/event/TestCaseFinished.java
@@ -7,8 +7,13 @@ public final class TestCaseFinished extends TestCaseEvent {
     public final Result result;
     public final TestCase testCase;
 
+    @Deprecated
     public TestCaseFinished(Long timeStamp, TestCase testCase, Result result) {
-        super(timeStamp, testCase);
+        this(timeStamp, 0, testCase, result);
+    }
+
+    public TestCaseFinished(Long timeStamp, long timeStampMillis, TestCase testCase, Result result) {
+        super(timeStamp, timeStampMillis, testCase);
         this.testCase = testCase;
         this.result = result;
     }

--- a/core/src/main/java/cucumber/api/event/TestCaseStarted.java
+++ b/core/src/main/java/cucumber/api/event/TestCaseStarted.java
@@ -4,20 +4,15 @@ import cucumber.api.TestCase;
 
 public final class TestCaseStarted extends TestCaseEvent {
     public final TestCase testCase;
-    private final long timeStampMillis; 
-    
+
     @Deprecated
     public TestCaseStarted(Long timeStamp, TestCase testCase) {
        this(timeStamp, 0L, testCase);
     }
 
-    public TestCaseStarted(Long timeStamp, Long timeStampMillis, TestCase testCase) {
-        super(timeStamp, testCase);
+    public TestCaseStarted(Long timeStamp, long timeStampMillis, TestCase testCase) {
+        super(timeStamp, timeStampMillis, testCase);
         this.testCase = testCase;
-        this.timeStampMillis = timeStampMillis;
     }
 
-    public long getTimeStampMillis() {
-        return timeStampMillis;
-    }
 }

--- a/core/src/main/java/cucumber/api/event/TestRunFinished.java
+++ b/core/src/main/java/cucumber/api/event/TestRunFinished.java
@@ -2,7 +2,12 @@ package cucumber.api.event;
 
 public final class TestRunFinished extends TimeStampedEvent {
 
+    @Deprecated
     public TestRunFinished(Long timeStamp) {
-        super(timeStamp);
+        this(timeStamp, 0);
+    }
+
+    public TestRunFinished(Long timeStamp, long timeStampMillis) {
+        super(timeStamp, timeStampMillis);
     }
 }

--- a/core/src/main/java/cucumber/api/event/TestRunStarted.java
+++ b/core/src/main/java/cucumber/api/event/TestRunStarted.java
@@ -2,7 +2,12 @@ package cucumber.api.event;
 
 public final class TestRunStarted extends TimeStampedEvent {
 
+    @Deprecated
     public TestRunStarted(Long timeStamp) {
-        super(timeStamp);
+        this(timeStamp, 0);
+    }
+
+    public TestRunStarted(Long timeStamp, long timeStampMillis) {
+        super(timeStamp, timeStampMillis);
     }
 }

--- a/core/src/main/java/cucumber/api/event/TestSourceRead.java
+++ b/core/src/main/java/cucumber/api/event/TestSourceRead.java
@@ -4,8 +4,13 @@ public final class TestSourceRead extends TimeStampedEvent {
     public final String uri;
     public final String source;
 
+    @Deprecated
     public TestSourceRead(Long timeStamp, String uri, String source) {
-        super(timeStamp);
+        this(timeStamp, 0, uri, source);
+    }
+
+    public TestSourceRead(Long timeStamp, long timeStampMillis, String uri, String source) {
+        super(timeStamp, timeStampMillis);
         this.uri = uri;
         this.source = source;
     }

--- a/core/src/main/java/cucumber/api/event/TestStepFinished.java
+++ b/core/src/main/java/cucumber/api/event/TestStepFinished.java
@@ -26,8 +26,13 @@ public final class TestStepFinished extends TestCaseEvent {
     public final TestStep testStep;
     public final Result result;
 
+    @Deprecated
     public TestStepFinished(Long timeStamp, TestCase testCase, TestStep testStep, Result result) {
-        super(timeStamp, testCase);
+        this(timeStamp, 0, testCase, testStep, result);
+    }
+
+    public TestStepFinished(Long timeStamp, long timeStampMillis, TestCase testCase, TestStep testStep, Result result) {
+        super(timeStamp, timeStampMillis, testCase);
         this.testStep = testStep;
         this.result = result;
     }

--- a/core/src/main/java/cucumber/api/event/TestStepStarted.java
+++ b/core/src/main/java/cucumber/api/event/TestStepStarted.java
@@ -25,8 +25,13 @@ import cucumber.api.TestStep;
 public final class TestStepStarted extends TestCaseEvent {
     public final TestStep testStep;
 
+    @Deprecated
     public TestStepStarted(Long timeStamp, TestCase testCase, TestStep testStep) {
-        super(timeStamp, testCase);
+        this(timeStamp, 0, testCase, testStep);
+    }
+
+    public TestStepStarted(Long timeStamp, long timeStampMillis, TestCase testCase, TestStep testStep) {
+        super(timeStamp, timeStampMillis, testCase);
         this.testStep = testStep;
     }
 

--- a/core/src/main/java/cucumber/api/event/TimeStampedEvent.java
+++ b/core/src/main/java/cucumber/api/event/TimeStampedEvent.java
@@ -1,14 +1,30 @@
 package cucumber.api.event;
 
 abstract class TimeStampedEvent implements Event {
-    private final Long timeStamp;
 
-    TimeStampedEvent(Long timeStamp) {
+    private final Long timeStamp;
+    private final long timeStampMillis;
+
+    TimeStampedEvent(Long timeStamp, Long timeStampMillis) {
         this.timeStamp = timeStamp;
+        this.timeStampMillis = timeStampMillis;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Long getTimeStamp() {
         return timeStamp;
+    }
+
+    /**
+     * Returns timestamp in milliseconds of the epoch.
+     *
+     * @return timestamp in milli seconds
+     * @see System#currentTimeMillis()
+     */
+    public long getTimeStampMillis() {
+        return timeStampMillis;
     }
 }

--- a/core/src/main/java/cucumber/api/event/WriteEvent.java
+++ b/core/src/main/java/cucumber/api/event/WriteEvent.java
@@ -5,8 +5,13 @@ import cucumber.api.TestCase;
 public final class WriteEvent extends TestCaseEvent {
     public final String text;
 
+    @Deprecated
     public WriteEvent(Long timeStamp, TestCase testCase, String text) {
-        super(timeStamp, testCase);
+        this(timeStamp, 0, testCase, text);
+    }
+
+    public WriteEvent(Long timeStamp, long timeStampMillis, TestCase testCase, String text) {
+        super(timeStamp, timeStampMillis, testCase);
         this.text = text;
     }
 }

--- a/core/src/main/java/cucumber/runner/EventBus.java
+++ b/core/src/main/java/cucumber/runner/EventBus.java
@@ -6,8 +6,8 @@ import cucumber.api.event.EventPublisher;
 public interface EventBus extends EventPublisher {
 
     Long getTime();
-    
-    Long getTimeStampMillis();
+
+    Long getTimeMillis();
 
     void send(Event event);
 

--- a/core/src/main/java/cucumber/runner/Runner.java
+++ b/core/src/main/java/cucumber/runner/Runner.java
@@ -78,7 +78,7 @@ public final class Runner {
                         snippets.addAll(snippet);
                     }
                     if (!snippets.isEmpty()) {
-                        bus.send(new SnippetsSuggestedEvent(bus.getTime(), pickleEvent.uri, step.getLocations(), snippets));
+                        bus.send(new SnippetsSuggestedEvent(bus.getTime(), bus.getTimeMillis(), pickleEvent.uri, step.getLocations(), snippets));
                     }
                     match = new UndefinedPickleStepDefinitionMatch(step);
                 }

--- a/core/src/main/java/cucumber/runner/Scenario.java
+++ b/core/src/main/java/cucumber/runner/Scenario.java
@@ -55,14 +55,14 @@ class Scenario implements cucumber.api.Scenario {
     @Override
     public void embed(byte[] data, String mimeType) {
         if (bus != null) {
-            bus.send(new EmbedEvent(bus.getTime(), testCase, data, mimeType));
+            bus.send(new EmbedEvent(bus.getTime(), bus.getTimeMillis(), testCase, data, mimeType));
         }
     }
 
     @Override
     public void write(String text) {
         if (bus != null) {
-            bus.send(new WriteEvent(bus.getTime(), testCase, text));
+            bus.send(new WriteEvent(bus.getTime(), bus.getTimeMillis(), testCase, text));
         }
     }
 

--- a/core/src/main/java/cucumber/runner/TestCase.java
+++ b/core/src/main/java/cucumber/runner/TestCase.java
@@ -33,9 +33,9 @@ final class TestCase implements cucumber.api.TestCase {
 
     void run(EventBus bus) {
         boolean skipNextStep = this.dryRun;
-        Long startTime = bus.getTime();
-        Long startTimeStampMillis = bus.getTimeStampMillis();
-        bus.send(new TestCaseStarted(startTime, startTimeStampMillis, this));
+        Long startTimeMillis = bus.getTimeMillis();
+        Long startTimeNanos = bus.getTime();
+        bus.send(new TestCaseStarted(startTimeNanos, startTimeMillis, this));
         Scenario scenario = new Scenario(bus, this);
 
         for (HookTestStep before : beforeHooks) {
@@ -50,8 +50,9 @@ final class TestCase implements cucumber.api.TestCase {
             after.run(this, bus, scenario, dryRun);
         }
 
-        Long stopTime = bus.getTime();
-        bus.send(new TestCaseFinished(stopTime, this, new Result(scenario.getStatus(), stopTime - startTime, scenario.getError())));
+        Long stopTimeNanos = bus.getTime();
+        Long stopTimeMillis = bus.getTimeMillis();
+        bus.send(new TestCaseFinished(stopTimeNanos, stopTimeMillis, this, new Result(scenario.getStatus(), stopTimeNanos - startTimeNanos, scenario.getError())));
     }
 
     @Override

--- a/core/src/main/java/cucumber/runner/TestStep.java
+++ b/core/src/main/java/cucumber/runner/TestStep.java
@@ -41,8 +41,9 @@ abstract class TestStep implements cucumber.api.TestStep {
      * @return true iff subsequent skippable steps should be skipped
      */
     boolean run(TestCase testCase, EventBus bus, Scenario scenario, boolean skipSteps) {
-        Long startTime = bus.getTime();
-        bus.send(new TestStepStarted(startTime, testCase, this));
+        Long startTimeMillis = bus.getTimeMillis();
+        Long startTimeNanos = bus.getTime();
+        bus.send(new TestStepStarted(startTimeNanos, startTimeMillis, testCase, this));
         Result.Type status;
         Throwable error = null;
         try {
@@ -51,10 +52,11 @@ abstract class TestStep implements cucumber.api.TestStep {
             error = t;
             status = mapThrowableToStatus(t);
         }
-        Long stopTime = bus.getTime();
-        Result result = mapStatusToResult(status, error, stopTime - startTime);
+        Long stopTimeNanos = bus.getTime();
+        Long stopTimeMillis = bus.getTimeMillis();
+        Result result = mapStatusToResult(status, error, stopTimeNanos - startTimeNanos);
         scenario.add(result);
-        bus.send(new TestStepFinished(stopTime, testCase, this, result));
+        bus.send(new TestStepFinished(stopTimeNanos, stopTimeMillis, testCase, this, result));
         return !result.is(Result.Type.PASSED);
     }
 

--- a/core/src/main/java/cucumber/runner/ThreadLocalRunnerSupplier.java
+++ b/core/src/main/java/cucumber/runner/ThreadLocalRunnerSupplier.java
@@ -62,8 +62,8 @@ public class ThreadLocalRunnerSupplier implements RunnerSupplier {
         }
 
         @Override
-        public Long getTimeStampMillis() {
-            return parent.getTimeStampMillis();
+        public Long getTimeMillis() {
+            return parent.getTimeMillis();
         }
     }
 
@@ -109,8 +109,8 @@ public class ThreadLocalRunnerSupplier implements RunnerSupplier {
         }
 
         @Override
-        public Long getTimeStampMillis() {
-            return delegate.getTimeStampMillis();
+        public Long getTimeMillis() {
+            return delegate.getTimeMillis();
         }
     }
 }

--- a/core/src/main/java/cucumber/runner/TimeService.java
+++ b/core/src/main/java/cucumber/runner/TimeService.java
@@ -2,7 +2,7 @@ package cucumber.runner;
 
 public interface TimeService {
     long time();
-    long timeStampMillis();
+    long timeMillis();
 
     TimeService SYSTEM = new TimeService() {
         @Override
@@ -11,7 +11,7 @@ public interface TimeService {
         }
 
         @Override
-        public long timeStampMillis() {
+        public long timeMillis() {
             return System.currentTimeMillis();
         }
     };

--- a/core/src/main/java/cucumber/runner/TimeServiceEventBus.java
+++ b/core/src/main/java/cucumber/runner/TimeServiceEventBus.java
@@ -13,7 +13,7 @@ public final class TimeServiceEventBus extends AbstractEventBus {
     }
 
     @Override
-    public Long getTimeStampMillis() {
-        return stopWatch.timeStampMillis();
+    public Long getTimeMillis() {
+        return stopWatch.timeMillis();
     }
 }

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -65,7 +65,7 @@ public class Runtime {
 
     public void run() {
         final List<CucumberFeature> features = featureSupplier.get();
-        bus.send(new TestRunStarted(bus.getTime()));
+        bus.send(new TestRunStarted(bus.getTime(), bus.getTimeMillis()));
         for (CucumberFeature feature : features) {
             feature.sendTestSourceRead(bus);
         }
@@ -93,7 +93,7 @@ public class Runtime {
             throw new CucumberException(e);
         }
 
-        bus.send(new TestRunFinished(bus.getTime()));
+        bus.send(new TestRunFinished(bus.getTime(), bus.getTimeMillis()));
     }
 
     public byte exitStatus() {

--- a/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
@@ -382,14 +382,14 @@ final class JSONFormatter implements EventListener {
         if (result.getErrorMessage() != null) {
             resultMap.put("error_message", result.getErrorMessage());
         }
-        if (result.getDuration() != null && result.getDuration() != 0) {
+        if (result.getDuration() != 0) {
             resultMap.put("duration", result.getDuration());
         }
         return resultMap;
     }
     
     private String getDateTimeFromTimeStamp(long timeStampMillis) {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         
         return sdf.format(new Date(timeStampMillis));

--- a/core/src/main/java/cucumber/runtime/formatter/Stats.java
+++ b/core/src/main/java/cucumber/runtime/formatter/Stats.java
@@ -1,7 +1,7 @@
 package cucumber.runtime.formatter;
 
-import cucumber.api.Result;
 import cucumber.api.PickleStepTestStep;
+import cucumber.api.Result;
 import cucumber.api.event.EventHandler;
 import cucumber.api.event.EventListener;
 import cucumber.api.event.EventPublisher;
@@ -11,10 +11,6 @@ import cucumber.api.event.TestRunStarted;
 import cucumber.api.event.TestStepFinished;
 import cucumber.api.formatter.ColorAware;
 import cucumber.api.formatter.StrictAware;
-import cucumber.runtime.formatter.AnsiFormats;
-import cucumber.runtime.formatter.Format;
-import cucumber.runtime.formatter.Formats;
-import cucumber.runtime.formatter.MonochromeFormats;
 
 import java.io.PrintStream;
 import java.text.DecimalFormat;
@@ -23,8 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 public class Stats implements EventListener, ColorAware, StrictAware {
-    static final long ONE_SECOND = 1000000000;
+    static final long ONE_SECOND = SECONDS.toNanos(1);
     static final long ONE_MINUTE = 60 * ONE_SECOND;
     private SubCounts scenarioSubCounts = new SubCounts();
     private SubCounts stepSubCounts = new SubCounts();

--- a/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/TestNGFormatter.java
@@ -38,6 +38,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 final class TestNGFormatter implements EventListener, StrictAware {
 
     private final Writer writer;
@@ -280,12 +282,12 @@ final class TestNGFormatter implements EventListener, StrictAware {
         private String calculateTotalDurationString() {
             long totalDurationNanos = 0;
             for (Result r : results) {
-                totalDurationNanos += r.getDuration() == null ? 0 : r.getDuration();
+                totalDurationNanos += r.getDuration();
             }
             for (Result r : hooks) {
-                totalDurationNanos += r.getDuration() == null ? 0 : r.getDuration();
+                totalDurationNanos += r.getDuration();
             }
-            return String.valueOf(totalDurationNanos / 1000000);
+            return String.valueOf(NANOSECONDS.toMillis(totalDurationNanos));
         }
 
         private void addStepAndResultListing(StringBuilder sb) {

--- a/core/src/main/java/cucumber/runtime/formatter/TimelineFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/TimelineFormatter.java
@@ -29,8 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-
 public class TimelineFormatter implements ConcurrentEventListener {
 
     //TODO: if accepted then should move resources out into own project as per HTML report
@@ -224,7 +222,7 @@ public class TimelineFormatter implements ConcurrentEventListener {
             final String uri = testCase.getUri();
             this.feature = TimelineFormatter.this.testSources.getFeatureName(uri);
             this.scenario = testCase.getName();
-            this.startTime = NANOSECONDS.toMillis(started.getTimeStamp());
+            this.startTime = started.getTimeStampMillis();
             this.threadId = threadId;
             this.tags = buildTagsValue(testCase);
         }
@@ -238,7 +236,7 @@ public class TimelineFormatter implements ConcurrentEventListener {
         }
 
         public void end(final TestCaseFinished event) {
-            this.endTime = NANOSECONDS.toMillis(event.getTimeStamp());
+            this.endTime = event.getTimeStampMillis();
             this.className = event.result.getStatus().lowerCaseName();
         }
     }

--- a/core/src/main/java/cucumber/runtime/model/CucumberFeature.java
+++ b/core/src/main/java/cucumber/runtime/model/CucumberFeature.java
@@ -41,7 +41,7 @@ public class CucumberFeature {
     }
 
     public void sendTestSourceRead(EventBus bus) {
-        bus.send(new TestSourceRead(bus.getTime(), getUri().toString(), gherkinSource));
+        bus.send(new TestSourceRead(bus.getTime(), bus.getTimeMillis(), getUri().toString(), gherkinSource));
     }
 
     String getSource() {

--- a/core/src/test/java/cucumber/api/event/CanonicalEventOrderTest.java
+++ b/core/src/test/java/cucumber/api/event/CanonicalEventOrderTest.java
@@ -36,14 +36,14 @@ public class CanonicalEventOrderTest {
         return new TestCaseStarted(getTime(), getTimeStampMillis(), testCase);
     }
 
-    private Event runStarted = new TestRunStarted(getTime());
-    private Event testRead = new TestSourceRead(getTime(), "uri", "source");
-    private Event suggested = new SnippetsSuggestedEvent(getTime(), "uri", Collections.<PickleLocation>emptyList(), Collections.<String>emptyList());
+    private Event runStarted = new TestRunStarted(getTime(), getTimeStampMillis());
+    private Event testRead = new TestSourceRead(getTime(), getTimeStampMillis(), "uri", "source");
+    private Event suggested = new SnippetsSuggestedEvent(getTime(), getTimeStampMillis(), "uri", Collections.<PickleLocation>emptyList(), Collections.<String>emptyList());
     private Event feature1Case1Started = createTestCaseEvent("feature1", 1);
     private Event feature1Case2Started = createTestCaseEvent("feature1", 9);
     private Event feature1Case3Started = createTestCaseEvent("feature1", 11);
     private Event feature2Case1Started = createTestCaseEvent("feature2", 1);
-    private Event runFinished = new TestRunFinished(getTime());
+    private Event runFinished = new TestRunFinished(getTime(), getTimeStampMillis());
 
     @Test
     public void verifyTestRunStartedSortedCorrectly() {

--- a/core/src/test/java/cucumber/runner/EventBusTest.java
+++ b/core/src/test/java/cucumber/runner/EventBusTest.java
@@ -20,7 +20,7 @@ public class EventBusTest {
         PickleStepTestStep testStep = mock(PickleStepTestStep.class);
         Result result = new Result(Result.Type.PASSED, 0L, null);
         TestCase testCase = mock(TestCase.class);
-        TestStepFinished event = new TestStepFinished(0L, testCase, testStep, result);
+        TestStepFinished event = new TestStepFinished(0L, 0L, testCase, testStep, result);
 
         EventBus bus = new TimeServiceEventBus(new TimeServiceStub(0));
         bus.registerHandlerFor(TestStepFinished.class, handler);
@@ -34,7 +34,7 @@ public class EventBusTest {
         EventHandler handler = mock(EventHandler.class);
         PickleStepTestStep testStep = mock(PickleStepTestStep.class);
         TestCase testCase = mock(TestCase.class);
-        TestStepStarted event = new TestStepStarted(0L, testCase, testStep);
+        TestStepStarted event = new TestStepStarted(0L, 0L, testCase, testStep);
 
         EventBus bus = new TimeServiceEventBus(new TimeServiceStub(0));
         bus.registerHandlerFor(TestStepFinished.class, handler);

--- a/core/src/test/java/cucumber/runner/PickleStepTestStepTest.java
+++ b/core/src/test/java/cucumber/runner/PickleStepTestStepTest.java
@@ -92,7 +92,6 @@ public class PickleStepTestStepTest {
         assertEquals(SKIPPED, scenario.getStatus());
     }
 
-
     @Test
     public void result_is_skipped_when_before_step_hook_does_not_pass() throws Throwable {
         doThrow(AssumptionViolatedException.class).when(beforeHookDefinition).execute(any(cucumber.api.Scenario.class));
@@ -137,6 +136,7 @@ public class PickleStepTestStepTest {
         List<TestCaseEvent> allValues = captor.getAllValues();
         assertEquals(failure, ((TestStepFinished) allValues.get(3)).result);
     }
+
     @Test
     public void result_is_result_from_hook_when_after_step_hook_does_not_pass() throws Throwable {
         Exception exception = new RuntimeException();
@@ -151,6 +151,7 @@ public class PickleStepTestStepTest {
         List<TestCaseEvent> allValues = captor.getAllValues();
         assertEquals(failure, ((TestStepFinished) allValues.get(5)).result);
     }
+
     @Test
     public void after_step_hook_is_run_when_before_step_hook_does_not_pass() throws Throwable {
         doThrow(RuntimeException.class).when(beforeHookDefinition).execute(any(cucumber.api.Scenario.class));
@@ -171,7 +172,7 @@ public class PickleStepTestStepTest {
         doThrow(expectedError).when(definitionMatch).runStep(any(Scenario.class));
         doThrow(new Exception()).when(afterHookDefinition).execute(argThat(scenarioDoesNotHave(expectedError)));
         step.run(testCase, bus, scenario, false);
-        assertThat(scenario.getError(),is(expectedError));
+        assertThat(scenario.getError(), is(expectedError));
     }
 
     @Test
@@ -180,7 +181,7 @@ public class PickleStepTestStepTest {
         doThrow(expectedError).when(beforeHookDefinition).execute(any(Scenario.class));
         doThrow(new Exception()).when(afterHookDefinition).execute(argThat(scenarioDoesNotHave(expectedError)));
         step.run(testCase, bus, scenario, false);
-        assertThat(scenario.getError(),is(expectedError));
+        assertThat(scenario.getError(), is(expectedError));
     }
 
     private static ArgumentMatcher<Scenario> scenarioDoesNotHave(final Throwable type) {

--- a/core/src/test/java/cucumber/runner/StepDurationTimeService.java
+++ b/core/src/test/java/cucumber/runner/StepDurationTimeService.java
@@ -4,21 +4,23 @@ import cucumber.api.event.EventHandler;
 import cucumber.api.event.EventListener;
 import cucumber.api.event.EventPublisher;
 import cucumber.api.event.TestStepStarted;
-import cucumber.runner.TimeService;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class StepDurationTimeService implements TimeService, EventListener {
-    private long stepDuration;
-    private final ThreadLocal<Long> currentTime = new ThreadLocal<Long>();
+
+    private final ThreadLocal<Long> currentTime = new ThreadLocal<>();
+    private final long stepDurationMillis;
+
     private EventHandler<TestStepStarted> stepStartedHandler = new EventHandler<TestStepStarted>() {
         @Override
         public void receive(TestStepStarted event) {
-            handleTestStepStarted(event);
+            handleTestStepStarted();
         }
     };
 
-
-    public StepDurationTimeService(long stepDuration) {
-        this.stepDuration = stepDuration;
+    public StepDurationTimeService(long stepDurationMillis) {
+        this.stepDurationMillis = stepDurationMillis;
     }
 
     @Override
@@ -29,18 +31,18 @@ public class StepDurationTimeService implements TimeService, EventListener {
     @Override
     public long time() {
         Long result = currentTime.get();
-        return result != null ? result : 0l;
-    }
-    
-    @Override
-    public long timeStampMillis() {
-        Long result = currentTime.get();
-        return result != null ? result : 0l;
+        return result != null ? MILLISECONDS.toNanos(result) : 0L;
     }
 
-    private void handleTestStepStarted(TestStepStarted event) {
-        long time = time();
-        currentTime.set(time + stepDuration);
+    @Override
+    public long timeMillis() {
+        Long result = currentTime.get();
+        return result != null ? result : 0L;
+    }
+
+    private void handleTestStepStarted() {
+        long time = timeMillis();
+        currentTime.set(time + stepDurationMillis);
     }
 
 }

--- a/core/src/test/java/cucumber/runner/TimeServiceStub.java
+++ b/core/src/test/java/cucumber/runner/TimeServiceStub.java
@@ -1,25 +1,29 @@
 package cucumber.runner;
 
-import cucumber.runner.TimeService;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class TimeServiceStub implements TimeService {
-    private final long duration;
-    private final ThreadLocal<Long> currentTime = new ThreadLocal<Long>();
+    private final long durationMillis;
+    private final ThreadLocal<Long> currentTime = new ThreadLocal<>();
+    private final ThreadLocal<Long> currentTimeMillis = new ThreadLocal<>();
 
-    public TimeServiceStub(long duration) {
-        this.duration = duration;
+    public TimeServiceStub(long durationMillis) {
+        this.durationMillis = durationMillis;
     }
 
     @Override
     public long time() {
         Long result = currentTime.get();
-        result = result != null ? result : 0l;
-        currentTime.set(result + duration);
-        return result;
+        result = result != null ? result : 0L;
+        currentTime.set(result + durationMillis);
+        return MILLISECONDS.toNanos(result);
     }
 
     @Override
-    public long timeStampMillis() {
-        return 0L;
+    public long timeMillis() {
+        Long result = currentTimeMillis.get();
+        result = result != null ? result : 0L;
+        currentTimeMillis.set(result + durationMillis);
+        return result;
     }
 }

--- a/core/src/test/java/cucumber/runtime/ExitStatusTest.java
+++ b/core/src/test/java/cucumber/runtime/ExitStatusTest.java
@@ -32,7 +32,7 @@ public class ExitStatusTest {
     }
 
     private TestCaseFinished testCaseFinishedWithStatus(Result.Type resultStatus) {
-        return new TestCaseFinished(ANY_TIMESTAMP, mock(TestCase.class), new Result(resultStatus, 0L, null));
+        return new TestCaseFinished(ANY_TIMESTAMP, ANY_TIMESTAMP, mock(TestCase.class), new Result(resultStatus, 0L, null));
     }
 
     private void createExitStatus(String... runtimeArgs) {

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -121,7 +121,7 @@ public class RuntimeTest {
             "        \"name\": \"scenario name\",\n" +
             "        \"description\": \"\",\n" +
             "        \"id\": \"feature-name;scenario-name\",\n" +
-			"        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+			"        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"type\": \"scenario\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
             "        \"steps\": [\n" +
@@ -558,6 +558,6 @@ public class RuntimeTest {
     }
 
     private TestCaseFinished testCaseFinishedWithStatus(Result.Type resultStatus) {
-        return new TestCaseFinished(ANY_TIMESTAMP, mock(TestCase.class), new Result(resultStatus, 0L, null));
+        return new TestCaseFinished(ANY_TIMESTAMP, ANY_TIMESTAMP, mock(TestCase.class), new Result(resultStatus, 0L, null));
     }
 }

--- a/core/src/test/java/cucumber/runtime/formatter/AverageUsageStatisticStrategyTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/AverageUsageStatisticStrategyTest.java
@@ -9,30 +9,30 @@ import static org.junit.Assert.assertEquals;
 
 public class AverageUsageStatisticStrategyTest {
     @Test
-    public void calculate() throws Exception {
+    public void calculate() {
         UsageFormatter.AverageUsageStatisticStrategy averageUsageStatisticStrategy = new UsageFormatter.AverageUsageStatisticStrategy();
         Long result = averageUsageStatisticStrategy.calculate(Arrays.asList(1L, 2L, 3L));
         assertEquals(result, Long.valueOf(2));
     }
 
     @Test
-    public void calculateNull() throws Exception {
+    public void calculateNull() {
         UsageFormatter.AverageUsageStatisticStrategy averageUsageStatisticStrategy = new UsageFormatter.AverageUsageStatisticStrategy();
         Long result = averageUsageStatisticStrategy.calculate(null);
         assertEquals(result, Long.valueOf(0));
     }
 
     @Test
-    public void calculateEmptylist() throws Exception {
+    public void calculateEmptyList() {
         UsageFormatter.AverageUsageStatisticStrategy averageUsageStatisticStrategy = new UsageFormatter.AverageUsageStatisticStrategy();
         Long result = averageUsageStatisticStrategy.calculate(Collections.<Long>emptyList());
         assertEquals(result, Long.valueOf(0));
     }
 
     @Test
-    public void calculateListWithNulls() throws Exception {
+    public void calculateListWithNulls() {
         UsageFormatter.AverageUsageStatisticStrategy averageUsageStatisticStrategy = new UsageFormatter.AverageUsageStatisticStrategy();
-        Long result = averageUsageStatisticStrategy.calculate(Arrays.<Long>asList(3L, null));
+        Long result = averageUsageStatisticStrategy.calculate(Arrays.asList(3L, null));
         assertEquals(result, Long.valueOf(0));
     }
 }

--- a/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JSONFormatterTest.java
@@ -45,7 +45,7 @@ public class JSONFormatterTest {
     private final List<SimpleEntry<String, Result>> hooks = new ArrayList<>();
     private final List<String> hookLocations = new ArrayList<>();
     private final List<Answer<Object>> hookActions = new ArrayList<>();
-    private Long stepDuration = 0L;
+    private Long stepDurationMillis = 0L;
 
     @Test
     public void featureWithOutlineTest() {
@@ -89,7 +89,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -123,7 +123,7 @@ public class JSONFormatterTest {
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -140,7 +140,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -177,7 +177,7 @@ public class JSONFormatterTest {
         features.add(feature);
         stepsToResult.put("there are bananas", result("failed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -194,7 +194,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -235,7 +235,7 @@ public class JSONFormatterTest {
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -252,7 +252,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"fruit-party;monkey-eats-fruits;fruit-table;2\",\n" +
             "        \"keyword\": \"Scenario Outline\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats fruits\",\n" +
             "        \"line\": 7,\n" +
             "        \"description\": \"\",\n" +
@@ -299,7 +299,7 @@ public class JSONFormatterTest {
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
         stepsToLocation.put("the monkey eats bananas", "StepDefs.monkey_eats_bananas()");
         stepsToLocation.put("the monkey eats more bananas", "StepDefs.monkey_eats_more_bananas()");
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -337,7 +337,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 6,\n" +
             "        \"description\": \"\",\n" +
@@ -381,7 +381,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-more-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:33:20.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.002Z\",\n" +
             "        \"name\": \"Monkey eats more bananas\",\n" +
             "        \"line\": 9,\n" +
             "        \"description\": \"\",\n" +
@@ -419,7 +419,7 @@ public class JSONFormatterTest {
         features.add(feature);
         stepsToResult.put("the monkey eats more bananas", result("passed"));
         stepsToLocation.put("the monkey eats more bananas", "StepDefs.monkey_eats_more_bananas()");
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -435,7 +435,7 @@ public class JSONFormatterTest {
             "        \"id\": \"banana-party;monkey-eats-more-bananas\",\n" +
             "        \"type\": \"scenario\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"steps\": [\n" +
             "          {\n" +
             "            \"result\": {\n" +
@@ -505,7 +505,7 @@ public class JSONFormatterTest {
         hooks.add(TestHelper.hookEntry("after", result("passed")));
         hookLocations.add("Hooks.before_hook_1()");
         hookLocations.add("Hooks.after_hook_1()");
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -522,7 +522,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -590,7 +590,7 @@ public class JSONFormatterTest {
         hookLocations.add("Hooks.beforestep_hooks_1()");
         hookLocations.add("Hooks.afterstep_hooks_1()");
         hookLocations.add("Hooks.afterstep_hooks_2()");
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -606,7 +606,7 @@ public class JSONFormatterTest {
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"type\": \"scenario\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"steps\": [\n" +
             "          {\n" +
             "            \"result\": {\n" +
@@ -721,7 +721,7 @@ public class JSONFormatterTest {
         hooks.add(TestHelper.hookEntry("before", result("passed")));
         hookLocations.add("Hooks.before_hook_1()");
         hookActions.add(createWriteHookAction("printed from hook"));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -738,7 +738,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -792,7 +792,7 @@ public class JSONFormatterTest {
         hooks.add(TestHelper.hookEntry("before", result("passed")));
         hookLocations.add("Hooks.before_hook_1()");
         hookActions.add(createEmbedHookAction(new byte[]{1, 2, 3}, "mime-type;base64"));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -809,7 +809,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -866,7 +866,7 @@ public class JSONFormatterTest {
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -883,7 +883,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -927,7 +927,7 @@ public class JSONFormatterTest {
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -944,7 +944,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -988,7 +988,7 @@ public class JSONFormatterTest {
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -1005,7 +1005,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -1064,7 +1064,7 @@ public class JSONFormatterTest {
         stepsToResult.put("there are oranges", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
         stepsToLocation.put("there are oranges", "StepDefs.there_are_oranges()");
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -1081,7 +1081,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
             "        \"name\": \"Monkey eats bananas\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -1115,7 +1115,7 @@ public class JSONFormatterTest {
             "      {\n" +
             "        \"id\": \"orange-party;monkey-eats-oranges\",\n" +
             "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:16:40.000\",\n" +
+            "        \"start_timestamp\": \"1970-01-01T00:00:00.001Z\",\n" +
             "        \"name\": \"Monkey eats oranges\",\n" +
             "        \"line\": 3,\n" +
             "        \"description\": \"\",\n" +
@@ -1234,14 +1234,11 @@ public class JSONFormatterTest {
             .withHooks(hooks)
             .withHookLocations(hookLocations)
             .withHookActions(hookActions)
-            .withTimeServiceIncrement(stepDuration)
+            .withTimeServiceIncrement(stepDurationMillis)
             .build()
             .run();
 
         return report.toString();
     }
 
-    private Long milliSeconds(int milliSeconds) {
-        return milliSeconds * 1000000L;
-    }
 }

--- a/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/JUnitFormatterTest.java
@@ -1,12 +1,9 @@
 package cucumber.runtime.formatter;
 
 import cucumber.api.Result;
-import cucumber.runtime.Backend;
 import cucumber.runner.TestHelper;
 import cucumber.runtime.Utils;
 import cucumber.runtime.model.CucumberFeature;
-import cucumber.runtime.snippets.FunctionNameGenerator;
-import gherkin.pickles.PickleStep;
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.AssumptionViolatedException;
@@ -31,10 +28,6 @@ import java.util.Scanner;
 import static cucumber.runner.TestHelper.result;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class JUnitFormatterTest {
 
@@ -44,7 +37,7 @@ public class JUnitFormatterTest {
     private final List<SimpleEntry<String, Result>> hooks = new ArrayList<>();
     private final List<String> hookLocations = new ArrayList<>();
     private final List<Answer<Object>> hookActions = new ArrayList<>();
-    private Long stepDuration = null;
+    private Long stepDurationMillis = null;
 
     @Test
     public void featureSimpleTest() throws Exception {
@@ -83,7 +76,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
         stepsToResult.put("third step", result("passed"));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -113,7 +106,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("first step", result("skipped", exception));
         stepsToResult.put("second step", result("skipped"));
         stepsToResult.put("third step", result("skipped"));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -146,7 +139,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("first step", result("pending"));
         stepsToResult.put("second step", result("skipped"));
         stepsToResult.put("third step", result("undefined"));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -175,7 +168,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
         stepsToResult.put("third step", result("failed"));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -208,7 +201,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("second step", result("passed"));
         stepsToResult.put("third step", result("passed"));
         hooks.add(TestHelper.hookEntry("before", result("failed")));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -241,7 +234,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("second step", result("skipped"));
         stepsToResult.put("third step", result("skipped"));
         hooks.add(TestHelper.hookEntry("before", result("pending")));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -272,7 +265,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("second step", result("passed"));
         stepsToResult.put("third step", result("passed"));
         hooks.add(TestHelper.hookEntry("before", result("failed")));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -305,7 +298,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("second step", result("passed"));
         stepsToResult.put("third step", result("passed"));
         hooks.add(TestHelper.hookEntry("after", result("failed")));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -337,7 +330,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("second step", result("passed"));
         hooks.add(TestHelper.hookEntry("before", result("passed")));
         hooks.add(TestHelper.hookEntry("after", result("passed")));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -370,7 +363,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("first step \"b\"", result("passed"));
         stepsToResult.put("second step", result("passed"));
         stepsToResult.put("third step", result("passed"));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -417,7 +410,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("first step \"d\"", result("passed"));
         stepsToResult.put("second step", result("passed"));
         stepsToResult.put("third step", result("passed"));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -472,7 +465,7 @@ public class JUnitFormatterTest {
         stepsToResult.put("first step \"b\"", result("passed"));
         stepsToResult.put("second step", result("passed"));
         stepsToResult.put("third step", result("passed"));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
 
         String formatterOutput = runFeaturesWithFormatter();
 
@@ -539,7 +532,7 @@ public class JUnitFormatterTest {
             .withHooks(hooks)
             .withHookLocations(hookLocations)
             .withHookActions(hookActions)
-            .withTimeServiceIncrement(stepDuration)
+            .withTimeServiceIncrement(stepDurationMillis)
             .build()
             .run();
 
@@ -564,10 +557,6 @@ public class JUnitFormatterTest {
 
     private JUnitFormatter createJUnitFormatter(final File report) throws IOException {
         return new JUnitFormatter(Utils.toURL(report.getAbsolutePath()));
-    }
-
-    private Long milliSeconds(int milliSeconds) {
-        return milliSeconds * 1000000L;
     }
 
     private String getStackTrace(Throwable exception) {

--- a/core/src/test/java/cucumber/runtime/formatter/PluginFactoryTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/PluginFactoryTest.java
@@ -78,7 +78,7 @@ public class PluginFactoryTest {
     }
 
     @Test
-    public void plugin_does_not_buffer_its_output() throws IOException {
+    public void plugin_does_not_buffer_its_output() {
         PrintStream previousSystemOut = System.out;
         OutputStream mockSystemOut = new ByteArrayOutputStream();
 
@@ -92,7 +92,7 @@ public class PluginFactoryTest {
             EventBus bus = new TimeServiceEventBus(new TimeServiceStub(0));
             plugin.setEventPublisher(bus);
             Result result = new Result(Result.Type.PASSED, 0L, null);
-            TestStepFinished event = new TestStepFinished(bus.getTime(), mock(TestCase.class), mock(PickleStepTestStep.class), result);
+            TestStepFinished event = new TestStepFinished(bus.getTime(), bus.getTimeMillis(), mock(TestCase.class), mock(PickleStepTestStep.class), result);
             bus.send(event);
 
             assertThat(mockSystemOut.toString(), is(not("")));

--- a/core/src/test/java/cucumber/runtime/formatter/StatsTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/StatsTest.java
@@ -1,5 +1,6 @@
 package cucumber.runtime.formatter;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.endsWith;
@@ -12,12 +13,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Locale;
 
-import cucumber.runtime.formatter.Stats;
 import org.junit.Test;
 
 public class StatsTest {
     private static final long ANY_TIME = 1234567890;
-    private static final long ONE_MILLI_SECOND = 1000000;
+    private static final long ONE_MILLI_SECOND = MILLISECONDS.toNanos(1);
     private static final long ONE_HOUR = 60 * Stats.ONE_MINUTE;
 
     @Test
@@ -150,8 +150,7 @@ public class StatsTest {
         counter.setFinishTime(ANY_TIME + Stats.ONE_MINUTE + Stats.ONE_SECOND + ONE_MILLI_SECOND);
         counter.printStats(new PrintStream(baos));
 
-        assertThat(baos.toString(), endsWith(String.format(
-                "1m1,001s%n")));
+        assertThat(baos.toString(), endsWith(String.format("1m1,001s%n")));
     }
 
     @Test

--- a/core/src/test/java/cucumber/runtime/formatter/TestNGFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/TestNGFormatterTest.java
@@ -33,7 +33,7 @@ public final class TestNGFormatterTest {
     private final List<SimpleEntry<String, Result>> hooks = new ArrayList<>();
     private final List<String> hookLocations = new ArrayList<>();
     private final List<Answer<Object>> hookActions = new ArrayList<>();
-    private Long stepDuration = null;
+    private Long stepDurationMillis = null;
 
     @Test
     public final void testScenarioWithUndefinedSteps() throws Throwable {
@@ -44,7 +44,7 @@ public final class TestNGFormatterTest {
                 "    Then step\n");
         features.add(feature);
         stepsToResult.put("step", result("undefined"));
-        stepDuration = milliSeconds(0);
+        stepDurationMillis = 0L;
         String actual = runFeaturesWithFormatter(false);
         assertXmlEqual("" +
                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
@@ -68,7 +68,7 @@ public final class TestNGFormatterTest {
                 "    Then step\n");
         features.add(feature);
         stepsToResult.put("step", result("undefined"));
-        stepDuration = milliSeconds(0);
+        stepDurationMillis = 0L;
         String actual = runFeaturesWithFormatter(true);
         assertXmlEqual("" +
                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
@@ -100,7 +100,7 @@ public final class TestNGFormatterTest {
         features.add(feature);
         stepsToResult.put("step1", result("pending"));
         stepsToResult.put("step2", result("skipped"));
-        stepDuration = milliSeconds(0);
+        stepDurationMillis = 0L;
         String actual = runFeaturesWithFormatter(false);
         assertXmlEqual("" +
                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
@@ -125,7 +125,7 @@ public final class TestNGFormatterTest {
         features.add(feature);
         stepsToResult.put("step1", result("failed", new TestNGException("message", "stacktrace")));
         stepsToResult.put("step2", result("skipped"));
-        stepDuration = milliSeconds(0);
+        stepDurationMillis = 0L;
         String actual = runFeaturesWithFormatter(false);
         assertXmlEqual("" +
                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
@@ -156,7 +156,7 @@ public final class TestNGFormatterTest {
                 "    Then step\n");
         features.add(feature);
         stepsToResult.put("step", result("passed"));
-        stepDuration = milliSeconds(0);
+        stepDurationMillis = 0L;
         String actual = runFeaturesWithFormatter(false);
         assertXmlEqual("" +
                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
@@ -184,7 +184,7 @@ public final class TestNGFormatterTest {
         features.add(feature);
         stepsToResult.put("background", result("undefined"));
         stepsToResult.put("step", result("undefined"));
-        stepDuration = milliSeconds(0);
+        stepDurationMillis = 0L;
         String actual = runFeaturesWithFormatter(false);
         assertXmlEqual("" +
                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
@@ -212,7 +212,7 @@ public final class TestNGFormatterTest {
                 "    |  2  |\n");
         features.add(feature);
         stepsToResult.put("step", result("undefined"));
-        stepDuration = milliSeconds(0);
+        stepDurationMillis = 0L;
         String actual = runFeaturesWithFormatter(false);
         assertXmlEqual("" +
                     "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
@@ -248,7 +248,7 @@ public final class TestNGFormatterTest {
         stepsToResult.put("step", result("passed"));
         hooks.add(TestHelper.hookEntry("before", result("passed")));
         hooks.add(TestHelper.hookEntry("after", result("passed")));
-        stepDuration = milliSeconds(1);
+        stepDurationMillis = 1L;
         String actual = runFeaturesWithFormatter(false);
         assertXmlEqual("" +
                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
@@ -277,7 +277,7 @@ public final class TestNGFormatterTest {
         features.add(feature);
         stepsToResult.put("step", result("skipped"));
         hooks.add(TestHelper.hookEntry("before", result("failed", new TestNGException("message", "stacktrace"))));
-        stepDuration = milliSeconds(0);
+        stepDurationMillis = 0L;
         String actual = runFeaturesWithFormatter(false);
         assertXmlEqual("" +
                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
@@ -309,7 +309,7 @@ public final class TestNGFormatterTest {
         features.add(feature);
         stepsToResult.put("step", result("passed"));
         hooks.add(TestHelper.hookEntry("after", result("failed", new TestNGException("message", "stacktrace"))));
-        stepDuration = milliSeconds(0);
+        stepDurationMillis = 0L;
         String actual = runFeaturesWithFormatter(false);
         assertXmlEqual("" +
                 "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
@@ -358,15 +358,11 @@ public final class TestNGFormatterTest {
             .withHooks(hooks)
             .withHookLocations(hookLocations)
             .withHookActions(hookActions)
-            .withTimeServiceIncrement(stepDuration)
+            .withTimeServiceIncrement(stepDurationMillis)
             .build()
             .run();
 
         return new Scanner(new FileInputStream(tempFile), "UTF-8").useDelimiter("\\A").next();
-    }
-
-    private Long milliSeconds(int milliSeconds) {
-        return milliSeconds * 1000000L;
     }
 
     private static class TestNGException extends Exception {

--- a/core/src/test/java/cucumber/runtime/formatter/TimelineFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/TimelineFormatterTest.java
@@ -233,7 +233,7 @@ public class TimelineFormatterTest {
             .withRuntimeArgs("--plugin", "timeline:" + reportDir.getAbsolutePath())
             .withStepsToResult(stepsToResult)
             .withStepsToLocation(stepsToLocation)
-            .withTimeServiceIncrement(TimeUnit.MILLISECONDS.toNanos(STEP_DURATION_MS))
+            .withTimeServiceIncrement(STEP_DURATION_MS)
             .build()
             .run();
     }

--- a/core/src/test/java/cucumber/runtime/formatter/UsageFormatterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/UsageFormatterTest.java
@@ -15,8 +15,9 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -37,7 +38,7 @@ public class UsageFormatterTest {
         Appendable out = mock(Appendable.class);
         UsageFormatter usageFormatter = new UsageFormatter(out);
         Result result = new Result(Result.Type.FAILED, 0L, null);
-        usageFormatter.handleTestStepFinished(new TestStepFinished(0L, mock(TestCase.class), mockTestStep(), result));
+        usageFormatter.handleTestStepFinished(new TestStepFinished(0L, 0L, mock(TestCase.class), mockTestStep(), result));
         verifyZeroInteractions(out);
     }
 
@@ -50,7 +51,7 @@ public class UsageFormatterTest {
         Result result = new Result(Result.Type.PASSED, 12345L, null);
 
 
-        usageFormatter.handleTestStepFinished(new TestStepFinished(0l, mock(TestCase.class), testStep, result));
+        usageFormatter.handleTestStepFinished(new TestStepFinished(0L, 0L, mock(TestCase.class), testStep, result));
 
         Map<String, List<UsageFormatter.StepContainer>> usageMap = usageFormatter.usageMap;
         assertEquals(usageMap.size(), 1);
@@ -69,7 +70,7 @@ public class UsageFormatterTest {
         TestStep testStep = mockTestStep();
         Result result = new Result(Result.Type.PASSED, 0L, null);
 
-        usageFormatter.handleTestStepFinished(new TestStepFinished(0L, mock(TestCase.class), testStep, result));
+        usageFormatter.handleTestStepFinished(new TestStepFinished(0L, 0L, mock(TestCase.class), testStep, result));
 
         Map<String, List<UsageFormatter.StepContainer>> usageMap = usageFormatter.usageMap;
         assertEquals(usageMap.size(), 1);
@@ -88,7 +89,7 @@ public class UsageFormatterTest {
         PickleStepTestStep testStep = mockTestStep();
         Result result = new Result(Result.Type.PASSED, 0L, null);
 
-        usageFormatter.handleTestStepFinished(new TestStepFinished(0L,mock(TestCase.class), testStep, result));
+        usageFormatter.handleTestStepFinished(new TestStepFinished(0L, 0L, mock(TestCase.class), testStep, result));
 
         Map<String, List<UsageFormatter.StepContainer>> usageMap = usageFormatter.usageMap;
         assertEquals(usageMap.size(), 1);
@@ -100,7 +101,7 @@ public class UsageFormatterTest {
     }
 
     @Test
-    public void doneWithoutUsageStatisticStrategies() throws IOException {
+    public void doneWithoutUsageStatisticStrategies() {
         StringBuffer out = new StringBuffer();
         UsageFormatter usageFormatter = new UsageFormatter(out);
 
@@ -114,11 +115,11 @@ public class UsageFormatterTest {
 
         usageFormatter.finishReport();
 
-        assertTrue(out.toString().contains("0.012345678"));
+        assertThat(out.toString(), containsString("0.012345678"));
     }
 
     @Test
-    public void doneWithUsageStatisticStrategies() throws IOException {
+    public void doneWithUsageStatisticStrategies() {
         StringBuffer out = new StringBuffer();
         UsageFormatter usageFormatter = new UsageFormatter(out);
 
@@ -136,8 +137,8 @@ public class UsageFormatterTest {
 
         usageFormatter.finishReport();
 
-        assertTrue(out.toString().contains("0.000023456"));
-        assertTrue(out.toString().contains("0.012345678"));
+        assertThat(out.toString(), containsString("0.000023456"));
+        assertThat(out.toString(), containsString("0.012345678"));
     }
 
     private PickleStepTestStep mockTestStep() {

--- a/core/src/test/resources/cucumber/runtime/formatter/JSONPrettyFormatterTest.json
+++ b/core/src/test/resources/cucumber/runtime/formatter/JSONPrettyFormatterTest.json
@@ -44,11 +44,11 @@
       },
       {
         "id": "feature-3;scenario-1",
-        "start_timestamp": "1970-01-01T00:00:00.000",
+        "start_timestamp": "1970-01-01T00:00:11.106Z",
         "before": [
           {
             "result": {
-              "duration": 1234,
+              "duration": 1234000000,
               "status": "passed"
             },
             "match": {}
@@ -136,11 +136,11 @@
       },
       {
         "id": "feature-3;scenariooutline-1;;2",
-        "start_timestamp": "1970-01-01T00:00:00.000",
+        "start_timestamp": "1970-01-01T00:00:40.722Z",
         "before": [
           {
             "result": {
-              "duration": 1234,
+              "duration": 1234000000,
               "status": "passed"
             },
             "match": {}
@@ -219,11 +219,11 @@
       },
       {
         "id": "feature-3;scenariooutline-1;;3",
-        "start_timestamp": "1970-01-01T00:00:00.000",
+        "start_timestamp": "1970-01-01T00:01:07.870Z",
         "before": [
           {
             "result": {
-              "duration": 1234,
+              "duration": 1234000000,
               "status": "passed"
             },
             "match": {}
@@ -302,11 +302,11 @@
       },
       {
         "id": "feature-3;scenario-2",
-        "start_timestamp": "1970-01-01T00:00:00.000",
+        "start_timestamp": "1970-01-01T00:01:35.018Z",
         "before": [
           {
             "result": {
-              "duration": 1234,
+              "duration": 1234000000,
               "status": "passed"
             },
             "match": {}

--- a/junit/src/main/java/cucumber/api/junit/Cucumber.java
+++ b/junit/src/main/java/cucumber/api/junit/Cucumber.java
@@ -138,14 +138,14 @@ public class Cucumber extends ParentRunner<FeatureRunner> {
 
         @Override
         public void evaluate() throws Throwable {
-            bus.send(new TestRunStarted(bus.getTime()));
+            bus.send(new TestRunStarted(bus.getTime(), bus.getTimeMillis()));
             for (CucumberFeature feature : features) {
                 feature.sendTestSourceRead(bus);
             }
             StepDefinitionReporter stepDefinitionReporter = plugins.stepDefinitionReporter();
             runnerSupplier.get().reportStepDefinitions(stepDefinitionReporter);
             runFeatures.evaluate();
-            bus.send(new TestRunFinished(bus.getTime()));
+            bus.send(new TestRunFinished(bus.getTime(), bus.getTimeMillis()));
         }
     }
 }

--- a/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/FeatureRunnerTest.java
@@ -158,7 +158,7 @@ public class FeatureRunnerTest {
             }
 
             @Override
-            public long timeStampMillis() {
+            public long timeMillis() {
                 return 0L;
             }
         };

--- a/testng/src/main/java/cucumber/api/testng/TestNGCucumberRunner.java
+++ b/testng/src/main/java/cucumber/api/testng/TestNGCucumberRunner.java
@@ -63,7 +63,7 @@ public class TestNGCucumberRunner {
     }
 
     public void finish() {
-        bus.send(new TestRunFinished(bus.getTime()));
+        bus.send(new TestRunFinished(bus.getTime(), bus.getTimeMillis()));
     }
 
     /**
@@ -91,7 +91,7 @@ public class TestNGCucumberRunner {
     List<CucumberFeature> getFeatures() {
 
         List<CucumberFeature> features = featureSupplier.get();
-        bus.send(new TestRunStarted(bus.getTime()));
+        bus.send(new TestRunStarted(bus.getTime(), bus.getTimeMillis()));
         for (CucumberFeature feature : features) {
             feature.sendTestSourceRead(bus);
         }


### PR DESCRIPTION
## Summary

A timestamp is more useful when that timestamp is relative to the epoch.
Unlike `System.currentTimeMillis`, `System.nanoTime` is relative to some
arbitrary point in time.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

