### PR TITLE
[JUnit] Do not include @ in TestTags

### DIFF
--- a/junit-platform-engine/README.md
+++ b/junit-platform-engine/README.md
@@ -143,8 +143,18 @@ features are selected from the classpath.
 
 ## Tags
 
-Cucumber tags are mapped to JUnit tags. See the relevant documentation on how to
-select tags:
+Cucumber tags are mapped to JUnit tags. Note that the `@` symbol is not part of
+the JUnit tag. So the scenario below is tagged with `Smoke` and `Sanity`. 
+
+```gherkin
+@Smoke @Sanity
+Scenario: A tagged scenario
+  Given I tag a scenario 
+  When I select tests with that tag for execution 
+  Then my tagged scenario is executed
+```
+ 
+See the relevant documentation on how to select tags:
 * [Maven: Filtering by Tags](https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html)
 * [Gradle: Test Grouping](https://docs.gradle.org/current/userguide/java_testing.html#test_grouping)
 * [JUnit 5 Console Launcher: Options](https://junit.org/junit5/docs/current/user-guide/#running-tests-console-launcher-options)

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
@@ -61,7 +61,7 @@ class FeatureResolverTest {
         TestDescriptor scenario = getScenario();
         assertEquals("A scenario", scenario.getDisplayName());
         assertEquals(
-            asSet(create("@FeatureTag"), create("@ScenarioTag")),
+            asSet(create("FeatureTag"), create("ScenarioTag")),
             scenario.getTags()
         );
         assertEquals(of(from(featurePath, from(5, 3))), scenario.getSource());
@@ -98,7 +98,7 @@ class FeatureResolverTest {
         TestDescriptor example = getExample();
         assertEquals("Example #1", example.getDisplayName());
         assertEquals(
-            asSet(create("@FeatureTag"), create("@Example1Tag"), create("@ScenarioOutlineTag")),
+            asSet(create("FeatureTag"), create("Example1Tag"), create("ScenarioOutlineTag")),
             example.getTags()
         );
         assertEquals(of(from(featurePath, from(19, 7))), example.getSource());


### PR DESCRIPTION
The JUnit Platform supports tag expressions. This allows users to select
groups of tests to execute. By not including the `@` symbol in the
`TestTag` it is possible to select both example below using the JUnit
tag expression `smoke` rather then `smoke & @smoke`.

```java
@Test
@Tag("Smoke")
void test(){}
```

```gherkin
@Smoke
Scenario: Smoke test
```

Additionally Maven interprets strings delimited by `@` symbols as
string interpolation[2]. This makes using the `@` symbol problematic in
tag expressions.

  1. https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions
  2. https://maven.apache.org/shared/maven-filtering/

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
