### PR TITLE
[Core] Clear RuntimeOptions.featurePaths if rerun was used

### DIFF
--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -69,7 +69,6 @@ public class RuntimeOptions implements FeatureOptions, FilterOptions, PluginOpti
     private boolean wip = false;
     private SnippetType snippetType = SnippetType.UNDERSCORE;
     private int threads = 1;
-    private boolean isRerun = false;
 
     private final List<String> pluginFormatterNames = new ArrayList<String>();
     private final List<String> pluginStepDefinitionReporterNames = new ArrayList<String>();
@@ -138,6 +137,7 @@ public class RuntimeOptions implements FeatureOptions, FilterOptions, PluginOpti
         List<URI> parsedGlue = new ArrayList<>();
         ParsedPluginData parsedPluginData = new ParsedPluginData();
         List<String> parsedJunitOptions = new ArrayList<String>();
+        boolean isRerun = false;
 
         while (!args.isEmpty()) {
             String arg = args.remove(0).trim();

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -69,6 +69,7 @@ public class RuntimeOptions implements FeatureOptions, FilterOptions, PluginOpti
     private boolean wip = false;
     private SnippetType snippetType = SnippetType.UNDERSCORE;
     private int threads = 1;
+    private boolean isRerun = false;
 
     private final List<String> pluginFormatterNames = new ArrayList<String>();
     private final List<String> pluginStepDefinitionReporterNames = new ArrayList<String>();
@@ -184,6 +185,7 @@ public class RuntimeOptions implements FeatureOptions, FilterOptions, PluginOpti
                 printUsage();
                 throw new CucumberException("Unknown option: " + arg);
             } else if (arg.startsWith("@")) {
+                isRerun = true;
                 URI rerunFile = FeaturePath.parse(arg.substring(1));
                 processPathWitheLinesFromRerunFile(parsedLineFilters, parsedFeaturePaths, rerunFile);
             } else if (!arg.isEmpty()){
@@ -201,7 +203,7 @@ public class RuntimeOptions implements FeatureOptions, FilterOptions, PluginOpti
                 lineFilters.put(path, parsedLineFilters.get(path));
             }
         }
-        if (!parsedFeaturePaths.isEmpty()) {
+        if (!parsedFeaturePaths.isEmpty() || isRerun) {
             featurePaths.clear();
             featurePaths.addAll(parsedFeaturePaths);
         }

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -67,7 +67,6 @@ public class RuntimeOptions implements FeatureOptions, FilterOptions, PluginOpti
     private boolean strict = false;
     private boolean monochrome = false;
     private boolean wip = false;
-    private boolean wasRerun = false;
     private SnippetType snippetType = SnippetType.UNDERSCORE;
     private int threads = 1;
 
@@ -187,7 +186,6 @@ public class RuntimeOptions implements FeatureOptions, FilterOptions, PluginOpti
                 throw new CucumberException("Unknown option: " + arg);
             } else if (arg.startsWith("@")) {
                 isRerun = true;
-                wasRerun = true;
                 URI rerunFile = FeaturePath.parse(arg.substring(1));
                 processPathWitheLinesFromRerunFile(parsedLineFilters, parsedFeaturePaths, rerunFile);
             } else if (!arg.isEmpty()){
@@ -195,7 +193,7 @@ public class RuntimeOptions implements FeatureOptions, FilterOptions, PluginOpti
                 processFeatureWithLines(parsedLineFilters, parsedFeaturePaths, featureWithLines);
             }
         }
-        if (isRerun || (wasRerun && !parsedFeaturePaths.isEmpty())){
+        if (isRerun || !parsedFeaturePaths.isEmpty()){
             featurePaths.clear();
             lineFilters.clear();
         }

--- a/core/src/main/java/cucumber/runtime/RuntimeOptions.java
+++ b/core/src/main/java/cucumber/runtime/RuntimeOptions.java
@@ -67,6 +67,7 @@ public class RuntimeOptions implements FeatureOptions, FilterOptions, PluginOpti
     private boolean strict = false;
     private boolean monochrome = false;
     private boolean wip = false;
+    private boolean wasRerun = false;
     private SnippetType snippetType = SnippetType.UNDERSCORE;
     private int threads = 1;
 
@@ -186,12 +187,17 @@ public class RuntimeOptions implements FeatureOptions, FilterOptions, PluginOpti
                 throw new CucumberException("Unknown option: " + arg);
             } else if (arg.startsWith("@")) {
                 isRerun = true;
+                wasRerun = true;
                 URI rerunFile = FeaturePath.parse(arg.substring(1));
                 processPathWitheLinesFromRerunFile(parsedLineFilters, parsedFeaturePaths, rerunFile);
             } else if (!arg.isEmpty()){
                 FeatureWithLines featureWithLines = FeatureWithLines.parse(arg);
                 processFeatureWithLines(parsedLineFilters, parsedFeaturePaths, featureWithLines);
             }
+        }
+        if (isRerun || (wasRerun && !parsedFeaturePaths.isEmpty())){
+            featurePaths.clear();
+            lineFilters.clear();
         }
         if (!parsedTagFilters.isEmpty() || !parsedNameFilters.isEmpty() || !parsedLineFilters.isEmpty()) {
             tagFilters.clear();
@@ -203,7 +209,7 @@ public class RuntimeOptions implements FeatureOptions, FilterOptions, PluginOpti
                 lineFilters.put(path, parsedLineFilters.get(path));
             }
         }
-        if (!parsedFeaturePaths.isEmpty() || isRerun) {
+        if (!parsedFeaturePaths.isEmpty() ) {
             featurePaths.clear();
             featurePaths.addAll(parsedFeaturePaths);
         }

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -324,6 +324,17 @@ public class RuntimeOptionsTest {
     }
 
     @Test
+    public void strips_lines_from_rerun_file_from_cli_if_filters_are_specified_in_cucumber_options_property()
+        throws IOException {
+        properties.setProperty("cucumber.options", "--tags @Tag");
+        String rerunPath = "file:path/rerun.txt";
+        String rerunFile = "file:path/file.feature:3\n";
+        mockFileResource(resourceLoader, rerunPath, rerunFile);
+        RuntimeOptions options = new RuntimeOptions(resourceLoader, new Env(properties), singletonList("@" + rerunPath));
+        assertThat(options.getFeaturePaths(), contains(uri("file:path/file.feature")));
+    }
+
+    @Test
     public void preserves_features_from_cli_if_features_not_specified_in_cucumber_options_property() {
         properties.setProperty("cucumber.options", "--plugin pretty");
         RuntimeOptions options = new RuntimeOptions(new Env(properties), asList("old", "older"));

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -468,6 +468,17 @@ public class RuntimeOptionsTest {
     }
 
     @Test
+    public void loads_features_specified_in_rerun_file_with_empty_cucumber_options() throws Exception {
+        properties.put("cucumber.options", "");
+        String rerunPath = "file:path/rerun.txt";
+        String rerunFile = "file:path/bar.feature:2\n";
+        mockFileResource(resourceLoader, rerunPath, rerunFile);
+        RuntimeOptions options = new RuntimeOptions(resourceLoader, new Env(properties), singletonList("@" + rerunPath));
+
+        assertThat(options.getFeaturePaths(), contains(uri("file:path/bar.feature")));
+        assertThat(options.getLineFilters(), hasEntry(uri("file:path/bar.feature"), singleton(2)));
+    }
+    @Test
     public void loads_no_features_when_rerun_file_is_empty() throws Exception {
         String rerunPath = "file:path/rerun.txt";
         String rerunFile = "";

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -478,6 +478,19 @@ public class RuntimeOptionsTest {
         assertThat(options.getFeaturePaths(), contains(uri("file:path/bar.feature")));
         assertThat(options.getLineFilters(), hasEntry(uri("file:path/bar.feature"), singleton(2)));
     }
+
+    @Test
+    public void clobbers_features_from_rerun_file_specified_in_cli_if_features_specified_in_cucumber_options_property() throws Exception {
+        properties.put("cucumber.options", "file:path/foo.feature");
+        String rerunPath = "file:path/rerun.txt";
+        String rerunFile = "file:path/bar.feature:2\n";
+        mockFileResource(resourceLoader, rerunPath, rerunFile);
+        RuntimeOptions options = new RuntimeOptions(resourceLoader, new Env(properties), singletonList("@" + rerunPath));
+
+        assertThat(options.getFeaturePaths(), contains(uri("file:path/foo.feature")));
+        assertThat(options.getLineFilters().size(), is(0));
+    }
+
     @Test
     public void loads_no_features_when_rerun_file_is_empty() throws Exception {
         String rerunPath = "file:path/rerun.txt";

--- a/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeOptionsTest.java
@@ -478,6 +478,14 @@ public class RuntimeOptionsTest {
         assertThat(options.getFeaturePaths(), emptyCollectionOf(URI.class));
     }
 
+
+    @Test
+    public void loads_no_features_when_rerun_file_specified_in_cucumber_options_property_is_empty() throws Exception {
+        properties.setProperty("cucumber.options", "@src/test/resources/cucumber/runtime/runtime-options-empty-rerun.txt");
+        RuntimeOptions options = new RuntimeOptions(new Env(properties), singletonList("src/test/resources/cucumber/runtime/formatter"));
+        assertThat(options.getFeaturePaths(), emptyCollectionOf(URI.class));
+    }
+
     @Test
     public void loads_no_features_when_rerun_file_contains_new_line() throws Exception {
         String rerunPath = "file:path/rerun.txt";


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
Fixes: #1630

## How Has This Been Tested?
Unit tests and a test run on my laptop

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
