### PR TITLE
Fix tests on Windows

### DIFF
--- a/core/src/test/java/io/cucumber/core/plugin/URLOutputStreamTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/URLOutputStreamTest.java
@@ -189,7 +189,8 @@ class URLOutputStreamTest {
                 try {
                     // Every thread should wait command to run
                     countDownLatch.await();
-                    new URLOutputStream(tmp.toURI().toURL());
+                    try (URLOutputStream urlOutputStream = new URLOutputStream(tmp.toURI().toURL())) {
+                    }
                 } catch (IOException e) {
                     threadErrors.add("Thread" + curThreadNo + ": parent dir not created. " + e.getMessage());
                 } catch (InterruptedException e) {

--- a/docstring/src/test/java/io/cucumber/docstring/DocStringTypeRegistryDocStringConverterTest.java
+++ b/docstring/src/test/java/io/cucumber/docstring/DocStringTypeRegistryDocStringConverterTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -119,12 +120,12 @@ class DocStringTypeRegistryDocStringConverterTest {
             () -> converter.convert(docString, JsonNode.class)
         );
 
-        assertThat(exception.getMessage(), is("" +
+        assertThat(exception.getMessage(), is(equalToCompressingWhiteSpace("" +
             "'json' could not transform\n" +
             "      \"\"\"json\n" +
             "      {\"hello\":\"world\"}\n" +
             "      \"\"\""
-        ));
+        )));
     }
 
 }

--- a/guice/src/test/java/io/cucumber/guice/GuiceFactoryTest.java
+++ b/guice/src/test/java/io/cucumber/guice/GuiceFactoryTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -57,7 +58,7 @@ class GuiceFactoryTest {
 
         Executable testMethod = () -> factory.start();
         ConfigurationException actualThrown = assertThrows(ConfigurationException.class, testMethod);
-        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalToCompressingWhiteSpace(
             "Guice configuration errors:\n\n" +
                 "1) No implementation for io.cucumber.guice.ScenarioScope was bound.\n" +
                 "  while locating io.cucumber.guice.ScenarioScope\n\n" +


### PR DESCRIPTION
## Summary

The following changes are needed to successfully run `mvn test` on Windows.

## Details

- exception messages have \r\n (CRLF) line separator, so the tests must account for it
- files can't be deleted while they are still open, so we have to `close()` URLOutputStreams

## How Has This Been Tested?

`mvn test` run successfully. Windows 10 latest, JDK 1.8, mvn 3.6.2

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
