### PR TITLE
[Core] Add StepDefinedEvent

### DIFF
--- a/core/src/main/java/cucumber/api/StepDefinitionReporter.java
+++ b/core/src/main/java/cucumber/api/StepDefinitionReporter.java
@@ -1,7 +1,12 @@
 package cucumber.api;
 
+import cucumber.api.event.StepDefinedEvent;
 import cucumber.runtime.StepDefinition;
 
+/**
+ * @deprecated in favor of {@link StepDefinedEvent}, as Lambda Step Definitions are not reported through this class.
+ */
+@Deprecated
 public interface StepDefinitionReporter extends Plugin {
     /**
      * Called when a step definition is defined

--- a/core/src/main/java/cucumber/api/event/CanonicalEventOrder.java
+++ b/core/src/main/java/cucumber/api/event/CanonicalEventOrder.java
@@ -31,6 +31,7 @@ final class CanonicalEventOrder implements Comparator<Event> {
                 TestRunStarted.class,
             TestSourceRead.class,
             SnippetsSuggestedEvent.class,
+            StepDefinedEvent.class,
             TestCaseEvent.class,
             TestRunFinished.class
         );

--- a/core/src/main/java/cucumber/api/event/EventPublisher.java
+++ b/core/src/main/java/cucumber/api/event/EventPublisher.java
@@ -11,6 +11,7 @@ public interface EventPublisher {
      * <li>{@link TestRunStarted} - the first event sent.
      * <li>{@link TestSourceRead} - sent for each feature file read, contains the feature file source.
      * <li>{@link SnippetsSuggestedEvent} - sent for each step that could not be matched to a step definition, contains the raw snippets for the step.
+     * <li>{@link StepDefinedEvent} - sent for each step definition as it is loaded, contains the StepDefinition
      * <li>{@link TestCaseStarted} - sent before starting the execution of a Test Case(/Pickle/Scenario), contains the Test Case
      * <li>{@link TestStepStarted} - sent before starting the execution of a Test Step, contains the Test Step
      * <li>{@link EmbedEvent} - calling scenario.embed in a hook triggers this event.

--- a/core/src/main/java/cucumber/api/event/StepDefinedEvent.java
+++ b/core/src/main/java/cucumber/api/event/StepDefinedEvent.java
@@ -1,0 +1,13 @@
+package cucumber.api.event;
+
+import cucumber.runtime.StepDefinition;
+
+public class StepDefinedEvent extends TimeStampedEvent {
+    public final StepDefinition stepDefinition;
+
+    public StepDefinedEvent(Long time, Long timeMillis, StepDefinition stepDefinition) {
+        super(time, timeMillis);
+        this.stepDefinition = stepDefinition;
+    }
+
+}

--- a/core/src/main/java/cucumber/runner/Glue.java
+++ b/core/src/main/java/cucumber/runner/Glue.java
@@ -2,6 +2,7 @@ package cucumber.runner;
 
 import cucumber.runtime.DuplicateStepDefinitionException;
 import cucumber.runtime.HookDefinition;
+import cucumber.runtime.ScenarioScoped;
 import cucumber.runtime.StepDefinition;
 import io.cucumber.stepexpression.Argument;
 import cucumber.api.StepDefinitionReporter;
@@ -138,6 +139,10 @@ final class Glue implements cucumber.runtime.Glue {
         Iterator<HookDefinition> hookIterator = beforeHooks.iterator();
         while (hookIterator.hasNext()) {
             HookDefinition hook = hookIterator.next();
+            if (hook instanceof ScenarioScoped) {
+                ScenarioScoped scenarioScopedHookDefinition = (ScenarioScoped) hook;
+                scenarioScopedHookDefinition.disposeScenarioScope();
+            }
             if (hook.isScenarioScoped()) {
                 hookIterator.remove();
             }
@@ -148,6 +153,10 @@ final class Glue implements cucumber.runtime.Glue {
         Iterator<Map.Entry<String, StepDefinition>> stepDefinitionIterator = stepDefinitions.entrySet().iterator();
         while(stepDefinitionIterator.hasNext()){
             StepDefinition stepDefinition = stepDefinitionIterator.next().getValue();
+            if (stepDefinition instanceof ScenarioScoped) {
+                ScenarioScoped scenarioScopedStepDefinition = (ScenarioScoped) stepDefinition;
+                scenarioScopedStepDefinition.disposeScenarioScope();
+            }
             if(stepDefinition.isScenarioScoped()){
                 stepDefinitionIterator.remove();
             }

--- a/core/src/main/java/cucumber/runner/Glue.java
+++ b/core/src/main/java/cucumber/runner/Glue.java
@@ -5,6 +5,7 @@ import cucumber.runtime.HookDefinition;
 import cucumber.runtime.StepDefinition;
 import io.cucumber.stepexpression.Argument;
 import cucumber.api.StepDefinitionReporter;
+import cucumber.api.event.StepDefinedEvent;
 import gherkin.pickles.PickleStep;
 
 import java.util.ArrayList;
@@ -23,6 +24,12 @@ final class Glue implements cucumber.runtime.Glue {
     final List<HookDefinition> afterHooks = new ArrayList<>();
     final List<HookDefinition> afterStepHooks = new ArrayList<>();
 
+    private final EventBus bus;
+
+    public Glue(EventBus bus) {
+        this.bus = bus;
+    }
+
     @Override
     public void addStepDefinition(StepDefinition stepDefinition) {
         StepDefinition previous = stepDefinitionsByPattern.get(stepDefinition.getPattern());
@@ -30,6 +37,7 @@ final class Glue implements cucumber.runtime.Glue {
             throw new DuplicateStepDefinitionException(previous, stepDefinition);
         }
         stepDefinitionsByPattern.put(stepDefinition.getPattern(), stepDefinition);
+        bus.send(new StepDefinedEvent(bus.getTime(), bus.getTimeMillis(), stepDefinition));
     }
 
     @Override

--- a/core/src/main/java/cucumber/runner/Runner.java
+++ b/core/src/main/java/cucumber/runner/Runner.java
@@ -22,13 +22,14 @@ public final class Runner {
 
     private static final Logger log = LoggerFactory.getLogger(Runner.class);
 
-    private final Glue glue = new Glue();
+    private final Glue glue;
     private final EventBus bus;
     private final Collection<? extends Backend> backends;
     private final RunnerOptions runnerOptions;
 
     public Runner(EventBus bus, Collection<? extends Backend> backends, RunnerOptions runnerOptions) {
         this.bus = bus;
+        this.glue = new Glue(bus);
         this.runnerOptions = runnerOptions;
         this.backends = backends;
         List<URI> gluePaths = runnerOptions.getGlue();

--- a/core/src/main/java/cucumber/runner/Runner.java
+++ b/core/src/main/java/cucumber/runner/Runner.java
@@ -6,12 +6,12 @@ import cucumber.api.event.SnippetsSuggestedEvent;
 import cucumber.runtime.Backend;
 import cucumber.runtime.HookDefinition;
 import cucumber.util.FixJava;
-import io.cucumber.core.logging.Logger;
-import io.cucumber.core.logging.LoggerFactory;
-import io.cucumber.core.options.RunnerOptions;
 import gherkin.events.PickleEvent;
 import gherkin.pickles.PickleStep;
 import gherkin.pickles.PickleTag;
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
+import io.cucumber.core.options.RunnerOptions;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -135,5 +135,6 @@ public final class Runner {
         for (Backend backend : backends) {
             backend.disposeWorld();
         }
+        glue.removeScenarioScopedGlue();
     }
 }

--- a/core/src/main/java/cucumber/runtime/HookDefinition.java
+++ b/core/src/main/java/cucumber/runtime/HookDefinition.java
@@ -21,7 +21,9 @@ public interface HookDefinition {
     int getOrder();
 
     /**
+     * @deprecated replaced with {@link ScenarioScoped}
      * @return true if this instance is scoped to a single scenario, or false if it can be reused across scenarios.
      */
+    @Deprecated
     boolean isScenarioScoped();
 }

--- a/core/src/main/java/cucumber/runtime/ScenarioScoped.java
+++ b/core/src/main/java/cucumber/runtime/ScenarioScoped.java
@@ -1,0 +1,8 @@
+package cucumber.runtime;
+
+public interface ScenarioScoped {
+    /**
+     * Dispose references to Runtime world to allow garbage collection to run.
+     */
+    void disposeScenarioScope();
+}

--- a/core/src/main/java/cucumber/runtime/StepDefinition.java
+++ b/core/src/main/java/cucumber/runtime/StepDefinition.java
@@ -44,7 +44,9 @@ public interface StepDefinition {
     String getPattern();
 
     /**
+     * @deprecated replaced with {@link ScenarioScoped}
      * @return true if this instance is scoped to a single scenario, or false if it can be reused across scenarios.
      */
+    @Deprecated
     boolean isScenarioScoped();
 }

--- a/core/src/test/java/cucumber/runner/GlueTest.java
+++ b/core/src/test/java/cucumber/runner/GlueTest.java
@@ -41,12 +41,12 @@ public class GlueTest {
 
     @Before
     public void setUp() {
-        glue = new Glue();
+        glue = new Glue(mock(EventBus.class));
     }
 
     @Test
     public void throws_duplicate_error_on_dupe_stepdefs() {
-        Glue glue = new Glue();
+        Glue glue = new Glue(mock(EventBus.class));
 
         StepDefinition a = mock(StepDefinition.class);
         when(a.getPattern()).thenReturn("hello");

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -28,14 +28,12 @@ import io.cucumber.stepexpression.Argument;
 import io.cucumber.stepexpression.TypeRegistry;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 
 import java.net.URI;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static cucumber.runner.TestHelper.feature;
@@ -46,7 +44,6 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
-import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -75,10 +72,10 @@ public class RuntimeTest {
 
         Plugin jsonFormatter = FormatterBuilder.jsonFormatter(out);
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        BackendSupplier backendSupplier = new BackendSupplier() {
+        BackendSupplier backendSupplier = new TestBackendSupplier() {
             @Override
-            public Collection<? extends Backend> get() {
-                return singletonList(mock(Backend.class));
+            public void loadGlue(Glue glue, List<URI> gluePaths) {
+
             }
         };
         FeatureSupplier featureSupplier = new FeatureSupplier() {
@@ -663,11 +660,10 @@ public class RuntimeTest {
     }
 
     private Runtime createRuntime(ResourceLoader resourceLoader, ClassLoader classLoader, String... runtimeArgs) {
-        BackendSupplier backendSupplier = new BackendSupplier() {
+        BackendSupplier backendSupplier = new TestBackendSupplier(){
             @Override
-            public Collection<? extends Backend> get() {
-                Backend backend = mock(Backend.class);
-                return singletonList(backend);
+            public void loadGlue(Glue glue, List<URI> gluePaths) {
+
             }
         };
 
@@ -799,7 +795,7 @@ public class RuntimeTest {
         }
 
         @Override
-        public void execute(Object[] args) throws Throwable {
+        public void execute(Object[] args) {
 
         }
 

--- a/core/src/test/java/cucumber/runtime/RuntimeTest.java
+++ b/core/src/test/java/cucumber/runtime/RuntimeTest.java
@@ -6,11 +6,8 @@ import cucumber.api.Result;
 import cucumber.api.Scenario;
 import cucumber.api.StepDefinitionReporter;
 import cucumber.api.TestCase;
-import cucumber.api.event.ConcurrentEventListener;
-import cucumber.api.event.EventHandler;
-import cucumber.api.event.EventPublisher;
-import cucumber.api.event.TestCaseFinished;
-import cucumber.api.event.TestStepFinished;
+import cucumber.api.event.*;
+import cucumber.api.event.EventListener;
 import cucumber.runner.EventBus;
 import cucumber.runner.TestBackendSupplier;
 import cucumber.runner.TestHelper;
@@ -25,7 +22,9 @@ import cucumber.runtime.io.ResourceLoader;
 import cucumber.runtime.model.CucumberFeature;
 import gherkin.ast.ScenarioDefinition;
 import gherkin.ast.Step;
+import gherkin.pickles.PickleStep;
 import gherkin.pickles.PickleTag;
+import io.cucumber.stepexpression.Argument;
 import io.cucumber.stepexpression.TypeRegistry;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,13 +34,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 
 import java.net.URI;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -52,10 +45,7 @@ import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -557,6 +547,83 @@ public class RuntimeTest {
         assertTrue(interruptHit.get());
     }
 
+    @Test
+    public void generates_events_for_glue_and_scenario_scoped_glue() {
+        final CucumberFeature feature = feature("test.feature", "" +
+            "Feature: feature name\n" +
+            "  Scenario: Run a scenario once\n" +
+            "    Given global scoped\n" +
+            "    And scenario scoped\n" +
+            "  Scenario: Then do it again\n" +
+            "    Given global scoped\n" +
+            "    And scenario scoped\n" +
+            "");
+
+        final List<StepDefinition> stepDefinedEvents = new ArrayList<>();
+
+        Plugin eventListener = new EventListener() {
+            @Override
+            public void setEventPublisher(EventPublisher publisher) {
+                publisher.registerHandlerFor(StepDefinedEvent.class, new EventHandler<StepDefinedEvent>() {
+                    @Override
+                    public void receive(StepDefinedEvent event) {
+                        stepDefinedEvents.add(event.stepDefinition);
+                    }
+                });
+            }
+        };
+
+
+        final List<StepDefinition> definedStepDefinitions = new ArrayList<>();
+
+        BackendSupplier backendSupplier = new TestBackendSupplier() {
+
+            private Glue glue;
+
+            @Override
+            public void loadGlue(Glue glue, List<URI> gluePaths) {
+                this.glue = glue;
+                final StepDefinition mockedStepDefinition = new MockedStepDefinition();
+                definedStepDefinitions.add(mockedStepDefinition);
+                glue.addStepDefinition(mockedStepDefinition);
+            }
+
+            @Override
+            public void buildWorld() {
+                final StepDefinition mockedScenarioScopedStepDefinition = new MockedScenarioScopedStepDefinition();
+                definedStepDefinitions.add(mockedScenarioScopedStepDefinition);
+                glue.addStepDefinition(mockedScenarioScopedStepDefinition);
+            }
+        };
+
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+        FeatureSupplier featureSupplier = new FeatureSupplier() {
+            @Override
+            public List<CucumberFeature> get() {
+                return singletonList(feature);
+            }
+        };
+        Runtime.builder()
+            .withBackendSupplier(backendSupplier)
+            .withAdditionalPlugins(eventListener)
+            .withResourceLoader(new ClasspathResourceLoader(classLoader))
+            .withEventBus(new TimeServiceEventBus(new TimeServiceStub(0)))
+            .withFeatureSupplier(featureSupplier)
+            .build()
+            .run();
+
+        assertThat(stepDefinedEvents, equalTo(definedStepDefinitions));
+
+        for (StepDefinition stepDefinedEvent : stepDefinedEvents) {
+            if(stepDefinedEvent instanceof MockedScenarioScopedStepDefinition){
+                MockedScenarioScopedStepDefinition mocked = (MockedScenarioScopedStepDefinition) stepDefinedEvent;
+                assertTrue("Scenario scoped step definition should be disposed of", mocked.disposed);
+            }
+        }
+
+    }
+
     private String runFeatureWithFormatterSpy(CucumberFeature feature, Map<String, Result> stepsToResult) {
         FormatterSpy formatterSpy = new FormatterSpy();
 
@@ -667,5 +734,88 @@ public class RuntimeTest {
 
     private TestCaseFinished testCaseFinishedWithStatus(Result.Type resultStatus) {
         return new TestCaseFinished(ANY_TIMESTAMP, ANY_TIMESTAMP, mock(TestCase.class), new Result(resultStatus, 0L, null));
+    }
+
+    private static final class MockedStepDefinition implements StepDefinition {
+
+        @Override
+        public List<Argument> matchedArguments(PickleStep step) {
+            return step.getText().equals(getPattern()) ? new ArrayList<Argument>() : null;
+        }
+
+        @Override
+        public String getLocation(boolean detail) {
+            return "mocked step definition";
+        }
+
+        @Override
+        public Integer getParameterCount() {
+            return 0;
+        }
+
+        @Override
+        public void execute(Object[] args) throws Throwable {
+
+        }
+
+        @Override
+        public boolean isDefinedAt(StackTraceElement stackTraceElement) {
+            return false;
+        }
+
+        @Override
+        public String getPattern() {
+            return "global scoped";
+        }
+
+        @Override
+        public boolean isScenarioScoped() {
+            return true;
+        }
+    }
+
+    private static final class MockedScenarioScopedStepDefinition implements StepDefinition, ScenarioScoped {
+
+        boolean disposed;
+
+        @Override
+        public void disposeScenarioScope() {
+            this.disposed = true;
+        }
+
+        @Override
+        public List<Argument> matchedArguments(PickleStep step) {
+            return step.getText().equals(getPattern()) ? new ArrayList<Argument>() : null;
+        }
+
+        @Override
+        public String getLocation(boolean detail) {
+            return "mocked scenario scoped step definition";
+        }
+
+        @Override
+        public Integer getParameterCount() {
+            return 0;
+        }
+
+        @Override
+        public void execute(Object[] args) throws Throwable {
+
+        }
+
+        @Override
+        public boolean isDefinedAt(StackTraceElement stackTraceElement) {
+            return false;
+        }
+
+        @Override
+        public String getPattern() {
+            return "scenario scoped";
+        }
+
+        @Override
+        public boolean isScenarioScoped() {
+            return true;
+        }
     }
 }

--- a/java/src/main/java/cucumber/runtime/java/JavaBackend.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaBackend.java
@@ -117,7 +117,6 @@ public class JavaBackend implements Backend, LambdaGlueRegistry {
         // in the constructor.
         try {
             INSTANCE.set(this);
-            glue.removeScenarioScopedGlue();
             for (Class<? extends GlueBase> glueBaseClass : glueBaseClasses) {
                 objectFactory.getInstance(glueBaseClass);
             }

--- a/java8/src/main/java/cucumber/runtime/java8/Java8HookDefinition.java
+++ b/java8/src/main/java/cucumber/runtime/java8/Java8HookDefinition.java
@@ -6,18 +6,19 @@ import cucumber.api.Scenario;
 import cucumber.api.java8.HookBody;
 import cucumber.api.java8.HookNoArgsBody;
 import cucumber.runtime.HookDefinition;
+import cucumber.runtime.ScenarioScoped;
 import cucumber.runtime.filter.TagPredicate;
 import cucumber.runtime.Timeout;
 import gherkin.pickles.PickleTag;
 
 import java.util.Collection;
 
-public class Java8HookDefinition implements HookDefinition {
+public class Java8HookDefinition implements HookDefinition, ScenarioScoped {
     private final TagPredicate tagPredicate;
     private final int order;
     private final long timeoutMillis;
     private final HookNoArgsBody hookNoArgsBody;
-    private final HookBody hookBody;
+    private HookBody hookBody;
     private final StackTraceElement location;
 
     private Java8HookDefinition(String[] tagExpressions, int order, long timeoutMillis, HookBody hookBody, HookNoArgsBody hookNoArgsBody) {
@@ -68,5 +69,10 @@ public class Java8HookDefinition implements HookDefinition {
     @Override
     public boolean isScenarioScoped() {
         return true;
+    }
+
+    @Override
+    public void disposeScenarioScope() {
+        this.hookBody = null;
     }
 }

--- a/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
+++ b/java8/src/main/java/cucumber/runtime/java8/Java8StepDefinition.java
@@ -9,6 +9,7 @@ import io.cucumber.stepexpression.TypeRegistry;
 import cucumber.api.java8.StepdefBody;
 import io.cucumber.stepexpression.ArgumentMatcher;
 import cucumber.runtime.CucumberException;
+import cucumber.runtime.ScenarioScoped;
 import io.cucumber.stepexpression.ExpressionArgumentMatcher;
 import cucumber.runtime.StepDefinition;
 import io.cucumber.stepexpression.StepExpression;
@@ -24,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class Java8StepDefinition implements StepDefinition {
+public class Java8StepDefinition implements StepDefinition, ScenarioScoped {
 
     public static <T extends StepdefBody> Java8StepDefinition create(
         String expression, Class<T> bodyClass, T body, TypeRegistry typeRegistry) {
@@ -37,7 +38,7 @@ public class Java8StepDefinition implements StepDefinition {
     }
 
     private final long timeoutMillis;
-    private final StepdefBody body;
+    private StepdefBody body;
 
     private final StepExpression expression;
     private final StackTraceElement location;
@@ -160,5 +161,10 @@ public class Java8StepDefinition implements StepDefinition {
             }
             return argumentType;
         }
+    }
+
+    @Override
+    public void disposeScenarioScope() {
+        this.body = null;
     }
 }


### PR DESCRIPTION
## Summary

Adds a `StepDefinedEvent` to replace the `StepDefinitionReporter` plugin interface.

## Details

Publish an event from `Glue.addStepDefinition`, as `Runner.reportStepDefinitions` is called before step definition classes are instantiated, which fails to pick up on lambda based steps.

## Motivation and Context

Provide an event to listen for steps being registered, so all steps registrations are available, instead of only the annotation based step definitions.
https://github.com/cucumber/cucumber-jvm/issues/1633

## How Has This Been Tested?

Not yet; Change seems small.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
