### PR TITLE
Print comment before and after StepText

### DIFF
--- a/core/src/main/java/cucumber/api/event/CommentAfterStepText.java
+++ b/core/src/main/java/cucumber/api/event/CommentAfterStepText.java
@@ -1,0 +1,12 @@
+package cucumber.api.event;
+
+public class CommentAfterStepText {
+    String after;
+
+    public CommentAfterStepText(String after) {
+        this.after = after;
+        CommentEventSender.getInstance().sendCommentAfterStepText(after);
+    }
+    
+    
+}

--- a/core/src/main/java/cucumber/api/event/CommentAfterStepTextEvent.java
+++ b/core/src/main/java/cucumber/api/event/CommentAfterStepTextEvent.java
@@ -1,0 +1,26 @@
+package cucumber.api.event;
+
+import cucumber.api.TestCase;
+
+public final class CommentAfterStepTextEvent extends TestCaseEvent {
+    
+    final TestCase testCase;
+    final String after;
+    final String stepText;
+
+    public CommentAfterStepTextEvent(Long timeStamp, long timeStampMillis, TestCase testCase, String after, String stepText) {
+    	super(timeStamp, timeStampMillis, testCase);
+        this.testCase = testCase;
+        this.after = after;
+        this.stepText = stepText;
+    }
+
+    public String getAfter() {
+        return after;
+    }
+    
+    public String getStepText() {
+        return stepText;
+    }
+    
+}

--- a/core/src/main/java/cucumber/api/event/CommentBeforeStepText.java
+++ b/core/src/main/java/cucumber/api/event/CommentBeforeStepText.java
@@ -1,0 +1,12 @@
+package cucumber.api.event;
+
+public class CommentBeforeStepText {
+    String before;
+
+    public CommentBeforeStepText(String before) {
+        this.before = before;
+        CommentEventSender.getInstance().sendCommentBeforeStepText(before);
+    }
+    
+    
+}

--- a/core/src/main/java/cucumber/api/event/CommentBeforeStepTextEvent.java
+++ b/core/src/main/java/cucumber/api/event/CommentBeforeStepTextEvent.java
@@ -1,0 +1,26 @@
+package cucumber.api.event;
+
+import cucumber.api.TestCase;
+
+public final class CommentBeforeStepTextEvent extends TestCaseEvent {
+    
+    final TestCase testCase;
+    final String before;
+    final String stepText;
+
+    public CommentBeforeStepTextEvent(Long timeStamp, long timeStampMillis, TestCase testCase, String before, String stepText) {
+    	super(timeStamp, timeStampMillis, testCase);
+        this.testCase = testCase;
+        this.before = before;
+        this.stepText = stepText;
+    }
+
+    public String getBefore() {
+        return before;
+    }
+    
+    public String getStepText() {
+        return stepText;
+    }
+    
+}

--- a/core/src/main/java/cucumber/api/event/CommentEventSender.java
+++ b/core/src/main/java/cucumber/api/event/CommentEventSender.java
@@ -1,0 +1,39 @@
+package cucumber.api.event;
+
+import cucumber.api.TestCase;
+import cucumber.runner.EventBus;
+
+public class CommentEventSender {
+    private EventBus bus;
+    private TestCase testCase;
+    private String stepText;
+    
+    private static final CommentEventSender instance = new CommentEventSender();
+    
+    private CommentEventSender() {
+    }
+    
+    public void setBus(EventBus bus) {
+        this.bus = bus;
+    }
+    
+    public void setTestCase(TestCase testCase) {
+        this.testCase = testCase;
+    }
+    
+    public void setStepText(String stepText) {
+        this.stepText = stepText;
+    }
+    
+    public void sendCommentBeforeStepText(String before) {
+        bus.send(new CommentBeforeStepTextEvent(bus.getTime(), bus.getTimeMillis(), this.testCase, before, this.stepText));
+    }
+    public void sendCommentAfterStepText(String after) {
+        bus.send(new CommentAfterStepTextEvent(bus.getTime(), bus.getTimeMillis(), this.testCase, after, this.stepText));
+    }
+    
+    public static final CommentEventSender getInstance() 
+    {
+        return instance;
+    }
+}

--- a/core/src/main/java/cucumber/runner/PickleStepTestStep.java
+++ b/core/src/main/java/cucumber/runner/PickleStepTestStep.java
@@ -1,6 +1,7 @@
 package cucumber.runner;
 
 import cucumber.api.TestCase;
+import cucumber.api.event.CommentEventSender;
 import cucumber.runtime.DefinitionArgument;
 import gherkin.pickles.PickleStep;
 
@@ -39,6 +40,10 @@ class PickleStepTestStep extends TestStep implements cucumber.api.PickleStepTest
         for (HookTestStep before : beforeStepHookSteps) {
             skipNextStep |= before.run(testCase, bus,  scenario, skipSteps);
         }
+        
+        CommentEventSender.getInstance().setBus(bus);
+        CommentEventSender.getInstance().setTestCase(testCase);
+        CommentEventSender.getInstance().setStepText(step.getText());
 
         skipNextStep |= super.run(testCase, bus,  scenario, skipNextStep);
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Print some comments before and after the stepText in the console.

## Details

Add the possibility to print custom comments before and after stepText in the console. 
```
new CommentBeforeStepText("This is an example comment before stepText");
new CommentAfterStepText("This is an example comment after stepText");
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
