### PR TITLE
[All] Add missing JPMS config

### DIFF
--- a/cdi2/pom.xml
+++ b/cdi2/pom.xml
@@ -1,6 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
+        <project.Automatic-Module-Name>io.cucumber.cdi2</project.Automatic-Module-Name>
         <openwebbeans.version>2.0.10</openwebbeans.version>
     </properties>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,6 +12,7 @@
     <name>Cucumber-JVM: Core</name>
 
     <properties>
+        <project.Automatic-Module-Name>io.cucumber.core</project.Automatic-Module-Name>
         <!-- version 2.4.0 does not work on Java 7 -->
         <jsoup.version>1.12.1</jsoup.version>
         <xmlunit.version>1.6</xmlunit.version>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -12,6 +12,7 @@
     <name>Cucumber-JVM: Guice</name>
 
     <properties>
+        <project.Automatic-Module-Name>io.cucumber.guice</project.Automatic-Module-Name>
         <guice.version>4.2.0</guice.version>
     </properties>
 

--- a/kotlin-java8/pom.xml
+++ b/kotlin-java8/pom.xml
@@ -12,6 +12,7 @@
     <name>Cucumber-JVM: Kotlin Java8</name>
 
     <properties>
+        <project.Automatic-Module-Name>io.cucumber.kotlin.java8</project.Automatic-Module-Name>
         <kotlin.version>1.3.0</kotlin.version>
     </properties>
 


### PR DESCRIPTION
## Summary

Trying to build Java 11 project using cucumber and discovered a few projects are missing Automatic-Module-Name in the Manifest.mf file.

## Details

MANIFEST.MF update only

## Motivation and Context

Getting a pure JPMS build and test working.

## How Has This Been Tested?

Built locally and testing as 4.7.1-SNAPSHOT

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
