### PR TITLE
[Spring] Add public constant for glue scope.

### DIFF
--- a/spring/README.md
+++ b/spring/README.md
@@ -100,6 +100,19 @@ public class SomeServiceSteps {
 }
 ```
 
+Changing a Spring bean's scope to `SCOPE_CUCUMBER_GLUE` will bound its lifecycle to the standard glue lifecycle.
+
+```java
+import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Scope;
+import static io.cucumber.spring.api.CucumberTestContext.SCOPE_CUCUMBER_GLUE;
+
+@Component
+@Scope(SCOPE_CUCUMBER_GLUE)
+public class MyComponent {
+}
+```
+
 ### XML Configuration
 
 If you are using xml based configuration, you can to register the beans in a `cucumber.xml` file:

--- a/spring/src/main/java/io/cucumber/spring/GlueCodeScope.java
+++ b/spring/src/main/java/io/cucumber/spring/GlueCodeScope.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.config.Scope;
 
 class GlueCodeScope implements Scope {
-    public static final String NAME = "cucumber-glue";
 
     @Override
     public Object get(String name, ObjectFactory<?> objectFactory) {

--- a/spring/src/main/java/io/cucumber/spring/SpringFactory.java
+++ b/spring/src/main/java/io/cucumber/spring/SpringFactory.java
@@ -24,6 +24,7 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.Set;
 
+import static io.cucumber.spring.api.CucumberTestContext.SCOPE_CUCUMBER_GLUE;
 import static io.cucumber.spring.FixBootstrapUtils.createBootstrapContext;
 import static io.cucumber.spring.FixBootstrapUtils.resolveTestContextBootstrapper;
 import static java.util.Arrays.asList;
@@ -153,7 +154,7 @@ public final class SpringFactory implements ObjectFactory {
         }
         applicationContext.registerShutdownHook();
         ConfigurableListableBeanFactory beanFactory = applicationContext.getBeanFactory();
-        beanFactory.registerScope(GlueCodeScope.NAME, new GlueCodeScope());
+        beanFactory.registerScope(SCOPE_CUCUMBER_GLUE, new GlueCodeScope());
         for (Class<?> stepClass : stepClasses) {
             registerStepClassBeanDefinition(beanFactory, stepClass);
         }
@@ -180,9 +181,9 @@ public final class SpringFactory implements ObjectFactory {
     private void registerStepClassBeanDefinition(ConfigurableListableBeanFactory beanFactory, Class<?> stepClass) {
         BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
         BeanDefinition beanDefinition = BeanDefinitionBuilder
-            .genericBeanDefinition(stepClass)
-            .setScope(GlueCodeScope.NAME)
-            .getBeanDefinition();
+                .genericBeanDefinition(stepClass)
+                .setScope(SCOPE_CUCUMBER_GLUE)
+                .getBeanDefinition();
         registry.registerBeanDefinition(stepClass.getName(), beanDefinition);
     }
 
@@ -246,7 +247,7 @@ public final class SpringFactory implements ObjectFactory {
 
         private void registerGlueCodeScope(ConfigurableApplicationContext context) {
             do {
-                context.getBeanFactory().registerScope(GlueCodeScope.NAME, new GlueCodeScope());
+                context.getBeanFactory().registerScope(SCOPE_CUCUMBER_GLUE, new GlueCodeScope());
                 context = (ConfigurableApplicationContext) context.getParent();
             } while (context != null);
         }

--- a/spring/src/main/java/io/cucumber/spring/api/CucumberTestContext.java
+++ b/spring/src/main/java/io/cucumber/spring/api/CucumberTestContext.java
@@ -1,0 +1,8 @@
+package io.cucumber.spring.api;
+
+public final class CucumberTestContext {
+    public static final String SCOPE_CUCUMBER_GLUE = "cucumber-glue";
+
+    private CucumberTestContext() {
+    }
+}

--- a/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
+++ b/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
@@ -2,6 +2,8 @@ package io.cucumber.spring;
 
 import cucumber.runtime.CucumberException;
 import io.cucumber.core.backend.ObjectFactory;
+import io.cucumber.spring.beans.Belly;
+import io.cucumber.spring.beans.GlueScopedComponent;
 import io.cucumber.spring.beans.BellyBean;
 import io.cucumber.spring.commonglue.AutowiresPlatformTransactionManager;
 import io.cucumber.spring.commonglue.AutowiresThirdStepDef;
@@ -266,5 +268,27 @@ public class SpringFactoryTest {
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(WithControllerAnnotation.class);
 
+    }
+
+    @Test
+    public void shouldGlueScopedSpringBeanBehaveLikeGlueLifecycle() {
+        final ObjectFactory factory = new SpringFactory();
+        factory.addClass(WithSpringAnnotations.class);
+
+        // Scenario 1
+        factory.start();
+        final Belly belly1 = factory.getInstance(Belly.class);
+        final GlueScopedComponent glue1 = factory.getInstance(GlueScopedComponent.class);
+        assertNotNull(belly1);
+        assertNotNull(glue1);
+        factory.stop();
+
+        // Scenario 2
+        final Belly belly2 = factory.getInstance(Belly.class);
+        final GlueScopedComponent glue2 = factory.getInstance(GlueScopedComponent.class);
+        assertNotNull(belly2);
+        assertNotNull(glue2);
+        assertNotSame(glue1, glue2);
+        assertSame(belly1, belly2);
     }
 }

--- a/spring/src/test/java/io/cucumber/spring/beans/GlueScopedComponent.java
+++ b/spring/src/test/java/io/cucumber/spring/beans/GlueScopedComponent.java
@@ -1,0 +1,18 @@
+package io.cucumber.spring.beans;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import static io.cucumber.spring.api.CucumberTestContext.SCOPE_CUCUMBER_GLUE;
+
+@Component
+@Scope(SCOPE_CUCUMBER_GLUE)
+public class GlueScopedComponent {
+    @Autowired
+    private Belly belly;
+
+    public Belly getBelly() {
+        return belly;
+    }
+}


### PR DESCRIPTION
## Summary

Public constant for the glue scope.

## Details

The `io.cucumber.spring.api.CucumberTestContext` has the `SCOPE_CUCUMBER_GLUE` constant which holds the scope's name. The old private constant was deleted and the references were updated to the new one.

## Motivation and Context

This fixes the #1660 as discussed there.

## How Has This Been Tested?

The `SpringFactoryTest#shouldGlueScopedSpringBeanBehaveLikeGlueLifecycle` tests the proper string name is made public by using it in `@Scope` and checking its lifecycle.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
