### PR TITLE
[All] Replace ExpectedException with assertThrows

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,6 +68,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>

--- a/core/src/test/java/io/cucumber/core/feature/CucumberFeatureTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/CucumberFeatureTest.java
@@ -1,22 +1,22 @@
 package io.cucumber.core.feature;
 
 import io.cucumber.core.io.ResourceLoader;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.net.URI;
 import java.util.Collections;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CucumberFeatureTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void succeeds_if_no_features_are_found() {
@@ -31,8 +31,11 @@ public class CucumberFeatureTest {
         URI featurePath = URI.create("path/bar.feature");
         ResourceLoader resourceLoader = mock(ResourceLoader.class);
         when(resourceLoader.resources(featurePath, ".feature")).thenThrow(new IllegalArgumentException("Not a file or directory: " + "path/bar.feature"));
-        expectedException.expectMessage("Not a file or directory: path/bar.feature");
-        new FeatureLoader(resourceLoader).load(singletonList(featurePath));
+        final Executable testMethod = () -> new FeatureLoader(resourceLoader).load(singletonList(featurePath));
+        final IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "Not a file or directory: path/bar.feature"
+        )));
     }
 
     @Test
@@ -40,7 +43,12 @@ public class CucumberFeatureTest {
         URI featurePath = URI.create("classpath:path/bar.feature");
         ResourceLoader resourceLoader = mock(ResourceLoader.class);
         when(resourceLoader.resources(featurePath, ".feature")).thenReturn(emptyList());
-        expectedException.expectMessage("Feature not found: classpath:path/bar.feature");
-        new FeatureLoader(resourceLoader).load(singletonList(featurePath));
+        final Executable testMethod = () -> new FeatureLoader(resourceLoader).load(singletonList(featurePath));
+        final IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "Feature not found: classpath:path/bar.feature"
+        )));
+
     }
+
 }

--- a/core/src/test/java/io/cucumber/core/feature/FeatureIdentifierTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/FeatureIdentifierTest.java
@@ -1,34 +1,41 @@
 package io.cucumber.core.feature;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.net.URI;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FeatureIdentifierTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
-    public void can_parse_feature_path_with_feature(){
+    public void can_parse_feature_path_with_feature() {
         URI uri = FeatureIdentifier.parse(FeaturePath.parse("classpath:/path/to/file.feature"));
         assertEquals("classpath", uri.getScheme());
         assertEquals("/path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
     @Test
-    public void reject_feature_with_lines(){
-        expectedException.expectMessage("featureIdentifier does not reference a single feature file");
-        FeatureIdentifier.parse(URI.create("classpath:/path/to/file.feature:10:40"));
+    public void reject_feature_with_lines() {
+        final Executable testMethod = () -> FeatureIdentifier.parse(URI.create("classpath:/path/to/file.feature:10:40"));
+        final IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "featureIdentifier does not reference a single feature file: classpath:/path/to/file.feature:10:40"
+        )));
     }
 
     @Test
-    public void reject_directory_form(){
-        expectedException.expectMessage("featureIdentifier does not reference a single feature file");
-        FeatureIdentifier.parse(URI.create("classpath:/path/to"));
+    public void reject_directory_form() {
+        final Executable testMethod = () -> FeatureIdentifier.parse(URI.create("classpath:/path/to"));
+        final IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "featureIdentifier does not reference a single feature file: classpath:/path/to"
+        )));
     }
+
 }

--- a/core/src/test/java/io/cucumber/core/feature/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/FeaturePathTest.java
@@ -2,36 +2,38 @@ package io.cucumber.core.feature;
 
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.io.File;
 import java.net.URI;
 import java.util.Locale;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
-
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FeaturePathTest {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void can_parse_empty_feature_path(){
-        URI uri = FeaturePath.parse("");
-        assertThat(uri.getScheme(), is("classpath"));
-        assertThat(uri.getSchemeSpecificPart(), is("/"));
-    }
+    @Test
+    public void can_parse_empty_feature_path() {
+        final Executable testMethod = () -> FeaturePath.parse("");
+        final IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo("featureIdentifier may not be empty")));
+   }
 
     @Test
-    public void can_parse_root_package(){
+    public void can_parse_root_package() {
         URI uri = FeaturePath.parse("classpath:/");
         assertThat(uri.getScheme(), is("classpath"));
         assertThat(uri.getSchemeSpecificPart(), is("/"));
     }
 
     @Test
-    public void can_parse_eclipse_plugin_default_glue(){
+    public void can_parse_eclipse_plugin_default_glue() {
         // The eclipse plugin uses `classpath:` as the default
         URI uri = FeaturePath.parse("classpath:");
         assertThat(uri.getScheme(), is("classpath"));
@@ -39,42 +41,42 @@ public class FeaturePathTest {
     }
 
     @Test
-    public void can_parse_classpath_form(){
+    public void can_parse_classpath_form() {
         URI uri = FeaturePath.parse("classpath:/path/to/file.feature");
         assertEquals("classpath", uri.getScheme());
         assertEquals("/path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
     @Test
-    public void can_parse_classpath_directory_form(){
+    public void can_parse_classpath_directory_form() {
         URI uri = FeaturePath.parse("classpath:/path/to");
         assertEquals("classpath", uri.getScheme());
         assertEquals("/path/to", uri.getSchemeSpecificPart());
     }
 
     @Test
-    public void can_parse_absolute_file_form(){
+    public void can_parse_absolute_file_form() {
         URI uri = FeaturePath.parse("file:/path/to/file.feature");
         assertEquals("file", uri.getScheme());
         assertEquals("/path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
     @Test
-    public void can_parse_absolute_directory_form(){
+    public void can_parse_absolute_directory_form() {
         URI uri = FeaturePath.parse("file:/path/to");
         assertEquals("file", uri.getScheme());
         assertEquals("/path/to", uri.getSchemeSpecificPart());
     }
 
     @Test
-    public void can_parse_relative_file_form(){
+    public void can_parse_relative_file_form() {
         URI uri = FeaturePath.parse("file:path/to/file.feature");
         assertEquals("file", uri.getScheme());
         assertEquals("path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
     @Test
-    public void can_parse_absolute_path_form(){
+    public void can_parse_absolute_path_form() {
         URI uri = FeaturePath.parse("/path/to/file.feature");
         assertEquals("file", uri.getScheme());
         // Use File to work out the drive letter on windows.
@@ -83,14 +85,14 @@ public class FeaturePathTest {
     }
 
     @Test
-    public void can_parse_relative_path_form(){
+    public void can_parse_relative_path_form() {
         URI uri = FeaturePath.parse("path/to/file.feature");
         assertEquals("file", uri.getScheme());
         assertEquals("path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
     @Test
-    public void can_parse_windows_path_form(){
+    public void can_parse_windows_path_form() {
         assumeThat(File.separatorChar, is('\\')); //Requires windows
 
         URI uri = FeaturePath.parse("path\\to\\file.feature");
@@ -99,22 +101,23 @@ public class FeaturePathTest {
     }
 
     @Test
-    public void can_parse_windows_absolute_path_form(){
+    public void can_parse_windows_absolute_path_form() {
         assumeThat(File.separatorChar, is('\\')); //Requires windows
+
         URI uri = FeaturePath.parse("C:\\path\\to\\file.feature");
         assertEquals("file", uri.getScheme());
         assertEquals("/C:/path/to/file.feature", uri.getSchemeSpecificPart());
     }
 
     @Test
-    public void can_parse_whitespace_in_path(){
+    public void can_parse_whitespace_in_path() {
         URI uri = FeaturePath.parse("path/to the/file.feature");
         assertEquals("file", uri.getScheme());
         assertEquals("path/to the/file.feature", uri.getSchemeSpecificPart());
     }
-    
+
     @Test
-    public void can_parse_windows_file_path_with_standard_file_separator(){
+    public void can_parse_windows_file_path_with_standard_file_separator() {
         assumeThat(System.getProperty("os.name"), isWindows());
 
         URI uri = FeaturePath.parse("C:/path/to/file.feature");
@@ -136,4 +139,5 @@ public class FeaturePathTest {
             }
         };
     }
+
 }

--- a/core/src/test/java/io/cucumber/core/feature/GluePathTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/GluePathTest.java
@@ -1,38 +1,36 @@
 package io.cucumber.core.feature;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.io.File;
 import java.net.URI;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GluePathTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
-    public void can_parse_empty_glue_path(){
+    public void can_parse_empty_glue_path() {
         URI uri = GluePath.parse("");
         assertThat(uri.getScheme(), is("classpath"));
         assertThat(uri.getSchemeSpecificPart(), is("/"));
     }
 
     @Test
-    public void can_parse_root_package(){
+    public void can_parse_root_package() {
         URI uri = GluePath.parse("classpath:/");
         assertThat(uri.getScheme(), is("classpath"));
         assertThat(uri.getSchemeSpecificPart(), is("/"));
     }
 
     @Test
-    public void can_parse_eclipse_plugin_default_glue(){
+    public void can_parse_eclipse_plugin_default_glue() {
         // The eclipse plugin uses `classpath:` as the default
         URI uri = GluePath.parse("classpath:");
         assertThat(uri.getScheme(), is("classpath"));
@@ -40,47 +38,53 @@ public class GluePathTest {
     }
 
     @Test
-    public void can_parse_classpath_form(){
+    public void can_parse_classpath_form() {
         URI uri = GluePath.parse("classpath:com/example/app");
         assertThat(uri.getScheme(), is("classpath"));
         assertThat(uri.getSchemeSpecificPart(), is("com/example/app"));
     }
 
     @Test
-    public void can_parse_relative_path_form(){
+    public void can_parse_relative_path_form() {
         URI uri = GluePath.parse("com/example/app");
         assertThat(uri.getScheme(), is("classpath"));
         assertThat(uri.getSchemeSpecificPart(), is("com/example/app"));
     }
 
     @Test
-    public void can_parse_absolute_path_form(){
+    public void can_parse_absolute_path_form() {
         URI uri = GluePath.parse("/com/example/app");
         assertThat(uri.getScheme(), is("classpath"));
         assertThat(uri.getSchemeSpecificPart(), is("/com/example/app"));
     }
 
     @Test
-    public void can_parse_package_form(){
+    public void can_parse_package_form() {
         URI uri = GluePath.parse("com.example.app");
         assertThat(uri.getScheme(), is("classpath"));
         assertThat(uri.getSchemeSpecificPart(), is("com/example/app"));
     }
 
     @Test
-    public void glue_path_must_have_class_path_scheme(){
-        expectedException.expectMessage("The glue path must have a classpath scheme");
-        GluePath.parse("file:com/example/app");
+    public void glue_path_must_have_class_path_scheme() {
+        final Executable testMethod = () -> GluePath.parse("file:com/example/app");
+        final IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "The glue path must have a classpath scheme file:com/example/app"
+        )));
     }
 
     @Test
-    public void glue_path_must_have_valid_identifier_parts(){
-        expectedException.expectMessage("The glue path contained invalid identifiers");
-        GluePath.parse("01-examples");
+    public void glue_path_must_have_valid_identifier_parts() {
+        final Executable testMethod = () -> GluePath.parse("01-examples");
+        final IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "The glue path contained invalid identifiers 01-examples"
+        )));
     }
 
     @Test
-    public void can_parse_windows_path_form(){
+    public void can_parse_windows_path_form() {
         assumeThat(File.separatorChar, is('\\')); //Requires windows
 
         URI uri = GluePath.parse("com\\example\\app");
@@ -89,10 +93,14 @@ public class GluePathTest {
     }
 
     @Test
-    public void absolute_windows_path_form_is_not_valid(){
+    public void absolute_windows_path_form_is_not_valid() {
         assumeThat(File.separatorChar, is('\\')); //Requires windows
 
-        expectedException.expectMessage("The glue path must have a classpath scheme");
-        GluePath.parse("C:\\com\\example\\app");
+        final Executable testMethod = () -> GluePath.parse("C:\\com\\example\\app");
+        final IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "The glue path must have a classpath scheme"
+        )));
     }
+
 }

--- a/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
@@ -1,13 +1,14 @@
 package io.cucumber.core.options;
 
-import io.cucumber.core.plugin.Plugin;
-import io.cucumber.core.snippets.SnippetType;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.exception.CucumberException;
+import io.cucumber.core.plugin.Plugin;
 import io.cucumber.core.plugin.PluginFactory;
 import io.cucumber.core.plugin.Plugins;
 import io.cucumber.core.runtime.TimeServiceEventBus;
-import org.junit.Test;
+import io.cucumber.core.snippets.SnippetType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.net.URI;
 import java.time.Clock;
@@ -15,14 +16,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CucumberOptionsAnnotationParserTest {
     @Test
@@ -189,11 +192,12 @@ public class CucumberOptionsAnnotationParserTest {
         assertThat(runtimeOptions.getGlue(), contains(uri("classpath:app/features/user/hooks"), uri("classpath:app/features/user/registration"), uri("classpath:app/features/hooks")));
     }
 
-    @Test(expected = CucumberException.class)
+    @Test
     public void cannot_create_with_glue_and_extra_glue() {
-        parser().parse(ClassWithGlueAndExtraGlue.class).build();
+        final Executable testMethod = () -> parser().parse(ClassWithGlueAndExtraGlue.class).build();
+        final CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo("glue and extraGlue cannot be specified at the same time")));
     }
-
 
     @CucumberOptions(snippets = SnippetType.CAMELCASE)
     private static class Snippets {
@@ -386,4 +390,5 @@ public class CucumberOptionsAnnotationParserTest {
         public void stop() {}
         
     }
+
 }

--- a/core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionMatchsTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionMatchsTest.java
@@ -1,22 +1,21 @@
 package io.cucumber.core.runner;
 
-import static org.mockito.Mockito.mock;
-
-import java.util.Collections;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import gherkin.pickles.Argument;
 import gherkin.pickles.PickleLocation;
 import gherkin.pickles.PickleStep;
 import io.cucumber.core.api.Scenario;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 public class AmbiguousStepDefinitionMatchsTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private final PickleStep pickleStep = new PickleStep("", Collections.<Argument>emptyList(), Collections.<PickleLocation>emptyList());
     private final AmbiguousStepDefinitionsException e = new AmbiguousStepDefinitionsException(pickleStep, Collections.<PickleStepDefinitionMatch>emptyList());
@@ -24,13 +23,20 @@ public class AmbiguousStepDefinitionMatchsTest {
 
     @Test
     public void throws_ambiguous_step_definitions_exception_when_run() {
-        expectedException.expect(AmbiguousStepDefinitionsException.class);
-        match.runStep(mock(Scenario.class));
+        final Executable testMethod = () -> match.runStep(mock(Scenario.class));
+        final AmbiguousStepDefinitionsException actualThrown = assertThrows(AmbiguousStepDefinitionsException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "\"\" matches more than one step definition:\n"
+        )));
     }
 
     @Test
     public void throws_ambiguous_step_definitions_exception_when_dry_run() {
-        expectedException.expect(AmbiguousStepDefinitionsException.class);
-        match.dryRunStep(mock(Scenario.class));
+        final Executable testMethod = () -> match.dryRunStep(mock(Scenario.class));
+        final AmbiguousStepDefinitionsException actualThrown = assertThrows(AmbiguousStepDefinitionsException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "\"\" matches more than one step definition:\n"
+        )));
     }
+
 }

--- a/core/src/test/java/io/cucumber/core/runner/CoreStepDefinitionTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/CoreStepDefinitionTest.java
@@ -29,9 +29,6 @@ import static org.mockito.Mockito.mock;
 
 public class CoreStepDefinitionTest {
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     private final TypeRegistry typeRegistry = new TypeRegistry(Locale.ENGLISH);
 
     @Test

--- a/core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
@@ -6,6 +6,7 @@ import gherkin.pickles.PickleRow;
 import gherkin.pickles.PickleStep;
 import gherkin.pickles.PickleTable;
 import io.cucumber.core.backend.StepDefinition;
+import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.runtime.StubStepDefinition;
 import io.cucumber.core.stepexpression.Argument;
 import io.cucumber.core.stepexpression.TypeRegistry;
@@ -13,9 +14,8 @@ import io.cucumber.cucumberexpressions.ParameterType;
 import io.cucumber.cucumberexpressions.Transformer;
 import io.cucumber.datatable.DataTableType;
 import io.cucumber.datatable.TableCellTransformer;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.Collections;
 import java.util.List;
@@ -23,12 +23,14 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Locale.ENGLISH;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 public class StepDefinitionMatchTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
     private final TypeRegistry typeRegistry = new TypeRegistry(ENGLISH);
 
     @Test
@@ -43,7 +45,7 @@ public class StepDefinitionMatchTest {
     }
 
     @Test
-    public void throws_arity_mismatch_exception_when_there_are_fewer_parameters_than_arguments() throws Throwable {
+    public void throws_arity_mismatch_exception_when_there_are_fewer_parameters_than_arguments() {
         PickleStep step = new PickleStep("I have 4 cukes in my belly", Collections.<gherkin.pickles.Argument>emptyList(), asList(mock(PickleLocation.class)));
 
         StepDefinition stepDefinition = new StubStepDefinition("I have {int} cukes in my belly");
@@ -52,17 +54,18 @@ public class StepDefinitionMatchTest {
 
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
 
-        expectedException.expectMessage(
-            "" +
-                "Step [I have {int} cukes in my belly] is defined with 0 parameters at '{stubbed location with details}'.\n" +
+        final Executable testMethod = () -> stepDefinitionMatch.runStep(null);
+        final CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "Step [I have {int} cukes in my belly] is defined with 0 parameters at '{stubbed location with details}'.\n" +
                 "However, the gherkin step has 1 arguments:\n" +
                 " * 4\n" +
-                "Step text: I have 4 cukes in my belly");
-        stepDefinitionMatch.runStep(null);
+                "Step text: I have 4 cukes in my belly"
+        )));
     }
 
     @Test
-    public void throws_arity_mismatch_exception_when_there_are_fewer_parameters_than_arguments_with_data_table() throws Throwable {
+    public void throws_arity_mismatch_exception_when_there_are_fewer_parameters_than_arguments_with_data_table() {
         PickleTable table = new PickleTable(
             asList(
                 new PickleRow(asList(new PickleCell(mock(PickleLocation.class), "A"), new PickleCell(mock(PickleLocation.class), "B"))),
@@ -77,53 +80,60 @@ public class StepDefinitionMatchTest {
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
         PickleStepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
 
-        expectedException.expectMessage(
-            "" +
-                "Step [I have {int} cukes in my belly] is defined with 0 parameters at '{stubbed location with details}'.\n" +
+        final Executable testMethod = () -> stepDefinitionMatch.runStep(null);
+        final CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "Step [I have {int} cukes in my belly] is defined with 0 parameters at '{stubbed location with details}'.\n" +
                 "However, the gherkin step has 2 arguments:\n" +
                 " * 4\n" +
                 " * Table:\n" +
                 "      | A | B |\n" +
                 "      | C | D |\n" +
                 "\n" +
-                "Step text: I have 4 cukes in my belly");
-        stepDefinitionMatch.runStep(null);
+                "Step text: I have 4 cukes in my belly"
+        )));
     }
 
     @Test
-    public void throws_arity_mismatch_exception_when_there_are_more_parameters_than_arguments() throws Throwable {
+    public void throws_arity_mismatch_exception_when_there_are_more_parameters_than_arguments() {
         PickleStep step = new PickleStep("I have 4 cukes in my belly", asList((gherkin.pickles.Argument) mock(PickleTable.class)), asList(mock(PickleLocation.class)));
         StepDefinition stepDefinition = new StubStepDefinition("I have {int} cukes in my belly", Integer.TYPE, Short.TYPE, List.class);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, typeRegistry);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
         PickleStepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
-        expectedException.expectMessage("" +
+
+        final Executable testMethod = () -> stepDefinitionMatch.runStep(null);
+        final CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
             "Step [I have {int} cukes in my belly] is defined with 3 parameters at '{stubbed location with details}'.\n" +
-            "However, the gherkin step has 2 arguments:\n" +
-            " * 4\n" +
-            " * Table:\n" +
-            "\n" +
-            "Step text: I have 4 cukes in my belly");
-        stepDefinitionMatch.runStep(null);
+                "However, the gherkin step has 2 arguments:\n" +
+                " * 4\n" +
+                " * Table:\n" +
+                "\n" +
+                "Step text: I have 4 cukes in my belly"
+        )));
     }
 
 
     @Test
-    public void throws_arity_mismatch_exception_when_there_are_more_parameters_and_no_arguments() throws Throwable {
+    public void throws_arity_mismatch_exception_when_there_are_more_parameters_and_no_arguments() {
         PickleStep step = new PickleStep("I have cukes in my belly", Collections.<gherkin.pickles.Argument>emptyList(), asList(mock(PickleLocation.class)));
         StepDefinition stepDefinition = new StubStepDefinition("I have cukes in my belly", Integer.TYPE, Short.TYPE, List.class);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, typeRegistry);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
-        expectedException.expectMessage("" +
+
+        final Executable testMethod = () -> stepDefinitionMatch.runStep(null);
+        final CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
             "Step [I have cukes in my belly] is defined with 3 parameters at '{stubbed location with details}'.\n" +
-            "However, the gherkin step has 0 arguments.\n" +
-            "Step text: I have cukes in my belly");
-        stepDefinitionMatch.runStep(null);
+                "However, the gherkin step has 0 arguments.\n" +
+                "Step text: I have cukes in my belly"
+        )));
     }
 
     @Test
-    public void throws_register_type_in_configuration_exception_when_there_is_no_data_table_type_defined() throws Throwable {
+    public void throws_register_type_in_configuration_exception_when_there_is_no_data_table_type_defined() {
         // Empty table maps to null and doesn't trigger a type check.
         PickleTable table = new PickleTable(singletonList(new PickleRow(singletonList(new PickleCell(mock(PickleLocation.class), "A")))));
 
@@ -133,15 +143,18 @@ public class StepDefinitionMatchTest {
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
 
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
-        expectedException.expectMessage("" +
+
+        final Executable testMethod = () -> stepDefinitionMatch.runStep(null);
+        final CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
             "Could not convert arguments for step [I have a datatable] defined at '{stubbed location with details}'.\n" +
-            "It appears you did not register a data table type. The details are in the stacktrace below.");
-        stepDefinitionMatch.runStep(null);
+                "It appears you did not register a data table type. The details are in the stacktrace below."
+        )));
 
     }
 
     @Test
-    public void throws_could_not_convert_exception_for_transfomer_and_capture_group_mismatch() throws Throwable {
+    public void throws_could_not_convert_exception_for_transfomer_and_capture_group_mismatch() {
         typeRegistry.defineParameterType(new ParameterType<ItemQuantity>(
             "itemQuantity",
             "(few|some|lots of) (cukes|gherkins)",
@@ -159,16 +172,17 @@ public class StepDefinitionMatchTest {
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
 
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
-        expectedException.expectMessage("" +
-            "Could not convert arguments for step [I have {itemQuantity} in my belly] defined at '{stubbed location with details}'.\n" +
-            "The details are in the stacktrace below."
-        );
-        stepDefinitionMatch.runStep(null);
 
+        final Executable testMethod = () -> stepDefinitionMatch.runStep(null);
+        final CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "Could not convert arguments for step [I have {itemQuantity} in my belly] defined at '{stubbed location with details}'.\n" +
+                "The details are in the stacktrace below."
+        )));
     }
 
     @Test
-    public void throws_could_not_convert_exception_for_singleton_table_dimension_mismatch() throws Throwable {
+    public void throws_could_not_convert_exception_for_singleton_table_dimension_mismatch() {
         PickleTable table = new PickleTable(
             asList(
                 new PickleRow(asList(new PickleCell(mock(PickleLocation.class), "A"), new PickleCell(mock(PickleLocation.class), "B"))),
@@ -193,11 +207,13 @@ public class StepDefinitionMatchTest {
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
 
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
-        expectedException.expectMessage("" +
-            "Could not convert arguments for step [I have some cukes in my belly] defined at '{stubbed location with details}'.\n" +
-            "The details are in the stacktrace below.");
-        stepDefinitionMatch.runStep(null);
 
+        final Executable testMethod = () -> stepDefinitionMatch.runStep(null);
+        final CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "Could not convert arguments for step [I have some cukes in my belly] defined at '{stubbed location with details}'.\n" +
+                "The details are in the stacktrace below."
+        )));
     }
 
     private static final class ItemQuantity {
@@ -217,4 +233,5 @@ public class StepDefinitionMatchTest {
     private static final class UndefinedDataTableType {
 
     }
+
 }

--- a/core/src/test/java/io/cucumber/core/runtime/BackendServiceLoaderTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/BackendServiceLoaderTest.java
@@ -5,19 +5,17 @@ import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.io.MultiLoader;
 import io.cucumber.core.io.ResourceLoader;
 import io.cucumber.core.options.RuntimeOptions;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static java.util.Collections.emptyList;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BackendServiceLoaderTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void should_create_a_backend() {
@@ -39,8 +37,11 @@ public class BackendServiceLoaderTest {
         ObjectFactorySupplier objectFactory = new SingletonObjectFactorySupplier(objectFactoryServiceLoader);
         BackendServiceLoader backendSupplier = new BackendServiceLoader(resourceLoader, objectFactory);
 
-        expectedException.expect(CucumberException.class);
-        backendSupplier.get(emptyList()).iterator().next();
+        final Executable testMethod = () -> backendSupplier.get(emptyList()).iterator().next();
+        final CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "No backends were found. Please make sure you have a backend module on your CLASSPATH."
+        )));
     }
 
 }

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -51,6 +51,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -39,6 +39,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -50,6 +50,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>

--- a/java8/src/test/java/io/cucumber/java8/Java8LambdaStepDefinitionTest.java
+++ b/java8/src/test/java/io/cucumber/java8/Java8LambdaStepDefinitionTest.java
@@ -1,17 +1,18 @@
 package io.cucumber.java8;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import io.cucumber.core.exception.CucumberException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Java8LambdaStepDefinitionTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void should_calculate_parameters_count_from_body_with_one_param() {
@@ -40,21 +41,28 @@ public class Java8LambdaStepDefinitionTest {
 
     @Test
     public void should_fail_for_param_with_non_generic_list() {
-        expectedException.expectMessage("Can't use java.util.List in lambda step definition \"some step\". Declare a DataTable argument instead and convert manually with asList/asLists/asMap/asMaps");
-
         StepdefBody.A1<List> body = p1 -> {
         };
         Java8StepDefinition stepDefinition = Java8StepDefinition.create("some step", StepdefBody.A1.class, body);
-        stepDefinition.parameterInfos().get(0).getTypeResolver().resolve();
+
+        final Executable testMethod = () -> stepDefinition.parameterInfos().get(0).getTypeResolver().resolve();
+        final CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "Can't use java.util.List in lambda step definition \"some step\". Declare a DataTable argument instead and convert manually with asList/asLists/asMap/asMaps"
+        )));
     }
 
     @Test
     public void should_fail_for_param_with_generic_list() {
-        expectedException.expectMessage("Can't use java.util.List in lambda step definition \"some step\". Declare a DataTable argument instead and convert manually with asList/asLists/asMap/asMaps");
-
         StepdefBody.A1<List<String>> body = p1 -> {
         };
         Java8StepDefinition stepDefinition = Java8StepDefinition.create("some step", StepdefBody.A1.class, body);
-        stepDefinition.parameterInfos().get(0).getTypeResolver().resolve();
+
+        final Executable testMethod = () -> stepDefinition.parameterInfos().get(0).getTypeResolver().resolve();
+        final CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+            "Can't use java.util.List in lambda step definition \"some step\". Declare a DataTable argument instead and convert manually with asList/asLists/asMap/asMaps"
+        )));
     }
+
 }

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -33,6 +33,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>

--- a/needle/pom.xml
+++ b/needle/pom.xml
@@ -44,6 +44,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>

--- a/weld/src/test/java/io/cucumber/weld/WeldFactoryTest.java
+++ b/weld/src/test/java/io/cucumber/weld/WeldFactoryTest.java
@@ -1,30 +1,18 @@
 package io.cucumber.weld;
 
-import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.backend.ObjectFactory;
-
 import io.cucumber.core.logging.LogRecordListener;
 import io.cucumber.core.logging.LoggerFactory;
-import org.jboss.weld.environment.se.Weld;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class WeldFactoryTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private LogRecordListener logRecordListener;
 
@@ -35,7 +23,7 @@ public class WeldFactoryTest {
     }
 
     @After
-    public void tearDown(){
+    public void tearDown() {
         LoggerFactory.removeListener(logRecordListener);
     }
 
@@ -66,4 +54,5 @@ public class WeldFactoryTest {
         assertThat(logRecordListener.getLogRecords().get(0).getMessage(),
             containsString("your weld container didn't shut down properly"));
     }
+
 }


### PR DESCRIPTION
## Summary

assertThrows replacing ExpectedException

## Details

Only the quick wins done, some outstanding to be convert in future PR

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

mvn clean install passed

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
