### PR TITLE
[Core] Restore Scenario#getSourceTagNames()

### DIFF
--- a/core/src/main/java/io/cucumber/core/api/Scenario.java
+++ b/core/src/main/java/io/cucumber/core/api/Scenario.java
@@ -1,6 +1,7 @@
 package io.cucumber.core.api;
 
 import io.cucumber.core.event.Status;
+import java.util.Collection;
 import org.apiguardian.api.API;
 
 /**
@@ -9,6 +10,10 @@ import org.apiguardian.api.API;
  */
 @API(status = API.Status.STABLE)
 public interface Scenario {
+    /**
+     * @return source_tag_names.
+     */
+    Collection<String> getSourceTagNames();
 
     /**
      * @return the <em>most severe</em> status of the Scenario's Steps.

--- a/java/src/main/java/cucumber/runtime/java/JavaHookDefinition.java
+++ b/java/src/main/java/cucumber/runtime/java/JavaHookDefinition.java
@@ -88,6 +88,11 @@ public class JavaHookDefinition implements HookDefinition {
         }
 
         @Override
+        public Collection<String> getSourceTagNames() {
+            return scenario.getSourceTagNames();
+        }
+
+        @Override
         public Status getStatus() {
             return Status.valueOf(scenario.getStatus().name());
         }

--- a/java8/src/main/java/cucumber/runtime/java8/Java8HookDefinition.java
+++ b/java8/src/main/java/cucumber/runtime/java8/Java8HookDefinition.java
@@ -93,6 +93,11 @@ public class Java8HookDefinition implements HookDefinition, ScenarioScoped {
         }
 
         @Override
+        public Collection<String> getSourceTagNames() {
+            return scenario.getSourceTagNames();
+        }
+
+        @Override
         public Status getStatus() {
             return Status.valueOf(scenario.getStatus().name());
         }


### PR DESCRIPTION
## Summary

Restore `Scenario#getSourceTagNames()` as people are using it in their hooks.

## Motivation and Context
People are using hooks for variant settings, case insensitivity, posting information about tests execution into issue trackers using tags similar to [described in docs](https://cucumber.io/docs/cucumber/api/#link-to-other-documents). it would be nice to still have the ability to that.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
