### PR TITLE
[JUnit] Add JUnit Platform @Cucumber annotation

### DIFF
--- a/examples/java-calculator-junit5/src/test/java/io/cucumber/examples/junit5/calculator/RunCucumberTest.java
+++ b/examples/java-calculator-junit5/src/test/java/io/cucumber/examples/junit5/calculator/RunCucumberTest.java
@@ -1,0 +1,7 @@
+package io.cucumber.examples.junit5.calculator;
+
+import io.cucumber.junit.platform.engine.Cucumber;
+
+@Cucumber
+public class RunCucumberTest {
+}

--- a/junit-platform-engine/README.md
+++ b/junit-platform-engine/README.md
@@ -1,7 +1,7 @@
 Cucumber JUnit Platform Engine
 ==============================
 
-Use JUnit Platform to execute cucumber scenarios.
+Use JUnit Platform to execute Cucumber scenarios.
 
 Add the `cucumber-junit-platform-engine` dependency to your `pom.xml`:
 
@@ -17,11 +17,33 @@ Add the `cucumber-junit-platform-engine` dependency to your `pom.xml`:
 This will allow the IntelliJ IDEA, Eclipse, Maven, Gradle, ect, to discover,
 select and execute Cucumber scenarios. 
 
-## Maven Surefire workaround ##
+## Surefire and Gradle workarounds
 
-Maven Surefire does not yet support discovery of non-class based test as a
-workaround you can use the antrun plugin to start the the JUnit Platform 
+Maven Surefire and Gradle do not yet support discovery of non-class based tests
+(see: [gradle/#4773](https://github.com/gradle/gradle/issues/4773),
+[SUREFIRE-1724](https://issues.apache.org/jira/browse/SUREFIRE-1724)). As a
+workaround you can either use the `@Cucumber` annotation or the JUnit Platform
 Console Launcher.
+
+### Use the @Cucumber annotation ###
+
+Cucumber will scan the package of a class annotated with `@Cucumber` for feature
+files.  
+
+```java
+package com.example.app;
+
+import io.cucumber.junit.platform.engine.Cucumber;
+
+@Cucumber
+public class RunCucumberTest {
+}
+```
+
+### Use the JUnit Console Launcher ###
+
+As a workaround you can use the JUnit Platform Console Launcher by using either
+the Maven Antrun plugin or the Gradle JavaExec task.
 
 ```xml
 <dependencies>
@@ -69,12 +91,6 @@ Console Launcher.
     </plugins>
 </build>
 ```
-## Gradle Test workaround ##
-
-Gradle Test does not yet support discovery of non-class based test ([gradle/#4773](https://github.com/gradle/gradle/issues/4773)). 
-As a work around you can use a custom task to start the the JUnit Platform
-Console Launcher.
-
 ```groovy
 
 tasks {
@@ -115,6 +131,7 @@ For supported values see [Constants](src/main/java/io/cucumber/junit/platform/en
 Supported `DiscoverySelector`s are:
 * `ClasspathRootSelector`
 * `ClasspathResourceSelector`
+* `ClassSelector`
 * `PackageSelector`
 * `FileSelector`
 * `DirectorySelector`

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Cucumber.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Cucumber.java
@@ -1,0 +1,22 @@
+package io.cucumber.junit.platform.engine;
+
+import org.apiguardian.api.API;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Test discovery annotation. Marks the package of the annotated class for test
+ * discovery.
+ * <p>
+ * Some build tools do not support the {@link org.junit.platform.engine.discovery.DiscoverySelectors}
+ * used by Cucumber. As a work around Cucumber will scan the package of the
+ * annotated class for feature files and execute them.
+ */
+@API(status = API.Status.STABLE)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Cucumber {
+}

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
@@ -3,6 +3,7 @@ package io.cucumber.junit.platform.engine;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.ClasspathResourceSelector;
 import org.junit.platform.engine.discovery.ClasspathRootSelector;
 import org.junit.platform.engine.discovery.DirectorySelector;
@@ -35,6 +36,7 @@ class DiscoverySelectorResolver {
 
         request.getSelectorsByType(ClasspathRootSelector.class).forEach(featureResolver::resolveClasspathRoot);
         request.getSelectorsByType(ClasspathResourceSelector.class).forEach(featureResolver::resolveClasspathResource);
+        request.getSelectorsByType(ClassSelector.class).forEach(featureResolver::resolveClass);
         request.getSelectorsByType(PackageSelector.class).forEach(featureResolver::resolvePackageResource);
         request.getSelectorsByType(FileSelector.class).forEach(featureResolver::resolveFile);
         request.getSelectorsByType(DirectorySelector.class).forEach(featureResolver::resolveDirectory);

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
@@ -8,6 +8,7 @@ import org.junit.platform.commons.logging.Logger;
 import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.discovery.ClassSelector;
 import org.junit.platform.engine.discovery.ClasspathResourceSelector;
 import org.junit.platform.engine.discovery.ClasspathRootSelector;
 import org.junit.platform.engine.discovery.DirectorySelector;
@@ -63,6 +64,14 @@ final class FeatureResolver {
         );
     }
 
+    void resolveClass(ClassSelector classSelector) {
+        Class<?> javaClass = classSelector.getJavaClass();
+        Cucumber annotation = javaClass.getAnnotation(Cucumber.class);
+        if (annotation != null) {
+            resolvePackageResource(javaClass.getPackage().getName());
+        }
+    }
+
     void resolveDirectory(DirectorySelector selector) {
         resolvePath(selector.getPath());
     }
@@ -84,7 +93,10 @@ final class FeatureResolver {
     }
 
     void resolvePackageResource(PackageSelector selector) {
-        String packageName = selector.getPackageName();
+        resolvePackageResource(selector.getPackageName());
+    }
+
+    private void resolvePackageResource(String packageName) {
         featureScanner
             .scanForResourcesInPackage(packageName, packageFilter)
             .stream()

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
@@ -32,6 +32,7 @@ import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClasspathResource;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClasspathRoots;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectDirectory;
@@ -208,6 +209,14 @@ class DiscoverySelectorResolverTest {
                 .map(TestDescriptor::getUniqueId)
                 .collect(toSet())
         );
+    }
+
+    @Test
+    void resolveRequestWithClassSelector() {
+        DiscoverySelector resource = selectClass(RunCucumberTest.class);
+        EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
+        resolver.resolveSelectors(discoveryRequest, testDescriptor);
+        assertEquals(2, testDescriptor.getChildren().size());
     }
 
     private Optional<UniqueId> selectSomePickle(DiscoverySelector resource) {

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/RunCucumberTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/RunCucumberTest.java
@@ -1,0 +1,5 @@
+package io.cucumber.junit.platform.engine;
+
+@Cucumber
+public class RunCucumberTest {
+}


### PR DESCRIPTION
Maven Surefire and Gradle do not yet support discovery of non-class
based tests[1][2]. As a workaround you can either use the `@Cucumber`
annotation or the JUnit Platform Console Launcher.

Cucumber will scan the package of a class annotated with `@Cucumber`
for feature files.

```java
package com.example.app;

import io.cucumber.junit.platform.engine.Cucumber;

@Cucumber
public class RunCucumberTest {
}
```

 1. gradle/gradle#4773
 2. https://issues.apache.org/jira/browse/SUREFIRE-1724

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
