### PR TITLE
[Spring] Add examples to the documentation

### DIFF
--- a/spring/README.md
+++ b/spring/README.md
@@ -24,7 +24,7 @@ For your own classes:
 
 * Add a `@Component` annotation to each of the classes cucumber-spring should manage.
 ```java
-package cucumber.runtime.java.spring.beans;
+package com.example.app;
 
 import org.springframework.stereotype.Component;
 
@@ -50,7 +50,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan("cucumber.runtime.java.spring.beans")
+@ComponentScan("com.example.app")
 public class Config {
     // the rest of your configuration
 }
@@ -58,7 +58,7 @@ public class Config {
 
 * Add `@DirtiesContext` to your test configuration if each scenario should have a fresh application context.
 ```java
-package cucumber.runtime.java.spring.dirtiescontextconfig;
+package com.example.app;
 
 import com.example.app.Config;
 import cucumber.runtime.java.spring.beans.Belly;
@@ -69,7 +69,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(classes = { Config.class })
 @DirtiesContext
-public class DirtiesContextBellyStepDefs {
+public class SomeServiceSteps {
 
     @Autowired
     private Belly belly; // Each scenario have a new instance of Belly

--- a/spring/README.md
+++ b/spring/README.md
@@ -23,6 +23,24 @@ Add the `cucumber-spring` dependency to your `pom.xml`:
 For your own classes:
 
 * Add a `@Component` annotation to each of the classes cucumber-spring should manage.
+```java
+package cucumber.runtime.java.spring.beans;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class Belly {
+    private int cukes = 0;
+
+    public void setCukes(int cukes) {
+        this.cukes = cukes;
+    }
+
+    public int getCukes() {
+        return cukes;
+    }
+}
+```
 * Add the location of your classes to the `@ComponentScan` of your (test) configuration:
 
 ```java
@@ -32,13 +50,34 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan("com.example.app")
+@ComponentScan("cucumber.runtime.java.spring.beans")
 public class Config {
     // the rest of your configuration
 }
 ```
 
 * Add `@DirtiesContext` to your test configuration if each scenario should have a fresh application context.
+```java
+package cucumber.runtime.java.spring.dirtiescontextconfig;
+
+import com.example.app.Config;
+import cucumber.runtime.java.spring.beans.Belly;
+import cucumber.runtime.java.spring.beans.BellyBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(classes = { Config.class })
+@DirtiesContext
+public class DirtiesContextBellyStepDefs {
+
+    @Autowired
+    private Belly belly; // Each scenario have a new instance of Belly
+    
+    [...]
+    
+}
+```
 
 For classes from other frameworks:
 


### PR DESCRIPTION
## Summary

I try for almost 2-3 days to use the spring injection of bean in my cucumber scenarios, but the documentation was leading me in the wrong direction.

## Details

I added examples in the documentation of Spring so that others don't waste their times.

## Motivation and Context

I really thinks that this change can improve readability of your documentation.

## How Has This Been Tested?

I only did a change in documentation, so tests are not needed I think.

## Types of changes

No change other than a documentation with exemples

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
