### PR TITLE
[Core] Throw exception when multiple object factories are found

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -8,8 +8,8 @@ sub modules together e.g. `cucumber-junit` and `cucumber-java`.
 
 ## Backend ##
 
-Backends consists of two components an a Backend and ObjectFactory. Together
-they are responsible for discovering glue classes, registering step definitions
+Backends consists of two components, a `Backend` and `ObjectFactory`. They are
+respectively responsible for discovering glue classes, registering step definitions
 and creating instances of said glue classes.
 
 ## Plugin ##


### PR DESCRIPTION
When multiple object factories are available on the classpath Cucumber
would print out a warning and fall back to the default object factory.

With the introduction of `cucumber.object-factory` the user can specify
exactly which object factory should be used. There should be no need for
a soft failure any more.