### PR TITLE
[Core] Log class load errors while class scanning

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -3,21 +3,40 @@ Cucumber Core
 
 Provides components needed to discover, parse and execute feature files. The
 core is designed with a few extension systems and plugin points. You
-typically don't depend on `cucumber-core` but rather use the different
+typically don't depend directly on `cucumber-core` but rather use the different
 sub modules together e.g. `cucumber-junit` and `cucumber-java`.     
 
 ## Backend ##
 
 Backends consists of two components, a `Backend` and `ObjectFactory`. They are
 respectively responsible for discovering glue classes, registering step definitions
-and creating instances of said glue classes.
+and creating instances of said glue classes. Backend and object factory
+implementations are discovered via SPI
 
 ## Plugin ##
 
 By implementing the Plugin interface classes can listen to execution events
-inside Cucumber JVM.
+inside Cucumber JVM. Consider using a Plugin when creating test execution reports.
 
 ## FileSystem ##
 
 Cucumber uses `java.nio.fileFileSystems` to scan for features and will be able
 to scan features on any file system registered with the JVM.
+
+## Logging ##
+Cucumber uses the Java Logging APIs from `java.util.logging`. See the
+[LogManager](https://docs.oracle.com/javase/8/docs/api/java/util/logging/LogManager.html)
+for configuration options or use the [JUL to SLF4J Bridge](https://www.slf4j.org/legacy.html#jul-to-slf4j).
+
+For quick debugging run with:  
+
+```
+-Djava.util.logging.config.file=path/to/logging.properties
+```
+
+```properties
+handlers=java.util.logging.ConsoleHandler
+.level=FINE
+java.util.logging.ConsoleHandler.level=FINE
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+```

--- a/core/src/main/java/io/cucumber/core/resource/ClasspathScanner.java
+++ b/core/src/main/java/io/cucumber/core/resource/ClasspathScanner.java
@@ -1,5 +1,8 @@
 package io.cucumber.core.resource;
 
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
+
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -18,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 public final class ClasspathScanner {
+
+    private static final Logger log = LoggerFactory.getLogger(ClasspathScanner.class);
 
     private static final String CLASS_FILE_SUFFIX = ".class";
     private static final String PACKAGE_INFO_FILE_NAME = "package-info" + CLASS_FILE_SUFFIX;
@@ -95,7 +100,7 @@ public final class ClasspathScanner {
                     .filter(classFilter)
                     .ifPresent(classConsumer);
             } catch (ClassNotFoundException | NoClassDefFoundError e) {
-                throw new IllegalArgumentException("Unable to load " + fqn, e);
+                log.debug(e, () -> "Failed to load class " + fqn);
             }
         };
     }


### PR DESCRIPTION
## Summary

In practice the class path may be rather dirty and not all available classes can be loaded. Because Cucumber will by default scan in the root package it guaranteed to run into class loading errors. By logging these at debug level rather then throwing an exception Cucumber will most probably continue to work as expected. 

To debug occurrences of missing glue you can enable debug logging via: 
```
-Djava.util.logging.config.file=path/to/logging.properties
```

```properties
handlers=java.util.logging.ConsoleHandler
.level=FINE
java.util.logging.ConsoleHandler.level=FINE
java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
``` 

Fixes: #1843

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
