### PR TITLE
[Changelog] Added missing deprecated in 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
     - Use `io.cucumber.junit.Cucumber` instead. 
  * [TestNG] Deprecate `cucumber.api.testng.TestNGCucumberRunner`
     - Use `io.cucumber.testng.TestNGCucumberRunner` instead.
+ * [TestNG] Deprecate `cucumber.api.testng.AbstractTestNGCucumberTests`
+    - Use `io.cucumber.testng.AbstractTestNGCucumberTests` instead.
  * [Needle] Deprecate `cucumber.api.needle.*` 
     - Use `io.cucumber.needle.*` instead. 
  * [Spring] Deprecate `cucumber.api.spring.SpringTransactionHooks`


### PR DESCRIPTION
Added missing deprecated for AbstractTestNGCucumberTests to changelog for version 4.5.0

## Summary

* [TestNG] Deprecate `cucumber.api.testng.AbstractTestNGCucumberTests`
    - Use `io.cucumber.testng.AbstractTestNGCucumberTests` instead.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
