### PR TITLE
[Core] Fix UnusedStepSummaryPrinter and consistently handle plugin events

### DIFF
--- a/core/src/main/java/io/cucumber/core/plugin/DefaultSummaryPrinter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/DefaultSummaryPrinter.java
@@ -1,6 +1,5 @@
 package io.cucumber.core.plugin;
 
-import io.cucumber.core.event.EventHandler;
 import io.cucumber.core.event.EventPublisher;
 import io.cucumber.core.event.TestRunFinished;
 

--- a/core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
@@ -1,8 +1,7 @@
 package io.cucumber.core.plugin;
 
-import io.cucumber.core.event.TestCase;
-import io.cucumber.core.event.EventHandler;
 import io.cucumber.core.event.EventPublisher;
+import io.cucumber.core.event.TestCase;
 import io.cucumber.core.event.TestCaseFinished;
 import io.cucumber.core.event.TestRunFinished;
 import io.cucumber.core.feature.FeatureWithLines;
@@ -12,7 +11,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-
 /**
  * Formatter for reporting all failed test cases and print their locations
  * Failed means: results that make the exit code non-zero.
@@ -20,38 +18,8 @@ import java.util.Map;
 public final class RerunFormatter implements EventListener, StrictAware {
     private final NiceAppendable out;
     private final Map<String, Collection<Integer>> featureAndFailedLinesMapping = new HashMap<>();
-    private final EventHandler<TestRunFinished> runFinishHandler = new EventHandler<TestRunFinished>() {
 
-        @Override
-        public void receive(TestRunFinished event) {
-            for (Map.Entry<String, Collection<Integer>> entry : featureAndFailedLinesMapping.entrySet()) {
-                FeatureWithLines featureWithLines = FeatureWithLines.parse(entry.getKey(), entry.getValue());
-                out.println(featureWithLines.toString());
-            }
-
-            out.close();
-        }
-    };
     private boolean isStrict = false;
-    private final EventHandler<TestCaseFinished> testCaseFinishedHandler = new EventHandler<TestCaseFinished>() {
-
-        @Override
-        public void receive(TestCaseFinished event) {
-            if (!event.getResult().getStatus().isOk(isStrict)) {
-                recordTestFailed(event.getTestCase());
-            }
-        }
-
-        private void recordTestFailed(TestCase testCase) {
-            String uri = testCase.getUri();
-            Collection<Integer> failedTestCaseLines = getFailedTestCaseLines(uri);
-            failedTestCaseLines.add(testCase.getLine());
-        }
-
-        private Collection<Integer> getFailedTestCaseLines(String uri) {
-            return featureAndFailedLinesMapping.computeIfAbsent(uri, k -> new ArrayList<>());
-        }
-    };
 
     @SuppressWarnings("WeakerAccess") // Used by PluginFactory
     public RerunFormatter(Appendable out) {
@@ -60,13 +28,38 @@ public final class RerunFormatter implements EventListener, StrictAware {
 
     @Override
     public void setEventPublisher(EventPublisher publisher) {
-        publisher.registerHandlerFor(TestCaseFinished.class, testCaseFinishedHandler);
-        publisher.registerHandlerFor(TestRunFinished.class, runFinishHandler);
+        publisher.registerHandlerFor(TestCaseFinished.class, this::handleTestCaseFinished);
+        publisher.registerHandlerFor(TestRunFinished.class, event -> finishReport());
     }
 
     @Override
     public void setStrict(boolean strict) {
         isStrict = strict;
+    }
+
+    private void handleTestCaseFinished(TestCaseFinished event) {
+        if (!event.getResult().getStatus().isOk(isStrict)) {
+            recordTestFailed(event.getTestCase());
+        }
+    }
+
+    private void recordTestFailed(TestCase testCase) {
+        String uri = testCase.getUri();
+        Collection<Integer> failedTestCaseLines = getFailedTestCaseLines(uri);
+        failedTestCaseLines.add(testCase.getLine());
+    }
+
+    private Collection<Integer> getFailedTestCaseLines(String uri) {
+        return featureAndFailedLinesMapping.computeIfAbsent(uri, k -> new ArrayList<>());
+    }
+
+    private void finishReport() {
+        for (Map.Entry<String, Collection<Integer>> entry : featureAndFailedLinesMapping.entrySet()) {
+            FeatureWithLines featureWithLines = FeatureWithLines.parse(entry.getKey(), entry.getValue());
+            out.println(featureWithLines.toString());
+        }
+
+        out.close();
     }
 }
 

--- a/core/src/main/java/io/cucumber/core/plugin/TimelineFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/TimelineFormatter.java
@@ -1,7 +1,6 @@
 package io.cucumber.core.plugin;
 
 import io.cucumber.core.event.TestCase;
-import io.cucumber.core.event.EventHandler;
 import io.cucumber.core.event.EventPublisher;
 import io.cucumber.core.event.TestCaseEvent;
 import io.cucumber.core.event.TestCaseFinished;
@@ -45,16 +44,6 @@ public final class TimelineFormatter implements ConcurrentEventListener {
         "/io/cucumber/core/plugin/timeline/chosen-sprite.png"
     };
 
-    private final EventHandler<TestSourceRead> testSourceReadHandler = new EventHandler<TestSourceRead>() {
-        @Override
-        public void receive(TestSourceRead event) {
-            testSources.addTestSourceReadEvent(event.getUri(), event);
-        }
-    };
-    private final EventHandler<TestCaseStarted> caseStartedHandler = this::handleTestCaseStarted;
-    private final EventHandler<TestCaseFinished> caseFinishedHandler = this::handleTestCaseFinished;
-    private final EventHandler<TestRunFinished> runFinishedHandler = this::finishReport;
-
     private final TestSourcesModel testSources = new TestSourcesModel();
     private final Map<String, TestData> allTests = new HashMap<>();
     private final Map<Long, GroupData> allGroups = new HashMap<>();
@@ -71,12 +60,17 @@ public final class TimelineFormatter implements ConcurrentEventListener {
         this.reportJs = reportJs;
     }
 
+
     @Override
     public void setEventPublisher(final EventPublisher publisher) {
-        publisher.registerHandlerFor(TestSourceRead.class, testSourceReadHandler);
-        publisher.registerHandlerFor(TestCaseStarted.class, caseStartedHandler);
-        publisher.registerHandlerFor(TestCaseFinished.class, caseFinishedHandler);
-        publisher.registerHandlerFor(TestRunFinished.class, runFinishedHandler);
+        publisher.registerHandlerFor(TestSourceRead.class, this::handleTestSourceRead);
+        publisher.registerHandlerFor(TestCaseStarted.class,  this::handleTestCaseStarted);
+        publisher.registerHandlerFor(TestCaseFinished.class, this::handleTestCaseFinished);
+        publisher.registerHandlerFor(TestRunFinished.class, this::finishReport);
+    }
+
+    private void handleTestSourceRead(TestSourceRead event) {
+        testSources.addTestSourceReadEvent(event.getUri(), event);
     }
 
     private void handleTestCaseStarted(final TestCaseStarted event) {

--- a/core/src/main/java/io/cucumber/core/plugin/UndefinedStepsTracker.java
+++ b/core/src/main/java/io/cucumber/core/plugin/UndefinedStepsTracker.java
@@ -1,6 +1,5 @@
 package io.cucumber.core.plugin;
 
-import io.cucumber.core.event.EventHandler;
 import io.cucumber.core.event.EventPublisher;
 import io.cucumber.core.event.SnippetsSuggestedEvent;
 import io.cucumber.core.event.TestSourceRead;
@@ -28,13 +27,10 @@ final class UndefinedStepsTracker implements EventListener {
     private final Map<String, FeatureStepMap> pathToStepMap = new HashMap<>();
     private boolean hasUndefinedSteps = false;
 
-    private EventHandler<TestSourceRead> testSourceReadHandler = event -> pathToSourceMap.put(event.getUri(), event.getSource());
-    private EventHandler<SnippetsSuggestedEvent> snippetsSuggestedHandler = event -> handleSnippetsSuggested(event.getUri(), event.getStepLocations(), event.getSnippets());
-
     @Override
     public void setEventPublisher(EventPublisher publisher) {
-        publisher.registerHandlerFor(TestSourceRead.class, testSourceReadHandler);
-        publisher.registerHandlerFor(SnippetsSuggestedEvent.class, snippetsSuggestedHandler);
+        publisher.registerHandlerFor(TestSourceRead.class, this::handleTestSourceRead);
+        publisher.registerHandlerFor(SnippetsSuggestedEvent.class, this::handleSnippetsSuggestedEvent);
     }
 
     boolean hasUndefinedSteps() {
@@ -43,6 +39,14 @@ final class UndefinedStepsTracker implements EventListener {
 
     List<String> getSnippets() {
         return snippets;
+    }
+
+    private void handleTestSourceRead(TestSourceRead event) {
+        pathToSourceMap.put(event.getUri(), event.getSource());
+    }
+
+    private void handleSnippetsSuggestedEvent(SnippetsSuggestedEvent event) {
+        handleSnippetsSuggested(event.getUri(), event.getStepLocations(), event.getSnippets());
     }
 
     void handleSnippetsSuggested(String uri, List<SnippetsSuggestedEvent.Location> stepLocations, List<String> snippets) {

--- a/core/src/main/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinter.java
@@ -10,40 +10,6 @@ import static java.util.Locale.ROOT;
 
 public class UnusedStepsSummaryPrinter implements ColorAware, EventListener, SummaryPrinter {
 
-	private EventHandler<StepDefinedEvent> stepDefinedHandler = new EventHandler<StepDefinedEvent>() {
-		@Override
-		public void receive(StepDefinedEvent event) {
-			unusedSteps.put(event.getStepDefinition().getLocation(false), event.getStepDefinition().getPattern());
-		}
-	};
-	private EventHandler<TestStepFinished> testStepFinishedHandler = new EventHandler<TestStepFinished>() {
-		@Override
-		public void receive(TestStepFinished event) {
-			String codeLocation = event.getTestStep().getCodeLocation();
-			if (codeLocation != null) {
-				unusedSteps.remove(codeLocation);
-			}
-		}
-	};
-	private EventHandler<TestRunFinished> testRunFinishedhandler = new EventHandler<TestRunFinished>() {
-		@Override
-		public void receive(TestRunFinished event) {
-			if (unusedSteps.isEmpty()) {
-				return;
-			}
-
-            Format format = formats.get(Status.UNUSED.name().toLowerCase(ROOT));
-			out.println(format.text(unusedSteps.size() + " Unused steps:"));
-
-			// Output results when done
-			for (Entry<String, String> entry : unusedSteps.entrySet()) {
-				String location = entry.getKey();
-				String pattern = entry.getValue();
-				out.println(format.text(location) + " # " + pattern);
-			}
-		}
-	};
-
 	private final Map<String, String> unusedSteps = new TreeMap<>();
 	private final NiceAppendable out;
 	private Formats formats = new MonochromeFormats();
@@ -56,11 +22,38 @@ public class UnusedStepsSummaryPrinter implements ColorAware, EventListener, Sum
 	@Override
 	public void setEventPublisher(EventPublisher publisher) {
 		// Record any steps registered
-		publisher.registerHandlerFor(StepDefinedEvent.class, stepDefinedHandler);
+		publisher.registerHandlerFor(StepDefinedEvent.class, this::handleStepDefinedEvent);
 		// Remove any steps that run
-		publisher.registerHandlerFor(TestStepFinished.class, testStepFinishedHandler);
+		publisher.registerHandlerFor(TestStepFinished.class, this::handleTestStepFinished);
 		// Print summary when done
-		publisher.registerHandlerFor(TestRunFinished.class, testRunFinishedhandler);
+		publisher.registerHandlerFor(TestRunFinished.class, event -> finishReport());
+	}
+
+	private void handleStepDefinedEvent(StepDefinedEvent event) {
+		unusedSteps.put(event.getStepDefinition().getLocation(false), event.getStepDefinition().getPattern());
+	}
+
+	private void handleTestStepFinished(TestStepFinished event) {
+		String codeLocation = event.getTestStep().getCodeLocation();
+		if (codeLocation != null) {
+			unusedSteps.remove(codeLocation);
+		}
+	}
+
+	private void finishReport() {
+		if (unusedSteps.isEmpty()) {
+			return;
+		}
+
+		Format format = formats.get(Status.UNUSED.name().toLowerCase(ROOT));
+		out.println(format.text(unusedSteps.size() + " Unused steps:"));
+
+		// Output results when done
+		for (Entry<String, String> entry : unusedSteps.entrySet()) {
+			String location = entry.getKey();
+			String pattern = entry.getValue();
+			out.println(format.text(location) + " # " + pattern);
+		}
 	}
 
 	@Override

--- a/core/src/main/java/io/cucumber/core/plugin/UsageFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/UsageFormatter.java
@@ -4,7 +4,6 @@ import gherkin.deps.com.google.gson.Gson;
 import gherkin.deps.com.google.gson.GsonBuilder;
 import gherkin.deps.com.google.gson.JsonPrimitive;
 import gherkin.deps.com.google.gson.JsonSerializer;
-import io.cucumber.core.event.EventHandler;
 import io.cucumber.core.event.EventPublisher;
 import io.cucumber.core.event.PickleStepTestStep;
 import io.cucumber.core.event.Result;
@@ -30,9 +29,6 @@ public final class UsageFormatter implements Plugin, EventListener {
     final Map<String, List<StepContainer>> usageMap = new LinkedHashMap<>();
     private final NiceAppendable out;
 
-    private EventHandler<TestStepFinished> stepFinishedHandler = this::handleTestStepFinished;
-    private EventHandler<TestRunFinished> runFinishedHandler = event -> finishReport();
-
     /**
      * Constructor
      *
@@ -45,8 +41,8 @@ public final class UsageFormatter implements Plugin, EventListener {
 
     @Override
     public void setEventPublisher(EventPublisher publisher) {
-        publisher.registerHandlerFor(TestStepFinished.class, stepFinishedHandler);
-        publisher.registerHandlerFor(TestRunFinished.class, runFinishedHandler);
+        publisher.registerHandlerFor(TestStepFinished.class, this::handleTestStepFinished);
+        publisher.registerHandlerFor(TestRunFinished.class, event -> finishReport());
     }
 
     void handleTestStepFinished(TestStepFinished event) {

--- a/core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
@@ -1,18 +1,12 @@
 package io.cucumber.core.plugin;
 
-import io.cucumber.core.backend.StepDefinition;
-import io.cucumber.core.event.Result;
-import io.cucumber.core.event.Status;
-import io.cucumber.core.event.StepDefinedEvent;
-import io.cucumber.core.event.TestCase;
-import io.cucumber.core.event.TestRunFinished;
-import io.cucumber.core.event.TestStep;
-import io.cucumber.core.event.TestStepFinished;
-import io.cucumber.core.runtime.TimeServiceEventBus;
-import org.junit.jupiter.api.Test;
-
 import java.time.Clock;
 import java.time.Duration;
+
+import io.cucumber.core.backend.StepDefinition;
+import io.cucumber.core.event.*;
+import io.cucumber.core.runtime.TimeServiceEventBus;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -32,7 +26,12 @@ public class UnusedStepsSummaryPrinterTest {
         // Register two steps, use one, then finish the test run
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/belly.feature:3", "a few cukes")));
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/tummy.feature:5", "some more cukes")));
+        bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/gut.feature:7", "even more cukes")));
         bus.send(new TestStepFinished(bus.getInstant(), mock(TestCase.class), mockTestStep("my/belly.feature:3"), new Result(Status.UNUSED, Duration.ZERO, null)));
+        bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/belly.feature:3", "a few cukes")));
+        bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/tummy.feature:5", "some more cukes")));
+        bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/gut.feature:7", "even more cukes")));
+        bus.send(new TestStepFinished(bus.getInstant(), mock(TestCase.class), mockTestStep("my/gut.feature:7"), new Result(Status.UNUSED, Duration.ZERO, null)));
         bus.send(new TestRunFinished(bus.getInstant()));
 
         // Verify produced output


### PR DESCRIPTION
## Summary

Consistently handle events in plugins, after the initial push towards using lambdas where possible.
Also fixes an issue with the UnusedStepSummaryPrinter which failed to take into account that steps are registered at each scenario invocation. Fixed and improved test to verify.

## Details

Replace EventHandler instances with method references and apply consistent naming after the event handled.

## Motivation and Context

Consistency.

## How Has This Been Tested?

JUnit test suite.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Refactoring (non-breaking change which fixes an issue).
