### PR TITLE
[Core] Add more details to ParserException

### DIFF
--- a/core/src/main/java/cucumber/runtime/model/FeatureParser.java
+++ b/core/src/main/java/cucumber/runtime/model/FeatureParser.java
@@ -37,7 +37,7 @@ public class FeatureParser {
             List<PickleEvent> pickleEvents = compilePickles(gherkinDocument, resource);
             return new CucumberFeature(gherkinDocument, path, source, pickleEvents);
         } catch (ParserException e) {
-            throw new CucumberException("Failed to parse resourse : " + path.getPath(), e);
+            throw new CucumberException("Failed to parse resourse at: " + path.toString(), e);
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/model/FeatureParser.java
+++ b/core/src/main/java/cucumber/runtime/model/FeatureParser.java
@@ -37,7 +37,7 @@ public class FeatureParser {
             List<PickleEvent> pickleEvents = compilePickles(gherkinDocument, resource);
             return new CucumberFeature(gherkinDocument, path, source, pickleEvents);
         } catch (ParserException e) {
-            throw new CucumberException("Failed to parse resourse at: " + path.toString(), e);
+            throw new CucumberException("Failed to parse resource at: " + path.toString(), e);
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/model/FeatureParser.java
+++ b/core/src/main/java/cucumber/runtime/model/FeatureParser.java
@@ -37,7 +37,7 @@ public class FeatureParser {
             List<PickleEvent> pickleEvents = compilePickles(gherkinDocument, resource);
             return new CucumberFeature(gherkinDocument, path, source, pickleEvents);
         } catch (ParserException e) {
-            throw new CucumberException(e);
+            throw new CucumberException("Failed to parse resourse : " + path.getPath(), e);
         }
     }
 

--- a/junit/src/test/java/cucumber/runtime/junit/CucumberTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/CucumberTest.java
@@ -4,10 +4,13 @@ import cucumber.annotation.DummyWhen;
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 import cucumber.runtime.CucumberException;
+import gherkin.ParserException.CompositeParserException;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.ParallelComputer;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.Description;
 import org.junit.runner.Request;
 import org.junit.runner.RunWith;
@@ -22,15 +25,17 @@ import java.util.List;
 
 import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.ArgumentMatchers.argThat;
 
 public class CucumberTest {
 
+    @Rule
+    public ExpectedException thrownException = ExpectedException.none();
     private String dir;
 
     @Before
@@ -61,15 +66,11 @@ public class CucumberTest {
         assertEquals("Feature: Feature A", cucumber.getChildren().get(0).getName());
     }
 
-    @Test
-    public void testThatParsingErrorsIsNicelyReported() throws Exception {
-        try {
-            new Cucumber(LexerErrorFeature.class);
-            fail("Expecting error");
-        } catch (CucumberException e) {
-            assertThat(e.getCause().toString(), containsString("gherkin.ParserException$CompositeParserException: Parser errors:"));
-        }
-    }
+	@Test
+	public void testThatParsingErrorsIsNicelyReported() throws Exception {
+		thrownException.expectCause(isA(CompositeParserException.class));
+		new Cucumber(LexerErrorFeature.class);
+	}
 
     @Test
     public void testThatFileIsNotCreatedOnParsingError() throws Exception {

--- a/junit/src/test/java/cucumber/runtime/junit/CucumberTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/CucumberTest.java
@@ -18,7 +18,6 @@ import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -27,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.ArgumentMatchers.argThat;
 
 public class CucumberTest {
@@ -68,7 +67,7 @@ public class CucumberTest {
             new Cucumber(LexerErrorFeature.class);
             fail("Expecting error");
         } catch (CucumberException e) {
-            assertThat(e.getMessage(), startsWith("gherkin.ParserException$CompositeParserException: Parser errors:"));
+            assertThat(e.getCause().toString(), containsString("gherkin.ParserException$CompositeParserException: Parser errors:"));
         }
     }
 


### PR DESCRIPTION
## Summary
Adding the path to the resource for easier investigation during parsing exceptions in cucumber.

## Details
Added resource path to the exception thrown under `FeatureParser.parseResource()` method to allow user to see which file failed to parse.

## Motivation and Context
Better user experience. It is useful to know which file caused the parser exception. Refer slack conversation 

> Nicolas   [Mar 30th at 3:03 AM]
> Hello! I'm starting off with cucumber-jvm and I've noticed that the Parser errors don't specify which `.feature` file is broken. Is there any way to enable this behavior? We're looking at adding multiple feature files at a time in a medium sized QA team and this would help out quite a bit. Thanks!
> 
> mpkorstanje   [8 days ago]
> And if you're willing to invest a little time you could probably submit a patch too:
> 
> You'd have to add some details around here I think:
> 
> core/src/main/java/cucumber/runtime/model/FeatureParser.java:40
>             ```throw new CucumberException(e);```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.