### PR TITLE
[Core] Efficiently write JSON to output

### DIFF
--- a/core/src/main/java/cucumber/api/formatter/NiceAppendable.java
+++ b/core/src/main/java/cucumber/api/formatter/NiceAppendable.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 /**
  * A nice appendable that doesn't throw checked exceptions
  */
-public class NiceAppendable {
+public class NiceAppendable implements Appendable {
     private static final CharSequence NL = "\n";
     private final Appendable out;
 

--- a/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/HTMLFormatter.java
@@ -459,8 +459,7 @@ final class HTMLFormatter implements EventListener {
             if (comma) {
                 out.append(", ");
             }
-            String stringArg = gson.toJson(arg);
-            out.append(stringArg);
+            gson.toJson(arg, out);
             comma = true;
         }
         out.append(");").println();

--- a/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java
@@ -170,7 +170,7 @@ final class JSONFormatter implements EventListener {
     }
 
     private void finishReport() {
-        out.append(gson.toJson(featureMaps));
+        gson.toJson(featureMaps, out);
         out.close();
     }
 

--- a/core/src/main/java/cucumber/runtime/formatter/TimelineFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/TimelineFormatter.java
@@ -126,7 +126,7 @@ public class TimelineFormatter implements ConcurrentEventListener {
 
     private void appendAsJsonToJs(final Gson gson, final NiceAppendable out, final String pushTo, final Collection<?> content) {
         out.append("CucumberHTML." + pushTo + ".pushArray(");
-        out.append(gson.toJson(content));
+        gson.toJson(content, out);
         out.append(");");
     }
 

--- a/core/src/main/java/cucumber/runtime/formatter/UsageFormatter.java
+++ b/core/src/main/java/cucumber/runtime/formatter/UsageFormatter.java
@@ -75,7 +75,7 @@ final class UsageFormatter implements Plugin, EventListener {
             stepDefContainers.add(stepDefContainer);
         }
 
-        out.append(gson().toJson(stepDefContainers));
+        gson().toJson(stepDefContainers, out);
         out.close();
     }
 


### PR DESCRIPTION
## Summary

Replaces `Gson.toJson(Object)` with `Gson.toJson(Object, Appendable)`.
This avoids the intermediate memory consuming string representation
of the json output.

Fixes: #1661