### PR TITLE
[Core] Add UnusedStepsSummaryPrinter

### DIFF
--- a/core/src/main/java/cucumber/api/CucumberOptions.java
+++ b/core/src/main/java/cucumber/api/CucumberOptions.java
@@ -65,7 +65,7 @@ public @interface CucumberOptions {
      * Register plugins.
      * Built-in plugin types: {@code junit}, {@code html},
      * {@code pretty}, {@code progress}, {@code json}, {@code usage},
-     * {@code rerun}, {@code testng}.
+     * {@code unused}, {@code rerun}, {@code testng}.
      * <p>
      * Can also be a fully qualified class name, allowing
      * registration of 3rd party plugins.

--- a/core/src/main/java/cucumber/api/Result.java
+++ b/core/src/main/java/cucumber/api/Result.java
@@ -27,9 +27,9 @@ public final class Result {
         SKIPPED,
         PENDING,
         UNDEFINED,
-        UNUSED,
         AMBIGUOUS,
-        FAILED;
+        FAILED,
+        UNUSED;
 
         public static Type fromLowerCaseName(String lowerCaseName) {
             return valueOf(lowerCaseName.toUpperCase(ROOT));

--- a/core/src/main/java/cucumber/api/Result.java
+++ b/core/src/main/java/cucumber/api/Result.java
@@ -27,6 +27,7 @@ public final class Result {
         SKIPPED,
         PENDING,
         UNDEFINED,
+        UNUSED,
         AMBIGUOUS,
         FAILED;
 

--- a/core/src/main/java/cucumber/runtime/formatter/AnsiFormats.java
+++ b/core/src/main/java/cucumber/runtime/formatter/AnsiFormats.java
@@ -9,6 +9,8 @@ final class AnsiFormats implements Formats {
     private static final Map<String, Format> formats = new HashMap<String, Format>() {{
         put("undefined", new ColorFormat(AnsiEscapes.YELLOW));
         put("undefined_arg", new ColorFormat(AnsiEscapes.YELLOW, AnsiEscapes.INTENSITY_BOLD)); // Never used, but avoids NPE in formatters.
+        put("unused", new ColorFormat(AnsiEscapes.YELLOW));
+        put("unused_arg", new ColorFormat(AnsiEscapes.YELLOW, AnsiEscapes.INTENSITY_BOLD));
         put("pending", new ColorFormat(AnsiEscapes.YELLOW));
         put("pending_arg", new ColorFormat(AnsiEscapes.YELLOW, AnsiEscapes.INTENSITY_BOLD));
         put("executing", new ColorFormat(AnsiEscapes.GREY));

--- a/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
+++ b/core/src/main/java/cucumber/runtime/formatter/PluginFactory.java
@@ -45,6 +45,7 @@ public final class PluginFactory {
         put("rerun", RerunFormatter.class);
         put("default_summary", DefaultSummaryPrinter.class);
         put("null_summary", NullSummaryPrinter.class);
+        put("unused", UnusedStepsSummaryPrinter.class);
         put("timeline", TimelineFormatter.class);
     }};
     private static final Pattern PLUGIN_WITH_ARGUMENT_PATTERN = Pattern.compile("([^:]+):(.*)");

--- a/core/src/main/java/cucumber/runtime/formatter/UnusedStepsSummaryPrinter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/UnusedStepsSummaryPrinter.java
@@ -1,0 +1,38 @@
+package cucumber.runtime.formatter;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import cucumber.api.SummaryPrinter;
+import cucumber.api.event.*;
+import cucumber.api.formatter.NiceAppendable;
+
+public class UnusedStepsSummaryPrinter implements EventListener, SummaryPrinter {
+
+	private final Map<String, String> unusedSteps = new TreeMap<>();
+
+	private NiceAppendable out;
+
+	@SuppressWarnings("WeakerAccess") // Used by PluginFactory
+	public UnusedStepsPlugin(Appendable out) {
+		this.out = new NiceAppendable(out);
+	}
+
+	@Override
+	public void setEventPublisher(EventPublisher publisher) {
+		// Record any steps registered
+		publisher.registerHandlerFor(StepDefinedEvent.class,
+				event -> unusedSteps.put(event.stepDefinition.getLocation(false), event.stepDefinition.getPattern()));
+		// Remove any steps that run
+		publisher.registerHandlerFor(TestStepFinished.class,
+				event -> Optional.ofNullable(event.testStep.getCodeLocation()).ifPresent(unusedSteps::remove));
+		// Print summary when done
+		publisher.registerHandlerFor(TestRunFinished.class, event -> printSummary());
+	}
+
+	private void printSummary() {
+		// Output results when done
+		out.append("" + unusedSteps.size()).println(" Unused steps:");
+		unusedSteps.forEach((location, pattern) -> out.append(location).append(": ").println(pattern));
+	}

--- a/core/src/main/java/cucumber/runtime/formatter/UnusedStepsSummaryPrinter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/UnusedStepsSummaryPrinter.java
@@ -41,14 +41,14 @@ public class UnusedStepsSummaryPrinter implements ColorAware, EventListener, Sum
 			for (Entry<String, String> entry : unusedSteps.entrySet()) {
 				String location = entry.getKey();
 				String pattern = entry.getValue();
-				out.println(format.text(location + " # " + pattern));
+				out.println(format.text(location) + " # " + pattern);
 			}
 		}
 	};
 
-	final Map<String, String> unusedSteps = new TreeMap<>();
-	final NiceAppendable out;
-	Formats formats = new MonochromeFormats();
+	private final Map<String, String> unusedSteps = new TreeMap<>();
+	private final NiceAppendable out;
+	private Formats formats = new MonochromeFormats();
 
 	@SuppressWarnings("WeakerAccess") // Used by PluginFactory
 	public UnusedStepsSummaryPrinter(Appendable out) {

--- a/core/src/main/java/cucumber/runtime/formatter/UnusedStepsSummaryPrinter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/UnusedStepsSummaryPrinter.java
@@ -48,7 +48,7 @@ public class UnusedStepsSummaryPrinter implements ColorAware, EventListener, Sum
 
 	final Map<String, String> unusedSteps = new TreeMap<>();
 	final NiceAppendable out;
-	Formats formats;
+	Formats formats = new MonochromeFormats();
 
 	@SuppressWarnings("WeakerAccess") // Used by PluginFactory
 	public UnusedStepsSummaryPrinter(Appendable out) {

--- a/core/src/main/java/cucumber/runtime/formatter/UnusedStepsSummaryPrinter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/UnusedStepsSummaryPrinter.java
@@ -36,3 +36,4 @@ public class UnusedStepsSummaryPrinter implements EventListener, SummaryPrinter 
 		out.append("" + unusedSteps.size()).println(" Unused steps:");
 		unusedSteps.forEach((location, pattern) -> out.append(location).append(": ").println(pattern));
 	}
+}

--- a/core/src/main/resources/cucumber/api/cli/USAGE.txt
+++ b/core/src/main/resources/cucumber/api/cli/USAGE.txt
@@ -12,9 +12,9 @@ Options:
                                            Built-in formatter PLUGIN types: junit,
                                            html, pretty, progress, json, usage, rerun,
                                            testng. Built-in summary PLUGIN types:
-                                           default_summary, null_summary. PLUGIN can
-                                           also be a fully qualified class name, allowing
-                                           registration of 3rd party plugins.
+                                           default_summary, null_summary, unused. PLUGIN
+                                           can also be a fully qualified class name,
+                                           allowing registration of 3rd party plugins.
                                            --add-plugin does not clobber plugins of that
                                            type defined from a different source.
 

--- a/core/src/test/java/cucumber/runtime/formatter/UnusedStepsSummaryPrinterTest.java
+++ b/core/src/test/java/cucumber/runtime/formatter/UnusedStepsSummaryPrinterTest.java
@@ -1,0 +1,46 @@
+package cucumber.runtime.formatter;
+
+import cucumber.api.TestStep;
+import cucumber.api.event.StepDefinedEvent;
+import cucumber.api.event.TestRunFinished;
+import cucumber.api.event.TestStepFinished;
+import cucumber.runner.TimeService;
+import cucumber.runner.TimeServiceEventBus;
+import cucumber.runtime.StepDefinition;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UnusedStepsSummaryPrinterTest {
+    @Test
+    public void verifyUnusedStepsPrinted() {
+        StringBuilder out = new StringBuilder();
+        UnusedStepsSummaryPrinter summaryPrinter = new UnusedStepsSummaryPrinter(out);
+        TimeServiceEventBus bus = new TimeServiceEventBus(TimeService.SYSTEM);
+        summaryPrinter.setEventPublisher(bus);
+
+        // Register two steps, use one, then finish the test run
+        bus.send(new StepDefinedEvent(bus.getTime(), bus.getTimeMillis(), mockStepDef("my/belly.feature:3", "a few cukes")));
+        bus.send(new StepDefinedEvent(bus.getTime(), bus.getTimeMillis(), mockStepDef("my/tummy.feature:5", "some more cukes")));
+        bus.send(new TestStepFinished(bus.getTime(), bus.getTimeMillis(), null, mockTestStep("my/belly.feature:3"), null));
+        bus.send(new TestRunFinished(bus.getTime(), bus.getTimeMillis()));
+
+        // Verify produced output
+        assertEquals("1 Unused steps:\n" + "my/tummy.feature:5 # some more cukes\n", out.toString());
+    }
+
+    private static StepDefinition mockStepDef(String location, String pattern) {
+        StepDefinition stepDef1 = mock(StepDefinition.class);
+        when(stepDef1.getLocation(false)).thenReturn(location);
+        when(stepDef1.getPattern()).thenReturn(pattern);
+        return stepDef1;
+    }
+
+    private static TestStep mockTestStep(String location) {
+        TestStep testStep = mock(TestStep.class);
+        when(testStep.getCodeLocation()).thenReturn(location);
+        return testStep;
+    }
+}


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Adds a plugin to find and report on unused steps.

## Details

As discussed in https://github.com/cucumber/cucumber-jvm/pull/1634 it uses the new StepDefinedEvent to locate all registered steps, and prints a summary of unused steps to the argument file.

## Motivation and Context

Allows to easily find unused steps, which might be indicative of removed functionality or missed test coverage.

## How Has This Been Tested?

Not yet; as @mpkorstanje indicated some hesitation on whether this would warrant adoption. This PR is to record that discussion, and will be updated depending on the outcome. Same goes for the current Java8 baseline, so it might need to target a future version rather than the next.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
