### PR TITLE
[Core] Fix filtering scenarios loaded from jar

### DIFF
--- a/core/src/main/java/cucumber/runtime/io/ZipResource.java
+++ b/core/src/main/java/cucumber/runtime/io/ZipResource.java
@@ -19,7 +19,7 @@ class ZipResource implements Resource {
 
     @Override
     public URI getPath() {
-        return URI.create(CLASSPATH_SCHEME_PREFIX + "/" + jarEntry.getName());
+        return URI.create(CLASSPATH_SCHEME_PREFIX + jarEntry.getName());
     }
 
     @Override


### PR DESCRIPTION
## Summary
Don't add an extra slash after the `classpath:` scheme

## Details

Changed the `ZipResource` to preserve the original path of the zipped entity.

## Motivation and Context

I am running cucumber tests with features loaded from `classpath:`, like this:

```
java -cp fatjar.jar cucumber.api.cli.Main "classpath:features/FeatureWithExamples.feature:64"
```

However, when cucumber parses this path and creates a `ZipResource` from it, it adds an extra slash:
![image](https://user-images.githubusercontent.com/10754345/57017290-c4516c80-6c1e-11e9-8b54-08fcd83c1857.png)

And the url becomes `classpath:/features/FeatureWithExamples.feature:64`

![image](https://user-images.githubusercontent.com/10754345/57017264-ae43ac00-6c1e-11e9-9895-7b93c2ea50c0.png)

This becomes a problem down the line, when `LinePredicate` tries to filter out the pickles:
![image](https://user-images.githubusercontent.com/10754345/57017354-20b48c00-6c1f-11e9-8e2c-a46b157692d9.png)

This if does't pass (because the key is not the one in the map) and instead of filtering the pickles out, it just lets all of the though the filter.

I tried changing the path to be `classpath:/features/FeatureWithExamples.feature:64` right away. But then the loader is unable to get the resource:

![image](https://user-images.githubusercontent.com/10754345/57017591-0dee8700-6c20-11e9-8f71-5c04cb2d2bc1.png)

Can you please tell me whether this change makes sense or am I confusing things here?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] ~New feature (non-breaking change which adds functionality).~
- [ ] ~Breaking change (fix or feature that would cause existing functionality to not work as expected).~

