### PR TITLE
[Core] Remove ambigious class names

### DIFF
--- a/core/src/main/java/io/cucumber/core/backend/HookDefinition.java
+++ b/core/src/main/java/io/cucumber/core/backend/HookDefinition.java
@@ -5,7 +5,7 @@ import org.apiguardian.api.API;
 @API(status = API.Status.STABLE)
 public interface HookDefinition extends Located {
 
-    void execute(Scenario scenario);
+    void execute(TestCaseState state);
 
     String getTagExpression();
 

--- a/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
@@ -13,7 +13,7 @@ import java.util.Collection;
  * hooks after could provide. For an example see {@code io.cucumber.core.plugin.PrettyFormatter}.
  */
 @API(status = API.Status.STABLE)
-public interface Scenario {
+public interface TestCaseState {
     /**
      * @return source_tag_names.
      */
@@ -43,13 +43,13 @@ public interface Scenario {
      *
      * @param data     what to embed, for example an image.
      * @param mimeType what is the data?
-     * @deprecated use {@link Scenario#embed(byte[], String, String)} instead.
+     * @deprecated use {@link TestCaseState#embed(byte[], String, String)} instead.
      */
     @Deprecated
     void embed(byte[] data, String mimeType);
 
     /**
-     * Like {@link Scenario#embed(byte[], String)}, but with name for the embedding.
+     * Like {@link TestCaseState#embed(byte[], String)}, but with name for the embedding.
      *
      * @param data     what to embed, for example an image.
      * @param mimeType what is the data?

--- a/core/src/main/java/io/cucumber/core/runner/AmbiguousPickleStepDefinitionsMatch.java
+++ b/core/src/main/java/io/cucumber/core/runner/AmbiguousPickleStepDefinitionsMatch.java
@@ -13,13 +13,13 @@ final class AmbiguousPickleStepDefinitionsMatch extends PickleStepDefinitionMatc
     }
 
     @Override
-    public void runStep(Scenario scenario) throws AmbiguousStepDefinitionsException {
+    public void runStep(TestCaseState state) throws AmbiguousStepDefinitionsException {
         throw exception;
     }
 
     @Override
-    public void dryRunStep(Scenario scenario) throws AmbiguousStepDefinitionsException {
-        runStep(scenario);
+    public void dryRunStep(TestCaseState state) throws AmbiguousStepDefinitionsException {
+        runStep(state);
     }
 
     @Override

--- a/core/src/main/java/io/cucumber/core/runner/CachingGlue.java
+++ b/core/src/main/java/io/cucumber/core/runner/CachingGlue.java
@@ -13,7 +13,7 @@ import io.cucumber.core.backend.StepDefinition;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.feature.CucumberStep;
 import io.cucumber.core.stepexpression.Argument;
-import io.cucumber.core.stepexpression.TypeRegistry;
+import io.cucumber.core.stepexpression.StepTypeRegistry;
 import io.cucumber.cucumberexpressions.ParameterByTypeTransformer;
 import io.cucumber.datatable.TableCellByTypeTransformer;
 import io.cucumber.datatable.TableEntryByTypeTransformer;
@@ -181,15 +181,15 @@ final class CachingGlue implements Glue {
         return docStringTypeDefinitions;
     }
 
-    void prepareGlue(TypeRegistry typeRegistry) throws DuplicateStepDefinitionException {
-        parameterTypeDefinitions.forEach(ptd -> typeRegistry.defineParameterType(ptd.parameterType()));
-        dataTableTypeDefinitions.forEach(dtd -> typeRegistry.defineDataTableType(dtd.dataTableType()));
-        docStringTypeDefinitions.forEach(dtd -> typeRegistry.defineDocStringType(dtd.docStringType()));
+    void prepareGlue(StepTypeRegistry stepTypeRegistry) throws DuplicateStepDefinitionException {
+        parameterTypeDefinitions.forEach(ptd -> stepTypeRegistry.defineParameterType(ptd.parameterType()));
+        dataTableTypeDefinitions.forEach(dtd -> stepTypeRegistry.defineDataTableType(dtd.dataTableType()));
+        docStringTypeDefinitions.forEach(dtd -> stepTypeRegistry.defineDocStringType(dtd.docStringType()));
 
         if (defaultParameterTransformers.size() == 1) {
             DefaultParameterTransformerDefinition definition = defaultParameterTransformers.get(0);
             ParameterByTypeTransformer transformer = definition.parameterByTypeTransformer();
-            typeRegistry.setDefaultParameterTransformer(transformer);
+            stepTypeRegistry.setDefaultParameterTransformer(transformer);
         } else if (defaultParameterTransformers.size() > 1) {
             throw new DuplicateDefaultParameterTransformers(defaultParameterTransformers);
         }
@@ -197,7 +197,7 @@ final class CachingGlue implements Glue {
         if (defaultDataTableEntryTransformers.size() == 1) {
             DefaultDataTableEntryTransformerDefinition definition = defaultDataTableEntryTransformers.get(0);
             TableEntryByTypeTransformer transformer = definition.tableEntryByTypeTransformer();
-            typeRegistry.setDefaultDataTableEntryTransformer(transformer);
+            stepTypeRegistry.setDefaultDataTableEntryTransformer(transformer);
         } else if (defaultDataTableEntryTransformers.size() > 1) {
             throw new DuplicateDefaultDataTableEntryTransformers(defaultDataTableEntryTransformers);
         }
@@ -205,13 +205,13 @@ final class CachingGlue implements Glue {
         if (defaultDataTableCellTransformers.size() == 1) {
             DefaultDataTableCellTransformerDefinition definition = defaultDataTableCellTransformers.get(0);
             TableCellByTypeTransformer transformer = definition.tableCellByTypeTransformer();
-            typeRegistry.setDefaultDataTableCellTransformer(transformer);
+            stepTypeRegistry.setDefaultDataTableCellTransformer(transformer);
         } else if (defaultDataTableCellTransformers.size() > 1) {
             throw new DuplicateDefaultDataTableCellTransformers(defaultDataTableCellTransformers);
         }
 
         stepDefinitions.forEach(stepDefinition -> {
-            CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, typeRegistry);
+            CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, stepTypeRegistry);
             CoreStepDefinition previous = stepDefinitionsByPattern.get(stepDefinition.getPattern());
             if (previous != null) {
                 throw new DuplicateStepDefinitionException(previous.getStepDefinition(), stepDefinition);

--- a/core/src/main/java/io/cucumber/core/runner/CoreHookDefinition.java
+++ b/core/src/main/java/io/cucumber/core/runner/CoreHookDefinition.java
@@ -26,7 +26,7 @@ class CoreHookDefinition {
         this.tagExpression = new TagExpressionParser().parse(delegate.getTagExpression());
     }
 
-    void execute(Scenario scenario) throws Throwable {
+    void execute(TestCaseState scenario) {
         delegate.execute(scenario);
     }
 

--- a/core/src/main/java/io/cucumber/core/runner/CoreStepDefinition.java
+++ b/core/src/main/java/io/cucumber/core/runner/CoreStepDefinition.java
@@ -7,7 +7,7 @@ import io.cucumber.core.stepexpression.Argument;
 import io.cucumber.core.stepexpression.ArgumentMatcher;
 import io.cucumber.core.stepexpression.StepExpression;
 import io.cucumber.core.stepexpression.StepExpressionFactory;
-import io.cucumber.core.stepexpression.TypeRegistry;
+import io.cucumber.core.stepexpression.StepTypeRegistry;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -22,22 +22,22 @@ final class CoreStepDefinition {
     private final StepDefinition stepDefinition;
     private final Type[] types;
 
-    CoreStepDefinition(StepDefinition stepDefinition, TypeRegistry typeRegistry) {
+    CoreStepDefinition(StepDefinition stepDefinition, StepTypeRegistry stepTypeRegistry) {
         this.stepDefinition = requireNonNull(stepDefinition);
         List<ParameterInfo> parameterInfos = stepDefinition.parameterInfos();
-        this.expression = createExpression(parameterInfos, stepDefinition.getPattern(), typeRegistry);
+        this.expression = createExpression(parameterInfos, stepDefinition.getPattern(), stepTypeRegistry);
         this.argumentMatcher = new ArgumentMatcher(this.expression);
         this.types = getTypes(parameterInfos);
     }
 
-    private StepExpression createExpression(List<ParameterInfo> parameterInfos, String expression, TypeRegistry typeRegistry) {
+    private StepExpression createExpression(List<ParameterInfo> parameterInfos, String expression, StepTypeRegistry stepTypeRegistry) {
         if (parameterInfos == null || parameterInfos.isEmpty()) {
-            return new StepExpressionFactory(typeRegistry).createExpression(expression);
+            return new StepExpressionFactory(stepTypeRegistry).createExpression(expression);
         } else {
             ParameterInfo parameterInfo = parameterInfos.get(parameterInfos.size() - 1);
             Supplier<Type> typeResolver = parameterInfo.getTypeResolver()::resolve;
             boolean transposed = parameterInfo.isTransposed();
-            return new StepExpressionFactory(typeRegistry).createExpression(expression, typeResolver, transposed);
+            return new StepExpressionFactory(stepTypeRegistry).createExpression(expression, typeResolver, transposed);
         }
     }
 

--- a/core/src/main/java/io/cucumber/core/runner/HookDefinitionMatch.java
+++ b/core/src/main/java/io/cucumber/core/runner/HookDefinitionMatch.java
@@ -14,9 +14,9 @@ final class HookDefinitionMatch implements StepDefinitionMatch {
     }
 
     @Override
-    public void runStep(Scenario scenario) throws Throwable {
+    public void runStep(TestCaseState state) throws Throwable {
         try {
-            hookDefinition.execute(scenario);
+            hookDefinition.execute(state);
         } catch (CucumberBackendException e) {
             throw couldNotInvokeHook(e);
         } catch (CucumberInvocationTargetException e) {
@@ -34,7 +34,7 @@ final class HookDefinitionMatch implements StepDefinitionMatch {
     }
 
     @Override
-    public void dryRunStep(Scenario scenario) {
+    public void dryRunStep(TestCaseState state) {
         // Do nothing
     }
 

--- a/core/src/main/java/io/cucumber/core/runner/PickleStepDefinitionMatch.java
+++ b/core/src/main/java/io/cucumber/core/runner/PickleStepDefinitionMatch.java
@@ -31,7 +31,7 @@ class PickleStepDefinitionMatch extends Match implements StepDefinitionMatch {
     }
 
     @Override
-    public void runStep(Scenario scenario) throws Throwable {
+    public void runStep(TestCaseState state) throws Throwable {
         List<Argument> arguments = getArguments();
         List<ParameterInfo> parameterInfos = stepDefinition.parameterInfos();
         if (parameterInfos != null && arguments.size() != parameterInfos.size()) {
@@ -110,7 +110,7 @@ class PickleStepDefinitionMatch extends Match implements StepDefinitionMatch {
     }
 
     @Override
-    public void dryRunStep(Scenario scenario) throws Throwable {
+    public void dryRunStep(TestCaseState state) throws Throwable {
         // Do nothing
     }
 

--- a/core/src/main/java/io/cucumber/core/runner/PickleStepTestStep.java
+++ b/core/src/main/java/io/cucumber/core/runner/PickleStepTestStep.java
@@ -35,17 +35,17 @@ final class PickleStepTestStep extends TestStep implements io.cucumber.plugin.ev
     }
 
     @Override
-    boolean run(TestCase testCase, EventBus bus, Scenario scenario, boolean skipSteps) {
+    boolean run(TestCase testCase, EventBus bus, TestCaseState state, boolean skipSteps) {
         boolean skipNextStep = skipSteps;
 
         for (HookTestStep before : beforeStepHookSteps) {
-            skipNextStep |= before.run(testCase, bus, scenario, skipSteps);
+            skipNextStep |= before.run(testCase, bus, state, skipSteps);
         }
 
-        skipNextStep |= super.run(testCase, bus, scenario, skipNextStep);
+        skipNextStep |= super.run(testCase, bus, state, skipNextStep);
 
         for (HookTestStep after : afterStepHookSteps) {
-            skipNextStep |= after.run(testCase, bus, scenario, skipSteps);
+            skipNextStep |= after.run(testCase, bus, state, skipSteps);
         }
 
         return skipNextStep;

--- a/core/src/main/java/io/cucumber/core/runner/Runner.java
+++ b/core/src/main/java/io/cucumber/core/runner/Runner.java
@@ -9,7 +9,7 @@ import io.cucumber.core.feature.CucumberStep;
 import io.cucumber.core.logging.Logger;
 import io.cucumber.core.logging.LoggerFactory;
 import io.cucumber.core.snippets.SnippetGenerator;
-import io.cucumber.core.stepexpression.TypeRegistry;
+import io.cucumber.core.stepexpression.StepTypeRegistry;
 import io.cucumber.plugin.event.HookType;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent;
 
@@ -55,12 +55,12 @@ public final class Runner {
 
     public void runPickle(CucumberPickle pickle) {
         try {
-            TypeRegistry typeRegistry = createTypeRegistryForPickle(pickle);
-            snippetGenerators = createSnippetGeneratorsForPickle(typeRegistry);
+            StepTypeRegistry stepTypeRegistry = createTypeRegistryForPickle(pickle);
+            snippetGenerators = createSnippetGeneratorsForPickle(stepTypeRegistry);
 
             buildBackendWorlds(); // Java8 step definitions will be added to the glue here
 
-            glue.prepareGlue(typeRegistry);
+            glue.prepareGlue(stepTypeRegistry);
 
             TestCase testCase = createTestCaseForPickle(pickle);
             testCase.run(bus);
@@ -70,21 +70,21 @@ public final class Runner {
         }
     }
 
-    private List<SnippetGenerator> createSnippetGeneratorsForPickle(TypeRegistry typeRegistry) {
+    private List<SnippetGenerator> createSnippetGeneratorsForPickle(StepTypeRegistry stepTypeRegistry) {
         return backends.stream()
             .map(Backend::getSnippet)
-            .map(s -> new SnippetGenerator(s, typeRegistry.parameterTypeRegistry()))
+            .map(s -> new SnippetGenerator(s, stepTypeRegistry.parameterTypeRegistry()))
             .collect(Collectors.toList());
     }
 
-    private TypeRegistry createTypeRegistryForPickle(CucumberPickle pickle) {
+    private StepTypeRegistry createTypeRegistryForPickle(CucumberPickle pickle) {
         Locale locale = typeRegistryConfigurer.locale();
         if (locale == null) {
             locale = new Locale(pickle.getLanguage());
         }
-        TypeRegistry typeRegistry = new TypeRegistry(locale);
-        typeRegistryConfigurer.configureTypeRegistry(typeRegistry);
-        return typeRegistry;
+        StepTypeRegistry stepTypeRegistry = new StepTypeRegistry(locale);
+        typeRegistryConfigurer.configureTypeRegistry(stepTypeRegistry);
+        return stepTypeRegistry;
     }
 
     private TestCase createTestCaseForPickle(CucumberPickle pickle) {

--- a/core/src/main/java/io/cucumber/core/runner/StepDefinitionMatch.java
+++ b/core/src/main/java/io/cucumber/core/runner/StepDefinitionMatch.java
@@ -1,9 +1,9 @@
 package io.cucumber.core.runner;
 
 interface StepDefinitionMatch {
-    void runStep(Scenario scenario) throws Throwable;
+    void runStep(TestCaseState state) throws Throwable;
 
-    void dryRunStep(Scenario scenario) throws Throwable;
+    void dryRunStep(TestCaseState state) throws Throwable;
 
     String getCodeLocation();
 

--- a/core/src/main/java/io/cucumber/core/runner/TestCase.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCase.java
@@ -37,24 +37,24 @@ final class TestCase implements io.cucumber.plugin.event.TestCase {
         boolean skipNextStep = this.dryRun;
         Instant start = bus.getInstant();
         bus.send(new TestCaseStarted(start, this));
-        Scenario scenario = new Scenario(bus, this);
+        TestCaseState state = new TestCaseState(bus, this);
 
         for (HookTestStep before : beforeHooks) {
-            skipNextStep |= before.run(this, bus, scenario, dryRun);
+            skipNextStep |= before.run(this, bus, state, dryRun);
         }
 
         for (PickleStepTestStep step : testSteps) {
-            skipNextStep |= step.run(this, bus, scenario, skipNextStep);
+            skipNextStep |= step.run(this, bus, state, skipNextStep);
         }
 
         for (HookTestStep after : afterHooks) {
-            after.run(this, bus, scenario, dryRun);
+            after.run(this, bus, state, dryRun);
         }
 
         Instant stop = bus.getInstant();
         Duration duration = Duration.between(start, stop);
-        Status status = Status.valueOf(scenario.getStatus().name());
-        Result result = new Result(status, duration, scenario.getError());
+        Status status = Status.valueOf(state.getStatus().name());
+        Result result = new Result(status, duration, state.getError());
         bus.send(new TestCaseFinished(stop, this, result));
     }
 

--- a/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
@@ -15,13 +15,13 @@ import static java.util.Collections.max;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 
-class Scenario implements io.cucumber.core.backend.Scenario {
+class TestCaseState implements io.cucumber.core.backend.TestCaseState {
 
     private final List<Result> stepResults = new ArrayList<>();
     private final EventBus bus;
     private final TestCase testCase;
 
-    Scenario(EventBus bus, TestCase testCase) {
+    TestCaseState(EventBus bus, TestCase testCase) {
         this.bus = requireNonNull(bus);
         this.testCase = requireNonNull(testCase);
     }

--- a/core/src/main/java/io/cucumber/core/runner/TestStep.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestStep.java
@@ -37,30 +37,30 @@ abstract class TestStep implements io.cucumber.plugin.event.TestStep {
         return stepDefinitionMatch.getCodeLocation();
     }
 
-    boolean run(TestCase testCase, EventBus bus, Scenario scenario, boolean skipSteps) {
+    boolean run(TestCase testCase, EventBus bus, TestCaseState state, boolean skipSteps) {
         Instant startTimeMillis = bus.getInstant();
         bus.send(new TestStepStarted(startTimeMillis, testCase, this));
         Status status;
         Throwable error = null;
         try {
-            status = executeStep(scenario, skipSteps);
+            status = executeStep(state, skipSteps);
         } catch (Throwable t) {
             error = t;
             status = mapThrowableToStatus(t);
         }
         Instant stopTimeNanos = bus.getInstant();
         Result result = mapStatusToResult(status, error, Duration.between(startTimeMillis, stopTimeNanos));
-        scenario.add(result);
+        state.add(result);
         bus.send(new TestStepFinished(stopTimeNanos, testCase, this, result));
         return !result.getStatus().is(Status.PASSED);
     }
 
-    private Status executeStep(Scenario scenario, boolean skipSteps) throws Throwable {
+    private Status executeStep(TestCaseState state, boolean skipSteps) throws Throwable {
         if (!skipSteps) {
-            stepDefinitionMatch.runStep(scenario);
+            stepDefinitionMatch.runStep(state);
             return Status.PASSED;
         } else {
-            stepDefinitionMatch.dryRunStep(scenario);
+            stepDefinitionMatch.dryRunStep(state);
             return Status.SKIPPED;
         }
     }

--- a/core/src/main/java/io/cucumber/core/runner/UndefinedPickleStepDefinitionMatch.java
+++ b/core/src/main/java/io/cucumber/core/runner/UndefinedPickleStepDefinitionMatch.java
@@ -11,13 +11,13 @@ final class UndefinedPickleStepDefinitionMatch extends PickleStepDefinitionMatch
     }
 
     @Override
-    public void runStep(Scenario scenario) {
+    public void runStep(TestCaseState state) {
         throw new UndefinedStepDefinitionException();
     }
 
     @Override
-    public void dryRunStep(Scenario scenario) {
-        runStep(scenario);
+    public void dryRunStep(TestCaseState state) {
+        runStep(state);
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/stepexpression/StepExpressionFactory.java
+++ b/core/src/main/java/io/cucumber/core/stepexpression/StepExpressionFactory.java
@@ -2,6 +2,7 @@ package io.cucumber.core.stepexpression;
 
 import io.cucumber.core.exception.CucumberException;
 import io.cucumber.cucumberexpressions.Expression;
+import io.cucumber.cucumberexpressions.ExpressionFactory;
 import io.cucumber.cucumberexpressions.UndefinedParameterTypeException;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.datatable.DataTableTypeRegistryTableConverter;
@@ -14,12 +15,12 @@ import java.util.function.Supplier;
 
 public final class StepExpressionFactory {
 
-    private final io.cucumber.cucumberexpressions.ExpressionFactory expressionFactory;
+    private final ExpressionFactory expressionFactory;
     private final DataTableTypeRegistryTableConverter tableConverter;
     private final DocStringTypeRegistryDocStringConverter docStringConverter;
 
-    public StepExpressionFactory(TypeRegistry registry) {
-        this.expressionFactory = new io.cucumber.cucumberexpressions.ExpressionFactory(registry.parameterTypeRegistry());
+    public StepExpressionFactory(StepTypeRegistry registry) {
+        this.expressionFactory = new ExpressionFactory(registry.parameterTypeRegistry());
         this.tableConverter = new DataTableTypeRegistryTableConverter(registry.dataTableTypeRegistry());
         this.docStringConverter = new DocStringTypeRegistryDocStringConverter(registry.docStringTypeRegistry());
     }

--- a/core/src/main/java/io/cucumber/core/stepexpression/StepTypeRegistry.java
+++ b/core/src/main/java/io/cucumber/core/stepexpression/StepTypeRegistry.java
@@ -12,7 +12,7 @@ import io.cucumber.docstring.DocStringTypeRegistry;
 
 import java.util.Locale;
 
-public final class TypeRegistry implements io.cucumber.core.api.TypeRegistry {
+public final class StepTypeRegistry implements io.cucumber.core.api.TypeRegistry {
 
     private final ParameterTypeRegistry parameterTypeRegistry;
 
@@ -21,7 +21,7 @@ public final class TypeRegistry implements io.cucumber.core.api.TypeRegistry {
     private final DocStringTypeRegistry docStringTypeRegistry;
 
 
-    public TypeRegistry(Locale locale) {
+    public StepTypeRegistry(Locale locale) {
         parameterTypeRegistry = new ParameterTypeRegistry(locale);
         dataTableTypeRegistry = new DataTableTypeRegistry(locale);
         docStringTypeRegistry = new DocStringTypeRegistry();

--- a/core/src/test/java/io/cucumber/core/plugin/PrettyFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/PrettyFormatterTest.java
@@ -6,7 +6,7 @@ import io.cucumber.core.feature.TestFeatureParser;
 import io.cucumber.core.runner.TestHelper;
 import io.cucumber.core.stepexpression.StepExpression;
 import io.cucumber.core.stepexpression.StepExpressionFactory;
-import io.cucumber.core.stepexpression.TypeRegistry;
+import io.cucumber.core.stepexpression.StepTypeRegistry;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
@@ -387,7 +387,7 @@ class PrettyFormatterTest {
     void should_mark_subsequent_arguments_in_steps() {
         Formats formats = new AnsiFormats();
 
-        TypeRegistry registry = new TypeRegistry(Locale.ENGLISH);
+        StepTypeRegistry registry = new StepTypeRegistry(Locale.ENGLISH);
         StepExpressionFactory stepExpressionFactory = new StepExpressionFactory(registry);
         StepExpression expression = stepExpressionFactory.createExpression("text {string} text {string}");
 
@@ -406,7 +406,7 @@ class PrettyFormatterTest {
     void should_mark_nested_argument_as_part_of_full_argument() {
         Formats formats = new AnsiFormats();
 
-        TypeRegistry registry = new TypeRegistry(Locale.ENGLISH);
+        StepTypeRegistry registry = new StepTypeRegistry(Locale.ENGLISH);
         StepExpressionFactory stepExpressionFactory = new StepExpressionFactory(registry);
         StepExpression expression = stepExpressionFactory.createExpression("^the order is placed( and (not yet )?confirmed)?$");
 
@@ -424,7 +424,7 @@ class PrettyFormatterTest {
     void should_mark_nested_arguments_as_part_of_enclosing_argument() {
         Formats formats = new AnsiFormats();
         PrettyFormatter prettyFormatter = new PrettyFormatter(null);
-        TypeRegistry registry = new TypeRegistry(Locale.ENGLISH);
+        StepTypeRegistry registry = new StepTypeRegistry(Locale.ENGLISH);
         StepExpressionFactory stepExpressionFactory = new StepExpressionFactory(registry);
         StepExpression expression = stepExpressionFactory.createExpression("^the order is placed( and (not( yet)? )?confirmed)?$");
         String stepText = "the order is placed and not yet confirmed";

--- a/core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionMatchTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionMatchTest.java
@@ -26,7 +26,7 @@ class AmbiguousStepDefinitionMatchTest {
 
     @Test
     void throws_ambiguous_step_definitions_exception_when_run() {
-        Executable testMethod = () -> match.runStep(mock(Scenario.class));
+        Executable testMethod = () -> match.runStep(mock(TestCaseState.class));
         AmbiguousStepDefinitionsException actualThrown = assertThrows(AmbiguousStepDefinitionsException.class, testMethod);
         assertThat(actualThrown.getMessage(), is(equalTo(
             "\"I have 4 cukes in my belly\" matches more than one step definition:\n"
@@ -35,7 +35,7 @@ class AmbiguousStepDefinitionMatchTest {
 
     @Test
     void throws_ambiguous_step_definitions_exception_when_dry_run() {
-        Executable testMethod = () -> match.dryRunStep(mock(Scenario.class));
+        Executable testMethod = () -> match.dryRunStep(mock(TestCaseState.class));
         AmbiguousStepDefinitionsException actualThrown = assertThrows(AmbiguousStepDefinitionsException.class, testMethod);
         assertThat(actualThrown.getMessage(), is(equalTo(
             "\"I have 4 cukes in my belly\" matches more than one step definition:\n"

--- a/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -15,7 +15,7 @@ import io.cucumber.core.feature.CucumberFeature;
 import io.cucumber.core.feature.CucumberStep;
 import io.cucumber.core.feature.TestFeatureParser;
 import io.cucumber.core.runtime.TimeServiceEventBus;
-import io.cucumber.core.stepexpression.TypeRegistry;
+import io.cucumber.core.stepexpression.StepTypeRegistry;
 import io.cucumber.cucumberexpressions.ParameterByTypeTransformer;
 import io.cucumber.cucumberexpressions.ParameterType;
 import io.cucumber.datatable.DataTable;
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
 
 class CachingGlueTest {
 
-    private final TypeRegistry typeRegistry = new TypeRegistry(ENGLISH);
+    private final StepTypeRegistry stepTypeRegistry = new StepTypeRegistry(ENGLISH);
     private CachingGlue glue = new CachingGlue(new TimeServiceEventBus(Clock.systemUTC()));
 
     private static CucumberStep getPickleStep(String text) {
@@ -94,7 +94,7 @@ class CachingGlueTest {
 
         DuplicateStepDefinitionException exception = assertThrows(
             DuplicateStepDefinitionException.class,
-            () -> glue.prepareGlue(typeRegistry)
+            () -> glue.prepareGlue(stepTypeRegistry)
         );
         assertThat(exception.getMessage(), equalTo("Duplicate step definitions in foo.bf:10 and bar.bf:90"));
     }
@@ -106,7 +106,7 @@ class CachingGlueTest {
 
         DuplicateDefaultParameterTransformers exception = assertThrows(
             DuplicateDefaultParameterTransformers.class,
-            () -> glue.prepareGlue(typeRegistry)
+            () -> glue.prepareGlue(stepTypeRegistry)
         );
         assertThat(exception.getMessage(), equalTo("" +
             "There may not be more then one default parameter transformer. Found:\n" +
@@ -122,7 +122,7 @@ class CachingGlueTest {
 
         DuplicateDefaultDataTableEntryTransformers exception = assertThrows(
             DuplicateDefaultDataTableEntryTransformers.class,
-            () -> glue.prepareGlue(typeRegistry)
+            () -> glue.prepareGlue(stepTypeRegistry)
         );
         assertThat(exception.getMessage(), equalTo("" +
             "There may not be more then one default data table entry. Found:\n" +
@@ -138,7 +138,7 @@ class CachingGlueTest {
 
         DuplicateDefaultDataTableCellTransformers exception = assertThrows(
             DuplicateDefaultDataTableCellTransformers.class,
-            () -> glue.prepareGlue(typeRegistry)
+            () -> glue.prepareGlue(stepTypeRegistry)
         );
         assertThat(exception.getMessage(), equalTo("" +
             "There may not be more then one default table cell transformers. Found:\n" +
@@ -165,7 +165,7 @@ class CachingGlueTest {
         glue.addDefaultDataTableCellTransformer(new MockedDefaultDataTableCellTransformer());
         glue.addDefaultDataTableEntryTransformer(new MockedDefaultDataTableEntryTransformer());
 
-        glue.prepareGlue(typeRegistry);
+        glue.prepareGlue(stepTypeRegistry);
 
         assertAll("Checking Glue",
             () -> assertThat(glue.getStepDefinitions().size(), is(equalTo(1))),
@@ -215,7 +215,7 @@ class CachingGlueTest {
         StepDefinition stepDefinition2 = new MockedStepDefinition("^pattern2");
         glue.addStepDefinition(stepDefinition1);
         glue.addStepDefinition(stepDefinition2);
-        glue.prepareGlue(typeRegistry);
+        glue.prepareGlue(stepTypeRegistry);
 
         String featurePath = "someFeature.feature";
         String stepText = "pattern1";
@@ -242,7 +242,7 @@ class CachingGlueTest {
         StepDefinition stepDefinition2 = new MockedStepDefinition("^pattern2");
         glue.addStepDefinition(stepDefinition1);
         glue.addStepDefinition(stepDefinition2);
-        glue.prepareGlue(typeRegistry);
+        glue.prepareGlue(stepTypeRegistry);
 
         String featurePath = "someFeature.feature";
         String stepText = "pattern1";
@@ -273,7 +273,7 @@ class CachingGlueTest {
         StepDefinition stepDefinition2 = new MockedStepDefinition("^pattern2");
         glue.addStepDefinition(stepDefinition1);
         glue.addStepDefinition(stepDefinition2);
-        glue.prepareGlue(typeRegistry);
+        glue.prepareGlue(stepTypeRegistry);
 
         String featurePath = "someFeature.feature";
         String stepText = "pattern1";
@@ -307,7 +307,7 @@ class CachingGlueTest {
 
         StepDefinition stepDefinition1 = new MockedScenarioScopedStepDefinition("^pattern1");
         glue.addStepDefinition(stepDefinition1);
-        glue.prepareGlue(typeRegistry);
+        glue.prepareGlue(stepTypeRegistry);
 
 
         PickleStepDefinitionMatch pickleStepDefinitionMatch = glue.stepDefinitionMatch(featurePath, pickleStep1);
@@ -317,7 +317,7 @@ class CachingGlueTest {
 
         StepDefinition stepDefinition2 = new MockedScenarioScopedStepDefinition("^pattern1");
         glue.addStepDefinition(stepDefinition2);
-        glue.prepareGlue(typeRegistry);
+        glue.prepareGlue(stepTypeRegistry);
 
         PickleStepDefinitionMatch pickleStepDefinitionMatch2 = glue.stepDefinitionMatch(featurePath, pickleStep1);
         assertThat(pickleStepDefinitionMatch2.getStepDefinition(), is(equalTo(stepDefinition2)));
@@ -332,7 +332,7 @@ class CachingGlueTest {
 
         StepDefinition stepDefinition1 = new MockedScenarioScopedStepDefinition("^pattern1");
         glue.addStepDefinition(stepDefinition1);
-        glue.prepareGlue(typeRegistry);
+        glue.prepareGlue(stepTypeRegistry);
 
 
         PickleStepDefinitionMatch pickleStepDefinitionMatch = glue.stepDefinitionMatch(featurePath, pickleStep1);
@@ -340,7 +340,7 @@ class CachingGlueTest {
 
         glue.removeScenarioScopedGlue();
 
-        glue.prepareGlue(typeRegistry);
+        glue.prepareGlue(stepTypeRegistry);
 
         PickleStepDefinitionMatch pickleStepDefinitionMatch2 = glue.stepDefinitionMatch(featurePath, pickleStep1);
         assertThat(pickleStepDefinitionMatch2, nullValue());
@@ -354,7 +354,7 @@ class CachingGlueTest {
         glue.addStepDefinition(stepDefinition1);
         glue.addStepDefinition(stepDefinition2);
         glue.addStepDefinition(stepDefinition3);
-        glue.prepareGlue(typeRegistry);
+        glue.prepareGlue(stepTypeRegistry);
 
         String featurePath = "someFeature.feature";
 

--- a/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -1,5 +1,6 @@
 package io.cucumber.core.runner;
 
+import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.core.backend.DataTableTypeDefinition;
 import io.cucumber.core.backend.DefaultDataTableCellTransformerDefinition;
 import io.cucumber.core.backend.DefaultDataTableEntryTransformerDefinition;
@@ -8,7 +9,6 @@ import io.cucumber.core.backend.DocStringTypeDefinition;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.ParameterInfo;
 import io.cucumber.core.backend.ParameterTypeDefinition;
-import io.cucumber.core.backend.Scenario;
 import io.cucumber.core.backend.ScenarioScoped;
 import io.cucumber.core.backend.StepDefinition;
 import io.cucumber.core.feature.CucumberFeature;
@@ -526,7 +526,7 @@ class CachingGlueTest {
         }
 
         @Override
-        public void execute(Scenario scenario) {
+        public void execute(TestCaseState state) {
 
         }
 
@@ -565,7 +565,7 @@ class CachingGlueTest {
         }
 
         @Override
-        public void execute(Scenario scenario) {
+        public void execute(TestCaseState state) {
 
         }
 

--- a/core/src/test/java/io/cucumber/core/runner/CoreStepDefinitionTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/CoreStepDefinitionTest.java
@@ -4,7 +4,7 @@ import io.cucumber.core.feature.CucumberFeature;
 import io.cucumber.core.feature.CucumberStep;
 import io.cucumber.core.feature.TestFeatureParser;
 import io.cucumber.core.stepexpression.Argument;
-import io.cucumber.core.stepexpression.TypeRegistry;
+import io.cucumber.core.stepexpression.StepTypeRegistry;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.docstring.DocString;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CoreStepDefinitionTest {
 
-    private final TypeRegistry typeRegistry = new TypeRegistry(Locale.ENGLISH);
+    private final StepTypeRegistry stepTypeRegistry = new StepTypeRegistry(Locale.ENGLISH);
 
     @Test
     void should_apply_identity_transform_to_doc_string_when_target_type_is_object() {
@@ -39,7 +39,7 @@ class CoreStepDefinitionTest {
             "       \"\"\"\n"
         );
         StubStepDefinition stub = new StubStepDefinition("I have some step", Object.class);
-        CoreStepDefinition stepDefinition = new CoreStepDefinition(stub, typeRegistry);
+        CoreStepDefinition stepDefinition = new CoreStepDefinition(stub, stepTypeRegistry);
         CucumberStep step = feature.getPickles().get(0).getSteps().get(0);
         List<Argument> arguments = stepDefinition.matchedArguments(step);
         assertThat(arguments.get(0).getValue(), is(equalTo(DocString.create("content"))));
@@ -55,7 +55,7 @@ class CoreStepDefinitionTest {
             "      | content |\n"
         );
         StubStepDefinition stub = new StubStepDefinition("I have some step", Object.class);
-        CoreStepDefinition stepDefinition = new CoreStepDefinition(stub, typeRegistry);
+        CoreStepDefinition stepDefinition = new CoreStepDefinition(stub, stepTypeRegistry);
         List<Argument> arguments = stepDefinition.matchedArguments(feature.getPickles().get(0).getSteps().get(0));
         assertThat(arguments.get(0).getValue(), is(equalTo(DataTable.create(singletonList(singletonList("content"))))));
     }
@@ -69,7 +69,7 @@ class CoreStepDefinitionTest {
             "       |  |\n"
         );
         StubStepDefinition stub = new StubStepDefinition("I have some step", Object.class);
-        CoreStepDefinition stepDefinition = new CoreStepDefinition(stub, typeRegistry);
+        CoreStepDefinition stepDefinition = new CoreStepDefinition(stub, stepTypeRegistry);
         List<Argument> arguments = stepDefinition.matchedArguments(feature.getPickles().get(0).getSteps().get(0));
         assertEquals(DataTable.create(singletonList(singletonList(null))), arguments.get(0).getValue());
     }
@@ -193,7 +193,7 @@ class CoreStepDefinitionTest {
     @SuppressWarnings("unchecked")
     private <T> T runStepDef(Method method, boolean transposed, CucumberFeature feature) throws Throwable {
         StubStepDefinition stub = new StubStepDefinition("some text", transposed, method.getGenericParameterTypes());
-        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stub, typeRegistry);
+        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stub, stepTypeRegistry);
         CucumberStep stepWithTable = feature.getPickles().get(0).getSteps().get(0);
         List<Argument> arguments = coreStepDefinition.matchedArguments(stepWithTable);
 

--- a/core/src/test/java/io/cucumber/core/runner/HookTestStepTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/HookTestStepTest.java
@@ -43,7 +43,7 @@ class HookTestStepTest {
         false
     );
     private final EventBus bus = mock(EventBus.class);
-    private final Scenario scenario = new Scenario(bus, testCase);
+    private final TestCaseState state = new TestCaseState(bus, testCase);
     private HookTestStep step = new HookTestStep(HookType.AFTER_STEP, definitionMatch);
 
     @BeforeEach
@@ -53,36 +53,36 @@ class HookTestStepTest {
 
     @Test
     void run_does_run() throws Throwable {
-        step.run(testCase, bus, scenario, false);
+        step.run(testCase, bus, state, false);
 
         InOrder order = inOrder(bus, hookDefintion);
         order.verify(bus).send(isA(TestStepStarted.class));
-        order.verify(hookDefintion).execute(scenario);
+        order.verify(hookDefintion).execute(state);
         order.verify(bus).send(isA(TestStepFinished.class));
     }
 
     @Test
     void run_does_dry_run() throws Throwable {
-        step.run(testCase, bus, scenario, true);
+        step.run(testCase, bus, state, true);
 
         InOrder order = inOrder(bus, hookDefintion);
         order.verify(bus).send(isA(TestStepStarted.class));
-        order.verify(hookDefintion, never()).execute(scenario);
+        order.verify(hookDefintion, never()).execute(state);
         order.verify(bus).send(isA(TestStepFinished.class));
     }
 
     @Test
     void result_is_passed_when_step_definition_does_not_throw_exception() {
-        boolean skipNextStep = step.run(testCase, bus, scenario, false);
+        boolean skipNextStep = step.run(testCase, bus, state, false);
         assertFalse(skipNextStep);
-        assertThat(scenario.getStatus(), is(equalTo(PASSED)));
+        assertThat(state.getStatus(), is(equalTo(PASSED)));
     }
 
     @Test
     void result_is_skipped_when_skip_step_is_skip_all_skipable() {
-        boolean skipNextStep = step.run(testCase, bus, scenario, true);
+        boolean skipNextStep = step.run(testCase, bus, state, true);
         assertTrue(skipNextStep);
-        assertThat(scenario.getStatus(), is(equalTo(SKIPPED)));
+        assertThat(state.getStatus(), is(equalTo(SKIPPED)));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/runner/PickleStepTestStepTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/PickleStepTestStepTest.java
@@ -58,7 +58,7 @@ class PickleStepTestStepTest {
     private final CucumberPickle pickle = feature.getPickles().get(0);
     private final TestCase testCase = new TestCase(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), pickle, false);
     private final EventBus bus = mock(EventBus.class);
-    private final Scenario scenario = new Scenario(bus, testCase);
+    private final TestCaseState state = new TestCaseState(bus, testCase);
     private final PickleStepDefinitionMatch definitionMatch = mock(PickleStepDefinitionMatch.class);
     private CoreHookDefinition afterHookDefinition = mock(CoreHookDefinition.class);
     private final HookTestStep afterHook = new HookTestStep(AFTER_STEP, new HookDefinitionMatch(afterHookDefinition));
@@ -71,7 +71,7 @@ class PickleStepTestStepTest {
         singletonList(afterHook),
         definitionMatch
     );
-    private static ArgumentMatcher<Scenario> scenarioDoesNotHave(final Throwable type) {
+    private static ArgumentMatcher<TestCaseState> scenarioDoesNotHave(final Throwable type) {
         return argument -> !type.equals(argument.getError());
     }
 
@@ -82,62 +82,62 @@ class PickleStepTestStepTest {
 
     @Test
     void run_wraps_run_step_in_test_step_started_and_finished_events() throws Throwable {
-        step.run(testCase, bus, scenario, false);
+        step.run(testCase, bus, state, false);
 
         InOrder order = inOrder(bus, definitionMatch);
         order.verify(bus).send(isA(TestStepStarted.class));
-        order.verify(definitionMatch).runStep(scenario);
+        order.verify(definitionMatch).runStep(state);
         order.verify(bus).send(isA(TestStepFinished.class));
     }
 
     @Test
     void run_does_dry_run_step_when_skip_steps_is_true() throws Throwable {
-        step.run(testCase, bus, scenario, true);
+        step.run(testCase, bus, state, true);
 
         InOrder order = inOrder(bus, definitionMatch);
         order.verify(bus).send(isA(TestStepStarted.class));
-        order.verify(definitionMatch).dryRunStep(scenario);
+        order.verify(definitionMatch).dryRunStep(state);
         order.verify(bus).send(isA(TestStepFinished.class));
     }
 
     @Test
     void result_is_passed_when_step_definition_does_not_throw_exception() {
-        boolean skipNextStep = step.run(testCase, bus, scenario, false);
+        boolean skipNextStep = step.run(testCase, bus, state, false);
         assertFalse(skipNextStep);
-        assertThat(scenario.getStatus(), is(equalTo(PASSED)));
+        assertThat(state.getStatus(), is(equalTo(PASSED)));
     }
 
     @Test
     void result_is_skipped_when_skip_step_is_not_run_all() {
-        boolean skipNextStep = step.run(testCase, bus, scenario, true);
+        boolean skipNextStep = step.run(testCase, bus, state, true);
 
         assertTrue(skipNextStep);
-        assertThat(scenario.getStatus(), is(equalTo(SKIPPED)));
+        assertThat(state.getStatus(), is(equalTo(SKIPPED)));
     }
 
     @Test
-    void result_is_skipped_when_before_step_hook_does_not_pass() throws Throwable {
-        doThrow(TestAbortedException.class).when(beforeHookDefinition).execute(any(Scenario.class));
-        boolean skipNextStep = step.run(testCase, bus, scenario, false);
+    void result_is_skipped_when_before_step_hook_does_not_pass() {
+        doThrow(TestAbortedException.class).when(beforeHookDefinition).execute(any(TestCaseState.class));
+        boolean skipNextStep = step.run(testCase, bus, state, false);
         assertTrue(skipNextStep);
-        assertThat(scenario.getStatus(), is(equalTo(SKIPPED)));
+        assertThat(state.getStatus(), is(equalTo(SKIPPED)));
     }
 
     @Test
     void step_execution_is_dry_run_when_before_step_hook_does_not_pass() throws Throwable {
-        doThrow(TestAbortedException.class).when(beforeHookDefinition).execute(any(Scenario.class));
-        step.run(testCase, bus, scenario, false);
-        verify(definitionMatch).dryRunStep(any(Scenario.class));
+        doThrow(TestAbortedException.class).when(beforeHookDefinition).execute(any(TestCaseState.class));
+        step.run(testCase, bus, state, false);
+        verify(definitionMatch).dryRunStep(any(TestCaseState.class));
     }
 
     @Test
-    void result_is_result_from_hook_when_before_step_hook_does_not_pass() throws Throwable {
+    void result_is_result_from_hook_when_before_step_hook_does_not_pass() {
         Exception exception = new RuntimeException();
-        doThrow(exception).when(beforeHookDefinition).execute(any(Scenario.class));
+        doThrow(exception).when(beforeHookDefinition).execute(any(TestCaseState.class));
         Result failure = new Result(Status.FAILED, ZERO, exception);
-        boolean skipNextStep = step.run(testCase, bus, scenario, false);
+        boolean skipNextStep = step.run(testCase, bus, state, false);
         assertTrue(skipNextStep);
-        assertThat(scenario.getStatus(), is(equalTo(FAILED)));
+        assertThat(state.getStatus(), is(equalTo(FAILED)));
 
         ArgumentCaptor<TestCaseEvent> captor = forClass(TestCaseEvent.class);
         verify(bus, times(6)).send(captor.capture());
@@ -149,10 +149,10 @@ class PickleStepTestStepTest {
     void result_is_result_from_step_when_step_hook_does_not_pass() throws Throwable {
         RuntimeException runtimeException = new RuntimeException();
         Result failure = new Result(Status.FAILED, ZERO, runtimeException);
-        doThrow(runtimeException).when(definitionMatch).runStep(any(Scenario.class));
-        boolean skipNextStep = step.run(testCase, bus, scenario, false);
+        doThrow(runtimeException).when(definitionMatch).runStep(any(TestCaseState.class));
+        boolean skipNextStep = step.run(testCase, bus, state, false);
         assertTrue(skipNextStep);
-        assertThat(scenario.getStatus(), is(equalTo(FAILED)));
+        assertThat(state.getStatus(), is(equalTo(FAILED)));
 
         ArgumentCaptor<TestCaseEvent> captor = forClass(TestCaseEvent.class);
         verify(bus, times(6)).send(captor.capture());
@@ -161,13 +161,13 @@ class PickleStepTestStepTest {
     }
 
     @Test
-    void result_is_result_from_hook_when_after_step_hook_does_not_pass() throws Throwable {
+    void result_is_result_from_hook_when_after_step_hook_does_not_pass() {
         Exception exception = new RuntimeException();
         Result failure = new Result(Status.FAILED, ZERO, exception);
-        doThrow(exception).when(afterHookDefinition).execute(any(Scenario.class));
-        boolean skipNextStep = step.run(testCase, bus, scenario, false);
+        doThrow(exception).when(afterHookDefinition).execute(any(TestCaseState.class));
+        boolean skipNextStep = step.run(testCase, bus, state, false);
         assertTrue(skipNextStep);
-        assertThat(scenario.getStatus(), is(equalTo(FAILED)));
+        assertThat(state.getStatus(), is(equalTo(FAILED)));
 
         ArgumentCaptor<TestCaseEvent> captor = forClass(TestCaseEvent.class);
         verify(bus, times(6)).send(captor.capture());
@@ -176,65 +176,65 @@ class PickleStepTestStepTest {
     }
 
     @Test
-    void after_step_hook_is_run_when_before_step_hook_does_not_pass() throws Throwable {
-        doThrow(RuntimeException.class).when(beforeHookDefinition).execute(any(Scenario.class));
-        step.run(testCase, bus, scenario, false);
-        verify(afterHookDefinition).execute(any(Scenario.class));
+    void after_step_hook_is_run_when_before_step_hook_does_not_pass() {
+        doThrow(RuntimeException.class).when(beforeHookDefinition).execute(any(TestCaseState.class));
+        step.run(testCase, bus, state, false);
+        verify(afterHookDefinition).execute(any(TestCaseState.class));
     }
 
     @Test
     void after_step_hook_is_run_when_step_does_not_pass() throws Throwable {
-        doThrow(Exception.class).when(definitionMatch).runStep(any(Scenario.class));
-        step.run(testCase, bus, scenario, false);
-        verify(afterHookDefinition).execute(any(Scenario.class));
+        doThrow(Exception.class).when(definitionMatch).runStep(any(TestCaseState.class));
+        step.run(testCase, bus, state, false);
+        verify(afterHookDefinition).execute(any(TestCaseState.class));
     }
 
     @Test
     void after_step_hook_scenario_contains_step_failure_when_step_does_not_pass() throws Throwable {
         Throwable expectedError = new TestAbortedException("oops");
-        doThrow(expectedError).when(definitionMatch).runStep(any(Scenario.class));
-        doThrow(new Exception()).when(afterHookDefinition).execute(argThat(scenarioDoesNotHave(expectedError)));
-        step.run(testCase, bus, scenario, false);
-        assertThat(scenario.getError(), is(expectedError));
+        doThrow(expectedError).when(definitionMatch).runStep(any(TestCaseState.class));
+        doThrow(new RuntimeException()).when(afterHookDefinition).execute(argThat(scenarioDoesNotHave(expectedError)));
+        step.run(testCase, bus, state, false);
+        assertThat(state.getError(), is(expectedError));
     }
 
     @Test
-    void after_step_hook_scenario_contains_before_step_hook_failure_when_before_step_hook_does_not_pass() throws Throwable {
+    void after_step_hook_scenario_contains_before_step_hook_failure_when_before_step_hook_does_not_pass() {
         Throwable expectedError = new TestAbortedException("oops");
-        doThrow(expectedError).when(beforeHookDefinition).execute(any(Scenario.class));
-        doThrow(new Exception()).when(afterHookDefinition).execute(argThat(scenarioDoesNotHave(expectedError)));
-        step.run(testCase, bus, scenario, false);
-        assertThat(scenario.getError(), is(expectedError));
+        doThrow(expectedError).when(beforeHookDefinition).execute(any(TestCaseState.class));
+        doThrow(new RuntimeException()).when(afterHookDefinition).execute(argThat(scenarioDoesNotHave(expectedError)));
+        step.run(testCase, bus, state, false);
+        assertThat(state.getError(), is(expectedError));
     }
 
     @Test
     void result_is_skipped_when_step_definition_throws_assumption_violated_exception() throws Throwable {
         doThrow(TestAbortedException.class).when(definitionMatch).runStep(any());
 
-        boolean skipNextStep = step.run(testCase, bus, scenario, false);
+        boolean skipNextStep = step.run(testCase, bus, state, false);
         assertTrue(skipNextStep);
 
-        assertThat(scenario.getStatus(), is(equalTo(SKIPPED)));
+        assertThat(state.getStatus(), is(equalTo(SKIPPED)));
     }
 
     @Test
     void result_is_failed_when_step_definition_throws_exception() throws Throwable {
-        doThrow(RuntimeException.class).when(definitionMatch).runStep(any(Scenario.class));
+        doThrow(RuntimeException.class).when(definitionMatch).runStep(any(TestCaseState.class));
 
-        boolean skipNextStep = step.run(testCase, bus, scenario, false);
+        boolean skipNextStep = step.run(testCase, bus, state, false);
         assertTrue(skipNextStep);
 
-        assertThat(scenario.getStatus(), is(equalTo(FAILED)));
+        assertThat(state.getStatus(), is(equalTo(FAILED)));
     }
 
     @Test
     void result_is_pending_when_step_definition_throws_pending_exception() throws Throwable {
-        doThrow(TestPendingException.class).when(definitionMatch).runStep(any(Scenario.class));
+        doThrow(TestPendingException.class).when(definitionMatch).runStep(any(TestCaseState.class));
 
-        boolean skipNextStep = step.run(testCase, bus, scenario, false);
+        boolean skipNextStep = step.run(testCase, bus, state, false);
         assertTrue(skipNextStep);
 
-        assertThat(scenario.getStatus(), is(equalTo(PENDING)));
+        assertThat(state.getStatus(), is(equalTo(PENDING)));
     }
 
     @Test
@@ -251,7 +251,7 @@ class PickleStepTestStepTest {
             definitionMatch
         );
         when(bus.getInstant()).thenReturn(ofEpochMilli(234L), ofEpochMilli(1234L));
-        step.run(testCase, bus, scenario, false);
+        step.run(testCase, bus, state, false);
 
         ArgumentCaptor<TestCaseEvent> captor = forClass(TestCaseEvent.class);
         verify(bus, times(2)).send(captor.capture());

--- a/core/src/test/java/io/cucumber/core/runner/RunnerTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/RunnerTest.java
@@ -65,8 +65,8 @@ class RunnerTest {
 
         InOrder inOrder = inOrder(beforeHook, afterHook, backend);
         inOrder.verify(backend).buildWorld();
-        inOrder.verify(beforeHook).execute(any(Scenario.class));
-        inOrder.verify(afterHook).execute(any(Scenario.class));
+        inOrder.verify(beforeHook).execute(any(TestCaseState.class));
+        inOrder.verify(afterHook).execute(any(TestCaseState.class));
         inOrder.verify(backend).disposeWorld();
     }
 
@@ -88,7 +88,7 @@ class RunnerTest {
         runnerSupplier.get().runPickle(pickleEventMatchingStepDefinitions);
 
         InOrder inOrder = inOrder(failingBeforeHook, stepDefinition);
-        inOrder.verify(failingBeforeHook).execute(any(Scenario.class));
+        inOrder.verify(failingBeforeHook).execute(any(TestCaseState.class));
         inOrder.verify(stepDefinition, never()).execute(any(Object[].class));
     }
 
@@ -119,7 +119,7 @@ class RunnerTest {
 
         InOrder inOrder = inOrder(afteStepHook, stepDefinition);
         inOrder.verify(stepDefinition).execute(any(Object[].class));
-        inOrder.verify(afteStepHook).execute(any(Scenario.class));
+        inOrder.verify(afteStepHook).execute(any(TestCaseState.class));
     }
 
     @Test
@@ -143,14 +143,14 @@ class RunnerTest {
 
         InOrder inOrder = inOrder(afteStepHook1, afteStepHook2, stepDefinition);
         inOrder.verify(stepDefinition).execute(any(Object[].class));
-        inOrder.verify(afteStepHook2).execute(any(Scenario.class));
-        inOrder.verify(afteStepHook1).execute(any(Scenario.class));
+        inOrder.verify(afteStepHook2).execute(any(TestCaseState.class));
+        inOrder.verify(afteStepHook1).execute(any(TestCaseState.class));
     }
 
     @Test
     void hooks_execute_also_after_failure() {
         final HookDefinition failingBeforeHook = addBeforeHook();
-        doThrow(RuntimeException.class).when(failingBeforeHook).execute(any(Scenario.class));
+        doThrow(RuntimeException.class).when(failingBeforeHook).execute(any(TestCaseState.class));
         final HookDefinition beforeHook = addBeforeHook();
         final HookDefinition afterHook = addAfterHook();
 
@@ -166,9 +166,9 @@ class RunnerTest {
         runnerSupplier.get().runPickle(createPickleEventWithSteps());
 
         InOrder inOrder = inOrder(failingBeforeHook, beforeHook, afterHook);
-        inOrder.verify(failingBeforeHook).execute(any(Scenario.class));
-        inOrder.verify(beforeHook).execute(any(Scenario.class));
-        inOrder.verify(afterHook).execute(any(Scenario.class));
+        inOrder.verify(failingBeforeHook).execute(any(TestCaseState.class));
+        inOrder.verify(beforeHook).execute(any(TestCaseState.class));
+        inOrder.verify(afterHook).execute(any(TestCaseState.class));
     }
 
     @Test
@@ -220,9 +220,9 @@ class RunnerTest {
         };
         runnerSupplier.get().runPickle(createPickleEventWithSteps());
 
-        verify(beforeHook, never()).execute(any(Scenario.class));
-        verify(afterStepHook, never()).execute(any(Scenario.class));
-        verify(afterHook, never()).execute(any(Scenario.class));
+        verify(beforeHook, never()).execute(any(TestCaseState.class));
+        verify(afterStepHook, never()).execute(any(TestCaseState.class));
+        verify(afterHook, never()).execute(any(TestCaseState.class));
     }
 
     @Test
@@ -243,9 +243,9 @@ class RunnerTest {
 
         runnerSupplier.get().runPickle(createEmptyPickleEvent());
 
-        verify(beforeHook, never()).execute(any(Scenario.class));
-        verify(afterStepHook, never()).execute(any(Scenario.class));
-        verify(afterHook, never()).execute(any(Scenario.class));
+        verify(beforeHook, never()).execute(any(TestCaseState.class));
+        verify(afterStepHook, never()).execute(any(TestCaseState.class));
+        verify(afterHook, never()).execute(any(TestCaseState.class));
     }
 
     @Test

--- a/core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
@@ -8,7 +8,7 @@ import io.cucumber.core.feature.CucumberStep;
 import io.cucumber.core.feature.TestFeatureParser;
 import io.cucumber.core.runtime.StubStepDefinition;
 import io.cucumber.core.stepexpression.Argument;
-import io.cucumber.core.stepexpression.TypeRegistry;
+import io.cucumber.core.stepexpression.StepTypeRegistry;
 import io.cucumber.cucumberexpressions.ParameterType;
 import io.cucumber.datatable.DataTableType;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class StepDefinitionMatchTest {
 
-    private final TypeRegistry typeRegistry = new TypeRegistry(ENGLISH);
+    private final StepTypeRegistry stepTypeRegistry = new StepTypeRegistry(ENGLISH);
 
     @Test
     void executes_a_step() throws Throwable {
@@ -38,7 +38,7 @@ class StepDefinitionMatchTest {
         CucumberStep step = feature.getPickles().get(0).getSteps().get(0);
 
         StepDefinition stepDefinition = new StubStepDefinition("I have {int} cukes in my belly", Integer.class);
-        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, typeRegistry);
+        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, stepTypeRegistry);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
         stepDefinitionMatch.runStep(null);
@@ -54,7 +54,7 @@ class StepDefinitionMatchTest {
         CucumberStep step = feature.getPickles().get(0).getSteps().get(0);
 
         StepDefinition stepDefinition = new StubStepDefinition("I have {int} cukes in my belly");
-        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, typeRegistry);
+        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, stepTypeRegistry);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
 
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
@@ -81,7 +81,7 @@ class StepDefinitionMatchTest {
         CucumberStep step = feature.getPickles().get(0).getSteps().get(0);
 
         StepDefinition stepDefinition = new StubStepDefinition("I have {int} cukes in my belly");
-        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, typeRegistry);
+        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, stepTypeRegistry);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
         PickleStepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
 
@@ -111,7 +111,7 @@ class StepDefinitionMatchTest {
         CucumberStep step = feature.getPickles().get(0).getSteps().get(0);
 
         StepDefinition stepDefinition = new StubStepDefinition("I have {int} cukes in my belly", Integer.TYPE, Short.TYPE, List.class);
-        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, typeRegistry);
+        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, stepTypeRegistry);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
         PickleStepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
 
@@ -138,7 +138,7 @@ class StepDefinitionMatchTest {
         );
         CucumberStep step = feature.getPickles().get(0).getSteps().get(0);
         StepDefinition stepDefinition = new StubStepDefinition("I have cukes in my belly", Integer.TYPE, Short.TYPE, List.class);
-        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, typeRegistry);
+        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, stepTypeRegistry);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
 
@@ -165,7 +165,7 @@ class StepDefinitionMatchTest {
             "I have a data table",
             UndefinedDataTableType.class
         );
-        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, typeRegistry);
+        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, stepTypeRegistry);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
 
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(
@@ -185,7 +185,7 @@ class StepDefinitionMatchTest {
 
     @Test
     void throws_could_not_convert_exception_for_transfomer_and_capture_group_mismatch() {
-        typeRegistry.defineParameterType(new ParameterType<>(
+        stepTypeRegistry.defineParameterType(new ParameterType<>(
             "itemQuantity",
             "(few|some|lots of) (cukes|gherkins)",
             ItemQuantity.class,
@@ -199,7 +199,7 @@ class StepDefinitionMatchTest {
         );
         CucumberStep step = feature.getPickles().get(0).getSteps().get(0);
         StepDefinition stepDefinition = new StubStepDefinition("I have {itemQuantity} in my belly", ItemQuantity.class);
-        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, typeRegistry);
+        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, stepTypeRegistry);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
 
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
@@ -223,11 +223,11 @@ class StepDefinitionMatchTest {
             "       | 15 | \n"
         );
 
-        typeRegistry.defineDataTableType(new DataTableType(ItemQuantity.class, ItemQuantity::new));
+        stepTypeRegistry.defineDataTableType(new DataTableType(ItemQuantity.class, ItemQuantity::new));
 
         CucumberStep step = feature.getPickles().get(0).getSteps().get(0);
         StepDefinition stepDefinition = new StubStepDefinition("I have some cukes in my belly", ItemQuantity.class);
-        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, typeRegistry);
+        CoreStepDefinition coreStepDefinition = new CoreStepDefinition(stepDefinition, stepTypeRegistry);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
 
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);

--- a/core/src/test/java/io/cucumber/core/runner/TestCaseStateResultTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestCaseStateResultTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class ScenarioResultTest {
+class TestCaseStateResultTest {
 
     private final CucumberFeature feature = TestFeatureParser.parse("file:path/file.feature", "" +
         "Feature: Test feature\n" +
@@ -40,7 +40,7 @@ class ScenarioResultTest {
         "     Given I have 4 cukes in my belly\n"
     );
     private final EventBus bus = mock(EventBus.class);
-    private final Scenario s = new Scenario(
+    private final TestCaseState s = new TestCaseState(
         bus,
         new TestCase(
             Collections.emptyList(),

--- a/core/src/test/java/io/cucumber/core/runner/TestCaseStateTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestCaseStateTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 
-class ScenarioTest {
+class TestCaseStateTest {
 
     @Test
     void provides_the_uri_of_the_feature_file() {
@@ -21,8 +21,8 @@ class ScenarioTest {
             "  Scenario: Test scenario\n" +
             "     Given I have 4 cukes in my belly\n"
         );
-        Scenario scenario = createScenario(feature);
-        assertThat(scenario.getUri(), is(equalTo("file:path/file.feature")));
+        TestCaseState state = createTestCaseState(feature);
+        assertThat(state.getUri(), is(equalTo("file:path/file.feature")));
     }
 
     @Test
@@ -33,8 +33,8 @@ class ScenarioTest {
             "     Given I have 4 cukes in my belly\n"
         );
 
-        Scenario scenario = createScenario(feature);
-        assertThat(scenario.getLine(), is(equalTo(2)));
+        TestCaseState state = createTestCaseState(feature);
+        assertThat(state.getLine(), is(equalTo(2)));
     }
 
     @Test
@@ -48,8 +48,8 @@ class ScenarioTest {
             "       | cuke  | \n"
         );
 
-        Scenario scenario = createScenario(feature);
-        assertThat(scenario.getLine(), is(equalTo(6)));
+        TestCaseState state = createTestCaseState(feature);
+        assertThat(state.getLine(), is(equalTo(6)));
     }
 
     @Test
@@ -60,9 +60,9 @@ class ScenarioTest {
             "     Given I have 4 cukes in my belly\n"
         );
 
-        Scenario scenario = createScenario(feature);
+        TestCaseState state = createTestCaseState(feature);
 
-        assertThat(scenario.getId(), is(equalTo("file:path/file.feature:2")));
+        assertThat(state.getId(), is(equalTo("file:path/file.feature:2")));
     }
 
     @Test
@@ -75,13 +75,13 @@ class ScenarioTest {
             "       | thing | \n" +
             "       | cuke  | \n"
         );
-        Scenario scenario = createScenario(feature);
+        TestCaseState state = createTestCaseState(feature);
 
-        assertThat(scenario.getId(), is(equalTo("file:path/file.feature:6")));
+        assertThat(state.getId(), is(equalTo("file:path/file.feature:6")));
     }
 
-    private Scenario createScenario(CucumberFeature feature) {
-        return new Scenario(mock(EventBus.class), new TestCase(
+    private TestCaseState createTestCaseState(CucumberFeature feature) {
+        return new TestCaseState(mock(EventBus.class), new TestCase(
             Collections.emptyList(),
             Collections.emptyList(),
             Collections.emptyList(),

--- a/core/src/test/java/io/cucumber/core/runner/TestCaseTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestCaseTest.java
@@ -65,13 +65,13 @@ class TestCaseTest {
 
     @Test
     void run_wraps_execute_in_test_case_started_and_finished_events() throws Throwable {
-        doThrow(new UndefinedStepDefinitionException()).when(definitionMatch1).runStep(isA(Scenario.class));
+        doThrow(new UndefinedStepDefinitionException()).when(definitionMatch1).runStep(isA(TestCaseState.class));
 
         createTestCase(testStep1).run(bus);
 
         InOrder order = inOrder(bus, definitionMatch1);
         order.verify(bus).send(isA(TestCaseStarted.class));
-        order.verify(definitionMatch1).runStep(isA(Scenario.class));
+        order.verify(definitionMatch1).runStep(isA(TestCaseState.class));
         order.verify(bus).send(isA(TestCaseFinished.class));
     }
 
@@ -81,47 +81,47 @@ class TestCaseTest {
         testCase.run(bus);
 
         InOrder order = inOrder(definitionMatch1, definitionMatch2);
-        order.verify(definitionMatch1).runStep(isA(Scenario.class));
-        order.verify(definitionMatch2).runStep(isA(Scenario.class));
+        order.verify(definitionMatch1).runStep(isA(TestCaseState.class));
+        order.verify(definitionMatch2).runStep(isA(TestCaseState.class));
     }
 
     @Test
     void run_hooks_after_the_first_non_passed_result_for_gherkin_step() throws Throwable {
-        doThrow(new UndefinedStepDefinitionException()).when(definitionMatch1).runStep(isA(Scenario.class));
+        doThrow(new UndefinedStepDefinitionException()).when(definitionMatch1).runStep(isA(TestCaseState.class));
 
         TestCase testCase = createTestCase(testStep1, testStep2);
         testCase.run(bus);
 
         InOrder order = inOrder(beforeStep1HookDefinition1, definitionMatch1, afterStep1HookDefinition1);
-        order.verify(beforeStep1HookDefinition1).execute(isA(Scenario.class));
-        order.verify(definitionMatch1).runStep(isA(Scenario.class));
-        order.verify(afterStep1HookDefinition1).execute(isA(Scenario.class));
+        order.verify(beforeStep1HookDefinition1).execute(isA(TestCaseState.class));
+        order.verify(definitionMatch1).runStep(isA(TestCaseState.class));
+        order.verify(afterStep1HookDefinition1).execute(isA(TestCaseState.class));
     }
 
 
     @Test
     void skip_hooks_of_step_after_skipped_step() throws Throwable {
-        doThrow(new UndefinedStepDefinitionException()).when(definitionMatch1).runStep(isA(Scenario.class));
+        doThrow(new UndefinedStepDefinitionException()).when(definitionMatch1).runStep(isA(TestCaseState.class));
 
         TestCase testCase = createTestCase(testStep1, testStep2);
         testCase.run(bus);
 
         InOrder order = inOrder(beforeStep1HookDefinition2, definitionMatch2, afterStep1HookDefinition2);
-        order.verify(beforeStep1HookDefinition2, never()).execute(isA(Scenario.class));
-        order.verify(definitionMatch2).dryRunStep(isA(Scenario.class));
-        order.verify(afterStep1HookDefinition2, never()).execute(isA(Scenario.class));
+        order.verify(beforeStep1HookDefinition2, never()).execute(isA(TestCaseState.class));
+        order.verify(definitionMatch2).dryRunStep(isA(TestCaseState.class));
+        order.verify(afterStep1HookDefinition2, never()).execute(isA(TestCaseState.class));
     }
 
     @Test
     void skip_steps_at_first_gherkin_step_after_non_passed_result() throws Throwable {
-        doThrow(new UndefinedStepDefinitionException()).when(definitionMatch1).runStep(isA(Scenario.class));
+        doThrow(new UndefinedStepDefinitionException()).when(definitionMatch1).runStep(isA(TestCaseState.class));
 
         TestCase testCase = createTestCase(testStep1, testStep2);
         testCase.run(bus);
 
         InOrder order = inOrder(definitionMatch1, definitionMatch2);
-        order.verify(definitionMatch1).runStep(isA(Scenario.class));
-        order.verify(definitionMatch2).dryRunStep(isA(Scenario.class));
+        order.verify(definitionMatch1).runStep(isA(TestCaseState.class));
+        order.verify(definitionMatch2).dryRunStep(isA(TestCaseState.class));
     }
 
     private TestCase createTestCase(PickleStepTestStep... steps) {

--- a/core/src/test/java/io/cucumber/core/runner/TestHelper.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestHelper.java
@@ -110,8 +110,8 @@ public class TestHelper {
 
     public static Answer<Object> createWriteHookAction(final String output) {
         return invocation -> {
-            Scenario scenario = (Scenario) invocation.getArguments()[0];
-            scenario.write(output);
+            TestCaseState state = (TestCaseState) invocation.getArguments()[0];
+            state.write(output);
             return null;
         };
     }
@@ -123,11 +123,11 @@ public class TestHelper {
     @SuppressWarnings("deprecation")
     public static Answer<Object> createEmbedHookAction(final byte[] data, final String mimeType, final String name) {
         return invocation -> {
-            Scenario scenario = (Scenario) invocation.getArguments()[0];
+            TestCaseState state = (TestCaseState) invocation.getArguments()[0];
             if (name != null) {
-                scenario.embed(data, mimeType, name);
+                state.embed(data, mimeType, name);
             } else {
-                scenario.embed(data, mimeType);
+                state.embed(data, mimeType);
             }
             return null;
         };

--- a/core/src/test/java/io/cucumber/core/runner/UndefinedStepDefinitionMatchTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/UndefinedStepDefinitionMatchTest.java
@@ -26,14 +26,14 @@ class UndefinedStepDefinitionMatchTest {
 
     @Test
     void throws_ambiguous_step_definitions_exception_when_run() {
-        Executable testMethod = () -> match.runStep(mock(Scenario.class));
+        Executable testMethod = () -> match.runStep(mock(TestCaseState.class));
         UndefinedStepDefinitionException expectedThrown = assertThrows(UndefinedStepDefinitionException.class, testMethod);
         assertThat(expectedThrown.getMessage(), is(equalTo("No step definitions found")));
     }
 
     @Test
     void throws_ambiguous_step_definitions_exception_when_dry_run() {
-        Executable testMethod = () -> match.dryRunStep(mock(Scenario.class));
+        Executable testMethod = () -> match.dryRunStep(mock(TestCaseState.class));
         UndefinedStepDefinitionException expectedThrown = assertThrows(UndefinedStepDefinitionException.class, testMethod);
         assertThat(expectedThrown.getMessage(), is(equalTo("No step definitions found")));
     }

--- a/core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
@@ -1,9 +1,9 @@
 package io.cucumber.core.runtime;
 
+import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.core.backend.Glue;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.ParameterInfo;
-import io.cucumber.core.backend.Scenario;
 import io.cucumber.plugin.event.HookType;
 import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.Status;
@@ -280,7 +280,7 @@ class RuntimeTest {
             .build();
         runtime.run();
 
-        ArgumentCaptor<Scenario> capturedScenario = ArgumentCaptor.forClass(Scenario.class);
+        ArgumentCaptor<TestCaseState> capturedScenario = ArgumentCaptor.forClass(TestCaseState.class);
         verify(beforeHook).execute(capturedScenario.capture());
         assertThat(capturedScenario.getValue().getName(), is(equalTo("scenario name")));
     }

--- a/core/src/test/java/io/cucumber/core/stepexpression/StepExpressionFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/stepexpression/StepExpressionFactoryTest.java
@@ -36,12 +36,12 @@ class StepExpressionFactoryTest {
         }
     }
 
-    private final TypeRegistry registry = new TypeRegistry(Locale.ENGLISH);
+    private final StepTypeRegistry registry = new StepTypeRegistry(Locale.ENGLISH);
     private final List<List<String>> table = asList(asList("name", "amount", "unit"), asList("chocolate", "2", "tbsp"));
     private final List<List<String>> tableTransposed = asList(asList("name", "chocolate"), asList("amount", "2"), asList("unit", "tbsp"));
 
 
-    private TableEntryTransformer<Ingredient> listBeanMapper(final TypeRegistry registry) {
+    private TableEntryTransformer<Ingredient> listBeanMapper(final StepTypeRegistry registry) {
         //Just pretend this is a bean mapper.
         return tableRow -> {
             Ingredient bean = new Ingredient();
@@ -53,7 +53,7 @@ class StepExpressionFactoryTest {
     }
 
 
-    private TableTransformer<Ingredient> beanMapper(final TypeRegistry registry) {
+    private TableTransformer<Ingredient> beanMapper(final StepTypeRegistry registry) {
         return table -> {
             Map<String, String> tableRow = table.transpose().asMaps().get(0);
             return listBeanMapper(registry).transform(tableRow);

--- a/core/src/test/java/io/cucumber/core/stepexpression/StepTypeRegistryTest.java
+++ b/core/src/test/java/io/cucumber/core/stepexpression/StepTypeRegistryTest.java
@@ -18,9 +18,9 @@ import static java.util.Locale.ENGLISH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-class TypeRegistryTest {
+class StepTypeRegistryTest {
 
-    private final TypeRegistry registry = new TypeRegistry(ENGLISH);
+    private final StepTypeRegistry registry = new StepTypeRegistry(ENGLISH);
     private final ExpressionFactory expressionFactory = new ExpressionFactory(registry.parameterTypeRegistry());
 
     @Test

--- a/java/src/main/java/io/cucumber/java/JavaHookDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaHookDefinition.java
@@ -1,8 +1,8 @@
 package io.cucumber.java;
 
+import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.Lookup;
-import io.cucumber.core.backend.Scenario;
 
 import java.lang.reflect.Method;
 
@@ -50,10 +50,10 @@ final class JavaHookDefinition extends AbstractGlueDefinition implements HookDef
     }
 
     @Override
-    public void execute(Scenario scenario) {
+    public void execute(TestCaseState state) {
         Object[] args;
         if (method.getParameterTypes().length == 1) {
-            args = new Object[]{new io.cucumber.java.Scenario(scenario)};
+            args = new Object[]{new io.cucumber.java.Scenario(state)};
         } else {
             args = new Object[0];
         }

--- a/java/src/main/java/io/cucumber/java/Scenario.java
+++ b/java/src/main/java/io/cucumber/java/Scenario.java
@@ -1,5 +1,6 @@
 package io.cucumber.java;
 
+import io.cucumber.core.backend.TestCaseState;
 import org.apiguardian.api.API;
 
 import java.util.Collection;
@@ -7,9 +8,9 @@ import java.util.Collection;
 @API(status = API.Status.STABLE)
 public final class Scenario {
 
-    private final io.cucumber.core.backend.Scenario delegate;
+    private final TestCaseState delegate;
 
-    Scenario(io.cucumber.core.backend.Scenario delegate) {
+    Scenario(TestCaseState delegate) {
         this.delegate = delegate;
     }
 

--- a/java/src/test/java/io/cucumber/java/JavaDocStringTypeDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDocStringTypeDefinitionTest.java
@@ -1,11 +1,9 @@
 package io.cucumber.java;
 
 import io.cucumber.core.backend.Lookup;
-import io.cucumber.core.stepexpression.TypeRegistry;
 import io.cucumber.docstring.DocString;
 import io.cucumber.docstring.DocStringTypeRegistry;
 import io.cucumber.docstring.DocStringTypeRegistryDocStringConverter;
-import io.cucumber.java.eo.Do;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;

--- a/java/src/test/java/io/cucumber/java/JavaHookDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaHookDefinitionTest.java
@@ -1,5 +1,6 @@
 package io.cucumber.java;
 
+import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.core.backend.Lookup;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +32,7 @@ public class JavaHookDefinitionTest {
     };
 
     @Mock
-    private io.cucumber.core.backend.Scenario scenario;
+    private TestCaseState state;
 
     private boolean invoked = false;
 
@@ -39,7 +40,7 @@ public class JavaHookDefinitionTest {
     void can_create_with_no_argument() throws Throwable {
         Method method = JavaHookDefinitionTest.class.getMethod("no_arguments");
         JavaHookDefinition definition = new JavaHookDefinition(method, "", 0, lookup);
-        definition.execute(scenario);
+        definition.execute(state);
         assertTrue(invoked);
     }
 
@@ -53,7 +54,7 @@ public class JavaHookDefinitionTest {
     void can_create_with_single_scenario_argument() throws Throwable {
         Method method = JavaHookDefinitionTest.class.getMethod("single_argument", Scenario.class);
         JavaHookDefinition definition = new JavaHookDefinition(method, "", 0, lookup);
-        definition.execute(scenario);
+        definition.execute(state);
         assertTrue(invoked);
     }
 

--- a/java8/src/main/java/io/cucumber/java8/Java8HookDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8HookDefinition.java
@@ -1,7 +1,7 @@
 package io.cucumber.java8;
 
+import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.core.backend.HookDefinition;
-import io.cucumber.core.backend.Scenario;
 
 import static java.util.Objects.requireNonNull;
 
@@ -24,12 +24,12 @@ final class Java8HookDefinition extends AbstractGlueDefinition implements HookDe
     }
 
     @Override
-    public void execute(final Scenario scenario) {
+    public void execute(final TestCaseState state) {
         Object[] args;
         if (method.getParameterCount() == 0) {
             args = new Object[0];
         } else {
-            args = new Object[]{new io.cucumber.java8.Scenario(scenario)};
+            args = new Object[]{new io.cucumber.java8.Scenario(state)};
         }
         Invoker.invoke(this, body, method, args);
     }

--- a/java8/src/main/java/io/cucumber/java8/Scenario.java
+++ b/java8/src/main/java/io/cucumber/java8/Scenario.java
@@ -1,5 +1,6 @@
 package io.cucumber.java8;
 
+import io.cucumber.core.backend.TestCaseState;
 import org.apiguardian.api.API;
 
 import java.util.Collection;
@@ -7,9 +8,9 @@ import java.util.Collection;
 @API(status = API.Status.STABLE)
 public final class Scenario {
 
-    private final io.cucumber.core.backend.Scenario delegate;
+    private final TestCaseState delegate;
 
-    Scenario(io.cucumber.core.backend.Scenario delegate) {
+    Scenario(TestCaseState delegate) {
         this.delegate = delegate;
     }
 

--- a/java8/src/test/java/io/cucumber/java8/LambdaGlueTest.java
+++ b/java8/src/test/java/io/cucumber/java8/LambdaGlueTest.java
@@ -1,5 +1,6 @@
 package io.cucumber.java8;
 
+import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.StepDefinition;
 import org.junit.jupiter.api.BeforeEach;
@@ -112,7 +113,7 @@ class LambdaGlueTest {
         assertHook(afterStepHook, "taxExpression", 42);
     }
 
-    private final io.cucumber.core.backend.Scenario scenario = Mockito.mock(io.cucumber.core.backend.Scenario.class);
+    private final TestCaseState state = Mockito.mock(TestCaseState.class);
 
     private final LambdaGlueRegistry lambdaGlueRegistry = new LambdaGlueRegistry() {
         @Override
@@ -150,7 +151,7 @@ class LambdaGlueTest {
     private void assertHook(HookDefinition hook, String tagExpression, int beforeOrder) {
         assertThat(hook.getTagExpression(), is(tagExpression));
         assertThat(hook.getOrder(), is(beforeOrder));
-        hook.execute(scenario);
+        hook.execute(state);
         assertTrue(invoked.get());
         invoked.set(false);
     }


### PR DESCRIPTION
## Summary

As noticed by users of Cucumber #1780 multiple classes named `Scenario` and `TypeRegistry` made it harder to determine which class should be imported.

## Details

* Renames the step expression `TypeRegistry` to `StepTypeRegistry`.
* Renames the backend `Scenario` to `TestCaseState`.