### PR TITLE
Fixing junit categories

### DIFF
--- a/junit/src/main/java/io/cucumber/junit/Cucumber.java
+++ b/junit/src/main/java/io/cucumber/junit/Cucumber.java
@@ -40,6 +40,7 @@ import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.RunnerScheduler;
 import org.junit.runners.model.Statement;
 
+import java.lang.annotation.Annotation;
 import java.time.Clock;
 import java.util.List;
 import java.util.function.Predicate;
@@ -152,8 +153,9 @@ public final class Cucumber extends ParentRunner<FeatureRunner> {
         TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(classFinder, runtimeOptions);
         ThreadLocalRunnerSupplier runnerSupplier = new ThreadLocalRunnerSupplier(runtimeOptions, bus, backendSupplier, objectFactorySupplier, typeRegistryConfigurerSupplier);
         Predicate<CucumberPickle> filters = new Filters(runtimeOptions);
+        Annotation[] annotations = clazz.getAnnotations();
         this.children = features.stream()
-            .map(feature -> FeatureRunner.create(feature, filters, runnerSupplier, junitOptions))
+            .map(feature -> FeatureRunner.create(feature, filters, runnerSupplier, junitOptions, annotations))
             .filter(runner -> !runner.isEmpty())
             .collect(toList());
     }

--- a/junit/src/test/java/io/cucumber/junit/CategoryFilterFactory.java
+++ b/junit/src/test/java/io/cucumber/junit/CategoryFilterFactory.java
@@ -1,0 +1,16 @@
+package io.cucumber.junit;
+
+import org.junit.experimental.categories.IncludeCategories;
+import org.junit.runner.Description;
+import org.junit.runner.FilterFactory;
+import org.junit.runner.FilterFactoryParams;
+import org.junit.runner.manipulation.Filter;
+
+import java.lang.annotation.Annotation;
+
+public class CategoryFilterFactory {
+    public static Filter includeCategory(Class category, Annotation...annotations) throws FilterFactory.FilterNotCreatedException {
+        Description description = Description.createTestDescription(CategoryFilterFactory.class, "CategoryFilterFactory", annotations);
+        return new IncludeCategories().createFilter(new FilterFactoryParams(description, category.getName()));
+    }
+}

--- a/junit/src/test/java/io/cucumber/junit/UsedCategory.java
+++ b/junit/src/test/java/io/cucumber/junit/UsedCategory.java
@@ -1,0 +1,4 @@
+package io.cucumber.junit;
+
+public interface UsedCategory {
+}


### PR DESCRIPTION
## Summary

This tries to fix the issue described https://groups.google.com/forum/#!searchin/cukes/junit$20categories%7Csort:date/cukes/jVqbTdwoAPo/SbyYmoeWEAAJ and previously addressed on the denied PR https://github.com/cucumber/cucumber-jvm/pull/1021

## Details

I take a different approach here than in the aforementioned PR, passing down the annotations to the `FeatureRunner` and `PickleRunners` so that they pass the filtering process.

Notice that my intent for this PR is primarily to get feedback - there are comments which would be removed / addressed as needed prior to merge. I also have an ugly hack to preserve the Pickle id and the annotations, which at this point I don't see an easy fix for without an upstream JUnit fix.

## How Has This Been Tested?

There are unit tests, and I've manually tested on a Java project (closed source unfortunately).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [x] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
