### PR TITLE
[Core] Fix JUnit report xml attributes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.Automatic-Module-Name>io.cucumber.core</project.Automatic-Module-Name>
         <jsoup.version>1.12.1</jsoup.version>
-        <xmlunit.version>1.6</xmlunit.version>
+        <xmlunit.version>2.6.3</xmlunit.version>
         <webbit.version>0.4.15</webbit.version>
         <webbit-rest.version>0.3.0</webbit-rest.version>
         <hamcrest-json.version>0.2</hamcrest-json.version>
@@ -51,8 +51,14 @@
         </dependency>
 
         <dependency>
-            <groupId>xmlunit</groupId>
-            <artifactId>xmlunit</artifactId>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>${xmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-matchers</artifactId>
             <version>${xmlunit.version}</version>
             <scope>test</scope>
         </dependency>

--- a/core/src/test/java/io/cucumber/core/plugin/JUnitFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/JUnitFormatterTest.java
@@ -1,24 +1,18 @@
 package io.cucumber.core.plugin;
 
-import io.cucumber.plugin.event.Result;
 import io.cucumber.core.feature.CucumberFeature;
 import io.cucumber.core.feature.TestFeatureParser;
 import io.cucumber.core.runner.TestHelper;
-import org.custommonkey.xmlunit.Diff;
-import org.custommonkey.xmlunit.XMLUnit;
+import io.cucumber.plugin.event.Result;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 import org.opentest4j.TestAbortedException;
-import org.xml.sax.SAXException;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -31,8 +25,8 @@ import static io.cucumber.core.runner.TestHelper.result;
 import static java.time.Duration.ZERO;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.xmlunit.matchers.CompareMatcher.isIdenticalTo;
+import static org.xmlunit.matchers.ValidationMatcher.valid;
 
 class JUnitFormatterTest {
 
@@ -43,30 +37,36 @@ class JUnitFormatterTest {
     private final List<String> hookLocations = new ArrayList<>();
     private final List<Answer<Object>> hookActions = new ArrayList<>();
     private Duration stepDuration = null;
+    private boolean strict = false;
+
+    private static void assertXmlEqual(Object expected, Object actual) throws IOException {
+        assertThat(actual, isIdenticalTo(expected).ignoreWhitespace());
+        assertThat(actual, valid(JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/surefire-test-report-3.0.xsd")));
+    }
 
     @Test
     void featureSimpleTest() throws Exception {
         File report = runFeaturesWithJunitFormatter(singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_1.feature"));
-        assertXmlEqual("io/cucumber/core/plugin//JUnitFormatterTest_1.report.xml", report);
+        assertXmlEqual(JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_1.report.xml"), report);
     }
 
     @Test
     void featureWithBackgroundTest() throws Exception {
         File report = runFeaturesWithJunitFormatter(singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_2.feature"));
-        assertXmlEqual("io/cucumber/core/plugin//JUnitFormatterTest_2.report.xml", report);
+        assertXmlEqual(JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_2.report.xml"), report);
     }
 
     @Test
     void featureWithOutlineTest() throws Exception {
         File report = runFeaturesWithJunitFormatter(singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_3.feature"));
-        assertXmlEqual("io/cucumber/core/plugin//JUnitFormatterTest_3.report.xml", report);
+        assertXmlEqual(JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_3.report.xml"), report);
     }
 
     @Test
     void featureSimpleStrictTest() throws Exception {
         boolean strict = true;
         File report = runFeaturesWithJunitFormatter(singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_1.feature"), strict);
-        assertXmlEqual("io/cucumber/core/plugin//JUnitFormatterTest_1_strict.report.xml", report);
+        assertXmlEqual(JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_1_strict.report.xml"), report);
     }
 
     @Test
@@ -86,13 +86,52 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.003\">\n" +
+            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.003\">\n" +
             "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
             "        <system-out><![CDATA[" +
             "Given first step............................................................passed\n" +
             "When second step............................................................passed\n" +
             "Then third step.............................................................passed\n" +
             "]]></system-out>\n" +
+            "    </testcase>\n" +
+            "</testsuite>\n";
+        assertXmlEqual(expected, formatterOutput);
+    }
+
+    @Test
+    void should_format_empty_scenario() throws Throwable {
+        CucumberFeature feature = TestFeatureParser.parse("path/test.feature",
+            "Feature: feature name\n" +
+                "  Scenario: scenario name\n");
+        features.add(feature);
+        stepDuration = Duration.ofMillis(1L);
+
+        String formatterOutput = runFeaturesWithFormatter();
+
+        String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"1\" errors=\"0\" tests=\"1\" time=\"0\">\n" +
+            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0\">\n" +
+            "        <skipped message=\"The scenario has no steps\"/>\n" +
+            "    </testcase>\n" +
+            "</testsuite>\n";
+        assertXmlEqual(expected, formatterOutput);
+    }
+
+    @Test
+    void should_format_empty_scenario_strict() throws Throwable {
+        CucumberFeature feature = TestFeatureParser.parse("path/test.feature",
+            "Feature: feature name\n" +
+                "  Scenario: scenario name\n");
+        features.add(feature);
+        stepDuration = Duration.ofMillis(1L);
+        strict = true;
+
+        String formatterOutput = runFeaturesWithFormatter();
+
+        String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0\">\n" +
+            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0\">\n" +
+            "        <failure message=\"The scenario has no steps\" type=\"java.lang.Exception\"/>\n" +
             "    </testcase>\n" +
             "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
@@ -111,13 +150,13 @@ class JUnitFormatterTest {
         stepsToResult.put("first step", result("skipped", exception));
         stepsToResult.put("second step", result("skipped"));
         stepsToResult.put("third step", result("skipped"));
-        stepDuration = Duration.ofMillis(1L);
+        stepDuration = Duration.ofMillis(1);
 
         String formatterOutput = runFeaturesWithFormatter();
 
         String stackTrace = getStackTrace(exception);
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.003\">\n" +
+            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"1\" errors=\"0\" tests=\"1\" time=\"0.003\">\n" +
             "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
             "        <skipped message=\"" + stackTrace.replace("\n\t", "&#10;&#9;").replaceAll("\r", "&#13;") + "\"><![CDATA[" +
             "Given first step............................................................skipped\n" +
@@ -149,7 +188,7 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.003\">\n" +
+            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"1\" errors=\"0\" tests=\"1\" time=\"0.003\">\n" +
             "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
             "        <skipped><![CDATA[" +
             "Given first step............................................................pending\n" +
@@ -178,16 +217,15 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.003\">\n" +
+            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.003\">\n" +
             "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
-            "        <failure message=\"the stack trace\"><![CDATA[" +
+            "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA[" +
             "Given first step............................................................passed\n" +
             "When second step............................................................passed\n" +
             "Then third step.............................................................failed\n" +
             "\n" +
             "StackTrace:\n" +
-            "the stack trace" +
-            "]]></failure>\n" +
+            "the stack trace]]></failure>\n" +
             "    </testcase>\n" +
             "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
@@ -211,9 +249,9 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.004\">\n" +
+            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n" +
             "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
-            "        <failure message=\"the stack trace\"><![CDATA[" +
+            "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA[" +
             "Given first step............................................................skipped\n" +
             "When second step............................................................skipped\n" +
             "Then third step.............................................................skipped\n" +
@@ -244,7 +282,7 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"1\" tests=\"1\" time=\"0.004\">\n" +
+            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"1\" errors=\"0\" tests=\"1\" time=\"0.004\">\n" +
             "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
             "        <skipped><![CDATA[" +
             "Given first step............................................................skipped\n" +
@@ -275,9 +313,9 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.004\">\n" +
+            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n" +
             "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
-            "        <failure message=\"the stack trace\"><![CDATA[" +
+            "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA[" +
             "Given first step............................................................skipped\n" +
             "When second step............................................................skipped\n" +
             "Then third step.............................................................skipped\n" +
@@ -308,9 +346,9 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.004\">\n" +
+            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n" +
             "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
-            "        <failure message=\"the stack trace\"><![CDATA[" +
+            "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA[" +
             "Given first step............................................................passed\n" +
             "When second step............................................................passed\n" +
             "Then third step.............................................................passed\n" +
@@ -340,7 +378,7 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.004\">\n" +
+            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n" +
             "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
             "        <system-out><![CDATA[" +
             "* first step................................................................passed\n" +
@@ -373,7 +411,7 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" tests=\"2\" time=\"0.006\">\n" +
+            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"2\" time=\"0.006\">\n" +
             "    <testcase classname=\"feature name\" name=\"outline_name\" time=\"0.003\">\n" +
             "        <system-out><![CDATA[" +
             "Given first step \"a\"........................................................passed\n" +
@@ -420,7 +458,7 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" tests=\"4\" time=\"0.012\">\n" +
+            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"4\" time=\"0.012\">\n" +
             "    <testcase classname=\"feature name\" name=\"outline name\" time=\"0.003\">\n" +
             "        <system-out><![CDATA[" +
             "Given first step \"a\"........................................................passed\n" +
@@ -475,7 +513,7 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" tests=\"2\" time=\"0.006\">\n" +
+            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"2\" time=\"0.006\">\n" +
             "    <testcase classname=\"feature name\" name=\"outline name a\" time=\"0.003\">\n" +
             "        <system-out><![CDATA[" +
             "Given first step \"a\"........................................................passed\n" +
@@ -528,7 +566,7 @@ class JUnitFormatterTest {
     private String runFeaturesWithFormatter() throws IOException {
         final File report = File.createTempFile("cucumber-jvm-junit", ".xml");
         final JUnitFormatter formatter = createJUnitFormatter(report);
-
+        formatter.setStrict(strict);
         TestHelper.builder()
             .withFormatterUnderTest(formatter)
             .withFeatures(features)
@@ -545,23 +583,6 @@ class JUnitFormatterTest {
         String formatterOutput = scanner.useDelimiter("\\A").next();
         scanner.close();
         return formatterOutput;
-    }
-
-    private void assertXmlEqual(String expectedPath, File actual) throws IOException, SAXException {
-        XMLUnit.setIgnoreWhitespace(true);
-        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-        InputStreamReader control = new InputStreamReader(
-            contextClassLoader.getResourceAsStream(expectedPath),
-            StandardCharsets.UTF_8
-        );
-        Diff diff = new Diff(control, new FileReader(actual));
-        assertThat("XML files are similar " + diff, diff.identical(), is(equalTo(true)));
-    }
-
-    private void assertXmlEqual(String expected, String actual) throws SAXException, IOException {
-        XMLUnit.setIgnoreWhitespace(true);
-        Diff diff = new Diff(expected, actual);
-        assertThat("XML files are similar " + diff + "\nFormatterOutput = " + actual, diff.identical(), is(equalTo(true)));
     }
 
     private JUnitFormatter createJUnitFormatter(final File report) throws IOException {

--- a/core/src/test/java/io/cucumber/core/plugin/TestNGFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/TestNGFormatterTest.java
@@ -4,12 +4,8 @@ import io.cucumber.plugin.event.Result;
 import io.cucumber.core.feature.CucumberFeature;
 import io.cucumber.core.feature.TestFeatureParser;
 import io.cucumber.core.runner.TestHelper;
-import org.custommonkey.xmlunit.Diff;
-import org.custommonkey.xmlunit.Difference;
-import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
-import org.xml.sax.SAXException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -27,8 +23,7 @@ import static io.cucumber.core.runner.TestHelper.result;
 import static java.time.Duration.ZERO;
 import static java.time.Duration.ofMillis;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.xmlunit.matchers.CompareMatcher.isIdenticalTo;
 
 final class TestNGFormatterTest {
 
@@ -57,7 +52,7 @@ final class TestNGFormatterTest {
             "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"SKIP\" duration-ms=\"0\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\"/>" +
+            "                <test-method name=\"scenario\" status=\"SKIP\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\"/>" +
             "            </class>" +
             "        </test>" +
             "    </suite>" +
@@ -81,7 +76,7 @@ final class TestNGFormatterTest {
             "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\">" +
+            "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\">" +
             "                    <exception class=\"The scenario has pending or undefined step(s)\">" +
             "                        <message><![CDATA[When step...................................................................undefined\n" +
             "Then step...................................................................undefined\n" +
@@ -113,7 +108,7 @@ final class TestNGFormatterTest {
             "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"SKIP\" duration-ms=\"0\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\"/>" +
+            "                <test-method name=\"scenario\" status=\"SKIP\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\"/>" +
             "            </class>" +
             "        </test>" +
             "    </suite>" +
@@ -138,7 +133,7 @@ final class TestNGFormatterTest {
             "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\">" +
+            "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\">" +
             "                    <exception class=\"io.cucumber.core.plugin.TestNGFormatterTest$TestNGException\">" +
             "                        <message><![CDATA[When step1..................................................................failed\n" +
             "Then step2..................................................................skipped\n" +
@@ -169,7 +164,7 @@ final class TestNGFormatterTest {
             "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"PASS\" duration-ms=\"0\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\"/>" +
+            "                <test-method name=\"scenario\" status=\"PASS\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\"/>" +
             "            </class>" +
             "        </test>" +
             "    </suite>" +
@@ -197,7 +192,7 @@ final class TestNGFormatterTest {
             "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"SKIP\" duration-ms=\"0\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\"/>" +
+            "                <test-method name=\"scenario\" status=\"SKIP\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\"/>" +
             "            </class>" +
             "        </test>" +
             "    </suite>" +
@@ -225,8 +220,8 @@ final class TestNGFormatterTest {
             "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"SKIP\" duration-ms=\"0\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\"/>" +
-            "                <test-method name=\"scenario_2\" status=\"SKIP\" duration-ms=\"0\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\"/>" +
+            "                <test-method name=\"scenario\" status=\"SKIP\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\"/>" +
+            "                <test-method name=\"scenario_2\" status=\"SKIP\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\"/>" +
             "            </class>" +
             "        </test>" +
             "    </suite>" +
@@ -261,11 +256,11 @@ final class TestNGFormatterTest {
             "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"12\">" +
             "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"12\">" +
             "            <class name=\"feature_1\">" +
-            "                <test-method name=\"scenario_1\" status=\"PASS\" duration-ms=\"4\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\"/>" +
-            "                <test-method name=\"scenario_2\" status=\"PASS\" duration-ms=\"4\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\"/>" +
+            "                <test-method name=\"scenario_1\" status=\"PASS\" duration-ms=\"4\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00.004Z\"/>" +
+            "                <test-method name=\"scenario_2\" status=\"PASS\" duration-ms=\"4\" started-at=\"1970-01-01T00:00:00.004Z\" finished-at=\"1970-01-01T00:00:00.008Z\"/>" +
             "            </class>" +
             "            <class name=\"feature_2\">" +
-            "                <test-method name=\"scenario_3\" status=\"PASS\" duration-ms=\"4\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\"/>" +
+            "                <test-method name=\"scenario_3\" status=\"PASS\" duration-ms=\"4\" started-at=\"1970-01-01T00:00:00.008Z\" finished-at=\"1970-01-01T00:00:00.012Z\"/>" +
             "            </class>" +
             "        </test>" +
             "    </suite>" +
@@ -290,7 +285,7 @@ final class TestNGFormatterTest {
             "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\">" +
+            "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\">" +
             "                    <exception class=\"io.cucumber.core.plugin.TestNGFormatterTest$TestNGException\">" +
             "                        <message><![CDATA[When step...................................................................skipped\n" +
             "Then step...................................................................skipped\n" +
@@ -322,7 +317,7 @@ final class TestNGFormatterTest {
             "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
             "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"yyyy-MM-ddTHH:mm:ssZ\" finished-at=\"yyyy-MM-ddTHH:mm:ssZ\">" +
+            "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\">" +
             "                    <exception class=\"io.cucumber.core.plugin.TestNGFormatterTest$TestNGException\">" +
             "                        <message><![CDATA[When step...................................................................passed\n" +
             "Then step...................................................................passed\n" +
@@ -336,18 +331,8 @@ final class TestNGFormatterTest {
             "</testng-results>", actual);
     }
 
-    private void assertXmlEqual(String expected, String actual) throws SAXException, IOException {
-        XMLUnit.setIgnoreWhitespace(true);
-        Diff diff = new Diff(expected, actual) {
-            @Override
-            public int differenceFound(Difference difference) {
-                if (difference.getControlNodeDetail().getNode().getNodeName().matches("started-at|finished-at")) {
-                    return 0;
-                }
-                return super.differenceFound(difference);
-            }
-        };
-        assertThat("XML files are similar " + diff + "\nFormatterOutput = " + actual, diff.identical(), is(equalTo(true)));
+    private static void assertXmlEqual(String expected, String actual) {
+        assertThat(actual, isIdenticalTo(expected).ignoreWhitespace());
     }
 
     private String runFeaturesWithFormatter(boolean strict) throws IOException {

--- a/core/src/test/java/io/cucumber/core/runner/TestHelper.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestHelper.java
@@ -28,6 +28,7 @@ import io.cucumber.datatable.DataTable;
 import org.mockito.stubbing.Answer;
 import org.opentest4j.TestAbortedException;
 
+import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.lang.reflect.Type;
 import java.net.URI;
@@ -468,16 +469,22 @@ public class TestHelper {
     }
 
     private static TestAbortedException mockAssertionFailedError() {
-        TestAbortedException error = mock(TestAbortedException.class);
-        Answer<Object> printStackTraceHandler = invocation -> {
-            PrintWriter writer = (PrintWriter) invocation.getArguments()[0];
-            writer.print("the stack trace");
-            return null;
-        };
-        doAnswer(printStackTraceHandler).when(error).printStackTrace((PrintWriter) any());
-        when(error.getStackTrace()).thenReturn(new StackTraceElement[0]);
-        when(error.getMessage()).thenReturn("the message");
-        return error;
+        class MockedTestAbortedException extends TestAbortedException{
+            MockedTestAbortedException(){
+                super("the message");
+            }
+
+            @Override
+            public void printStackTrace(PrintStream s) {
+                s.print("the stack trace");
+            }
+
+            @Override
+            public void printStackTrace(PrintWriter s) {
+                s.print("the stack trace");
+            }
+        }
+        return new MockedTestAbortedException();
     }
 
     private static AmbiguousStepDefinitionsException mockAmbiguousStepDefinitionException() {

--- a/core/src/test/resources/io/cucumber/core/plugin/JUnitFormatterTest_1.report.xml
+++ b/core/src/test/resources/io/cucumber/core/plugin/JUnitFormatterTest_1.report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<testsuite tests="2" failures="0" skipped="2" time="0" name="io.cucumber.core.plugin.JUnitFormatter">
+<testsuite tests="2" failures="0" skipped="2" errors="0" time="0" name="io.cucumber.core.plugin.JUnitFormatter">
     <testcase classname="Feature_1" name="Scenario_1" time="0">
         <skipped><![CDATA[Given step_1................................................................undefined
 When step_2.................................................................undefined

--- a/core/src/test/resources/io/cucumber/core/plugin/JUnitFormatterTest_1_strict.report.xml
+++ b/core/src/test/resources/io/cucumber/core/plugin/JUnitFormatterTest_1_strict.report.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<testsuite failures="2" name="io.cucumber.core.plugin.JUnitFormatter" skipped="0" tests="2" time="0">
+<testsuite failures="2" name="io.cucumber.core.plugin.JUnitFormatter" skipped="0" errors="0" tests="2" time="0">
     <testcase classname="Feature_1" name="Scenario_1" time="0">
-        <failure message="The scenario has pending or undefined step(s)"><![CDATA[Given step_1................................................................undefined
+        <failure message="The scenario has pending or undefined step(s)" type="java.lang.Exception"><![CDATA[Given step_1................................................................undefined
 When step_2.................................................................undefined
 Then step_3.................................................................undefined
 ]]></failure>
     </testcase>
     <testcase classname="Feature_1" name="Scenario_2" time="0">
-        <failure message="The scenario has pending or undefined step(s)"><![CDATA[Given step_1................................................................undefined
+        <failure message="The scenario has pending or undefined step(s)" type="java.lang.Exception"><![CDATA[Given step_1................................................................undefined
 When step_2.................................................................undefined
 Then step_3.................................................................undefined
 ]]></failure>

--- a/core/src/test/resources/io/cucumber/core/plugin/JUnitFormatterTest_2.report.xml
+++ b/core/src/test/resources/io/cucumber/core/plugin/JUnitFormatterTest_2.report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<testsuite tests="2" failures="0" skipped="2" time="0" name="io.cucumber.core.plugin.JUnitFormatter">
+<testsuite tests="2" failures="0" skipped="2" errors="0" time="0" name="io.cucumber.core.plugin.JUnitFormatter">
     <testcase classname="Feature_2" name="Scenario_1" time="0">
         <skipped><![CDATA[Given bg_1..................................................................undefined
 When bg_2...................................................................undefined

--- a/core/src/test/resources/io/cucumber/core/plugin/JUnitFormatterTest_3.report.xml
+++ b/core/src/test/resources/io/cucumber/core/plugin/JUnitFormatterTest_3.report.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<testsuite failures="0" tests="4" skipped="4" time="0" name="io.cucumber.core.plugin.JUnitFormatter">
+<testsuite failures="0" tests="4" skipped="4" errors="0" time="0" name="io.cucumber.core.plugin.JUnitFormatter">
     <testcase classname="Feature_3" name="Scenario_1" time="0">
         <skipped><![CDATA[Given bg_1..................................................................undefined
 When bg_2...................................................................undefined

--- a/core/src/test/resources/io/cucumber/core/plugin/surefire-test-report-3.0.xsd
+++ b/core/src/test/resources/io/cucumber/core/plugin/surefire-test-report-3.0.xsd
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+From: https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd
+Via: https://maven.apache.org/surefire/maven-surefire-plugin/
+-->
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0">
+    <xs:simpleType name="SUREFIRE_TIME">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="properties" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:attribute name="name" type="xs:string" use="required"/>
+                                    <xs:attribute name="value" type="xs:string" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="testcase" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="failure" nillable="true" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:simpleContent>
+                                        <xs:extension base="xs:string">
+                                            <xs:attribute name="message" type="xs:string"/>
+                                            <xs:attribute name="type" type="xs:string" use="required"/>
+                                        </xs:extension>
+                                    </xs:simpleContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="rerunFailure" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="stackTrace" type="xs:string"/>
+                                        <xs:element name="system-out" type="xs:string" minOccurs="0"/>
+                                        <xs:element name="system-err" type="xs:string" minOccurs="0"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="message" type="xs:string"/>
+                                    <xs:attribute name="type" type="xs:string" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="flakyFailure" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="stackTrace" type="xs:string"/>
+                                        <xs:element name="system-out" type="xs:string" minOccurs="0"/>
+                                        <xs:element name="system-err" type="xs:string" minOccurs="0"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="message" type="xs:string"/>
+                                    <xs:attribute name="type" type="xs:string" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="skipped" nillable="true" minOccurs="0" maxOccurs="1">
+                                <xs:complexType>
+                                    <xs:simpleContent>
+                                        <xs:extension base="xs:string">
+                                            <xs:attribute name="message" type="xs:string"/>
+                                        </xs:extension>
+                                    </xs:simpleContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="error" nillable="true" minOccurs="0" maxOccurs="1">
+                                <xs:complexType>
+                                    <xs:simpleContent>
+                                        <xs:extension base="xs:string">
+                                            <xs:attribute name="message" type="xs:string"/>
+                                            <xs:attribute name="type" type="xs:string" use="required"/>
+                                        </xs:extension>
+                                    </xs:simpleContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="rerunError" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="stackTrace" type="xs:string"/>
+                                        <xs:element name="system-out" type="xs:string" minOccurs="0"/>
+                                        <xs:element name="system-err" type="xs:string" minOccurs="0"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="message" type="xs:string"/>
+                                    <xs:attribute name="type" type="xs:string" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="flakyError" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="stackTrace" type="xs:string"/>
+                                        <xs:element name="system-out" type="xs:string" minOccurs="0"/>
+                                        <xs:element name="system-err" type="xs:string" minOccurs="0"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="message" type="xs:string"/>
+                                    <xs:attribute name="type" type="xs:string" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="system-out" type="xs:string" minOccurs="0"/>
+                            <xs:element name="system-err" type="xs:string" minOccurs="0"/>
+                        </xs:sequence>
+                        <xs:attribute name="name" type="xs:string" use="required"/>
+                        <xs:attribute name="classname" type="xs:string"/>
+                        <xs:attribute name="group" type="xs:string"/>
+                        <xs:attribute name="time" type="SUREFIRE_TIME" use="required"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="time" type="SUREFIRE_TIME"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="errors" type="xs:string" use="required"/>
+            <xs:attribute name="skipped" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="required"/>
+            <xs:attribute name="group" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
## Summary

Cucumber JUnits xml format doesn't pass XSD validation in the
Jenkins XUnit plugin because it is missing the errors attribute.
Additionally time should be presented using numbers with both decimal
and thousands separators.

From: https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd
Via: https://maven.apache.org/surefire/maven-surefire-plugin/

Closes #1777

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
