### PR TITLE
[Core] Handle parallel execution exceptions

### DIFF
--- a/core/src/main/java/cucumber/runtime/CompositeCucumberException.java
+++ b/core/src/main/java/cucumber/runtime/CompositeCucumberException.java
@@ -1,0 +1,25 @@
+package cucumber.runtime;
+
+import java.util.Collections;
+import java.util.List;
+
+class CompositeCucumberException extends CucumberException {
+    private final List<Throwable> causes;
+
+    CompositeCucumberException(List<Throwable> causes) {
+        super(String.format("There were %d exceptions:", causes.size()));
+        this.causes = causes;
+    }
+
+    public List<Throwable> getCauses() {
+        return Collections.unmodifiableList(this.causes);
+    }
+
+    public String getMessage() {
+        StringBuilder sb = new StringBuilder(super.getMessage());
+        for (Throwable e : this.causes) {
+            sb.append(String.format("\n  %s(%s)", e.getClass().getName(), e.getMessage()));
+        }
+        return sb.toString();
+    }
+}

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -488,6 +488,9 @@ public class RuntimeTest {
             }
         };
 
+        expectedException.expect(CompositeCucumberException.class);
+        expectedException.expectMessage("There were 3 exceptions");
+
         TestHelper.builder()
             .withFeatures(Arrays.asList(feature1, feature2))
             .withFormatterUnderTest(brokenEventListener)
@@ -496,9 +499,6 @@ public class RuntimeTest {
             .build()
             .run();
 
-        expectedException.expect(CompositeCucumberException.class);
-        expectedException.expectMessage("There were 3 exceptions");
-        expectedException.expectCause(hasMessage(equalTo("boom")));
     }
 
     @Test

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -457,7 +457,7 @@ public class RuntimeTest {
             "TestRun finished\n", formatterOutput);
     }
 
-    @Test(expected = CucumberException.class)
+    @Test(expected = Runtime.MultipleFailureException.class)
     public void should_fail_on_eventlistener_exception_when_running_in_parallel() {
         CucumberFeature feature1 = TestHelper.feature("path/test.feature", "" +
             "Feature: feature name 1\n" +
@@ -491,6 +491,7 @@ public class RuntimeTest {
             .build()
             .run();
 
+        expectedException.expectMessage("There were 3 exceptions");
         expectedException.expectCause(ThrowableMessageMatcher.hasMessage(equalTo("boom")));
     }
 


### PR DESCRIPTION
See https://github.com/cucumber/cucumber-jvm/issues/1628

That should fix the mentioned issue sufficiently.
There would be some nice-to-have improvements IMO, e.g. reporting all the exceptions if multiple threads failed and failing as early as possible instead of waiting for the termination of all the callables, but that would increase the complexity.