### PR TITLE
[Changelog] Added missing deprecated api.Scenario to 4.5.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Please see [CONTRIBUTING.md](https://github.com/cucumber/cucumber/blob/master/CO
     - Use `io.cucumber.junit.CucumberOptions` or `io.cucumber.testng.CucumberOptions` instead
  * [Core] Deprecate `cucumber.api.cli.Main` ([#1670](https://github.com/cucumber/cucumber-jvm/pull/1670) M.P. Korstanje)
     - Use `io.cucumber.core.cli.Main` instead
+ * [Core] Deprecate `cucumber.api.Scenario`
+    - Use `io.cucumber.core.api.Scenario` instead
  * [JUnit] Deprecate `cucumber.api.junit.Cucumber`
     - Use `io.cucumber.junit.Cucumber` instead. 
  * [TestNG] Deprecate `cucumber.api.testng.TestNGCucumberRunner`


### PR DESCRIPTION
Added missing deprecated for cucumber.api.Scenario to changelog for version 4.5.0

## Summary
* [Core] Deprecate `cucumber.api.Scenario`
    - Use `io.cucumber.core.api.Scenario` instead

## Motivation and Context

Keeping changelog as precise as possible.

## How Has This Been Tested?

Nope, just changelog modification

## Checklist:
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
