### PR TITLE
[Core] Print warning when using --non-strict

### DIFF
--- a/core/src/main/java/io/cucumber/core/cli/Main.java
+++ b/core/src/main/java/io/cucumber/core/cli/Main.java
@@ -1,5 +1,7 @@
 package io.cucumber.core.cli;
 
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
 import io.cucumber.core.options.CommandlineOptionsParser;
 import io.cucumber.core.options.Constants;
 import io.cucumber.core.options.CucumberProperties;
@@ -22,6 +24,8 @@ import org.apiguardian.api.API;
  */
 @API(status = API.Status.STABLE)
 public class Main {
+
+    private static final Logger log = LoggerFactory.getLogger(Main.class);
 
     public static void main(String... argv) {
         byte exitStatus = run(argv, Thread.currentThread().getContextClassLoader());
@@ -54,6 +58,12 @@ public class Main {
             .addDefaultSummaryPrinterIfAbsent()
             .build(systemOptions);
 
+        if (!runtimeOptions.isStrict()) {
+            log.warn(() -> "By default Cucumber is running in --non-strict mode.\n" +
+                "This default will change to --strict and --non-strict will be removed.\n" +
+                "You can use --strict to suppress this warning"
+            );
+        }
 
         final Runtime runtime = Runtime.builder()
             .withRuntimeOptions(runtimeOptions)

--- a/junit/src/main/java/io/cucumber/junit/Cucumber.java
+++ b/junit/src/main/java/io/cucumber/junit/Cucumber.java
@@ -1,9 +1,12 @@
 package io.cucumber.junit;
 
+import io.cucumber.core.cli.Main;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.feature.CucumberFeature;
 import io.cucumber.core.feature.CucumberPickle;
 import io.cucumber.core.filter.Filters;
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
 import io.cucumber.core.options.Constants;
 import io.cucumber.core.options.CucumberOptionsAnnotationParser;
 import io.cucumber.core.options.CucumberProperties;
@@ -78,6 +81,9 @@ import static java.util.stream.Collectors.toList;
  */
 @API(status = API.Status.STABLE)
 public final class Cucumber extends ParentRunner<ParentRunner<?>> {
+
+    private static final Logger log = LoggerFactory.getLogger(Cucumber.class);
+
     private final List<ParentRunner<?>> children;
     private final EventBus bus;
     private final List<CucumberFeature> features;
@@ -91,7 +97,7 @@ public final class Cucumber extends ParentRunner<ParentRunner<?>> {
      * @param clazz the class with the @RunWith annotation.
      * @throws org.junit.runners.model.InitializationError if there is another problem
      */
-    public Cucumber(Class clazz) throws InitializationError {
+    public Cucumber(Class<?> clazz) throws InitializationError {
         super(clazz);
         Assertions.assertNoCucumberAnnotatedMethods(clazz);
 
@@ -113,6 +119,14 @@ public final class Cucumber extends ParentRunner<ParentRunner<?>> {
             .parse(CucumberProperties.fromSystemProperties())
             .addDefaultSummaryPrinterIfAbsent()
             .build(environmentOptions);
+
+
+        if (!runtimeOptions.isStrict()) {
+            log.warn(() -> "By default Cucumber is running in --non-strict mode.\n" +
+                "This default will change to --strict and --non-strict will be removed.\n" +
+                "You can use --strict or @CucumberOptions(strict = true) to suppress this warning"
+            );
+        }
 
         // Next parse the junit options
         JUnitOptions junitPropertiesFileOptions = new JUnitOptionsParser()

--- a/pom.xml
+++ b/pom.xml
@@ -361,6 +361,7 @@
                                         <item>.* io.cucumber.java8.DefaultParameterTransformerBody.*</item>
                                         <item>.* io.cucumber.java8.LambdaGlue::DefaultParameterTransformer.*</item>
                                         <item>.* io.cucumber.java8.LambdaGlue::DefaultDataTableEntryTransformer.*</item>
+                                        <item>.* io.cucumber.testng.TestNGCucumberRunner.*</item>
                                     </exclude>
                                 </elements>
                             </revapi.filter>

--- a/testng/src/main/java/io/cucumber/testng/TestNGCucumberRunner.java
+++ b/testng/src/main/java/io/cucumber/testng/TestNGCucumberRunner.java
@@ -5,6 +5,8 @@ import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.feature.CucumberFeature;
 import io.cucumber.core.feature.CucumberPickle;
 import io.cucumber.core.filter.Filters;
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
 import io.cucumber.core.options.Constants;
 import io.cucumber.core.options.CucumberOptionsAnnotationParser;
 import io.cucumber.core.options.CucumberProperties;
@@ -50,6 +52,8 @@ import static java.util.stream.Collectors.toList;
 @API(status = API.Status.STABLE)
 public final class TestNGCucumberRunner {
 
+    private static final Logger log = LoggerFactory.getLogger(TestNGCucumberRunner.class);
+
     private final EventBus bus;
     private final Predicate<CucumberPickle> filters;
     private final ThreadLocalRunnerSupplier runnerSupplier;
@@ -63,7 +67,7 @@ public final class TestNGCucumberRunner {
      * @param clazz Which has the {@link CucumberOptions}
      *              and {@link org.testng.annotations.Test} annotations
      */
-    public TestNGCucumberRunner(Class clazz) {
+    public TestNGCucumberRunner(Class<?> clazz) {
         // Parse the options early to provide fast feedback about invalid options
         RuntimeOptions propertiesFileOptions = new CucumberPropertiesParser()
             .parse(CucumberProperties.fromPropertiesFile())
@@ -82,6 +86,14 @@ public final class TestNGCucumberRunner {
             .parse(CucumberProperties.fromSystemProperties())
             .addDefaultSummaryPrinterIfAbsent()
             .build(environmentOptions);
+
+
+        if (!runtimeOptions.isStrict()) {
+            log.warn(() -> "By default Cucumber is running in --non-strict mode.\n" +
+                "This default will change to --strict and --non-strict will be removed.\n" +
+                "You can use --strict or @CucumberOptions(strict = true) to suppress this warning"
+            );
+        }
 
         Supplier<ClassLoader> classLoader = ClassLoaders::getDefaultClassLoader;
         featureSupplier = new FeaturePathFeatureSupplier(classLoader, runtimeOptions);


### PR DESCRIPTION
## Summary

Aside from the common `PASSED`, `SKIPPED` and `FAILED` states Cucumber also
uses `PENDING`, `UNDEFINED`, `AMBIGUOUS`. This makes mapping a test execution
state to a `OK` or `NOK` test run state complicated. By defaulting to
`--strict` only `PASSED`, `SKIPPED` are considered `OK`. This makes it easier
to integrate tooling with Cucumber.

However before we can default to `--strict` all usage should be `--strict`.
This PR will print a warning when Cucumber is not ran in `--strict` mode.

Part of #1788
