### PR TITLE
[Java] Use ServiceLoader for ObjectFactory

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-core</artifactId>

--- a/core/src/main/java/cucumber/runtime/TooManyInstancesException.java
+++ b/core/src/main/java/cucumber/runtime/TooManyInstancesException.java
@@ -4,7 +4,7 @@ import java.util.Collection;
 
 public class TooManyInstancesException extends CucumberException {
 
-    TooManyInstancesException(Collection instances) {
+    public TooManyInstancesException(Collection instances) {
         super(createMessage(instances));
     }
 

--- a/core/src/main/java/io/cucumber/core/backend/ObjectFactory.java
+++ b/core/src/main/java/io/cucumber/core/backend/ObjectFactory.java
@@ -1,0 +1,40 @@
+package io.cucumber.core.backend;
+
+/**
+ * Minimal facade for Dependency Injection containers
+ */
+public interface ObjectFactory {
+
+    /**
+     * Instantiate glue code <b>before</b> scenario execution. Called once per
+     * scenario.
+     */
+    void start();
+
+    /**
+     * Dispose glue code <b>after</b> scenario execution. Called once per
+     * scenario.
+     */
+    void stop();
+
+    /**
+     * Collects glue classes in the classpath. Called once on init.
+     *
+     * @param glueClass Glue class containing cucumber.api annotations (Before,
+     * Given, When, ...)
+     * @return true if stepdefs and hooks in this class should be used, false if
+     * they should be ignored.
+     */
+    boolean addClass(Class<?> glueClass);
+
+    /**
+     * Provides the glue instances used to execute the current scenario. The
+     * instance can be prepared in {@link #start()}.
+     *
+     * @param glueClass type of instance to be created.
+     * @param <T> type of Glue class
+     * @return new Glue instance of type T
+     */
+    <T> T getInstance(Class<T> glueClass);
+
+}

--- a/examples/java-calculator-testng/pom.xml
+++ b/examples/java-calculator-testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-calculator-testng</artifactId>

--- a/examples/java-calculator/pom.xml
+++ b/examples/java-calculator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-calculator</artifactId>

--- a/examples/java-wicket/java-wicket-main/pom.xml
+++ b/examples/java-wicket/java-wicket-main/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>java-wicket</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket-main</artifactId>
     <name>Examples: Wicket application</name>

--- a/examples/java-wicket/java-wicket-test/pom.xml
+++ b/examples/java-wicket/java-wicket-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>java-wicket</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket-test</artifactId>
     <name>Examples: Wicket application tested with Selenium</name>

--- a/examples/java-wicket/pom.xml
+++ b/examples/java-wicket/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket</artifactId>
     <packaging>pom</packaging>

--- a/examples/java8-calculator/pom.xml
+++ b/examples/java8-calculator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java8-calculator</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-examples</artifactId>

--- a/examples/spring-txn/pom.xml
+++ b/examples/spring-txn/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-txn</artifactId>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-guice</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-java</artifactId>

--- a/java/src/main/java/cucumber/api/java/ObjectFactory.java
+++ b/java/src/main/java/cucumber/api/java/ObjectFactory.java
@@ -2,7 +2,10 @@ package cucumber.api.java;
 
 /**
  * Minimal facade for Dependency Injection containers
+ *
+ * @deprecated use @code io.cucumber.core.backend.ObjectFactory instead
  */
+@Deprecated
 public interface ObjectFactory {
 
     /**

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-java8</artifactId>

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-junit</artifactId>

--- a/kotlin-java8/pom.xml
+++ b/kotlin-java8/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-kotlin-java8</artifactId>

--- a/needle/pom.xml
+++ b/needle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-needle</artifactId>

--- a/openejb/pom.xml
+++ b/openejb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-openejb</artifactId>

--- a/picocontainer/pom.xml
+++ b/picocontainer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-picocontainer</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <version>1.0.3</version>
     </parent>
     <artifactId>cucumber-jvm</artifactId>
-    <version>4.3.2-SNAPSHOT</version>
+    <version>4.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Cucumber-JVM</name>
     <description>Cucumber for the JVM</description>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-spring</artifactId>

--- a/testng/pom.xml
+++ b/testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-testng</artifactId>

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>4.3.2-SNAPSHOT</version>
+        <version>4.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-weld</artifactId>


### PR DESCRIPTION
backport of commit a03dd01 for cucumber 4.x

## Summary

Backport ServiceLoader for ObjectFactory to 4.x.

## Details
So it is possible to use ServciceLoader for ObjectFactory also with 4.x and must not be change when changed to 5.x. Easier migration to next major-version.

## Motivation and Context

## How Has This Been Tested?

Difficult to test, have not found any test in develop-v5 for it .. and not sure how to provide a usefull test. Had test it with my own ObjectFactory (not public :( )

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
