### PR TITLE
[Core] Use meaningful thread names

### DIFF
--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -214,26 +214,19 @@ public class Runtime {
 
     private static final class CucumberThreadFactory implements ThreadFactory {
 
+        private static final AtomicInteger poolNumber = new AtomicInteger(1);
         private final AtomicInteger threadNumber = new AtomicInteger(1);
-        private final ThreadGroup group;
+        private final String namePrefix;
 
         CucumberThreadFactory() {
             SecurityManager s = System.getSecurityManager();
             this.group = s != null ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+            this.namePrefix = "cucumber-runner-" + poolNumber.getAndIncrement() + "-thread-";
         }
         
         @Override
         public Thread newThread(Runnable r) {
-            Thread t = new Thread(this.group, r, "cucumber-runner-thread-" + this.threadNumber.getAndIncrement(), 0L);
-            if (t.isDaemon()) {
-                t.setDaemon(false);
-            }
-
-            if (t.getPriority() != 5) {
-                t.setPriority(5);
-            }
-
-            return t;
+            return new Thread(r, namePrefix + this.threadNumber.getAndIncrement());
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -224,7 +224,7 @@ public class Runtime {
         
         @Override
         public Thread newThread(Runnable r) {
-            Thread t = new Thread(this.group, r, "cucumber-thread-" + this.threadNumber.getAndIncrement(), 0L);
+            Thread t = new Thread(this.group, r, "cucumber-runner-thread-" + this.threadNumber.getAndIncrement(), 0L);
             if (t.isDaemon()) {
                 t.setDaemon(false);
             }

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -26,7 +26,9 @@ import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This is the main entry point for running Cucumber features from the CLI.
@@ -195,7 +197,7 @@ public class Runtime {
                 : new SingletonRunnerSupplier(this.runtimeOptions, eventBus, backendSupplier);
 
             final ExecutorService executor = runtimeOptions.isMultiThreaded()
-                ? Executors.newFixedThreadPool(runtimeOptions.getThreads())
+                ? Executors.newFixedThreadPool(runtimeOptions.getThreads(), new CucumberThreadFactory())
                 : new SameThreadExecutorService();
 
 
@@ -207,6 +209,31 @@ public class Runtime {
 
             final Filters filters = new Filters(this.runtimeOptions);
             return new Runtime(plugins, this.runtimeOptions, eventBus, filters, runnerSupplier, featureSupplier, executor);
+        }
+    }
+
+    private static final class CucumberThreadFactory implements ThreadFactory {
+
+        private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private final ThreadGroup group;
+
+        CucumberThreadFactory() {
+            SecurityManager s = System.getSecurityManager();
+            this.group = s != null ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        }
+        
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(this.group, r, "cucumber-thread-" + this.threadNumber.getAndIncrement(), 0L);
+            if (t.isDaemon()) {
+                t.setDaemon(false);
+            }
+
+            if (t.getPriority() != 5) {
+                t.setPriority(5);
+            }
+
+            return t;
         }
     }
 

--- a/core/src/main/java/cucumber/runtime/Runtime.java
+++ b/core/src/main/java/cucumber/runtime/Runtime.java
@@ -219,8 +219,6 @@ public class Runtime {
         private final String namePrefix;
 
         CucumberThreadFactory() {
-            SecurityManager s = System.getSecurityManager();
-            this.group = s != null ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
             this.namePrefix = "cucumber-runner-" + poolNumber.getAndIncrement() + "-thread-";
         }
         


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

When running with --threads, give the the pool threads some meaningful names

## Details

Before it was using the standard threadfactory, which was naming threads like 'pool-x-thread-y'
Now it is 'cucumber-runner-thread-x'

## Motivation and Context

It's better for logging to see which threads belong to cucumber and which are unrelated background threads

