### PR TITLE
[Core] Fix mainClass in manifest

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -111,7 +111,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>io.cucumber.core.api.cli.Main</mainClass>
+                            <mainClass>io.cucumber.core.cli.Main</mainClass>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
## Summary

Whilst build using Java 11 and getting the Module-Info.java correct this was highlighted by the latest maven-jar-plugin. The mainClass listed doesn't match
