### PR TITLE
[Core] Do not clobber line filters from rerun file

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,11 +98,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind.version}</version>

--- a/core/src/main/java/io/cucumber/core/options/CucumberOptionsAnnotationParser.java
+++ b/core/src/main/java/io/cucumber/core/options/CucumberOptionsAnnotationParser.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.regex.Pattern;
 
+import static io.cucumber.core.options.OptionsFileParser.parseFeatureWithLinesFile;
 import static java.util.Objects.requireNonNull;
 
 public final class CucumberOptionsAnnotationParser {
@@ -101,11 +102,8 @@ public final class CucumberOptionsAnnotationParser {
         if (options != null && options.features().length != 0) {
             for (String feature : options.features()) {
                 if (feature.startsWith("@")) {
-                    args.setIsRerun(true);
                     Path rerunFile = Paths.get(feature.substring(1));
-                    for (FeatureWithLines featureWithLines : OptionsFileParser.parseFeatureWithLinesFile(rerunFile)) {
-                        args.addFeature(featureWithLines);
-                    }
+                    args.addRerun(parseFeatureWithLinesFile(rerunFile));
                 } else {
                     FeatureWithLines featureWithLines = FeatureWithLines.parse(feature);
                     args.addFeature(featureWithLines);

--- a/core/src/main/java/io/cucumber/core/options/OptionsFileParser.java
+++ b/core/src/main/java/io/cucumber/core/options/OptionsFileParser.java
@@ -2,15 +2,13 @@ package io.cucumber.core.options;
 
 import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.feature.FeatureWithLines;
-import io.cucumber.core.feature.GluePath;
 
-import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.nio.file.Files.readAllLines;
@@ -22,7 +20,7 @@ class OptionsFileParser {
 
     }
 
-    static List<FeatureWithLines> parseFeatureWithLinesFile(Path path) {
+    static Collection<FeatureWithLines> parseFeatureWithLinesFile(Path path) {
         try {
             List<FeatureWithLines> featurePaths = new ArrayList<>();
             readAllLines(path).forEach(line -> {
@@ -34,17 +32,6 @@ class OptionsFileParser {
             return featurePaths;
         } catch (Exception e) {
             throw new CucumberException(format("Failed to parse '%s'", path), e);
-        }
-    }
-
-    static List<URI> parseGlueFile(Path path) {
-        try {
-            return readAllLines(path)
-                .stream()
-                .map(GluePath::parse)
-                .collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new CucumberException(format("Failed to parse'%s'", path), e);
         }
     }
 }

--- a/core/src/main/java/io/cucumber/core/options/RuntimeOptionsParser.java
+++ b/core/src/main/java/io/cucumber/core/options/RuntimeOptionsParser.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static io.cucumber.core.options.ObjectFactoryParser.parseObjectFactory;
+import static io.cucumber.core.options.OptionsFileParser.parseFeatureWithLinesFile;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.joining;
@@ -205,9 +206,8 @@ final class RuntimeOptionsParser {
                 throw new CucumberException("Unknown option: " + arg);
             } else if (!arg.isEmpty()) {
                 if (arg.startsWith("@")) {
-                    parsedOptions.setIsRerun(true);
                     Path rerunFile = Paths.get(arg.substring(1));
-                    OptionsFileParser.parseFeatureWithLinesFile(rerunFile).forEach(parsedOptions::addFeature);
+                    parsedOptions.addRerun(parseFeatureWithLinesFile(rerunFile));
                 } else {
                     FeatureWithLines featureWithLines = FeatureWithLines.parse(arg);
                     parsedOptions.addFeature(featureWithLines);

--- a/core/src/test/java/io/cucumber/core/options/RerunFileTest.java
+++ b/core/src/test/java/io/cucumber/core/options/RerunFileTest.java
@@ -9,7 +9,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 
 import static io.cucumber.core.options.Constants.OPTIONS_PROPERTY_NAME;
@@ -22,7 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -161,20 +159,6 @@ class RerunFileTest {
         );
     }
 
-    @Test
-    void clobbers_tag_and_name_filters_from_cli_if_rerun_file_specified_in_cucumber_options_property() throws IOException {
-        Map<String, String> properties = mockFileResource("foo.feature:4");
-
-        RuntimeOptions options = new CommandlineOptionsParser()
-            .parse("--tags", "@should_be_clobbered", "--name", "should_be_clobbered")
-            .build();
-
-        RuntimeOptions runtimeOptions = new CucumberPropertiesParser()
-            .parse(properties)
-            .build(options);
-
-        assertThat(runtimeOptions.getTagExpressions(), is(equalTo(Collections.emptyList())));
-    }
 
     @Test
     void loads_features_specified_in_rerun_file_with_empty_cucumber_options() throws Exception {

--- a/docstring/pom.xml
+++ b/docstring/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
+            <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/docstring/src/test/java/io/cucumber/docstring/DocStringTypeRegistryTest.java
+++ b/docstring/src/test/java/io/cucumber/docstring/DocStringTypeRegistryTest.java
@@ -1,11 +1,11 @@
 package io.cucumber.docstring;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DocStringTypeRegistryTest {
@@ -24,7 +24,7 @@ class DocStringTypeRegistryTest {
             CucumberDocStringException.class, () ->
                 registry.defineDocStringType(docStringType)
         );
-        MatcherAssert.assertThat(actualThrown.getMessage(), is(equalTo(
+        assertThat(actualThrown.getMessage(), is(equalTo(
             "There is already docstring type registered for '[anonymous]' and java.lang.String.\n" +
                 "You are trying to add '[anonymous]' and java.lang.String"
         )));
@@ -48,7 +48,7 @@ class DocStringTypeRegistryTest {
             CucumberDocStringException.class,
             () -> registry.defineDocStringType(duplicate)
         );
-        MatcherAssert.assertThat(exception.getMessage(), is("" +
+        assertThat(exception.getMessage(), is("" +
             "There is already docstring type registered for 'json' and com.fasterxml.jackson.databind.JsonNode.\n" +
             "You are trying to add 'application/json' and com.fasterxml.jackson.databind.JsonNode"
         ));

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -43,11 +43,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,11 +28,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -37,13 +37,6 @@
             <artifactId>cucumber-junit</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -25,12 +25,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/needle/pom.xml
+++ b/needle/pom.xml
@@ -52,11 +52,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -159,11 +159,6 @@
                 <version>${hamcrest.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>${hamcrest.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
                 <version>${junit-jupiter.version}</version>


### PR DESCRIPTION
A typical setup to rerun tests uses two Cucumber runners, where the
second runner uses the rerun file produced by the first to rerun
tests. E.g:

- `@CucumberOptions(plugin = "return:path/to/rerun.txt")`
- `@CucumberOptions(features = "path/to/rerun.txt")`

Then from the cli the entire suite is invoked with some tags:

```
mvn verify -Dcucumber.options="@smoke"
```

The expectation is that the first runner executes all features tagged
with `@smoke`. And that the second runner will rerun all failed features
tagged with `@smoke`. However because `@smoke` removes all line filters
the line filters from the rerun file were also removed.

By treating rerun files and feature files as distinct elements in the
`RuntimeOptions` builder we can properly reflect this nuance.

Fixes: #1785