### PR TITLE
[JUnit/TestNG] Always print snippets and summary

### DIFF
--- a/core/src/main/java/io/cucumber/core/cli/Main.java
+++ b/core/src/main/java/io/cucumber/core/cli/Main.java
@@ -50,8 +50,8 @@ public class Main {
 
         RuntimeOptions runtimeOptions = new CommandlineOptionsParser()
             .parse(argv)
-            .addDefaultFormatterIfNotPresent()
-            .addDefaultSummaryPrinterIfNotPresent()
+            .addDefaultFormatterIfAbsent()
+            .addDefaultSummaryPrinterIfAbsent()
             .build(systemOptions);
 
 

--- a/core/src/main/java/io/cucumber/core/options/PluginOption.java
+++ b/core/src/main/java/io/cucumber/core/options/PluginOption.java
@@ -1,9 +1,5 @@
 package io.cucumber.core.options;
 
-import io.cucumber.plugin.Plugin;
-import io.cucumber.plugin.SummaryPrinter;
-import io.cucumber.plugin.ConcurrentEventListener;
-import io.cucumber.plugin.EventListener;
 import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.logging.Logger;
 import io.cucumber.core.logging.LoggerFactory;
@@ -20,6 +16,10 @@ import io.cucumber.core.plugin.TestNGFormatter;
 import io.cucumber.core.plugin.TimelineFormatter;
 import io.cucumber.core.plugin.UnusedStepsSummaryPrinter;
 import io.cucumber.core.plugin.UsageFormatter;
+import io.cucumber.plugin.ConcurrentEventListener;
+import io.cucumber.plugin.EventListener;
+import io.cucumber.plugin.Plugin;
+import io.cucumber.plugin.SummaryPrinter;
 
 import java.util.HashMap;
 import java.util.regex.Matcher;
@@ -31,19 +31,19 @@ public class PluginOption implements Options.Plugin {
 
     private static final Pattern PLUGIN_WITH_ARGUMENT_PATTERN = Pattern.compile("([^:]+):(.*)");
     private static final HashMap<String, Class<? extends Plugin>> PLUGIN_CLASSES = new HashMap<String, Class<? extends Plugin>>() {{
-        put("junit", JUnitFormatter.class);
-        put("testng", TestNGFormatter.class);
+        put("default_summary", DefaultSummaryPrinter.class);
         put("html", HTMLFormatter.class);
+        put("json", JSONFormatter.class);
+        put("junit", JUnitFormatter.class);
+        put("null_summary", NullSummaryPrinter.class);
         put("pretty", PrettyFormatter.class);
         put("progress", ProgressFormatter.class);
-        put("json", JSONFormatter.class);
-        put("usage", UsageFormatter.class);
         put("rerun", RerunFormatter.class);
         put("summary", DefaultSummaryPrinter.class);
-        put("default_summary", DefaultSummaryPrinter.class);
-        put("null_summary", NullSummaryPrinter.class);
-        put("unused", UnusedStepsSummaryPrinter.class);
+        put("testng", TestNGFormatter.class);
         put("timeline", TimelineFormatter.class);
+        put("unused", UnusedStepsSummaryPrinter.class);
+        put("usage", UsageFormatter.class);
     }};
 
     // Refuse plugins known to implement the old API

--- a/core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
+++ b/core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
@@ -53,6 +53,17 @@ public final class RuntimeOptions implements
         return new RuntimeOptions();
     }
 
+    void addDefaultFormatterIfAbsent(){
+        if (formatters.isEmpty()) {
+            formatters.add(PluginOption.parse("progress"));
+        }
+    }
+    void addDefaultSummaryPrinterIfAbsent(){
+        if (summaryPrinters.isEmpty()) {
+            summaryPrinters.add(PluginOption.parse("default_summary"));
+        }
+    }
+
     public int getCount() {
         return count;
     }

--- a/core/src/main/java/io/cucumber/core/options/RuntimeOptionsBuilder.java
+++ b/core/src/main/java/io/cucumber/core/options/RuntimeOptionsBuilder.java
@@ -30,6 +30,8 @@ public final class RuntimeOptionsBuilder {
     private PickleOrder parsedPickleOrder = null;
     private Integer parsedCount = null;
     private Class<? extends ObjectFactory> parsedObjectFactoryClass = null;
+    private boolean addDefaultSummaryPrinterIfAbsent;
+    private boolean addDefaultFormatterIfAbsent;
 
     public RuntimeOptionsBuilder addRerun(Collection<FeatureWithLines> featureWithLines) {
         if (parsedRerunPaths == null) {
@@ -124,6 +126,14 @@ public final class RuntimeOptionsBuilder {
             runtimeOptions.setObjectFactoryClass(parsedObjectFactoryClass);
         }
 
+        if(addDefaultFormatterIfAbsent) {
+            runtimeOptions.addDefaultFormatterIfAbsent();
+        }
+
+        if(addDefaultSummaryPrinterIfAbsent) {
+            runtimeOptions.addDefaultSummaryPrinterIfAbsent();
+        }
+
         return runtimeOptions;
     }
 
@@ -185,13 +195,13 @@ public final class RuntimeOptionsBuilder {
         return this;
     }
 
-    public RuntimeOptionsBuilder addDefaultSummaryPrinterIfNotPresent() {
-        parsedPluginData.addDefaultSummaryPrinterIfNotPresent();
+    public RuntimeOptionsBuilder addDefaultSummaryPrinterIfAbsent() {
+        this.addDefaultSummaryPrinterIfAbsent = true;
         return this;
     }
 
-    public RuntimeOptionsBuilder addDefaultFormatterIfNotPresent() {
-        parsedPluginData.addDefaultFormatterIfNotPresent();
+    public RuntimeOptionsBuilder addDefaultFormatterIfAbsent() {
+        this.addDefaultFormatterIfAbsent = true;
         return this;
     }
 
@@ -211,18 +221,6 @@ public final class RuntimeOptionsBuilder {
                 formatters.addName(pluginOption, isAddPlugin);
             } else {
                 throw new CucumberException("Unrecognized plugin: " + name);
-            }
-        }
-
-        void addDefaultSummaryPrinterIfNotPresent() {
-            if (summaryPrinters.names.isEmpty()) {
-                addPluginName("summary", false);
-            }
-        }
-
-        void addDefaultFormatterIfNotPresent() {
-            if (formatters.names.isEmpty()) {
-                addPluginName("progress", false);
             }
         }
 

--- a/core/src/main/java/io/cucumber/core/plugin/DefaultSummaryPrinter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/DefaultSummaryPrinter.java
@@ -30,17 +30,23 @@ public final class DefaultSummaryPrinter implements SummaryPrinter, ColorAware, 
     private void print() {
         out.println();
         printStats();
-        out.println();
         printErrors();
         printSnippets();
+        out.println();
     }
 
     private void printStats() {
         stats.printStats(out);
+        out.println();
     }
 
     private void printErrors() {
-        for (Throwable error : stats.getErrors()) {
+        List<Throwable> errors = stats.getErrors();
+        if (errors.isEmpty()) {
+            return;
+        }
+        out.println();
+        for (Throwable error : errors) {
             error.printStackTrace(out);
             out.println();
         }
@@ -56,6 +62,7 @@ public final class DefaultSummaryPrinter implements SummaryPrinter, ColorAware, 
         out.println();
         for (String snippet : snippets) {
             out.println(snippet);
+            out.println();
         }
     }
 

--- a/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
@@ -2,11 +2,11 @@ package io.cucumber.core.options;
 
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.exception.CucumberException;
-import io.cucumber.plugin.Plugin;
 import io.cucumber.core.plugin.PluginFactory;
 import io.cucumber.core.plugin.Plugins;
 import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.core.snippets.SnippetType;
+import io.cucumber.plugin.Plugin;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -50,8 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
      void create_without_options() {
         RuntimeOptions runtimeOptions = parser()
             .parse(WithoutOptions.class)
-            .addDefaultSummaryPrinterIfNotPresent()
-            .addDefaultFormatterIfNotPresent()
+            .addDefaultSummaryPrinterIfAbsent()
+            .addDefaultFormatterIfAbsent()
             .build();
 
         assertAll("Checking RuntimeOptions",
@@ -80,8 +80,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         Class<?> subClassWithMonoChromeTrueClass = WithoutOptionsWithBaseClassWithoutOptions.class;
         RuntimeOptions runtimeOptions = parser()
             .parse(subClassWithMonoChromeTrueClass)
-            .addDefaultFormatterIfNotPresent()
-            .addDefaultSummaryPrinterIfNotPresent()
+            .addDefaultFormatterIfAbsent()
+            .addDefaultSummaryPrinterIfAbsent()
             .build();
         Plugins plugins = new Plugins(new PluginFactory(), runtimeOptions);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC()));
@@ -140,7 +140,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
      void create_default_summary_printer_when_no_summary_printer_plugin_is_defined() {
         RuntimeOptions runtimeOptions = parser()
             .parse(ClassWithNoSummaryPrinterPlugin.class)
-            .addDefaultSummaryPrinterIfNotPresent()
+            .addDefaultSummaryPrinterIfAbsent()
             .build();
         Plugins plugins = new Plugins(new PluginFactory(), runtimeOptions);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC()));

--- a/core/src/test/java/io/cucumber/core/options/RuntimeOptionsTest.java
+++ b/core/src/test/java/io/cucumber/core/options/RuntimeOptionsTest.java
@@ -165,7 +165,7 @@ class RuntimeOptionsTest {
     void creates_progress_formatter_as_default() {
         RuntimeOptions options = new CommandlineOptionsParser()
             .parse()
-            .addDefaultFormatterIfNotPresent()
+            .addDefaultFormatterIfAbsent()
             .build();
         Plugins plugins = new Plugins(new PluginFactory(), options);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC()));
@@ -177,7 +177,7 @@ class RuntimeOptionsTest {
     void creates_default_summary_printer_when_no_summary_printer_plugin_is_specified() {
         RuntimeOptions options = new CommandlineOptionsParser()
             .parse("--plugin", "pretty")
-            .addDefaultSummaryPrinterIfNotPresent()
+            .addDefaultSummaryPrinterIfAbsent()
             .build();
         Plugins plugins = new Plugins(new PluginFactory(), options);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC()));

--- a/examples/java-calculator-testng/src/test/java/io/cucumber/examples/testng/ShoppingStepdefs.java
+++ b/examples/java-calculator-testng/src/test/java/io/cucumber/examples/testng/ShoppingStepdefs.java
@@ -1,6 +1,5 @@
 package io.cucumber.examples.testng;
 
-import io.cucumber.examples.testng.RpnCalculator;
 import io.cucumber.java.DataTableType;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;

--- a/java/src/main/java/io/cucumber/java/JavaSnippet.java
+++ b/java/src/main/java/io/cucumber/java/JavaSnippet.java
@@ -11,6 +11,6 @@ final class JavaSnippet extends AbstractJavaSnippet {
             "public void {2}({3}) '{'\n" +
             "    // {4}\n" +
             "{5}    throw new " + PendingException.class.getName() + "();\n" +
-            "'}'\n");
+            "'}'");
     }
 }

--- a/java8/src/main/java/io/cucumber/java8/Java8Snippet.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8Snippet.java
@@ -10,6 +10,6 @@ final class Java8Snippet extends AbstractJavaSnippet {
             "{0}(\"{1}\", ({3}) -> '{'\n" +
             "    // {4}\n" +
             "{5}    throw new " + PendingException.class.getName() + "();\n" +
-            "'}');\n");
+            "'}');");
     }
 }

--- a/junit/src/main/java/io/cucumber/junit/Cucumber.java
+++ b/junit/src/main/java/io/cucumber/junit/Cucumber.java
@@ -114,6 +114,7 @@ public final class Cucumber extends ParentRunner<FeatureRunner> {
 
         RuntimeOptions runtimeOptions = new CucumberPropertiesParser()
             .parse(CucumberProperties.fromSystemProperties())
+            .addDefaultSummaryPrinterIfAbsent()
             .build(environmentOptions);
 
         // Next parse the junit options

--- a/testng/src/main/java/io/cucumber/testng/TestNGCucumberRunner.java
+++ b/testng/src/main/java/io/cucumber/testng/TestNGCucumberRunner.java
@@ -85,6 +85,7 @@ public final class TestNGCucumberRunner {
 
         runtimeOptions = new CucumberPropertiesParser()
             .parse(CucumberProperties.fromSystemProperties())
+            .addDefaultSummaryPrinterIfAbsent()
             .build(environmentOptions);
 
         ClassLoader classLoader = clazz.getClassLoader();
@@ -111,26 +112,11 @@ public final class TestNGCucumberRunner {
         runner.runPickle(cucumberPickle);
         testCaseResultListener.finishExecutionUnit();
 
-        if (testCaseResultListener.isPassed()) {
-            return;
+        if (!testCaseResultListener.isPassed()) {
+            // null pointer is covered by isPassed
+            // noinspection ConstantConditions
+            throw testCaseResultListener.getError();
         }
-
-        // Log the reason we skipped the test. TestNG doesn't provide it by
-        // default
-        Throwable error = testCaseResultListener.getError();
-        if (error instanceof SkipException) {
-            SkipException skipException = (SkipException) error;
-            if (skipException.isSkip()) {
-                System.out.println(format("Skipped scenario: '%s'. %s",
-                    cucumberPickle.getName(),
-                    skipException.getMessage()
-                ));
-            }
-        }
-
-        // null pointer is covered by isPassed
-        // noinspection ConstantConditions
-        throw error;
     }
 
     public void finish() {


### PR DESCRIPTION
## Summary

Cucumber can be ran through the CLI, JUnit and TestNG. The latter two can also be run through Maven, Gradle, IDEA and Eclipse. Each of these runners has different ways and needs to output information. To be a good CLI citizen Cucumber should integrate with these runners to ensure only the necessary information is printed.

This is achieved by using the hooks provided by each frameworks to log undefined steps. This information is then always logged to formatted xml files in the XUnit format. However when not running in strict mode (i.e. the test is skipped) Surefire and Gradle will not print or log this information.

This makes Cucumber harder to use. By always enabling the summary printer we can avoid this.

## How Has This Been Tested?

Manually checked combinations of JUnit, TestNG, IDEA, Eclipse, Maven and Gradle. The output is less then ideal because the missing steps are also included in the step definition but after https://github.com/cucumber/cucumber-jvm/issues/1788 is done we can remove them from the summary printer (except for CLI).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
