### PR TITLE
[Code] Clean up unnecessary public modifiers

### DIFF
--- a/core/src/test/java/io/cucumber/core/backend/JavaObjectFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/backend/JavaObjectFactoryTest.java
@@ -10,21 +10,21 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class JavaObjectFactoryTest {
+class JavaObjectFactoryTest {
 
     @Test
-    public void shouldGiveUsNewInstancesForEachScenario() {
+    void shouldGiveUsNewInstancesForEachScenario() {
         ObjectFactory factory = new DefaultJavaObjectFactory();
-        factory.addClass(SteDef.class);
+        factory.addClass(StepDefinition.class);
 
         // Scenario 1
         factory.start();
-        SteDef o1 = factory.getInstance(SteDef.class);
+        StepDefinition o1 = factory.getInstance(StepDefinition.class);
         factory.stop();
 
         // Scenario 2
         factory.start();
-        SteDef o2 = factory.getInstance(SteDef.class);
+        StepDefinition o2 = factory.getInstance(StepDefinition.class);
         factory.stop();
 
         assertAll("Checking SteDef",
@@ -34,7 +34,7 @@ public class JavaObjectFactoryTest {
         );
     }
 
-    public static class SteDef {
+    public static class StepDefinition {
         // we just test the instances
     }
 

--- a/core/src/test/java/io/cucumber/core/feature/CucumberFeatureTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/CucumberFeatureTest.java
@@ -16,10 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class CucumberFeatureTest {
+class CucumberFeatureTest {
 
     @Test
-    public void succeeds_if_no_features_are_found() {
+    void succeeds_if_no_features_are_found() {
         URI featurePath = URI.create("does/not/exist");
         ResourceLoader resourceLoader = mock(ResourceLoader.class);
         when(resourceLoader.resources(featurePath, ".feature")).thenReturn(Collections.emptyList());
@@ -27,7 +27,7 @@ public class CucumberFeatureTest {
     }
 
     @Test
-    public void gives_error_message_if_path_does_not_exist() {
+    void gives_error_message_if_path_does_not_exist() {
         URI featurePath = URI.create("path/bar.feature");
         ResourceLoader resourceLoader = mock(ResourceLoader.class);
         when(resourceLoader.resources(featurePath, ".feature")).thenThrow(new IllegalArgumentException("Not a file or directory: " + "path/bar.feature"));
@@ -39,7 +39,7 @@ public class CucumberFeatureTest {
     }
 
     @Test
-    public void gives_error_message_if_feature_on_class_path_does_not_exist() {
+    void gives_error_message_if_feature_on_class_path_does_not_exist() {
         URI featurePath = URI.create("classpath:path/bar.feature");
         ResourceLoader resourceLoader = mock(ResourceLoader.class);
         when(resourceLoader.resources(featurePath, ".feature")).thenReturn(emptyList());

--- a/core/src/test/java/io/cucumber/core/feature/FeatureBuilderTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/FeatureBuilderTest.java
@@ -16,10 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class FeatureBuilderTest {
+class FeatureBuilderTest {
 
     @Test
-    public void ignores_duplicate_features() throws IOException {
+    void ignores_duplicate_features() throws IOException {
         FeatureBuilder builder = new FeatureBuilder();
         URI featurePath = URI.create("foo.feature");
         Resource resource1 = createResourceMock(featurePath);
@@ -34,7 +34,7 @@ public class FeatureBuilderTest {
     }
 
     @Test
-    public void works_when_path_and_uri_are_the_same() throws IOException {
+    void works_when_path_and_uri_are_the_same() throws IOException {
         URI featurePath = URI.create("path/foo.feature");
         Resource resource = createResourceMock(featurePath);
         FeatureBuilder builder = new FeatureBuilder();

--- a/core/src/test/java/io/cucumber/core/feature/FeatureIdentifierTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/FeatureIdentifierTest.java
@@ -11,10 +11,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class FeatureIdentifierTest {
+class FeatureIdentifierTest {
 
     @Test
-    public void can_parse_feature_path_with_feature() {
+    void can_parse_feature_path_with_feature() {
         URI uri = FeatureIdentifier.parse(FeaturePath.parse("classpath:/path/to/file.feature"));
 
         assertAll("Checking uri",
@@ -24,7 +24,7 @@ public class FeatureIdentifierTest {
     }
 
     @Test
-    public void reject_feature_with_lines() {
+    void reject_feature_with_lines() {
         Executable testMethod = () -> FeatureIdentifier.parse(URI.create("classpath:/path/to/file.feature:10:40"));
         IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
@@ -33,7 +33,7 @@ public class FeatureIdentifierTest {
     }
 
     @Test
-    public void reject_directory_form() {
+    void reject_directory_form() {
         Executable testMethod = () -> FeatureIdentifier.parse(URI.create("classpath:/path/to"));
         IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(

--- a/core/src/test/java/io/cucumber/core/feature/FeatureWithLinesTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/FeatureWithLinesTest.java
@@ -11,10 +11,10 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class FeatureWithLinesTest {
+class FeatureWithLinesTest {
 
     @Test
-    public void should_create_FileWithFilters_with_no_lines() {
+    void should_create_FileWithFilters_with_no_lines() {
         FeatureWithLines featureWithLines = FeatureWithLines.parse("foo.feature");
 
         assertAll("Checking FeatureWithLines",
@@ -24,7 +24,7 @@ public class FeatureWithLinesTest {
     }
 
     @Test
-    public void should_create_FileWithFilters_with_1_line() {
+    void should_create_FileWithFilters_with_1_line() {
         FeatureWithLines featureWithLines = FeatureWithLines.parse("foo.feature:999");
 
         assertAll("Checking FeatureWithLines",
@@ -34,7 +34,7 @@ public class FeatureWithLinesTest {
     }
 
     @Test
-    public void should_create_FileWithFilters_with_2_lines() {
+    void should_create_FileWithFilters_with_2_lines() {
         FeatureWithLines featureWithLines = FeatureWithLines.parse("foo.feature:999:2000");
 
         assertAll("Checking FeatureWithLines",

--- a/core/src/test/java/io/cucumber/core/io/DelegatingResourceIteratorFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/io/DelegatingResourceIteratorFactoryTest.java
@@ -9,10 +9,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.isA;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DelegatingResourceIteratorFactoryTest {
+class DelegatingResourceIteratorFactoryTest {
 
     @Test
-    public void should_load_test_resource_iterator() {
+    void should_load_test_resource_iterator() {
         ResourceIteratorFactory factory =
             new DelegatingResourceIteratorFactory(new ZipThenFileResourceIteratorFactory());
         URI url = URI.create(TestResourceIteratorFactory.TEST_URL);

--- a/core/src/test/java/io/cucumber/core/io/FileResourceTest.java
+++ b/core/src/test/java/io/cucumber/core/io/FileResourceTest.java
@@ -10,10 +10,10 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class FileResourceTest {
+class FileResourceTest {
 
     @Test
-    public void for_classpath_files_get_path_should_return_relative_path_from_classpath_root() {
+    void for_classpath_files_get_path_should_return_relative_path_from_classpath_root() {
         FileResource toTest1 = FileResource.createClasspathFileResource(new File("/testPath"), new File("/testPath/test1/test.feature"));
         FileResource toTest2 = FileResource.createClasspathFileResource(new File("testPath"), new File("testPath/test1/test.feature"));
 
@@ -24,7 +24,7 @@ public class FileResourceTest {
     }
 
     @Test
-    public void for_filesystem_files_get_path_should_return_the_path() {
+    void for_filesystem_files_get_path_should_return_the_path() {
         // setup
         FileResource toTest1 = FileResource.createFileResource(new File("test1"), new File("test1/test.feature"));
         FileResource toTest2 = FileResource.createFileResource(new File("test1/test.feature"), new File("test1/test.feature"));

--- a/core/src/test/java/io/cucumber/core/io/FlatteningIteratorTest.java
+++ b/core/src/test/java/io/cucumber/core/io/FlatteningIteratorTest.java
@@ -16,10 +16,10 @@ import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class FlatteningIteratorTest {
+class FlatteningIteratorTest {
 
     @Test
-    public void flattens_iterators() {
+    void flattens_iterators() {
         final FlatteningIterator<Integer> fi = new FlatteningIterator<>();
         fi.push(asList(3, 4).iterator());
         fi.push(asList(1, 2).iterator());

--- a/core/src/test/java/io/cucumber/core/io/HelpersTest.java
+++ b/core/src/test/java/io/cucumber/core/io/HelpersTest.java
@@ -10,10 +10,10 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class HelpersTest {
+class HelpersTest {
 
     @Test
-    public void computes_file_path_for_jar_protocols() {
+    void computes_file_path_for_jar_protocols() {
 
         assertAll("Checking Helpers.jarFilePath",
             () -> assertThat(jarFilePath(URI.create("jar:file:foo%20bar+zap/cucumber-core.jar!/cucumber/runtime/io")).getSchemeSpecificPart(), is(equalTo("foo bar+zap/cucumber-core.jar"))),

--- a/core/src/test/java/io/cucumber/core/io/ZipResourceIteratorFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/io/ZipResourceIteratorFactoryTest.java
@@ -9,10 +9,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 // https://github.com/cucumber/cucumber-jvm/issues/808
-public class ZipResourceIteratorFactoryTest {
+class ZipResourceIteratorFactoryTest {
 
     @Test
-    public void is_factory_for_jar_protocols() {
+    void is_factory_for_jar_protocols() {
         ZipResourceIteratorFactory factory = new ZipResourceIteratorFactory();
 
         assertAll("Checking ZipResourceIteratorFactory",

--- a/core/src/test/java/io/cucumber/core/logging/LoggerFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/logging/LoggerFactoryTest.java
@@ -50,7 +50,7 @@ public class LoggerFactoryTest {
     }
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         Handler handler = new Handler() {
             @Override
             public void publish(LogRecord record) {
@@ -77,7 +77,7 @@ public class LoggerFactoryTest {
     }
 
     @Test
-    public void error() {
+    void error() {
         logger.error("Error");
         assertThat(logged, logRecord("Error", Level.SEVERE, null));
         logger.error("Error", exception);
@@ -85,7 +85,7 @@ public class LoggerFactoryTest {
     }
 
     @Test
-    public void warn() {
+    void warn() {
         logger.warn("Warn");
         assertThat(logged, logRecord("Warn", Level.WARNING, null));
         logger.warn("Warn", exception);
@@ -93,7 +93,7 @@ public class LoggerFactoryTest {
     }
 
     @Test
-    public void info() {
+    void info() {
         logger.info("Info");
         assertThat(logged, logRecord("Info", Level.INFO, null));
         logger.info("Info", exception);
@@ -101,7 +101,7 @@ public class LoggerFactoryTest {
     }
 
     @Test
-    public void config() {
+    void config() {
         logger.config("Config");
         assertThat(logged, logRecord("Config", Level.CONFIG, null));
         logger.config("Config", exception);
@@ -110,7 +110,7 @@ public class LoggerFactoryTest {
 
 
     @Test
-    public void debug() {
+    void debug() {
         logger.debug("Debug");
         assertThat(logged, logRecord("Debug", Level.FINE, null));
         logger.debug("Debug", exception);
@@ -118,7 +118,7 @@ public class LoggerFactoryTest {
     }
 
     @Test
-    public void trace() {
+    void trace() {
         logger.trace("Trace");
         assertThat(logged, logRecord("Trace", Level.FINER, null));
         logger.trace("Trace", exception);

--- a/core/src/test/java/io/cucumber/core/options/CucumberOptions.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberOptions.java
@@ -7,125 +7,34 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * This annotation provides the same options as the cucumber command line, {@link io.cucumber.core.cli.Main}.
- *
- * @deprecated use either {@code io.cucumber.junit.CucumberOptions} or {@code io.cucumber.testng.CucumberOptions}.
- */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface CucumberOptions {
 
-    /**
-     * Skip execution of glue code.
-     *
-     * @return True when dry run, false otherwise.
-     */
     boolean dryRun() default false;
 
-    /**
-     * Treat undefined and pending steps as errors.
-     *
-     * @return True when strict, false otherwise.
-     */
     boolean strict() default false;
 
-    /**
-     * Either a URI or path to a directory of features or a URI or path to a single
-     * feature optionally followed by a colon and line numbers.
-     * <p>
-     * When no feature path is provided, Cucumber will use the package of the annotated
-     * class. For example, if the annotated class is {@code com.example.RunCucumber}
-     * then features are assumed to be located in {@code classpath:com/example}.
-     *
-     * @see io.cucumber.core.feature.FeatureWithLines
-     * @return The location(s) of the features.
-     */
     String[] features() default {};
 
-    /**
-     * Package to load glue code (step definitions,
-     * hooks and plugins) from. E.g: {@code com.example.app}
-     * <p>
-     * When no glue is provided, Cucumber will use the package of the annotated
-     * class. For example, if the annotated class is {@code com.example.RunCucumber}
-     * then glue is assumed to be located in {@code com.example}.
-     *
-     * @see io.cucumber.core.feature.GluePath
-     * @return The package(s) that contain glue code.
-     */
     String[] glue() default {};
 
-    /**
-     * Package to load additional glue code (step definitions, hooks and
-     * plugins) from. E.g: {@code com.example.app}
-     * <p>
-     * These packages are used in addition to the default described in {@code #glue}.
-     *
-     * @return The package(s) that contain the extra glue code.
-     */
     String[] extraGlue() default {};
 
-    /**
-     * Only run scenarios tagged with tags matching {@code TAG_EXPRESSION}.
-     * <p>
-     * For example {@code "@smoke and not @fast"}.
-     *
-     * @return The tags that should be matched.
-     */
     String[] tags() default {};
 
-    /**
-     * Register plugins.
-     * Built-in plugin types: {@code junit}, {@code html},
-     * {@code pretty}, {@code progress}, {@code json}, {@code usage},
-     * {@code unused}, {@code rerun}, {@code testng}.
-     * <p>
-     * Can also be a fully qualified class name, allowing
-     * registration of 3rd party plugins.
-     * <p>
-     * Plugins can be provided with an argument. For example
-     * {@code json:target/cucumber-report.json}
-     *
-     * @see io.cucumber.core.plugin.Plugin
-     * @return The plugins that should be added.
-     */
     String[] plugin() default {};
 
-    /**
-     * Don't colour terminal output.
-     *
-     * @return True when no color should be present in the terminal output, false when color is allowed.
-     */
+
     boolean monochrome() default false;
 
-    /**
-     * Only run scenarios whose names match provided regular expression.
-     *
-     * @return The name(s) that should be matched via regular expressions.
-     */
     String[] name() default {};
 
-    /**
-     * Format of the generated snippets.
-     *
-     * @see SnippetType
-     * @return The snippet type to be generated for missing steps.
-     */
+
     SnippetType snippets() default SnippetType.UNDERSCORE;
 
-    /**
-     * A custom ObjectFactory.
-     *
-     * @return The class of the custim ObjectFactory to use.
-     */
     Class<? extends io.cucumber.core.backend.ObjectFactory> objectFactory() default NoObjectFactory.class;
 
-    /**
-     * Pass options to the JUnit runner.
-     *
-     * @return The JUnit options to pass on.
-     */
     String[] junit() default {};
 
 }

--- a/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
@@ -27,11 +27,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@SuppressWarnings("deprecation")
-public class CucumberOptionsAnnotationParserTest {
+ class CucumberOptionsAnnotationParserTest {
 
     @Test
-    public void create_strict() {
+     void create_strict() {
         RuntimeOptions runtimeOptions = parser().parse(Strict.class).build();
         assertTrue(runtimeOptions.isStrict());
     }
@@ -42,13 +41,13 @@ public class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
-    public void create_non_strict() {
+     void create_non_strict() {
         RuntimeOptions runtimeOptions = parser().parse(NotStrict.class).build();
         assertFalse(runtimeOptions.isStrict());
     }
 
     @Test
-    public void create_without_options() {
+     void create_without_options() {
         RuntimeOptions runtimeOptions = parser()
             .parse(WithoutOptions.class)
             .addDefaultSummaryPrinterIfNotPresent()
@@ -77,7 +76,7 @@ public class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
-    public void create_without_options_with_base_class_without_options() {
+     void create_without_options_with_base_class_without_options() {
         Class<?> subClassWithMonoChromeTrueClass = WithoutOptionsWithBaseClassWithoutOptions.class;
         RuntimeOptions runtimeOptions = parser()
             .parse(subClassWithMonoChromeTrueClass)
@@ -97,7 +96,7 @@ public class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
-    public void create_with_no_name() {
+     void create_with_no_name() {
         RuntimeOptions runtimeOptions = parser().parse(NoName.class).build();
 
         assertAll("Checking RuntimeOptions",
@@ -108,7 +107,7 @@ public class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
-    public void create_with_multiple_names() {
+     void create_with_multiple_names() {
         RuntimeOptions runtimeOptions = parser().parse(MultipleNames.class).build();
 
         List<Pattern> filters = runtimeOptions.getNameFilters();
@@ -122,13 +121,13 @@ public class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
-    public void testObjectFactory() {
+     void testObjectFactory() {
         RuntimeOptions runtimeOptions = parser().parse(ClassWithCustomObjectFactory.class).build();
         assertThat(runtimeOptions.getObjectFactoryClass(), is(equalTo(TestObjectFactory.class)));
     }
 
     @Test
-    public void create_with_snippets() {
+     void create_with_snippets() {
         RuntimeOptions runtimeOptions = parser().parse(Snippets.class).build();
         assertThat(runtimeOptions.getSnippetType(), is(equalTo(SnippetType.CAMELCASE)));
     }
@@ -138,7 +137,7 @@ public class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
-    public void create_default_summary_printer_when_no_summary_printer_plugin_is_defined() {
+     void create_default_summary_printer_when_no_summary_printer_plugin_is_defined() {
         RuntimeOptions runtimeOptions = parser()
             .parse(ClassWithNoSummaryPrinterPlugin.class)
             .addDefaultSummaryPrinterIfNotPresent()
@@ -149,7 +148,7 @@ public class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
-    public void inherit_plugin_from_baseclass() {
+     void inherit_plugin_from_baseclass() {
         RuntimeOptions runtimeOptions = parser().parse(SubClassWithFormatter.class).build();
         Plugins plugins = new Plugins(new PluginFactory(), runtimeOptions);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC()));
@@ -162,7 +161,7 @@ public class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
-    public void override_monochrome_flag_from_baseclass() {
+     void override_monochrome_flag_from_baseclass() {
         RuntimeOptions runtimeOptions = parser().parse(SubClassWithMonoChromeTrue.class).build();
 
         assertTrue(runtimeOptions.isMonochrome());
@@ -179,14 +178,14 @@ public class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
-    public void create_with_glue() {
+     void create_with_glue() {
         RuntimeOptions runtimeOptions = parser().parse(ClassWithGlue.class).build();
 
         assertThat(runtimeOptions.getGlue(), contains(uri("classpath:app/features/user/registration"), uri("classpath:app/features/hooks")));
     }
 
     @Test
-    public void create_with_extra_glue() {
+     void create_with_extra_glue() {
         RuntimeOptions runtimeOptions = parser().parse(ClassWithExtraGlue.class).build();
 
         assertThat(runtimeOptions.getGlue(), contains(uri("classpath:app/features/hooks"), uri("classpath:io/cucumber/core/options")));
@@ -194,7 +193,7 @@ public class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
-    public void create_with_extra_glue_in_subclass_of_extra_glue() {
+     void create_with_extra_glue_in_subclass_of_extra_glue() {
         RuntimeOptions runtimeOptions = parser()
             .parse(SubClassWithExtraGlueOfExtraGlue.class)
             .build();
@@ -204,14 +203,14 @@ public class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
-    public void create_with_extra_glue_in_subclass_of_glue() {
+     void create_with_extra_glue_in_subclass_of_glue() {
         RuntimeOptions runtimeOptions = parser().parse(SubClassWithExtraGlueOfGlue.class).build();
 
         assertThat(runtimeOptions.getGlue(), contains(uri("classpath:app/features/user/hooks"), uri("classpath:app/features/user/registration"), uri("classpath:app/features/hooks")));
     }
 
     @Test
-    public void cannot_create_with_glue_and_extra_glue() {
+     void cannot_create_with_glue_and_extra_glue() {
         Executable testMethod = () -> parser().parse(ClassWithGlueAndExtraGlue.class).build();
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo("glue and extraGlue cannot be specified at the same time")));

--- a/core/src/test/java/io/cucumber/core/options/CucumberPropertiesTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberPropertiesTest.java
@@ -11,12 +11,12 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
-public class CucumberPropertiesTest {
+ class CucumberPropertiesTest {
 
     private CucumberProperties.CucumberPropertiesMap env = new CucumberProperties.CucumberPropertiesMap(Collections.emptyMap());
 
     @BeforeEach
-    public void setup() {
+     void setup() {
         env.put("ENV_TEST", "from-bundle");
         env.put("a.b", "a.b");
         env.put("B_C", "B_C");
@@ -24,32 +24,32 @@ public class CucumberPropertiesTest {
     }
 
     @Test
-    public void looks_up_value_from_environment() {
+     void looks_up_value_from_environment() {
         assertThat(CucumberProperties.fromEnvironment().get("PATH"), is(notNullValue()));
     }
 
     @Test
-    public void returns_null_for_absent_key() {
+     void returns_null_for_absent_key() {
         assertThat(env.get("pxfj54#"), is(nullValue()));
     }
 
     @Test
-    public void looks_up_dotted_value_from_resource_bundle_with_dots() {
+     void looks_up_dotted_value_from_resource_bundle_with_dots() {
         assertThat(env.get("a.b"), is(equalTo("a.b")));
     }
 
     @Test
-    public void looks_up_underscored_value_from_resource_bundle_with_dots() {
+     void looks_up_underscored_value_from_resource_bundle_with_dots() {
         assertThat(env.get("b.c"), is(equalTo("B_C")));
     }
 
     @Test
-    public void looks_up_underscored_value_from_resource_bundle_with_underscores() {
+     void looks_up_underscored_value_from_resource_bundle_with_underscores() {
         assertThat(env.get("B_C"), is(equalTo("B_C")));
     }
 
     @Test
-    public void looks_up_value_by_exact_case_key() {
+     void looks_up_value_by_exact_case_key() {
         assertThat(env.get("c.D"), is(equalTo("C_D")));
     }
 

--- a/core/src/test/java/io/cucumber/core/options/ShellWordsTest.java
+++ b/core/src/test/java/io/cucumber/core/options/ShellWordsTest.java
@@ -7,25 +7,25 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class ShellWordsTest {
+class ShellWordsTest {
 
     @Test
-    public void parses_single_quoted_strings() {
+    void parses_single_quoted_strings() {
         assertThat(ShellWords.parse("--name 'The Fox'"), is(equalTo(asList("--name", "The Fox"))));
     }
 
     @Test
-    public void parses_double_quoted_strings() {
+    void parses_double_quoted_strings() {
         assertThat(ShellWords.parse("--name \"The Fox\""), is(equalTo(asList("--name", "The Fox"))));
     }
 
     @Test
-    public void parses_both_single_and_double_quoted_strings() {
+    void parses_both_single_and_double_quoted_strings() {
         assertThat(ShellWords.parse("--name \"The Fox\" --fur 'Brown White'"), is(equalTo(asList("--name", "The Fox", "--fur", "Brown White"))));
     }
 
     @Test
-    public void can_quote_both_single_and_double_quotes() {
+    void can_quote_both_single_and_double_quotes() {
         assertThat(ShellWords.parse("\"'\" '\"'"), is(equalTo(asList("'", "\""))));
     }
 

--- a/core/src/test/java/io/cucumber/core/plugin/JsonParallelRuntimeTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/JsonParallelRuntimeTest.java
@@ -11,10 +11,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
 //TODO: Merge with the existing test
-public class JsonParallelRuntimeTest {
+class JsonParallelRuntimeTest {
 
     @Test
-    public void testSingleFeature() {
+    void testSingleFeature() {
         StringBuilder parallel = new StringBuilder();
 
         Runtime.builder()
@@ -49,7 +49,7 @@ public class JsonParallelRuntimeTest {
     }
 
     @Test
-    public void testMultipleFeatures() {
+    void testMultipleFeatures() {
         StringBuilder parallel = new StringBuilder();
 
         Runtime.builder()

--- a/core/src/test/java/io/cucumber/core/plugin/PluginFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/PluginFactoryTest.java
@@ -32,24 +32,24 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
-public class PluginFactoryTest {
+ class PluginFactoryTest {
 
     private PluginFactory fc = new PluginFactory();
 
     @Test
-    public void instantiates_junit_plugin_with_file_arg() throws IOException {
+     void instantiates_junit_plugin_with_file_arg() throws IOException {
         Object plugin = fc.create(parse("junit:" + File.createTempFile("cucumber", "xml")));
         assertThat(plugin.getClass(), is(equalTo(JUnitFormatter.class)));
     }
 
     @Test
-    public void instantiates_html_plugin_with_dir_arg() throws IOException {
+     void instantiates_html_plugin_with_dir_arg() throws IOException {
         Object plugin = fc.create(parse("html:" + TempDir.createTempDirectory().getAbsolutePath()));
         assertThat(plugin.getClass(), is(equalTo(HTMLFormatter.class)));
     }
 
     @Test
-    public void fails_to_instantiate_html_plugin_without_dir_arg() {
+     void fails_to_instantiate_html_plugin_without_dir_arg() {
         Executable testMethod = () -> fc.create(parse("html"));
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
@@ -58,31 +58,31 @@ public class PluginFactoryTest {
     }
 
     @Test
-    public void instantiates_pretty_plugin_with_file_arg() throws IOException {
+     void instantiates_pretty_plugin_with_file_arg() throws IOException {
         Object plugin = fc.create(parse("pretty:" + TempDir.createTempFile().toURI().toURL()));
         assertThat(plugin.getClass(), is(equalTo(PrettyFormatter.class)));
     }
 
     @Test
-    public void instantiates_pretty_plugin_without_file_arg() {
+     void instantiates_pretty_plugin_without_file_arg() {
         Object plugin = fc.create(parse("pretty"));
         assertThat(plugin.getClass(), is(equalTo(PrettyFormatter.class)));
     }
 
     @Test
-    public void instantiates_usage_plugin_without_file_arg() {
+     void instantiates_usage_plugin_without_file_arg() {
         Object plugin = fc.create(parse("usage"));
         assertThat(plugin.getClass(), is(equalTo(UsageFormatter.class)));
     }
 
     @Test
-    public void instantiates_usage_plugin_with_file_arg() throws IOException {
+     void instantiates_usage_plugin_with_file_arg() throws IOException {
         Object plugin = fc.create(parse("usage:" + TempDir.createTempFile().getAbsolutePath()));
         assertThat(plugin.getClass(), is(equalTo(UsageFormatter.class)));
     }
 
     @Test
-    public void plugin_does_not_buffer_its_output() {
+     void plugin_does_not_buffer_its_output() {
         PrintStream previousSystemOut = System.out;
         OutputStream mockSystemOut = new ByteArrayOutputStream();
 
@@ -106,7 +106,7 @@ public class PluginFactoryTest {
     }
 
     @Test
-    public void instantiates_single_custom_appendable_plugin_with_stdout() {
+     void instantiates_single_custom_appendable_plugin_with_stdout() {
         WantsAppendable plugin = (WantsAppendable) fc.create(parse("io.cucumber.core.plugin.PluginFactoryTest$WantsAppendable"));
         assertThat(plugin.out, is(instanceOf(PrintStream.class)));
 
@@ -120,7 +120,7 @@ public class PluginFactoryTest {
     }
 
     @Test
-    public void instantiates_custom_appendable_plugin_with_stdout_and_file() throws IOException {
+     void instantiates_custom_appendable_plugin_with_stdout_and_file() throws IOException {
         WantsAppendable plugin = (WantsAppendable) fc.create(parse("io.cucumber.core.plugin.PluginFactoryTest$WantsAppendable"));
         assertThat(plugin.out, is(instanceOf(PrintStream.class)));
 
@@ -129,56 +129,56 @@ public class PluginFactoryTest {
     }
 
     @Test
-    public void instantiates_custom_url_plugin() throws IOException {
+     void instantiates_custom_url_plugin() throws IOException {
         WantsUrl plugin = (WantsUrl) fc.create(parse("io.cucumber.core.plugin.PluginFactoryTest$WantsUrl:halp"));
         assertThat(plugin.out, is(equalTo(new URL("file:halp/"))));
     }
 
     @Test
-    public void instantiates_custom_url_plugin_with_http() throws IOException {
+     void instantiates_custom_url_plugin_with_http() throws IOException {
         WantsUrl plugin = (WantsUrl) fc.create(parse("io.cucumber.core.plugin.PluginFactoryTest$WantsUrl:http://halp/"));
         assertThat(plugin.out, is(equalTo(new URL("http://halp/"))));
     }
 
     @Test
-    public void instantiates_custom_uri_plugin_with_ws() throws URISyntaxException {
+     void instantiates_custom_uri_plugin_with_ws() throws URISyntaxException {
         WantsUri plugin = (WantsUri) fc.create(parse("io.cucumber.core.plugin.PluginFactoryTest$WantsUri:ws://halp/"));
         assertThat(plugin.out, is(equalTo(new URI("ws://halp/"))));
     }
 
     @Test
-    public void instantiates_custom_file_plugin() {
+     void instantiates_custom_file_plugin() {
         WantsFile plugin = (WantsFile) fc.create(parse("io.cucumber.core.plugin.PluginFactoryTest$WantsFile:halp.txt"));
         assertThat(plugin.out, is(equalTo(new File("halp.txt"))));
     }
 
     @Test
-    public void instantiates_custom_string_arg_plugin() {
+     void instantiates_custom_string_arg_plugin() {
         WantsString plugin = (WantsString) fc.create(parse("io.cucumber.core.plugin.PluginFactoryTest$WantsString:hello"));
         assertThat(plugin.arg, is(equalTo("hello")));
     }
 
     @Test
-    public void instantiates_plugin_using_empty_constructor_when_unspecified() {
+     void instantiates_plugin_using_empty_constructor_when_unspecified() {
         WantsStringOrDefault plugin = (WantsStringOrDefault) fc.create(parse("io.cucumber.core.plugin.PluginFactoryTest$WantsStringOrDefault"));
         assertThat(plugin.arg, is(equalTo("defaultValue")));
     }
 
     @Test
-    public void instantiates_plugin_using_arg_constructor_when_specified() {
+     void instantiates_plugin_using_arg_constructor_when_specified() {
         WantsStringOrDefault plugin = (WantsStringOrDefault) fc.create(parse("io.cucumber.core.plugin.PluginFactoryTest$WantsStringOrDefault:hello"));
         assertThat(plugin.arg, is(equalTo("hello")));
     }
 
     @Test
-    public void instantiates_timeline_plugin_with_dir_arg() throws IOException {
+     void instantiates_timeline_plugin_with_dir_arg() throws IOException {
         Object plugin = fc.create(parse("timeline:" + TempDir.createTempDirectory().getAbsolutePath()));
         assertThat(plugin.getClass(), is(equalTo(TimelineFormatter.class)));
     }
 
 
     @Test
-    public void test_url() throws MalformedURLException {
+     void test_url() throws MalformedURLException {
         URL dotCucumber = PluginFactory.toURL("foo/bar/.cucumber");
         URL url = new URL(dotCucumber, "stepdefs.json");
         assertThat(url, is(equalTo(new URL("file:foo/bar/.cucumber/stepdefs.json"))));

--- a/core/src/test/java/io/cucumber/core/plugin/PluginsTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/PluginsTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class})
-public class PluginsTest {
+class PluginsTest {
 
     @Mock
     private EventPublisher rootEventPublisher;
@@ -31,7 +31,7 @@ public class PluginsTest {
     private PluginFactory pluginFactory = new PluginFactory();
 
     @Test
-    public void shouldSetStrictOnPlugin() {
+    void shouldSetStrictOnPlugin() {
         RuntimeOptions runtimeOptions = RuntimeOptions.defaultOptions();
         Plugins plugins = new Plugins(pluginFactory, runtimeOptions);
         StrictAware plugin = mock(StrictAware.class);
@@ -40,7 +40,7 @@ public class PluginsTest {
     }
 
     @Test
-    public void shouldSetMonochromeOnPlugin() {
+    void shouldSetMonochromeOnPlugin() {
         RuntimeOptions runtimeOptions = RuntimeOptions.defaultOptions();
         Plugins plugins = new Plugins(pluginFactory, runtimeOptions);
         ColorAware plugin = mock(ColorAware.class);
@@ -49,7 +49,7 @@ public class PluginsTest {
     }
 
     @Test
-    public void shouldSetConcurrentEventListener() {
+    void shouldSetConcurrentEventListener() {
         RuntimeOptions runtimeOptions = RuntimeOptions.defaultOptions();
         Plugins plugins = new Plugins(pluginFactory, runtimeOptions);
         ConcurrentEventListener plugin = mock(ConcurrentEventListener.class);
@@ -59,7 +59,7 @@ public class PluginsTest {
     }
 
     @Test
-    public void shouldSetNonConcurrentEventListener() {
+    void shouldSetNonConcurrentEventListener() {
         RuntimeOptions runtimeOptions = RuntimeOptions.defaultOptions();
         Plugins plugins = new Plugins(pluginFactory, runtimeOptions);
         EventListener plugin = mock(EventListener.class);
@@ -70,7 +70,7 @@ public class PluginsTest {
     }
 
     @Test
-    public void shouldRegisterCanonicalOrderEventPublisherWithRootEventPublisher() {
+    void shouldRegisterCanonicalOrderEventPublisherWithRootEventPublisher() {
         RuntimeOptions runtimeOptions = RuntimeOptions.defaultOptions();
         Plugins plugins = new Plugins(pluginFactory, runtimeOptions);
         EventListener plugin = mock(EventListener.class);

--- a/core/src/test/java/io/cucumber/core/plugin/StatsTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/StatsTest.java
@@ -17,12 +17,12 @@ import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class StatsTest {
+class StatsTest {
 
     private static final Instant ANY_TIME = Instant.ofEpochMilli(1234567890);
 
     @Test
-    public void should_print_zero_scenarios_zero_steps_if_nothing_has_executed() {
+    void should_print_zero_scenarios_zero_steps_if_nothing_has_executed() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         counter.printStats(new PrintStream(baos));
@@ -33,7 +33,7 @@ public class StatsTest {
     }
 
     @Test
-    public void should_only_print_sub_counts_if_not_zero() {
+    void should_only_print_sub_counts_if_not_zero() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -49,7 +49,7 @@ public class StatsTest {
     }
 
     @Test
-    public void should_print_sub_counts_in_order_failed_ambiguous_skipped_pending_undefined_passed() {
+    void should_print_sub_counts_in_order_failed_ambiguous_skipped_pending_undefined_passed() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -67,7 +67,7 @@ public class StatsTest {
     }
 
     @Test
-    public void should_print_sub_counts_in_order_failed_ambiguous_skipped_undefined_passed_in_color() {
+    void should_print_sub_counts_in_order_failed_ambiguous_skipped_undefined_passed_in_color() {
         Stats counter = createColorSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -92,7 +92,7 @@ public class StatsTest {
     }
 
     @Test
-    public void should_print_zero_m_zero_s_if_nothing_has_executed() {
+    void should_print_zero_m_zero_s_if_nothing_has_executed() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -103,7 +103,7 @@ public class StatsTest {
     }
 
     @Test
-    public void should_report_the_difference_between_finish_time_and_start_time() {
+    void should_report_the_difference_between_finish_time_and_start_time() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -116,7 +116,7 @@ public class StatsTest {
     }
 
     @Test
-    public void should_print_minutes_seconds_and_milliseconds() {
+    void should_print_minutes_seconds_and_milliseconds() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -129,7 +129,7 @@ public class StatsTest {
     }
 
     @Test
-    public void should_print_minutes_instead_of_hours() {
+    void should_print_minutes_instead_of_hours() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -142,7 +142,7 @@ public class StatsTest {
     }
 
     @Test
-    public void should_use_locale_for_decimal_separator() {
+    void should_use_locale_for_decimal_separator() {
         Stats counter = new Stats(Locale.GERMANY);
         counter.setStrict(true);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -155,7 +155,7 @@ public class StatsTest {
     }
 
     @Test
-    public void should_print_failed_ambiguous_scenarios() {
+    void should_print_failed_ambiguous_scenarios() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -180,7 +180,7 @@ public class StatsTest {
     }
 
     @Test
-    public void should_print_failed_ambiguous_pending_undefined_scenarios_if_strict() {
+    void should_print_failed_ambiguous_pending_undefined_scenarios_if_strict() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 

--- a/core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
@@ -14,10 +14,10 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class UnusedStepsSummaryPrinterTest {
+class UnusedStepsSummaryPrinterTest {
 
     @Test
-    public void verifyUnusedStepsPrinted() {
+    void verifyUnusedStepsPrinted() {
         StringBuilder out = new StringBuilder();
         UnusedStepsSummaryPrinter summaryPrinter = new UnusedStepsSummaryPrinter(out);
         TimeServiceEventBus bus = new TimeServiceEventBus(Clock.systemUTC());

--- a/core/src/test/java/io/cucumber/core/reflection/MethodFormatTest.java
+++ b/core/src/test/java/io/cucumber/core/reflection/MethodFormatTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MethodFormatTest {
+class MethodFormatTest {
 
     private Method methodWithArgsAndException;
     private Method methodWithoutArgs;
@@ -25,23 +25,23 @@ public class MethodFormatTest {
     }
 
     @BeforeEach
-    public void lookupMethod() throws NoSuchMethodException {
+    void lookupMethod() throws NoSuchMethodException {
         this.methodWithoutArgs = this.getClass().getMethod("methodWithoutArgs");
         this.methodWithArgsAndException = this.getClass().getMethod("methodWithArgsAndException", String.class, Map.class);
     }
 
     @Test
-    public void shouldUseSimpleFormatWhenMethodHasException() {
+    void shouldUseSimpleFormatWhenMethodHasException() {
         assertThat(MethodFormat.SHORT.format(methodWithArgsAndException), is(equalTo("MethodFormatTest.methodWithArgsAndException(String,Map)")));
     }
 
     @Test
-    public void shouldUseSimpleFormatWhenMethodHasNoException() {
+    void shouldUseSimpleFormatWhenMethodHasNoException() {
         assertThat(MethodFormat.SHORT.format(methodWithoutArgs), is(equalTo("MethodFormatTest.methodWithoutArgs()")));
     }
 
     @Test
-    public void prints_code_source() {
+    void prints_code_source() {
         String format = MethodFormat.FULL.format(methodWithoutArgs);
         assertTrue(format.startsWith("io.cucumber.core.reflection.MethodFormatTest.methodWithoutArgs() in file:"));
     }

--- a/core/src/test/java/io/cucumber/core/runtime/BackendServiceLoaderTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/BackendServiceLoaderTest.java
@@ -15,10 +15,10 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class BackendServiceLoaderTest {
+class BackendServiceLoaderTest {
 
     @Test
-    public void should_create_a_backend() {
+    void should_create_a_backend() {
         ClassLoader classLoader = getClass().getClassLoader();
         RuntimeOptions runtimeOptions = RuntimeOptions.defaultOptions();
         ResourceLoader resourceLoader = new MultiLoader(classLoader);
@@ -29,7 +29,7 @@ public class BackendServiceLoaderTest {
     }
 
     @Test
-    public void should_throw_an_exception_when_no_backend_could_be_found() {
+    void should_throw_an_exception_when_no_backend_could_be_found() {
         ClassLoader classLoader = getClass().getClassLoader();
         RuntimeOptions runtimeOptions = RuntimeOptions.defaultOptions();
         ResourceLoader resourceLoader = new MultiLoader(classLoader);

--- a/core/src/test/java/io/cucumber/core/runtime/ExitStatusTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/ExitStatusTest.java
@@ -18,7 +18,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 
-public class ExitStatusTest {
+class ExitStatusTest {
 
     private final static Instant ANY_INSTANT = Instant.ofEpochMilli(1234567890);
 
@@ -26,7 +26,7 @@ public class ExitStatusTest {
     private Runtime.ExitStatus exitStatus;
 
     @Test
-    public void non_strict_wip_with_ambiguous_scenarios() {
+    void non_strict_wip_with_ambiguous_scenarios() {
         createNonStrictWipExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.AMBIGUOUS));
 
@@ -51,7 +51,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void non_strict_wip_with_failed_scenarios() {
+    void non_strict_wip_with_failed_scenarios() {
         createNonStrictWipExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
@@ -59,7 +59,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void non_strict_wip_with_passed_scenarios() {
+    void non_strict_wip_with_passed_scenarios() {
         createNonStrictWipExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
 
@@ -67,7 +67,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void non_strict_wip_with_pending_scenarios() {
+    void non_strict_wip_with_pending_scenarios() {
         createNonStrictWipExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.PENDING));
 
@@ -75,7 +75,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void non_strict_wip_with_skipped_scenarios() {
+    void non_strict_wip_with_skipped_scenarios() {
         createNonStrictWipExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.SKIPPED));
 
@@ -83,14 +83,14 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void non_strict_wip_with_undefined_scenarios() {
+    void non_strict_wip_with_undefined_scenarios() {
         createNonStrictWipExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.UNDEFINED));
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
     }
 
     @Test
-    public void non_strict_with_ambiguous_scenarios() {
+    void non_strict_with_ambiguous_scenarios() {
         createNonStrictExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.AMBIGUOUS));
 
@@ -102,7 +102,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void non_strict_with_failed_scenarios() {
+    void non_strict_with_failed_scenarios() {
         createNonStrictExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
@@ -110,7 +110,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void non_strict_with_passed_scenarios() {
+    void non_strict_with_passed_scenarios() {
         createNonStrictExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
 
@@ -118,7 +118,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void non_strict_with_pending_scenarios() {
+    void non_strict_with_pending_scenarios() {
         createNonStrictExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.PENDING));
 
@@ -126,7 +126,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void non_strict_with_skipped_scenarios() {
+    void non_strict_with_skipped_scenarios() {
         createNonStrictExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.SKIPPED));
 
@@ -134,20 +134,20 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void non_strict_with_undefined_scenarios() {
+    void non_strict_with_undefined_scenarios() {
         createNonStrictExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.UNDEFINED));
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
     }
 
     @Test
-    public void should_pass_if_no_features_are_found() {
+    void should_pass_if_no_features_are_found() {
         createStrictRuntime();
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
     }
 
     @Test
-    public void strict_wip_with_ambiguous_scenarios() {
+    void strict_wip_with_ambiguous_scenarios() {
         createStrictWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.AMBIGUOUS));
 
@@ -159,7 +159,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_wip_with_failed_failed_scenarios() {
+    void strict_wip_with_failed_failed_scenarios() {
         createStrictWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
@@ -168,7 +168,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_wip_with_failed_passed_scenarios() {
+    void strict_wip_with_failed_passed_scenarios() {
         createStrictWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
@@ -177,7 +177,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_wip_with_failed_scenarios() {
+    void strict_wip_with_failed_scenarios() {
         createStrictWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
@@ -185,7 +185,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_wip_with_passed_failed_scenarios() {
+    void strict_wip_with_passed_failed_scenarios() {
         createStrictWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
@@ -194,7 +194,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_wip_with_passed_scenarios() {
+    void strict_wip_with_passed_scenarios() {
         createStrictWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
 
@@ -202,7 +202,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_wip_with_pending_scenarios() {
+    void strict_wip_with_pending_scenarios() {
         createStrictWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PENDING));
 
@@ -210,7 +210,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_wip_with_skipped_scenarios() {
+    void strict_wip_with_skipped_scenarios() {
         createNonStrictWipExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.SKIPPED));
 
@@ -218,14 +218,14 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_wip_with_undefined_scenarios() {
+    void strict_wip_with_undefined_scenarios() {
         createStrictWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.UNDEFINED));
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
     }
 
     @Test
-    public void strict_with_ambiguous_scenarios() {
+    void strict_with_ambiguous_scenarios() {
         createStrictRuntime();
         bus.send(testCaseFinishedWithStatus(Status.AMBIGUOUS));
 
@@ -237,7 +237,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_with_failed_failed_scenarios() {
+    void strict_with_failed_failed_scenarios() {
         createStrictRuntime();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
@@ -246,7 +246,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_with_failed_passed_scenarios() {
+    void strict_with_failed_passed_scenarios() {
         createStrictRuntime();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
@@ -255,7 +255,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_with_failed_scenarios() {
+    void strict_with_failed_scenarios() {
         createStrictRuntime();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
@@ -263,7 +263,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_with_passed_failed_scenarios() {
+    void strict_with_passed_failed_scenarios() {
         createStrictRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
@@ -272,7 +272,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_with_passed_passed_scenarios() {
+    void strict_with_passed_passed_scenarios() {
         createStrictRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
@@ -281,7 +281,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_with_passed_scenarios() {
+    void strict_with_passed_scenarios() {
         createStrictRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
 
@@ -289,7 +289,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_with_pending_scenarios() {
+    void strict_with_pending_scenarios() {
         createStrictRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PENDING));
 
@@ -297,7 +297,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_with_skipped_scenarios() {
+    void strict_with_skipped_scenarios() {
         createNonStrictExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.SKIPPED));
 
@@ -305,7 +305,7 @@ public class ExitStatusTest {
     }
 
     @Test
-    public void strict_with_undefined_scenarios() {
+    void strict_with_undefined_scenarios() {
         createStrictRuntime();
         bus.send(testCaseFinishedWithStatus(Status.UNDEFINED));
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x1)));

--- a/core/src/test/java/io/cucumber/core/runtime/FeaturePathFeatureSupplierTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/FeaturePathFeatureSupplierTest.java
@@ -18,23 +18,23 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class FeaturePathFeatureSupplierTest {
+class FeaturePathFeatureSupplierTest {
 
     private LogRecordListener logRecordListener;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         logRecordListener = new LogRecordListener();
         LoggerFactory.addListener(logRecordListener);
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         LoggerFactory.removeListener(logRecordListener);
     }
 
     @Test
-    public void logs_message_if_no_features_are_found() {
+    void logs_message_if_no_features_are_found() {
         ResourceLoader resourceLoader = mock(ResourceLoader.class);
         when(resourceLoader.resources(URI.create("file:does/not/exist"), ".feature")).thenReturn(Collections.emptyList());
         Options featureOptions = () -> Collections.singletonList(FeaturePath.parse("does/not/exist"));
@@ -45,7 +45,7 @@ public class FeaturePathFeatureSupplierTest {
     }
 
     @Test
-    public void logs_message_if_no_feature_paths_are_given() {
+    void logs_message_if_no_feature_paths_are_given() {
         ResourceLoader resourceLoader = mock(ResourceLoader.class);
         Options featureOptions = Collections::emptyList;
 

--- a/core/src/test/java/io/cucumber/core/runtime/SingletonRunnerSupplierTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/SingletonRunnerSupplierTest.java
@@ -17,12 +17,12 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-public class SingletonRunnerSupplierTest {
+class SingletonRunnerSupplierTest {
 
     private SingletonRunnerSupplier runnerSupplier;
 
     @BeforeEach
-    public void before() {
+    void before() {
         ClassLoader classLoader = getClass().getClassLoader();
         ResourceLoader resourceLoader = new MultiLoader(classLoader);
         RuntimeOptions runtimeOptions = RuntimeOptions.defaultOptions();
@@ -36,12 +36,12 @@ public class SingletonRunnerSupplierTest {
     }
 
     @Test
-    public void should_create_a_runner() {
+    void should_create_a_runner() {
         assertThat(runnerSupplier.get(), is(notNullValue()));
     }
 
     @Test
-    public void should_return_the_same_runner_on_subsequent_calls() {
+    void should_return_the_same_runner_on_subsequent_calls() {
         assertThat(runnerSupplier.get(), is(equalTo(runnerSupplier.get())));
     }
 

--- a/core/src/test/java/io/cucumber/core/snippets/ArgumentPatternTest.java
+++ b/core/src/test/java/io/cucumber/core/snippets/ArgumentPatternTest.java
@@ -8,23 +8,23 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-public class ArgumentPatternTest {
+class ArgumentPatternTest {
 
     private Pattern singleDigit = Pattern.compile("(\\d)");
     private ArgumentPattern argumentPattern = new ArgumentPattern(singleDigit);
 
     @Test
-    public void replacesMatchWithoutEscapedNumberClass() {
+    void replacesMatchWithoutEscapedNumberClass() {
         assertThat(argumentPattern.replaceMatchesWithGroups("1"), is(equalTo("(\\d)")));
     }
 
     @Test
-    public void replacesMultipleMatchesWithPattern() {
+    void replacesMultipleMatchesWithPattern() {
         assertThat(argumentPattern.replaceMatchesWithGroups("13"), is(equalTo("(\\d)(\\d)")));
     }
 
     @Test
-    public void replaceMatchWithSpace() {
+    void replaceMatchWithSpace() {
         assertThat(argumentPattern.replaceMatchesWithSpace("4"), is(equalTo(" ")));
     }
 

--- a/core/src/test/java/io/cucumber/core/snippets/FunctionNameGeneratorTest.java
+++ b/core/src/test/java/io/cucumber/core/snippets/FunctionNameGeneratorTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class FunctionNameGeneratorTest {
+class FunctionNameGeneratorTest {
 
     private FunctionNameGenerator underscore = new FunctionNameGenerator(SnippetType.UNDERSCORE.joiner());
     private FunctionNameGenerator camelCase = new FunctionNameGenerator(SnippetType.CAMELCASE.joiner());
@@ -22,14 +22,14 @@ public class FunctionNameGeneratorTest {
     }
 
     @Test
-    public void testSanitizeEmptyFunctionName() {
+    void testSanitizeEmptyFunctionName() {
         Executable testMethod = () -> underscore.generateFunctionName("");
         IllegalArgumentException expectedThrown = assertThrows(IllegalArgumentException.class, testMethod);
         assertThat(expectedThrown.getMessage(), is(equalTo("Cannot create function name from empty sentence")));
     }
 
     @Test
-    public void testSanitizeFunctionName() {
+    void testSanitizeFunctionName() {
         assertFunctionNames(
             "test_function_123",
             "testFunction123",
@@ -37,7 +37,7 @@ public class FunctionNameGeneratorTest {
     }
 
     @Test
-    public void sanitizes_simple_sentence() {
+    void sanitizes_simple_sentence() {
         assertFunctionNames(
             "i_am_a_function_name",
             "iAmAFunctionName",
@@ -45,7 +45,7 @@ public class FunctionNameGeneratorTest {
     }
 
     @Test
-    public void sanitizes_sentence_with_multiple_spaces() {
+    void sanitizes_sentence_with_multiple_spaces() {
         assertFunctionNames(
             "i_am_a_function_name",
             "iAmAFunctionName",
@@ -53,7 +53,7 @@ public class FunctionNameGeneratorTest {
     }
 
     @Test
-    public void sanitizes_pascal_case_word() {
+    void sanitizes_pascal_case_word() {
         assertFunctionNames(
             "function_name_with_pascalCase_word",
             "functionNameWithPascalCaseWord",
@@ -61,7 +61,7 @@ public class FunctionNameGeneratorTest {
     }
 
     @Test
-    public void sanitizes_camel_case_word() {
+    void sanitizes_camel_case_word() {
         assertFunctionNames(
             "function_name_with_CamelCase_word",
             "functionNameWithCamelCaseWord",
@@ -69,7 +69,7 @@ public class FunctionNameGeneratorTest {
     }
 
     @Test
-    public void sanitizes_acronyms() {
+    void sanitizes_acronyms() {
         assertFunctionNames(
             "function_name_with_multi_char_acronym_HTTP_Server",
             "functionNameWithMultiCharAcronymHTTPServer",
@@ -77,7 +77,7 @@ public class FunctionNameGeneratorTest {
     }
 
     @Test
-    public void sanitizes_two_char_acronym() {
+    void sanitizes_two_char_acronym() {
         assertFunctionNames(
             "function_name_with_two_char_acronym_US",
             "functionNameWithTwoCharAcronymUS",

--- a/guice/src/test/java/io/cucumber/guice/GuiceFactoryTest.java
+++ b/guice/src/test/java/io/cucumber/guice/GuiceFactoryTest.java
@@ -24,14 +24,14 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class GuiceFactoryTest {
+class GuiceFactoryTest {
 
     private ObjectFactory factory;
     private List<?> instancesFromSameScenario;
     private List<?> instancesFromDifferentScenarios;
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         // If factory is left in start state it can cause cascading failures due to scope being left open
         try {
             factory.stop();
@@ -40,19 +40,19 @@ public class GuiceFactoryTest {
     }
 
     @Test
-    public void factoryCanBeIntantiatedWithDefaultConstructor() {
+    void factoryCanBeIntantiatedWithDefaultConstructor() {
         factory = new GuiceFactory();
         assertThat(factory, notNullValue());
     }
 
     @Test
-    public void factoryCanBeIntantiatedWithArgConstructor() {
+    void factoryCanBeIntantiatedWithArgConstructor() {
         factory = new GuiceFactory(Guice.createInjector());
         assertThat(factory, notNullValue());
     }
 
     @Test
-    public void factoryStartFailsIfScenarioScopeIsNotBound() {
+    void factoryStartFailsIfScenarioScopeIsNotBound() {
         factory = new GuiceFactory(Guice.createInjector());
 
         Executable testMethod = () -> factory.start();
@@ -69,14 +69,14 @@ public class GuiceFactoryTest {
     }
 
     @Test
-    public void shouldGiveNewInstancesOfUnscopedClassWithinAScenario() {
+    void shouldGiveNewInstancesOfUnscopedClassWithinAScenario() {
         factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromSameScenario = getInstancesFromSameScenario(factory, UnscopedClass.class);
         assertThat(instancesFromSameScenario, ElementsAreAllUniqueMatcher.elementsAreAllUnique());
     }
 
     @Test
-    public void shouldGiveNewInstanceOfUnscopedClassForEachScenario() {
+    void shouldGiveNewInstanceOfUnscopedClassForEachScenario() {
         factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory, UnscopedClass.class);
         assertThat(instancesFromDifferentScenarios, ElementsAreAllUniqueMatcher.elementsAreAllUnique());
@@ -87,14 +87,14 @@ public class GuiceFactoryTest {
     }
 
     @Test
-    public void shouldGiveTheSameInstanceOfAnnotatedScenarioScopedClassWithinAScenario() {
+    void shouldGiveTheSameInstanceOfAnnotatedScenarioScopedClassWithinAScenario() {
         factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromSameScenario = getInstancesFromSameScenario(factory, AnnotatedScenarioScopedClass.class);
         assertThat(instancesFromSameScenario, ElementsAreAllEqualMatcher.elementsAreAllEqual());
     }
 
     @Test
-    public void shouldGiveNewInstanceOfAnnotatedScenarioScopedClassForEachScenario() {
+    void shouldGiveNewInstanceOfAnnotatedScenarioScopedClassForEachScenario() {
         factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory, AnnotatedScenarioScopedClass.class);
         assertThat(instancesFromDifferentScenarios, ElementsAreAllUniqueMatcher.elementsAreAllUnique());
@@ -105,14 +105,14 @@ public class GuiceFactoryTest {
     }
 
     @Test
-    public void shouldGiveTheSameInstanceOfAnnotatedSingletonClassWithinAScenario() {
+    void shouldGiveTheSameInstanceOfAnnotatedSingletonClassWithinAScenario() {
         factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromSameScenario = getInstancesFromSameScenario(factory, AnnotatedSingletonClass.class);
         assertThat(instancesFromSameScenario, ElementsAreAllEqualMatcher.elementsAreAllEqual());
     }
 
     @Test
-    public void shouldGiveTheSameInstanceOfAnnotatedSingletonClassForEachScenario() {
+    void shouldGiveTheSameInstanceOfAnnotatedSingletonClassForEachScenario() {
         factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
         instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory, AnnotatedSingletonClass.class);
         assertThat(instancesFromDifferentScenarios, ElementsAreAllEqualMatcher.elementsAreAllEqual());
@@ -129,14 +129,14 @@ public class GuiceFactoryTest {
     };
 
     @Test
-    public void shouldGiveTheSameInstanceOfBoundScenarioScopedClassWithinAScenario() {
+    void shouldGiveTheSameInstanceOfBoundScenarioScopedClassWithinAScenario() {
         factory = new GuiceFactory(injector(CucumberModules.createScenarioModule(), boundScenarioScopedClassModule));
         instancesFromSameScenario = getInstancesFromSameScenario(factory, BoundScenarioScopedClass.class);
         assertThat(instancesFromSameScenario, ElementsAreAllEqualMatcher.elementsAreAllEqual());
     }
 
     @Test
-    public void shouldGiveNewInstanceOfBoundScenarioScopedClassForEachScenario() {
+    void shouldGiveNewInstanceOfBoundScenarioScopedClassForEachScenario() {
         factory = new GuiceFactory(injector(CucumberModules.SCENARIO, boundScenarioScopedClassModule));
         instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory, BoundScenarioScopedClass.class);
         assertThat(instancesFromDifferentScenarios, ElementsAreAllUniqueMatcher.elementsAreAllUnique());
@@ -153,21 +153,21 @@ public class GuiceFactoryTest {
     };
 
     @Test
-    public void shouldGiveTheSameInstanceOfBoundSingletonClassWithinAScenario() {
+    void shouldGiveTheSameInstanceOfBoundSingletonClassWithinAScenario() {
         factory = new GuiceFactory(injector(CucumberModules.SCENARIO, boundSingletonClassModule));
         instancesFromSameScenario = getInstancesFromSameScenario(factory, BoundSingletonClass.class);
         assertThat(instancesFromSameScenario, ElementsAreAllEqualMatcher.elementsAreAllEqual());
     }
 
     @Test
-    public void shouldGiveTheSameInstanceOfBoundSingletonClassForEachScenario() {
+    void shouldGiveTheSameInstanceOfBoundSingletonClassForEachScenario() {
         factory = new GuiceFactory(injector(CucumberModules.createScenarioModule(), boundSingletonClassModule));
         instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory, BoundSingletonClass.class);
         assertThat(instancesFromDifferentScenarios, ElementsAreAllEqualMatcher.elementsAreAllEqual());
     }
 
     @Test
-    public void shouldGiveNewInstanceOfAnnotatedSingletonClassForEachScenarioWhenOverridingModuleBindingIsScenarioScope() {
+    void shouldGiveNewInstanceOfAnnotatedSingletonClassForEachScenarioWhenOverridingModuleBindingIsScenarioScope() {
         factory = new GuiceFactory(injector(CucumberModules.createScenarioModule(), new AbstractModule() {
             @Override
             protected void configure() {

--- a/java/src/test/java/io/cucumber/java/AbstractGlueDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/AbstractGlueDefinitionTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class AbstractGlueDefinitionTest {
+class AbstractGlueDefinitionTest {
 
     private final Lookup lookup = new Lookup() {
 
@@ -22,7 +22,7 @@ public class AbstractGlueDefinitionTest {
     };
 
     @Test
-    public void test() throws NoSuchMethodException {
+    void test() throws NoSuchMethodException {
         Method method = AbstractGlueDefinitionTest.class.getMethod("method");
 
         AbstractGlueDefinition definition = new AbstractGlueDefinition(method, lookup) {

--- a/java/src/test/java/io/cucumber/java/JavaDefaultParameterTransformerDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDefaultParameterTransformerDefinitionTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class JavaDefaultParameterTransformerDefinitionTest {
+class JavaDefaultParameterTransformerDefinitionTest {
 
     private final Lookup lookup = new Lookup() {
 
@@ -24,7 +24,7 @@ public class JavaDefaultParameterTransformerDefinitionTest {
     };
 
     @Test
-    public void can_transform_string_to_type() throws Throwable {
+    void can_transform_string_to_type() throws Throwable {
         Method method = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("transform_string_to_type", String.class, Type.class);
         JavaDefaultParameterTransformerDefinition definition = new JavaDefaultParameterTransformerDefinition(method, lookup);
         Object transformed = definition.parameterByTypeTransformer().transform("something", String.class);
@@ -36,7 +36,7 @@ public class JavaDefaultParameterTransformerDefinitionTest {
     }
 
     @Test
-    public void can_transform_object_to_type() throws Throwable {
+    void can_transform_object_to_type() throws Throwable {
         Method method = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("transform_object_to_type", Object.class, Type.class);
         JavaDefaultParameterTransformerDefinition definition = new JavaDefaultParameterTransformerDefinition(method, lookup);
         String transformed = (String) definition.parameterByTypeTransformer().transform("something", String.class);
@@ -48,7 +48,7 @@ public class JavaDefaultParameterTransformerDefinitionTest {
     }
 
     @Test
-    public void must_have_non_void_return() throws Throwable {
+    void must_have_non_void_return() throws Throwable {
         Method method = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("transforms_string_to_void", String.class, Type.class);
         InvalidMethodSignatureException exception = assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultParameterTransformerDefinition(method, lookup));
         assertThat(exception.getMessage(), startsWith("" +
@@ -63,7 +63,7 @@ public class JavaDefaultParameterTransformerDefinitionTest {
     }
 
     @Test
-    public void must_have_two_arguments() throws Throwable {
+    void must_have_two_arguments() throws Throwable {
         Method oneArg = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("one_argument", String.class);
         assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultParameterTransformerDefinition(oneArg, lookup));
         Method threeArg = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("three_arguments", String.class, Type.class, Object.class);
@@ -79,7 +79,7 @@ public class JavaDefaultParameterTransformerDefinitionTest {
     }
 
     @Test
-    public void must_have_string_or_object_as_from_value() throws Throwable {
+    void must_have_string_or_object_as_from_value() throws Throwable {
         Method threeArg = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("map_as_from_value", Map.class, Type.class);
         assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultParameterTransformerDefinition(threeArg, lookup));
     }
@@ -90,7 +90,7 @@ public class JavaDefaultParameterTransformerDefinitionTest {
     }
 
     @Test
-    public void must_have_type_as_to_value_type() throws Throwable {
+    void must_have_type_as_to_value_type() throws Throwable {
         Method threeArg = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("object_as_to_value_type", String.class, Object.class);
         assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultParameterTransformerDefinition(threeArg, lookup));
     }

--- a/java/src/test/java/io/cucumber/java/JavaStepDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaStepDefinitionTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class JavaStepDefinitionTest {
+class JavaStepDefinitionTest {
 
     private final Lookup lookup = new Lookup() {
 
@@ -26,7 +26,7 @@ public class JavaStepDefinitionTest {
     private String argument;
 
     @Test
-    public void can_define_step() throws Throwable {
+    void can_define_step() throws Throwable {
         Method method = JavaStepDefinitionTest.class.getMethod("one_string_argument", String.class);
         JavaStepDefinition definition = new JavaStepDefinition(method, "three (.*) mice", 0, lookup);
         definition.execute(new Object[]{"one_string_argument"});
@@ -38,7 +38,7 @@ public class JavaStepDefinitionTest {
     }
 
     @Test
-    public void can_provide_location_of_step() throws Throwable {
+    void can_provide_location_of_step() throws Throwable {
         Method method = JavaStepDefinitionTest.class.getMethod("method_throws");
         JavaStepDefinition definition = new JavaStepDefinition(method, "three (.*) mice", 0, lookup);
         PendingException exception = assertThrows(PendingException.class, () -> definition.execute(new Object[0]));

--- a/java/src/test/java/io/cucumber/java/JavaStepDefinitionTransposeTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaStepDefinitionTransposeTest.java
@@ -11,26 +11,16 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class JavaStepDefinitionTransposeTest {
-
-    public static class Steps {
-
-        public void mapOfDoubleToDouble(Map<Double, Double> mapOfDoubleToDouble) {
-
-        }
-
-        public void transposedMapOfDoubleToListOfDouble(@Transpose Map<Double, List<Double>> mapOfDoubleToListOfDouble) {
-        }
-    }
+class JavaStepDefinitionTransposeTest {
 
     @Test
-    public void transforms_to_map_of_double_to_double() throws Throwable {
+    void transforms_to_map_of_double_to_double() throws Throwable {
         Method m = Steps.class.getMethod("mapOfDoubleToDouble", Map.class);
         assertFalse(isTransposed(m));
     }
 
     @Test
-    public void transforms_transposed_to_map_of_double_to_double() throws Throwable {
+    void transforms_transposed_to_map_of_double_to_double() throws Throwable {
         Method m = Steps.class.getMethod("transposedMapOfDoubleToListOfDouble", Map.class);
         assertTrue(isTransposed(m));
     }
@@ -41,6 +31,16 @@ public class JavaStepDefinitionTransposeTest {
         StepDefinition stepDefinition = new JavaStepDefinition(method, "some text", 0, lookup);
 
         return stepDefinition.parameterInfos().get(0).isTransposed();
+    }
+
+    public static class Steps {
+
+        public void mapOfDoubleToDouble(Map<Double, Double> mapOfDoubleToDouble) {
+
+        }
+
+        public void transposedMapOfDoubleToListOfDouble(@Transpose Map<Double, List<Double>> mapOfDoubleToListOfDouble) {
+        }
     }
 
 }

--- a/java/src/test/java/io/cucumber/java/MethodScannerTest.java
+++ b/java/src/test/java/io/cucumber/java/MethodScannerTest.java
@@ -17,32 +17,32 @@ import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class MethodScannerTest {
+class MethodScannerTest {
 
     private final List<Map.Entry<Method, Annotation>> scanResult = new ArrayList<>();
     private BiConsumer<Method, Annotation> backend = (method, annotation) ->
         scanResult.add(new SimpleEntry<>(method, annotation));
 
     @BeforeEach
-    public void createBackend() {
+    void createBackend() {
 
     }
 
     @Test
-    public void scan_finds_annotated_methods() throws NoSuchMethodException {
+    void scan_finds_annotated_methods() throws NoSuchMethodException {
         Method method = BaseSteps.class.getMethod("m");
         MethodScanner.scan(BaseSteps.class, backend);
         assertThat(scanResult, contains(new SimpleEntry<>(method, method.getAnnotations()[0])));
     }
 
     @Test
-    public void scan_ignores_object() {
+    void scan_ignores_object() {
         MethodScanner.scan(Object.class, backend);
         assertThat(scanResult, empty());
     }
 
     @Test
-    public void loadGlue_fails_when_class_is_not_method_declaring_class() {
+    void loadGlue_fails_when_class_is_not_method_declaring_class() {
         InvalidMethodException exception = assertThrows(InvalidMethodException.class, () -> MethodScanner.scan(ExtendedSteps.class, backend));
         assertThat(exception.getMessage(), is(
             "You're not allowed to extend classes that define Step Definitions or hooks. " +

--- a/java8/src/test/java/io/cucumber/java8/Java8LambdaStepDefinitionTest.java
+++ b/java8/src/test/java/io/cucumber/java8/Java8LambdaStepDefinitionTest.java
@@ -12,10 +12,10 @@ import static org.hamcrest.core.Is.isA;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class Java8LambdaStepDefinitionTest {
+class Java8LambdaStepDefinitionTest {
 
     @Test
-    public void should_calculate_parameters_count_from_body_with_one_param() {
+    void should_calculate_parameters_count_from_body_with_one_param() {
         StepdefBody.A1<String> body = p1 -> {
         };
         Java8StepDefinition stepDefinition = Java8StepDefinition.create("some step", StepdefBody.A1.class, body);
@@ -23,7 +23,7 @@ public class Java8LambdaStepDefinitionTest {
     }
 
     @Test
-    public void should_calculate_parameters_count_from_body_with_two_params() {
+    void should_calculate_parameters_count_from_body_with_two_params() {
         StepdefBody.A2<String, String> body = (p1, p2) -> {
         };
         Java8StepDefinition stepDefinition = Java8StepDefinition.create("some step", StepdefBody.A2.class, body);
@@ -31,7 +31,7 @@ public class Java8LambdaStepDefinitionTest {
     }
 
     @Test
-    public void should_resolve_type_to_object() {
+    void should_resolve_type_to_object() {
         StepdefBody.A1 body = (p1) -> {
         };
         Java8StepDefinition stepDefinition = Java8StepDefinition.create("some step", StepdefBody.A1.class, body);
@@ -40,7 +40,7 @@ public class Java8LambdaStepDefinitionTest {
     }
 
     @Test
-    public void should_fail_for_param_with_non_generic_list() {
+    void should_fail_for_param_with_non_generic_list() {
         StepdefBody.A1<List> body = p1 -> {
         };
         Java8StepDefinition stepDefinition = Java8StepDefinition.create("some step", StepdefBody.A1.class, body);
@@ -53,7 +53,7 @@ public class Java8LambdaStepDefinitionTest {
     }
 
     @Test
-    public void should_fail_for_param_with_generic_list() {
+    void should_fail_for_param_with_generic_list() {
         StepdefBody.A1<List<String>> body = p1 -> {
         };
         Java8StepDefinition stepDefinition = Java8StepDefinition.create("some step", StepdefBody.A1.class, body);

--- a/needle/src/test/java/io/cucumber/needle/CollectInjectionProvidersFromStepsInstanceTest.java
+++ b/needle/src/test/java/io/cucumber/needle/CollectInjectionProvidersFromStepsInstanceTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.HashSet;
-import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -25,6 +24,18 @@ public class CollectInjectionProvidersFromStepsInstanceTest {
 
         return result;
     };
+    @ObjectUnderTest
+    private A a;
+
+    @Test
+    void shouldAddInjectionProviders() throws Exception {
+        final InjectionProvider<?>[] injectionProviders = function.apply(this);
+        assertThat(injectionProviders.length, is(1));
+
+        new MyNeedleTestcase(injectionProviders).initMyTestcase(this);
+
+        assertThat(a.bar, is("bar"));
+    }
 
     private static class MyNeedleTestcase extends NeedleTestcase {
 
@@ -42,19 +53,6 @@ public class CollectInjectionProvidersFromStepsInstanceTest {
         @Inject
         @Named("foo")
         private String bar;
-    }
-
-    @ObjectUnderTest
-    private A a;
-
-    @Test
-    public void shouldAddInjectionProviders() throws Exception {
-        final InjectionProvider<?>[] injectionProviders = function.apply(this);
-        assertThat(injectionProviders.length, is(1));
-
-        new MyNeedleTestcase(injectionProviders).initMyTestcase(this);
-
-        assertThat(a.bar, is("bar"));
     }
 
 }

--- a/needle/src/test/java/io/cucumber/needle/CreateInstanceByDefaultConstructorTest.java
+++ b/needle/src/test/java/io/cucumber/needle/CreateInstanceByDefaultConstructorTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class CreateInstanceByDefaultConstructorTest {
+class CreateInstanceByDefaultConstructorTest {
 
     public static class HasDefaultConstructor {
         // empty
@@ -24,12 +24,12 @@ public class CreateInstanceByDefaultConstructorTest {
     private final CreateInstanceByDefaultConstructor createInstanceByDefaultConstructor = CreateInstanceByDefaultConstructor.INSTANCE;
 
     @Test
-    public void shouldCreateNewInstance() {
+    void shouldCreateNewInstance() {
         assertThat(createInstanceByDefaultConstructor.apply(HasDefaultConstructor.class), is(notNullValue()));
     }
 
     @Test
-    public void shouldNotCreateNewInstanceWhenConstructorIsMissing() {
+    void shouldNotCreateNewInstanceWhenConstructorIsMissing() {
         Executable testMethod = () -> createInstanceByDefaultConstructor.apply(DoesNotHaveDefaultConstructor.class);
         IllegalStateException expectedThrown = assertThrows(IllegalStateException.class, testMethod);
         assertThat(expectedThrown.getMessage(), is(equalTo("Can not instantiate Instance by Default Constructor.")));

--- a/needle/src/test/java/io/cucumber/needle/CucumberNeedleConfigurationTest.java
+++ b/needle/src/test/java/io/cucumber/needle/CucumberNeedleConfigurationTest.java
@@ -11,13 +11,13 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CucumberNeedleConfigurationTest {
+class CucumberNeedleConfigurationTest {
 
     public abstract static class A implements InjectionProviderInstancesSupplier {
     }
 
     @Test
-    public void shouldReturnEmptyInstances() {
+    void shouldReturnEmptyInstances() {
         final InjectionProvider<?>[] allInjectionProviders = new CucumberNeedleConfiguration("resource-bundles/empty")
             .getInjectionProviders();
         assertThat(allInjectionProviders, is(notNullValue()));
@@ -25,7 +25,7 @@ public class CucumberNeedleConfigurationTest {
     }
 
     @Test
-    public void shouldEvaluateIfTypeIsInjectionProviderOrSupplier() {
+    void shouldEvaluateIfTypeIsInjectionProviderOrSupplier() {
         assertAll("Checking Needle Configuration",
             () -> assertTrue(CucumberNeedleConfiguration.isInjectionProvider(SimpleNameGetterProvider.class)),
             () -> assertFalse(CucumberNeedleConfiguration.isInjectionProviderInstanceSupplier(SimpleNameGetterProvider.class)),

--- a/needle/src/test/java/io/cucumber/needle/LoadCucumberNeedleResourceBundleTest.java
+++ b/needle/src/test/java/io/cucumber/needle/LoadCucumberNeedleResourceBundleTest.java
@@ -15,12 +15,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LoadCucumberNeedleResourceBundleTest {
+class LoadCucumberNeedleResourceBundleTest {
 
     private final LoadResourceBundle function = LoadResourceBundle.INSTANCE;
 
     @Test
-    public void shouldReturnEmptyResourceBundleWhenResourceDoesNotExist() {
+    void shouldReturnEmptyResourceBundleWhenResourceDoesNotExist() {
         final ResourceBundle resourceBundle = function.apply("does-not-exist");
 
         assertAll("Checking LoadResourceBundle",
@@ -30,14 +30,14 @@ public class LoadCucumberNeedleResourceBundleTest {
     }
 
     @Test
-    public void shouldReturnExistingResourceBundle() {
+    void shouldReturnExistingResourceBundle() {
         final ResourceBundle resourceBundle = function.apply("empty");
         assertThat(resourceBundle, is(notNullValue()));
         assertTrue(resourceBundle.keySet().isEmpty());
     }
 
     @Test
-    public void shouldAlwaysReturnEmptyForEmptyResourceBundle() {
+    void shouldAlwaysReturnEmptyForEmptyResourceBundle() {
         final ResourceBundle resourceBundle = LoadResourceBundle.EMPTY_RESOURCE_BUNDLE;
 
         assertAll("Checking ResourceBundle",
@@ -48,21 +48,21 @@ public class LoadCucumberNeedleResourceBundleTest {
     }
 
     @Test
-    public void shouldFailWhenResourceNameIsNull() {
+    void shouldFailWhenResourceNameIsNull() {
         Executable testMethod = () -> function.apply(null);
         IllegalArgumentException expectedThrown = assertThrows(IllegalArgumentException.class, testMethod);
         assertThat(expectedThrown.getMessage(), is(equalTo("resourceName must not be null or empty!")));
     }
 
     @Test
-    public void shouldFailWhenResourceNameIsEmpty() {
+    void shouldFailWhenResourceNameIsEmpty() {
         Executable testMethod = () -> function.apply("");
         IllegalArgumentException expectedThrown = assertThrows(IllegalArgumentException.class, testMethod);
         assertThat(expectedThrown.getMessage(), is(equalTo("resourceName must not be null or empty!")));
     }
 
     @Test
-    public void shouldFailWhenResourceNameIsBlank() {
+    void shouldFailWhenResourceNameIsBlank() {
         Executable testMethod = () -> function.apply(" ");
         IllegalArgumentException expectedThrown = assertThrows(IllegalArgumentException.class, testMethod);
         assertThat(expectedThrown.getMessage(), is(equalTo("resourceName must not be null or empty!")));

--- a/needle/src/test/java/io/cucumber/needle/NeedleFactoryTest.java
+++ b/needle/src/test/java/io/cucumber/needle/NeedleFactoryTest.java
@@ -8,10 +8,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-public class NeedleFactoryTest {
+class NeedleFactoryTest {
 
     @Test
-    public void shouldSetUpInjectionProviders() {
+    void shouldSetUpInjectionProviders() {
 
         final InjectionProvider<?>[] injectionProviders = NeedleFactory
             .setUpInjectionProviders();

--- a/needle/src/test/java/io/cucumber/needle/ReadInjectionProviderClassNamesTest.java
+++ b/needle/src/test/java/io/cucumber/needle/ReadInjectionProviderClassNamesTest.java
@@ -12,12 +12,12 @@ import static org.hamcrest.core.IsIterableContaining.hasItems;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class ReadInjectionProviderClassNamesTest {
+class ReadInjectionProviderClassNamesTest {
 
     private final ReadInjectionProviderClassNames function = ReadInjectionProviderClassNames.INSTANCE;
 
     @Test
-    public void shouldReturnProviderFromCucumberNeedleProperties() {
+    void shouldReturnProviderFromCucumberNeedleProperties() {
         final Set<String> classNames = function.apply(loadBundle(CucumberNeedleConfiguration.RESOURCE_CUCUMBER_NEEDLE));
         assertThat(classNames, is(notNullValue()));
         assertThat(classNames.size(), is(1));
@@ -25,28 +25,28 @@ public class ReadInjectionProviderClassNamesTest {
     }
 
     @Test
-    public void shouldReturnEmptySetWhenResourceBundleIsNull() {
+    void shouldReturnEmptySetWhenResourceBundleIsNull() {
         final Set<String> classNames = function.apply(null);
         assertThat(classNames, is(notNullValue()));
         assertThat(classNames.isEmpty(), is(true));
     }
 
     @Test
-    public void shouldReturnEmptySetWhenPropertyIsNotSet() {
+    void shouldReturnEmptySetWhenPropertyIsNotSet() {
         final Set<String> classNames = function.apply(loadBundle("resource-bundles/empty"));
         assertThat(classNames, is(notNullValue()));
         assertThat(classNames.isEmpty(), is(true));
     }
 
     @Test
-    public void shouldReturnEmptySetWhenPropertyIsEmpty() {
+    void shouldReturnEmptySetWhenPropertyIsEmpty() {
         final Set<String> classNames = function.apply(loadBundle("resource-bundles/no-classname"));
         assertThat(classNames, is(notNullValue()));
         assertThat(classNames.isEmpty(), is(true));
     }
 
     @Test
-    public void shouldReturnOneTrimmedClassName() {
+    void shouldReturnOneTrimmedClassName() {
         final Set<String> classNames = function.apply(loadBundle("resource-bundles/one-classname"));
         assertThat(classNames.size(), is(1));
         final String first = classNames.iterator().next();
@@ -54,7 +54,7 @@ public class ReadInjectionProviderClassNamesTest {
     }
 
     @Test
-    public void shouldReturnTwoTrimmedClassNames() {
+    void shouldReturnTwoTrimmedClassNames() {
         final Set<String> classNames = function.apply(loadBundle("resource-bundles/two-classname"));
 
         assertAll("Checking function",

--- a/needle/src/test/java/io/cucumber/needle/test/atm/AtmServiceBeanTest.java
+++ b/needle/src/test/java/io/cucumber/needle/test/atm/AtmServiceBeanTest.java
@@ -6,23 +6,23 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-public class AtmServiceBeanTest {
+class AtmServiceBeanTest {
 
     private final AtmServiceBean bean = new AtmServiceBean();
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         assertThat(bean.getAmount(), is(0));
     }
 
     @Test
-    public void shouldDeposit() {
+    void shouldDeposit() {
         bean.deposit(1000);
         assertThat(bean.getAmount(), is(1000));
     }
 
     @Test
-    public void shouldWithdraw() {
+    void shouldWithdraw() {
         bean.deposit(1000);
         bean.withdraw(300);
         assertThat(bean.getAmount(), is(700));

--- a/picocontainer/src/test/java/io/cucumber/picocontainer/PicoFactoryTest.java
+++ b/picocontainer/src/test/java/io/cucumber/picocontainer/PicoFactoryTest.java
@@ -12,10 +12,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class PicoFactoryTest {
+class PicoFactoryTest {
 
     @Test
-    public void shouldGiveUsNewInstancesForEachScenario() {
+    void shouldGiveUsNewInstancesForEachScenario() {
         ObjectFactory factory = new PicoFactory();
         factory.addClass(Steps.class);
 
@@ -37,7 +37,7 @@ public class PicoFactoryTest {
     }
 
     @Test
-    public void shouldDisposeOnStop() {
+    void shouldDisposeOnStop() {
         // Given
         ObjectFactory factory = new PicoFactory();
         factory.addClass(Steps.class);

--- a/picocontainer/src/test/java/io/cucumber/picocontainer/SanityTest.java
+++ b/picocontainer/src/test/java/io/cucumber/picocontainer/SanityTest.java
@@ -2,10 +2,10 @@ package io.cucumber.picocontainer;
 
 import org.junit.jupiter.api.Test;
 
-public class SanityTest {
+class SanityTest {
 
     @Test
-    public void reports_events_correctly_with_cucumber_runner() {
+    void reports_events_correctly_with_cucumber_runner() {
         SanityChecker.run(RunCucumberTest.class, true);
     }
 

--- a/picocontainer/src/test/java/io/cucumber/picocontainer/SomeTest.java
+++ b/picocontainer/src/test/java/io/cucumber/picocontainer/SomeTest.java
@@ -2,18 +2,18 @@ package io.cucumber.picocontainer;
 
 import org.junit.jupiter.api.Test;
 
-public class SomeTest {
+class SomeTest {
 
     @Test
-    public void one() {
+    void one() {
     }
 
     @Test
-    public void two() {
+    void two() {
     }
 
     @Test
-    public void three() {
+    void three() {
     }
 
 }

--- a/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
+++ b/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
@@ -28,10 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SpringFactoryTest {
+class SpringFactoryTest {
 
     @Test
-    public void shouldGiveUsNewStepInstancesForEachScenario() {
+    void shouldGiveUsNewStepInstancesForEachScenario() {
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(BellyStepdefs.class);
 
@@ -54,7 +54,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldNeverCreateNewApplicationBeanInstances() {
+    void shouldNeverCreateNewApplicationBeanInstances() {
         // Feature 1
         final ObjectFactory factory1 = new SpringFactory();
         factory1.addClass(BellyStepdefs.class);
@@ -78,7 +78,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldNeverCreateNewApplicationBeanInstancesUsingMetaConfiguration() {
+    void shouldNeverCreateNewApplicationBeanInstancesUsingMetaConfiguration() {
         // Feature 1
         final ObjectFactory factory1 = new SpringFactory();
         factory1.addClass(BellyMetaStepdefs.class);
@@ -102,7 +102,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldFindStepDefsCreatedImplicitlyForAutowiring() {
+    void shouldFindStepDefsCreatedImplicitlyForAutowiring() {
         final ObjectFactory factory1 = new SpringFactory();
         factory1.addClass(WithSpringAnnotations.class);
         factory1.addClass(OneStepDef.class);
@@ -122,7 +122,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldReuseStepDefsCreatedImplicitlyForAutowiring() {
+    void shouldReuseStepDefsCreatedImplicitlyForAutowiring() {
         final ObjectFactory factory1 = new SpringFactory();
         factory1.addClass(WithSpringAnnotations.class);
         factory1.addClass(OneStepDef.class);
@@ -142,7 +142,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldRespectCommonAnnotationsInStepDefs() {
+    void shouldRespectCommonAnnotationsInStepDefs() {
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(WithSpringAnnotations.class);
         factory.start();
@@ -154,7 +154,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldRespectContextHierarchyInStepDefs() {
+    void shouldRespectContextHierarchyInStepDefs() {
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(WithContextHierarchyAnnotation.class);
         factory.start();
@@ -166,7 +166,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldRespectDirtiesContextAnnotationsInStepDefs() {
+    void shouldRespectDirtiesContextAnnotationsInStepDefs() {
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(DirtiesContextBellyStepDefs.class);
 
@@ -190,7 +190,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldRespectDirtiesContextAnnotationsInStepDefsUsingMetaConfiguration() {
+    void shouldRespectDirtiesContextAnnotationsInStepDefsUsingMetaConfiguration() {
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(DirtiesContextBellyMetaStepDefs.class);
 
@@ -214,7 +214,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldRespectCustomPropertyPlaceholderConfigurer() {
+    void shouldRespectCustomPropertyPlaceholderConfigurer() {
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(WithSpringAnnotations.class);
         factory.start();
@@ -225,7 +225,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldUseCucumberXmlIfNoClassWithSpringAnnotationIsFound() {
+    void shouldUseCucumberXmlIfNoClassWithSpringAnnotationIsFound() {
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(Object.class);
         factory.start();
@@ -236,7 +236,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldFailIfMultipleClassesWithSpringAnnotationsAreFound() {
+    void shouldFailIfMultipleClassesWithSpringAnnotationsAreFound() {
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(WithSpringAnnotations.class);
 
@@ -248,7 +248,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldFailIfClassWithSpringComponentAnnotationsIsFound() {
+    void shouldFailIfClassWithSpringComponentAnnotationsIsFound() {
         final ObjectFactory factory = new SpringFactory();
 
         Executable testMethod = () -> factory.addClass(WithComponentAnnotation.class);
@@ -259,7 +259,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldFailIfClassWithAnnotationAnnotatedWithSpringComponentAnnotationsIsFound() {
+    void shouldFailIfClassWithAnnotationAnnotatedWithSpringComponentAnnotationsIsFound() {
         final ObjectFactory factory = new SpringFactory();
 
         Executable testMethod = () -> factory.addClass(WithControllerAnnotation.class);
@@ -270,7 +270,7 @@ public class SpringFactoryTest {
     }
 
     @Test
-    public void shouldGlueScopedSpringBeanBehaveLikeGlueLifecycle() {
+    void shouldGlueScopedSpringBeanBehaveLikeGlueLifecycle() {
         final ObjectFactory factory = new SpringFactory();
         factory.addClass(WithSpringAnnotations.class);
 

--- a/weld/src/test/java/io/cucumber/weld/WeldFactoryTest.java
+++ b/weld/src/test/java/io/cucumber/weld/WeldFactoryTest.java
@@ -15,23 +15,23 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class WeldFactoryTest {
+class WeldFactoryTest {
 
     private LogRecordListener logRecordListener;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         logRecordListener = new LogRecordListener();
         LoggerFactory.addListener(logRecordListener);
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         LoggerFactory.removeListener(logRecordListener);
     }
 
     @Test
-    public void shouldGiveUsNewInstancesForEachScenario() {
+    void shouldGiveUsNewInstancesForEachScenario() {
 
         final ObjectFactory factory = new WeldFactory();
         factory.addClass(BellyStepdefs.class);
@@ -54,7 +54,7 @@ public class WeldFactoryTest {
     }
 
     @Test
-    public void stopCalledWithoutStart() {
+    void stopCalledWithoutStart() {
         ObjectFactory factory = new WeldFactory();
         factory.stop();
         assertThat(logRecordListener.getLogRecords().get(0).getMessage(),


### PR DESCRIPTION
## Summary

JUnit 5 tests and test classes can be package private. The public
modifier simply adds nothing but ceremony. Cleaning this up will remove
a large number of inspection warnings.
