### PR TITLE
[JUnit] Always fire TestStarted/Finished for pickle

### DIFF
--- a/junit/src/main/java/io/cucumber/junit/Cucumber.java
+++ b/junit/src/main/java/io/cucumber/junit/Cucumber.java
@@ -170,12 +170,7 @@ public final class Cucumber extends ParentRunner<FeatureRunner> {
 
     @Override
     protected void runChild(FeatureRunner child, RunNotifier notifier) {
-        notifier.fireTestStarted(describeChild(child));
-        try {
-            child.run(notifier);
-        } finally {
-            notifier.fireTestFinished(describeChild(child));
-        }
+        child.run(notifier);
     }
 
     @Override

--- a/junit/src/main/java/io/cucumber/junit/Cucumber.java
+++ b/junit/src/main/java/io/cucumber/junit/Cucumber.java
@@ -170,7 +170,12 @@ public final class Cucumber extends ParentRunner<FeatureRunner> {
 
     @Override
     protected void runChild(FeatureRunner child, RunNotifier notifier) {
-        child.run(notifier);
+        notifier.fireTestStarted(describeChild(child));
+        try {
+            child.run(notifier);
+        } finally {
+            notifier.fireTestFinished(describeChild(child));
+        }
     }
 
     @Override

--- a/junit/src/main/java/io/cucumber/junit/FeatureRunner.java
+++ b/junit/src/main/java/io/cucumber/junit/FeatureRunner.java
@@ -16,6 +16,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static io.cucumber.junit.FileNameCompatibleNames.createName;
 import static io.cucumber.junit.PickleRunners.withNoStepDescriptions;
 import static io.cucumber.junit.PickleRunners.withStepDescriptions;
 import static java.util.stream.Collectors.toList;
@@ -24,6 +25,7 @@ final class FeatureRunner extends ParentRunner<PickleRunner> {
 
     private final List<PickleRunner> children;
     private final CucumberFeature cucumberFeature;
+    private final JUnitOptions options;
     private Description description;
 
     static FeatureRunner create(CucumberFeature feature, Predicate<CucumberPickle> filter, RunnerSupplier runners, JUnitOptions options) {
@@ -37,6 +39,7 @@ final class FeatureRunner extends ParentRunner<PickleRunner> {
     private FeatureRunner(CucumberFeature feature, Predicate<CucumberPickle> filter, RunnerSupplier runners, JUnitOptions options) throws InitializationError {
         super(null);
         this.cucumberFeature = feature;
+        this.options = options;
         this.children = feature.getPickles().stream()
             .filter(filter).
                 map(pickleEvent -> options.stepNotifications()
@@ -47,7 +50,7 @@ final class FeatureRunner extends ParentRunner<PickleRunner> {
 
     @Override
     protected String getName() {
-        return cucumberFeature.getKeyword() + ": " + cucumberFeature.getName();
+        return createName(cucumberFeature.getName(), options.filenameCompatibleNames());
     }
 
     @Override
@@ -75,14 +78,14 @@ final class FeatureRunner extends ParentRunner<PickleRunner> {
 
     @Override
     protected void runChild(PickleRunner child, RunNotifier notifier) {
-        notifier.fireTestStarted(getDescription());
+        notifier.fireTestStarted(describeChild(child));
         try {
             child.run(notifier);
         } catch (Throwable e) {
-            notifier.fireTestFailure(new Failure(getDescription(), e));
+            notifier.fireTestFailure(new Failure(describeChild(child), e));
             notifier.pleaseStop();
         } finally {
-            notifier.fireTestFinished(getDescription());
+            notifier.fireTestFinished(describeChild(child));
         }
     }
 

--- a/junit/src/main/java/io/cucumber/junit/FileNameCompatibleNames.java
+++ b/junit/src/main/java/io/cucumber/junit/FileNameCompatibleNames.java
@@ -1,0 +1,19 @@
+package io.cucumber.junit;
+
+final class FileNameCompatibleNames {
+    static String createName(final String name, boolean useFilenameCompatibleNames) {
+        if (name.isEmpty()) {
+            return "EMPTY_NAME";
+        }
+
+        if (useFilenameCompatibleNames) {
+            return makeNameFilenameCompatible(name);
+        }
+
+        return name;
+    }
+
+    private static String makeNameFilenameCompatible(String name) {
+        return name.replaceAll("[^A-Za-z0-9_]", "_");
+    }
+}

--- a/junit/src/main/java/io/cucumber/junit/JUnitReporter.java
+++ b/junit/src/main/java/io/cucumber/junit/JUnitReporter.java
@@ -76,7 +76,6 @@ final class JUnitReporter {
     }
 
     private void handleTestCaseStarted(TestCaseStarted testCaseStarted) {
-        pickleRunnerNotifier.fireTestStarted();
         stepErrors = new ArrayList<>();
     }
 
@@ -176,7 +175,6 @@ final class JUnitReporter {
                 stepErrors.forEach(error -> pickleRunnerNotifier.addFailure(error));
                 break;
         }
-        pickleRunnerNotifier.fireTestFinished();
     }
 
     private void handleHookResult(Result result) {

--- a/junit/src/main/java/io/cucumber/junit/PickleRunners.java
+++ b/junit/src/main/java/io/cucumber/junit/PickleRunners.java
@@ -16,6 +16,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.cucumber.junit.FileNameCompatibleNames.createName;
+
 
 final class PickleRunners {
 
@@ -65,7 +67,7 @@ final class PickleRunners {
 
         @Override
         protected String getName() {
-            return getPickleName(pickle, jUnitOptions.filenameCompatibleNames());
+            return createName(pickle.getName(), jUnitOptions.filenameCompatibleNames());
         }
 
         @Override
@@ -81,12 +83,7 @@ final class PickleRunners {
         public Description describeChild(CucumberStep step) {
             Description description = stepDescriptions.get(step);
             if (description == null) {
-                String testName;
-                if (jUnitOptions.filenameCompatibleNames()) {
-                    testName = makeNameFilenameCompatible(step.getText());
-                } else {
-                    testName = step.getText();
-                }
+                String testName = createName(step.getText(), jUnitOptions.filenameCompatibleNames());
                 description = Description.createTestDescription(getName(), testName, new PickleStepId(pickle, step));
                 stepDescriptions.put(step, description);
             }
@@ -131,7 +128,7 @@ final class PickleRunners {
         public Description getDescription() {
             if (description == null) {
                 String className = createName(featureName, jUnitOptions.filenameCompatibleNames());
-                String name = getPickleName(pickle, jUnitOptions.filenameCompatibleNames());
+                String name = createName(pickle.getName(), jUnitOptions.filenameCompatibleNames());
                 description = Description.createTestDescription(className, name, new PickleId(pickle));
             }
             return description;
@@ -151,28 +148,6 @@ final class PickleRunners {
             runner.runPickle(pickle);
             jUnitReporter.finishExecutionUnit();
         }
-    }
-
-    private static String getPickleName(CucumberPickle pickle, boolean useFilenameCompatibleNames) {
-        final String name = pickle.getName();
-        return createName(name, useFilenameCompatibleNames);
-    }
-
-
-    private static String createName(final String name, boolean useFilenameCompatibleNames) {
-        if (name.isEmpty()) {
-            return "EMPTY_NAME";
-        }
-
-        if (useFilenameCompatibleNames) {
-            return makeNameFilenameCompatible(name);
-        }
-
-        return name;
-    }
-
-    private static String makeNameFilenameCompatible(String name) {
-        return name.replaceAll("[^A-Za-z0-9_]", "_");
     }
 
     static final class PickleId implements Serializable {

--- a/junit/src/test/java/io/cucumber/junit/CucumberTest.java
+++ b/junit/src/test/java/io/cucumber/junit/CucumberTest.java
@@ -53,14 +53,14 @@ class CucumberTest {
     void finds_features_based_on_implicit_package() throws InitializationError {
         Cucumber cucumber = new Cucumber(ImplicitFeatureAndGluePath.class);
         assertThat(cucumber.getChildren().size(), is(equalTo(2)));
-        assertThat(cucumber.getChildren().get(0).getName(), is(equalTo("Feature: Feature A")));
+        assertThat(cucumber.getChildren().get(0).getName(), is(equalTo("Feature A")));
     }
 
     @Test
     void finds_features_based_on_explicit_root_package() throws InitializationError {
         Cucumber cucumber = new Cucumber(ExplicitFeaturePath.class);
         assertThat(cucumber.getChildren().size(), is(equalTo(2)));
-        assertThat(cucumber.getChildren().get(0).getName(), is(equalTo("Feature: Feature A")));
+        assertThat(cucumber.getChildren().get(0).getName(), is(equalTo("Feature A")));
     }
 
     @Test
@@ -98,7 +98,7 @@ class CucumberTest {
     }
 
     @Test
-    void cucumber_can_run_pickles_in_parallel() throws Exception {
+    void cucumber_can_run_features_in_parallel() throws Exception {
         RunNotifier notifier = new RunNotifier();
         RunListener listener = Mockito.mock(RunListener.class);
         notifier.addListener(listener);
@@ -106,48 +106,31 @@ class CucumberTest {
         Request.classes(computer, ValidEmpty.class).getRunner().run(notifier);
         {
             InOrder order = Mockito.inOrder(listener);
+            order.verify(listener).testStarted(argThat(new DescriptionMatcher("Feature A")));
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("A good start(Feature A)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("A good start(Feature A)")));
-        }
-        {
-            InOrder order = Mockito.inOrder(listener);
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
-        }
-        {
-            InOrder order = Mockito.inOrder(listener);
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
-        }
-        {
-            InOrder order = Mockito.inOrder(listener);
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
+            order.verify(listener).testFinished(argThat(new DescriptionMatcher("Feature A")));
         }
         {
             InOrder order = Mockito.inOrder(listener);
+            order.verify(listener).testStarted(argThat(new DescriptionMatcher("Feature B")));
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("A(Feature B)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("A(Feature B)")));
-        }
-        {
-            InOrder order = Mockito.inOrder(listener);
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("B(Feature B)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("B(Feature B)")));
-        }
-        {
-            InOrder order = Mockito.inOrder(listener);
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("C(Feature B)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("C(Feature B)")));
-        }
-        {
-            InOrder order = Mockito.inOrder(listener);
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("C(Feature B)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("C(Feature B)")));
-        }
-        {
-            InOrder order = Mockito.inOrder(listener);
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("C(Feature B)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("C(Feature B)")));
+            order.verify(listener).testFinished(argThat(new DescriptionMatcher("Feature B")));
         }
     }
 
@@ -157,7 +140,7 @@ class CucumberTest {
 
         assertThat(description.getDisplayName(), is("io.cucumber.junit.CucumberTest$ValidEmpty"));
         Description feature = description.getChildren().get(0);
-        assertThat(feature.getDisplayName(), is("Feature: Feature A"));
+        assertThat(feature.getDisplayName(), is("Feature A"));
         Description pickle = feature.getChildren().get(0);
         assertThat(pickle.getDisplayName(), is("A good start(Feature A)"));
     }
@@ -174,7 +157,7 @@ class CucumberTest {
     }
 
     @RunWith(Cucumber.class)
-    public static class Invalid {
+    private static class Invalid {
         @DummyWhen
         public void ignoreMe() {
         }

--- a/junit/src/test/java/io/cucumber/junit/CucumberTest.java
+++ b/junit/src/test/java/io/cucumber/junit/CucumberTest.java
@@ -106,20 +106,15 @@ class CucumberTest {
         Request.classes(computer, ValidEmpty.class).getRunner().run(notifier);
         {
             InOrder order = Mockito.inOrder(listener);
-            order.verify(listener).testStarted(argThat(new DescriptionMatcher("Feature A")));
-            order.verify(listener).testStarted(argThat(new DescriptionMatcher("A good start(Feature A)")));
-            order.verify(listener).testFinished(argThat(new DescriptionMatcher("A good start(Feature A)")));
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
-            order.verify(listener).testFinished(argThat(new DescriptionMatcher("Feature A")));
         }
         {
             InOrder order = Mockito.inOrder(listener);
-            order.verify(listener).testStarted(argThat(new DescriptionMatcher("Feature B")));
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("A(Feature B)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("A(Feature B)")));
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("B(Feature B)")));
@@ -130,7 +125,6 @@ class CucumberTest {
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("C(Feature B)")));
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("C(Feature B)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("C(Feature B)")));
-            order.verify(listener).testFinished(argThat(new DescriptionMatcher("Feature B")));
         }
     }
 

--- a/junit/src/test/java/io/cucumber/junit/FeatureRunnerTest.java
+++ b/junit/src/test/java/io/cucumber/junit/FeatureRunnerTest.java
@@ -367,9 +367,10 @@ class FeatureRunnerTest {
         FeatureRunner featureRunner = FeatureRunner.create(feature, filters, runnerSupplier, new JUnitOptions());
 
         RunNotifier notifier = mock(RunNotifier.class);
-        featureRunner.runChild(featureRunner.getChildren().get(0), notifier);
+        PickleRunners.PickleRunner pickleRunner = featureRunner.getChildren().get(0);
+        featureRunner.runChild(pickleRunner, notifier);
 
-        Description description = featureRunner.getDescription();
+        Description description = pickleRunner.getDescription();
         ArgumentCaptor<Failure> failureArgumentCaptor = ArgumentCaptor.forClass(Failure.class);
 
         InOrder order = inOrder(notifier);

--- a/junit/src/test/java/io/cucumber/junit/JUnitReporterWithStepNotificationsTest.java
+++ b/junit/src/test/java/io/cucumber/junit/JUnitReporterWithStepNotificationsTest.java
@@ -122,10 +122,8 @@ class JUnitReporterWithStepNotificationsTest {
         bus.send(new TestStepFinished(now(), testCase, mockTestStep(step), result));
         bus.send(new TestCaseFinished(now(), testCase, result));
 
-        verify(runNotifier).fireTestStarted(pickleRunner.getDescription());
         verify(runNotifier, never()).fireTestStarted(pickleRunner.describeChild(step));
         verify(runNotifier, never()).fireTestFinished(pickleRunner.describeChild(step));
-        verify(runNotifier).fireTestFinished(pickleRunner.getDescription());
     }
 
     @Test
@@ -139,10 +137,8 @@ class JUnitReporterWithStepNotificationsTest {
         bus.send(new TestStepFinished(now(), testCase, mockTestStep(step), result));
         bus.send(new TestCaseFinished(now(), testCase, result));
 
-        verify(runNotifier).fireTestStarted(pickleRunner.getDescription());
         verify(runNotifier).fireTestStarted(pickleRunner.describeChild(step));
         verify(runNotifier).fireTestFinished(pickleRunner.describeChild(step));
-        verify(runNotifier).fireTestFinished(pickleRunner.getDescription());
     }
 
     @Test
@@ -164,7 +160,6 @@ class JUnitReporterWithStepNotificationsTest {
         bus.send(new TestCaseFinished(now(), testCase, result));
 
         verify(runNotifier, times(2)).fireTestAssumptionFailed(failureArgumentCaptor.capture());
-        verify(runNotifier).fireTestFinished(pickleRunner.getDescription());
         Failure pickleFailure = failureArgumentCaptor.getValue();
         assertThat(pickleFailure.getDescription(), is(equalTo(pickleRunner.getDescription())));
         assertThat(pickleFailure.getException(), instanceOf(SkippedThrowable.class));


### PR DESCRIPTION
## Summary

Fixes a number of issues w.r.t. JUnit test events:

1. Only fires events for atomic tests (i.e. pickles).

2. Ensures pickle started/finished events are fired even when duplicate
   step definitions are encountered.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
