### PR TITLE
Added Named output hook

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -193,6 +193,16 @@
                                 <elementKind>method</elementKind>
                                 <justification>This class is part of Cucumbers internal API. The change adds a vararg argument.</justification>
                             </item>
+                            <item>
+                                <code>java.method.addedToInterface</code>
+                                <new>method void cucumber.api.Scenario::write(java.lang.String, java.lang.String)</new>
+                                <package>cucumber.api</package>
+                                <classQualifiedName>cucumber.api.Scenario</classQualifiedName>
+                                <classSimpleName>Scenario</classSimpleName>
+                                <methodName>write</methodName>
+                                <elementKind>method</elementKind>
+                                <justification>This interface can be used by users of Cucumber.</justification>
+                            </item>
                         </revapi.ignore>
                     </analysisConfiguration>
                 </configuration>

--- a/core/src/main/java/cucumber/api/Scenario.java
+++ b/core/src/main/java/cucumber/api/Scenario.java
@@ -48,6 +48,14 @@ public interface Scenario {
     void write(String text);
 
     /**
+     * Outputs some text into the report with name.
+     *
+     * @param name what to display name in the report.
+     * @param text what to put in the report.
+     */
+    void write(String name, String text);
+
+    /**
      *
      * @return the name of the Scenario
      */

--- a/core/src/main/java/cucumber/api/event/WriteEvent.java
+++ b/core/src/main/java/cucumber/api/event/WriteEvent.java
@@ -4,7 +4,8 @@ import cucumber.api.TestCase;
 
 public final class WriteEvent extends TestCaseEvent {
     public final String text;
-
+    public final String name;
+    
     @Deprecated
     public WriteEvent(Long timeStamp, TestCase testCase, String text) {
         this(timeStamp, 0, testCase, text);
@@ -12,6 +13,13 @@ public final class WriteEvent extends TestCaseEvent {
 
     public WriteEvent(Long timeStamp, long timeStampMillis, TestCase testCase, String text) {
         super(timeStamp, timeStampMillis, testCase);
+        this.text = text;
+        this.name = null;
+    }
+    
+    public WriteEvent(Long timeStamp, long timeStampMillis, TestCase testCase, String name, String text) {
+        super(timeStamp, timeStampMillis, testCase);
+        this.name = name;
         this.text = text;
     }
 }

--- a/core/src/main/java/cucumber/runner/Scenario.java
+++ b/core/src/main/java/cucumber/runner/Scenario.java
@@ -67,6 +67,13 @@ class Scenario implements cucumber.api.Scenario {
     }
 
     @Override
+    public void write(String name, String text) {
+        if (bus != null) {
+            bus.send(new WriteEvent(bus.getTime(), bus.getTimeMillis(), testCase, name, text));
+        }
+    }
+
+    @Override
     public String getName() {
         return testCase.getName();
     }

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -123,6 +123,27 @@ GherkinDialectProvider.DIALECTS.keySet().each { language ->
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+                <configuration>
+                    <analysisConfiguration>
+                        <revapi.ignore>
+                            <item>
+                                <code>java.method.addedToInterface</code>
+                                <new>method void cucumber.api.Scenario::write(java.lang.String, java.lang.String)</new>
+                                <justification>This interface can be used by users of Cucumber.</justification>
+                                <package>cucumber.api</package>
+                                <classQualifiedName>cucumber.api.Scenario</classQualifiedName>
+                                <classSimpleName>Scenario</classSimpleName>
+                                <methodName>write</methodName>
+                                <newArchive>io.cucumber:cucumber-core:jar:4.4.0-SNAPSHOT</newArchive>
+                                <elementKind>method</elementKind>
+                            </item>
+                        </revapi.ignore>
+                    </analysisConfiguration>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Summary
Capability to add name on outputs

## Details
Created new implementation to allow add name on outputs
Now is possible improve reports with beautiful output like this:
```json
"after":[
   {
      "output":[
         {
            "My Named Output":[
               "REQUEST - Executing POST on",
               "REQUEST Body: {}",
               "RESPONSE - ResponseType",
               "RESPONSE -Body: {}"
            ]
         }
      ],
      "result":{
         "duration":619511,
         "status":"passed"
      },
      "match":{
         "location":"Hooks.afterStep(Scenario)"
      }
   }
]
```

Usage:
```java 
@After
public void after(Scenario scenario){
    scenario.write("My Named Output", "message");
}
```
## Motivation and Context
I need to be able show personalized output in reports.