### PR TITLE
[Core] Escape spaces in ZipResource path

### DIFF
--- a/core/src/main/java/cucumber/runtime/io/ZipResource.java
+++ b/core/src/main/java/cucumber/runtime/io/ZipResource.java
@@ -3,10 +3,11 @@ package cucumber.runtime.io;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import static io.cucumber.core.model.Classpath.CLASSPATH_SCHEME_PREFIX;
+import static io.cucumber.core.model.Classpath.CLASSPATH_SCHEME;
 
 class ZipResource implements Resource {
     private final ZipFile jarFile;
@@ -19,7 +20,11 @@ class ZipResource implements Resource {
 
     @Override
     public URI getPath() {
-        return URI.create(CLASSPATH_SCHEME_PREFIX + jarEntry.getName());
+        try {
+            return new URI(CLASSPATH_SCHEME, jarEntry.getName(), null);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
 
     @Override

--- a/core/src/test/java/cucumber/runtime/io/ZipResourceTest.java
+++ b/core/src/test/java/cucumber/runtime/io/ZipResourceTest.java
@@ -1,0 +1,20 @@
+package cucumber.runtime.io;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+public class ZipResourceTest {
+
+    @Test
+    public void parses_feature_file_with_spaces_in_path(){
+        JarFile jarFile = mock(JarFile.class);
+        JarEntry jarEntry = new JarEntry("Feature with spaces in path.feature");
+        ZipResource zipResource = new ZipResource(jarFile, jarEntry);
+        assertEquals("classpath:Feature%20with%20spaces%20in%20path.feature", zipResource.getPath().toString());
+    }
+}


### PR DESCRIPTION
## Summary

Fix for error parsing feature file from jar when there is a space in path

Fixes: #1632

## How Has This Been Tested?

Unit test has been added. Also tested manually ;) 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
