### PR TITLE
[Core] Include name in duplicate feature detection

### DIFF
--- a/core/src/main/java/io/cucumber/core/feature/CucumberFeature.java
+++ b/core/src/main/java/io/cucumber/core/feature/CucumberFeature.java
@@ -3,7 +3,6 @@ package io.cucumber.core.feature;
 import gherkin.ast.GherkinDocument;
 
 import java.net.URI;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
@@ -53,10 +52,4 @@ public final class CucumberFeature {
         return Objects.hash(uri);
     }
 
-    public static class CucumberFeatureUriComparator implements Comparator<CucumberFeature> {
-        @Override
-        public int compare(CucumberFeature a, CucumberFeature b) {
-            return a.getUri().compareTo(b.getUri());
-        }
-    }
 }

--- a/core/src/main/java/io/cucumber/core/feature/FeatureBuilder.java
+++ b/core/src/main/java/io/cucumber/core/feature/FeatureBuilder.java
@@ -9,24 +9,53 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Comparator.comparing;
+
 final class FeatureBuilder {
 
     private final Logger log = LoggerFactory.getLogger(FeatureBuilder.class);
-    private final Map<String, CucumberFeature> sourceToFeature = new HashMap<>();
+    private final Map<String, Map<String, CucumberFeature>> sourceToFeature = new HashMap<>();
+    private final List<CucumberFeature> features = new ArrayList<>();
 
     public List<CucumberFeature> build() {
-        List<CucumberFeature> cucumberFeatures = new ArrayList<>(sourceToFeature.values());
-        cucumberFeatures.sort(new CucumberFeature.CucumberFeatureUriComparator());
+        List<CucumberFeature> cucumberFeatures = new ArrayList<>(features);
+        cucumberFeatures.sort(comparing(CucumberFeature::getUri));
         return cucumberFeatures;
     }
 
     public void parse(Resource resource) {
         CucumberFeature parsedFeature = FeatureParser.parseResource(resource);
-        CucumberFeature existingFeature = sourceToFeature.get(parsedFeature.getSource());
-        if (existingFeature != null) {
-            log.warn("Duplicate feature ignored. " + parsedFeature.getUri() + " was identical to " + existingFeature.getUri());
-            return;
+        String parsedFileName = getFileName(parsedFeature);
+
+        Map<String, CucumberFeature> existingFeatures = sourceToFeature.get(parsedFeature.getSource());
+        if (existingFeatures != null) {
+            // Same contents but different file names was probably intentional
+            CucumberFeature existingFeature = existingFeatures.get(parsedFileName);
+            if (existingFeature != null) {
+                log.error("" +
+                    "Duplicate feature found: " +
+                    parsedFeature.getUri() + " was identical to " + existingFeature.getUri() + "\n" +
+                    "\n" +
+                    "This typically happens when you configure cucumber to look " +
+                    "for features in the root of your project.\nYour build tool " +
+                    "creates a copy of these features in a 'target' or 'build'" +
+                    "directory.\n" +
+                    "\n" +
+                    "If your features are on the class path consider using a class path URI.\n" +
+                    "For example: 'classpath:com/example/app.feature'\n" +
+                    "Otherwise you'll have to provide a more specific location"
+                );
+                return;
+            }
         }
-        sourceToFeature.put(parsedFeature.getSource(), parsedFeature);
+        sourceToFeature.putIfAbsent(parsedFeature.getSource(), new HashMap<>());
+        sourceToFeature.get(parsedFeature.getSource()).put(parsedFileName, parsedFeature);
+        features.add(parsedFeature);
+    }
+
+    private String getFileName(CucumberFeature feature) {
+        String uri = feature.getUri().getSchemeSpecificPart();
+        int i = uri.lastIndexOf("/");
+        return i > 0 ? uri.substring(i) : uri;
     }
 }

--- a/core/src/test/java/io/cucumber/core/feature/FeatureBuilderTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/FeatureBuilderTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
@@ -18,41 +17,72 @@ import static org.mockito.Mockito.when;
 
 class FeatureBuilderTest {
 
+    private final FeatureBuilder builder = new FeatureBuilder();
+
     @Test
-    void ignores_duplicate_features() throws IOException {
-        FeatureBuilder builder = new FeatureBuilder();
-        URI featurePath = URI.create("foo.feature");
-        Resource resource1 = createResourceMock(featurePath);
-        Resource resource2 = createResourceMock(featurePath);
+    void ignores_identical_features_in_different_directories() throws IOException {
+        URI featurePath1 = URI.create("src/example.feature");
+        URI featurePath2 = URI.create("build/example.feature");
+
+        Resource resource1 = createResourceMock(featurePath1);
+        Resource resource2 = createResourceMock(featurePath2);
 
         builder.parse(resource1);
         builder.parse(resource2);
 
         List<CucumberFeature> features = builder.build();
 
-        assertThat(features.size(), is(equalTo(1)));
+        assertThat(features.size(), equalTo(1));
     }
 
     @Test
-    void works_when_path_and_uri_are_the_same() throws IOException {
-        URI featurePath = URI.create("path/foo.feature");
-        Resource resource = createResourceMock(featurePath);
-        FeatureBuilder builder = new FeatureBuilder();
+    void duplicate_content_with_different_file_names_are_intentionally_duplicated() throws IOException {
+        URI featurePath1 = URI.create("src/feature1/example-first.feature");
+        URI featurePath2 = URI.create("src/feature1/example-second.feature");
 
-        builder.parse(resource);
+        Resource resource1 = createResourceMock(featurePath1);
+        Resource resource2 = createResourceMock(featurePath2);
+
+        builder.parse(resource1);
+        builder.parse(resource2);
 
         List<CucumberFeature> features = builder.build();
 
-        assertAll("Checking CucumberFeature",
-            () -> assertThat(features.size(), is(equalTo(1))),
-            () -> assertThat(features.get(0).getUri(), is(equalTo(featurePath)))
+        assertAll(
+            () -> assertThat(features.size(), equalTo(2)),
+            () -> assertThat(features.get(0).getUri(), equalTo(featurePath1)),
+            () -> assertThat(features.get(1).getUri(), equalTo(featurePath2))
+        );
+    }
+
+
+    @Test
+    void features_are_sorted_by_uri() throws IOException {
+        URI featurePath1 = URI.create("c.feature");
+        URI featurePath2 = URI.create("b.feature");
+        URI featurePath3 = URI.create("a.feature");
+
+        Resource resource1 = createResourceMock(featurePath1);
+        Resource resource2 = createResourceMock(featurePath2);
+        Resource resource3 = createResourceMock(featurePath3);
+
+        builder.parse(resource1);
+        builder.parse(resource2);
+        builder.parse(resource3);
+
+        List<CucumberFeature> features = builder.build();
+
+        assertAll(
+            () -> assertThat(features.get(0).getUri(), equalTo(featurePath3)),
+            () -> assertThat(features.get(1).getUri(), equalTo(featurePath2)),
+            () -> assertThat(features.get(2).getUri(), equalTo(featurePath1))
         );
     }
 
     private Resource createResourceMock(URI featurePath) throws IOException {
         Resource resource = mock(Resource.class);
         when(resource.getPath()).thenReturn(featurePath);
-        ByteArrayInputStream feature = new ByteArrayInputStream("Feature: foo".getBytes(UTF_8));
+        ByteArrayInputStream feature = new ByteArrayInputStream("Feature: Example".getBytes(UTF_8));
         when(resource.getInputStream()).thenReturn(feature);
         return resource;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,7 @@
                                         be missing in the dependency hierarchy. A false positive. -->
                                         <item>class org\.springframework\..*</item>
                                         <item>.* io\.cucumber\.core\.runner\.AmbiguousStepDefinitionsException.*</item>
+                                        <item>.* io\.cucumber\.core\.feature\.CucumberFeature\.CucumberFeatureUriComparator.*</item>
                                         <item>.* io\.cucumber\.junit\..*</item>
                                         <item>.* io\.cucumber\.junit\..*</item>
                                         <item>.* io.cucumber.plugin.event.EmbedEvent::getMediaType().*</item>


### PR DESCRIPTION
## Summary

Build tools will typically copy the source files to a `build` or
`target` directory duplicating all feature files in the project. When
the root of the project is used as the feature path cucumber will
discover both sets of feature files (https://github.com/cucumber/cucumber-jvm/issues/165).

By including the file name we can distinguish between accidental
duplication and intentional duplication.

We could make this scenario an error but given the complexities of https://github.com/cucumber/cucumber-jvm/issues/259
this is best left as a separate issue.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
