### PR TITLE
[JUnit] Support `line` query parameter in `UriSelector`

### DIFF
--- a/junit-platform-engine/README.md
+++ b/junit-platform-engine/README.md
@@ -158,6 +158,13 @@ Supported `DiscoverySelector`s are:
 The only supported `DiscoveryFilter` is the `PackageNameFilter` and only when
 features are selected from the classpath.
 
+The `UriSelector` supports URI's with a `line` query parameter:
+  - `classpath:/com/example/example.feature?line=20`
+  - `file:/path/to/com/example/example.feature?line=20`
+ 
+Any `TestDescriptor` that matches the line *and* its descendents will be 
+included in the discovery result.
+
 ## Tags
 
 Cucumber tags are mapped to JUnit tags. Note that the `@` symbol is not part of

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
@@ -15,6 +15,7 @@ import org.junit.platform.engine.discovery.UriSelector;
 
 import java.util.function.Predicate;
 
+import static io.cucumber.junit.platform.engine.FeatureResolver.createFeatureResolver;
 import static org.junit.platform.engine.Filter.composeFilters;
 
 class DiscoverySelectorResolver {
@@ -32,7 +33,7 @@ class DiscoverySelectorResolver {
     }
 
     private void resolve(EngineDiscoveryRequest request, TestDescriptor engineDescriptor, Predicate<String> packageFilter) {
-        FeatureResolver featureResolver = FeatureResolver.createFeatureResolver(engineDescriptor, packageFilter);
+        FeatureResolver featureResolver = createFeatureResolver(engineDescriptor, packageFilter);
 
         request.getSelectorsByType(ClasspathRootSelector.class).forEach(featureResolver::resolveClasspathRoot);
         request.getSelectorsByType(ClasspathResourceSelector.class).forEach(featureResolver::resolveClasspathResource);

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
@@ -15,6 +15,9 @@ import org.junit.platform.engine.discovery.FileSelector;
 import org.junit.platform.engine.discovery.PackageSelector;
 import org.junit.platform.engine.discovery.UniqueIdSelector;
 import org.junit.platform.engine.discovery.UriSelector;
+import org.junit.platform.engine.support.descriptor.ClasspathResourceSource;
+import org.junit.platform.engine.support.descriptor.FilePosition;
+import org.junit.platform.engine.support.descriptor.FileSource;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -22,10 +25,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static java.util.Optional.of;
+import static org.junit.platform.engine.support.descriptor.FilePosition.fromQuery;
 
 final class FeatureResolver {
 
@@ -61,12 +66,58 @@ final class FeatureResolver {
         );
     }
 
-    void resolveClass(ClassSelector classSelector) {
-        Class<?> javaClass = classSelector.getJavaClass();
-        Cucumber annotation = javaClass.getAnnotation(Cucumber.class);
-        if (annotation != null) {
-            resolvePackageResource(javaClass.getPackage().getName());
+    private static URI stripQuery(URI uri) {
+        if (uri.getQuery() == null) {
+            return uri;
         }
+        String uriString = uri.toString();
+        return URI.create(uriString.substring(0, uriString.indexOf('?')));
+    }
+
+    private static Predicate<TestDescriptor> testDescriptorOnLine(Integer line) {
+        return descriptor -> descriptor.getSource()
+            .flatMap(testSource -> {
+                if (testSource instanceof FileSource) {
+                    FileSource fileSystemSource = (FileSource) testSource;
+                    return fileSystemSource.getPosition();
+                }
+                if (testSource instanceof ClasspathResourceSource) {
+                    ClasspathResourceSource classpathResourceSource = (ClasspathResourceSource) testSource;
+                    return classpathResourceSource.getPosition();
+                }
+                return Optional.empty();
+            })
+            .map(FilePosition::getLine)
+            .map(line::equals)
+            .orElse(false);
+    }
+
+    private static Function<TestDescriptor, TestDescriptor> pruneDescriptions(Predicate<TestDescriptor> toKeep) {
+        return descriptor -> {
+            pruneDescriptionRecursively(descriptor, toKeep);
+            return descriptor;
+        };
+    }
+
+    private static void pruneDescriptionRecursively(TestDescriptor descriptor, Predicate<TestDescriptor> toKeep) {
+        if (toKeep.test(descriptor)) {
+            return;
+        }
+
+        if (descriptor.isTest()) {
+            descriptor.removeFromHierarchy();
+        }
+
+        List<TestDescriptor> children = new ArrayList<>(descriptor.getChildren());
+        children.forEach(child -> pruneDescriptionRecursively(child, toKeep));
+    }
+
+    private void merge(TestDescriptor featureDescriptor) {
+        recursivelyMerge(featureDescriptor, engineDescriptor);
+    }
+
+    void resolveFile(FileSelector selector) {
+        resolvePath(selector.getPath());
     }
 
     void resolveDirectory(DirectorySelector selector) {
@@ -81,16 +132,16 @@ final class FeatureResolver {
             .forEach(this::merge);
     }
 
-    private void merge(TestDescriptor featureDescriptor) {
-        recursivelyMerge(featureDescriptor, engineDescriptor);
-    }
-
-    void resolveFile(FileSelector selector) {
-        resolvePath(selector.getPath());
-    }
-
     void resolvePackageResource(PackageSelector selector) {
         resolvePackageResource(selector.getPackageName());
+    }
+
+    void resolveClass(ClassSelector classSelector) {
+        Class<?> javaClass = classSelector.getJavaClass();
+        Cucumber annotation = javaClass.getAnnotation(Cucumber.class);
+        if (annotation != null) {
+            resolvePackageResource(javaClass.getPackage().getName());
+        }
     }
 
     private void resolvePackageResource(String packageName) {
@@ -118,9 +169,36 @@ final class FeatureResolver {
             .forEach(this::merge);
     }
 
+    void resolveUniqueId(UniqueIdSelector uniqueIdSelector) {
+        UniqueId uniqueId = uniqueIdSelector.getUniqueId();
+        // Ignore any ids not from our own engine
+        if (!engineDescriptor.getUniqueId().getEngineId().equals(uniqueId.getEngineId())) {
+            return;
+        }
+
+        Predicate<TestDescriptor> keepTestWithSelectedId = testDescriptor
+            -> uniqueId.equals(testDescriptor.getUniqueId());
+
+        uniqueId.getSegments()
+            .stream()
+            .filter(FeatureOrigin::isFeatureSegment)
+            .map(UniqueId.Segment::getValue)
+            .map(URI::create)
+            .flatMap(this::resolveUri)
+            .map(pruneDescriptions(keepTestWithSelectedId))
+            .forEach(this::merge);
+    }
+
     void resolveUri(UriSelector selector) {
         URI uri = selector.getUri();
-        resolveUri(uri)
+
+        Predicate<TestDescriptor> keepTestOnSelectedLine = fromQuery(uri.getQuery())
+            .map(FilePosition::getLine)
+            .map(FeatureResolver::testDescriptorOnLine)
+            .orElse(testDescriptor -> true);
+
+        resolveUri(stripQuery(uri))
+            .map(pruneDescriptions(keepTestOnSelectedLine))
             .forEach(this::merge);
     }
 
@@ -129,38 +207,6 @@ final class FeatureResolver {
             .scanForResourcesUri(uri)
             .stream()
             .map(this::resolveFeature);
-    }
-
-    void resolveUniqueId(UniqueIdSelector uniqueIdSelector) {
-        UniqueId uniqueId = uniqueIdSelector.getUniqueId();
-        // Ignore any ids not from our own engine
-        if (!engineDescriptor.getUniqueId().getEngineId().equals(uniqueId.getEngineId())) {
-            return;
-        }
-
-        uniqueId.getSegments()
-            .stream()
-            .filter(FeatureOrigin::isFeatureSegment)
-            .map(UniqueId.Segment::getValue)
-            .map(URI::create)
-            .flatMap(this::resolveUri)
-            .map(descriptor -> pruneDescription(descriptor, uniqueId))
-            .forEach(this::merge);
-    }
-
-    private TestDescriptor pruneDescription(TestDescriptor descriptor, UniqueId toKeep) {
-        pruneDescriptionRecursively(descriptor, toKeep);
-        return descriptor;
-    }
-
-    private void pruneDescriptionRecursively(TestDescriptor descriptor, UniqueId toKeep) {
-        if (descriptor.isTest() && !descriptor.getUniqueId().hasPrefix(toKeep)) {
-            descriptor.removeFromHierarchy();
-            return;
-        }
-
-        List<TestDescriptor> children = new ArrayList<>(descriptor.getChildren());
-        children.forEach(child -> pruneDescriptionRecursively(child, toKeep));
     }
 
     private TestDescriptor resolveFeature(Feature feature) {

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
@@ -12,6 +12,8 @@ import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.engine.discovery.UniqueIdSelector;
+import org.junit.platform.engine.support.descriptor.ClasspathResourceSource;
+import org.junit.platform.engine.support.descriptor.FilePosition;
 
 import java.io.File;
 import java.net.URI;
@@ -102,6 +104,58 @@ class DiscoverySelectorResolverTest {
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
         assertEquals(1, testDescriptor.getChildren().size());
+    }
+    @Test
+    void resolveRequestWithUriSelectorWithScenarioOutlineLine() {
+        File file = new File("src/test/resources/io/cucumber/junit/platform/engine/feature-with-outline.feature");
+        URI uri = URI.create(file.toURI() + "?line=11");
+        DiscoverySelector resource = selectUri(uri);
+        EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
+        resolver.resolveSelectors(discoveryRequest, testDescriptor);
+        List<? extends TestDescriptor> tests = testDescriptor.getDescendants().stream()
+            .filter(TestDescriptor::isTest)
+            .collect(Collectors.toList());
+        assertEquals(4, tests.size()); // 4 examples in the outline
+    }
+
+    @Test
+    void resolveRequestWithUriSelectorWithExamplesSectionLine() {
+        File file = new File("src/test/resources/io/cucumber/junit/platform/engine/feature-with-outline.feature");
+        URI uri = URI.create(file.toURI() + "?line=17");
+        DiscoverySelector resource = selectUri(uri);
+        EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
+        resolver.resolveSelectors(discoveryRequest, testDescriptor);
+        List<? extends TestDescriptor> tests = testDescriptor.getDescendants().stream()
+            .filter(TestDescriptor::isTest)
+            .collect(Collectors.toList());
+        assertEquals(2, tests.size()); // 2 examples in the examples section
+    }
+
+
+    @Test
+    void resolveRequestWithUriSelectorWithExampleLine() {
+        File file = new File("src/test/resources/io/cucumber/junit/platform/engine/feature-with-outline.feature");
+        URI uri1 = URI.create(file.toURI() + "?line=20");
+        DiscoverySelector resource = selectUri(uri1);
+        EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
+        resolver.resolveSelectors(discoveryRequest, testDescriptor);
+        List<? extends TestDescriptor> tests = testDescriptor.getDescendants().stream()
+            .filter(TestDescriptor::isTest)
+            .collect(Collectors.toList());
+        assertEquals(1, tests.size());
+    }
+
+
+    @Test
+    void resolveRequestWithClassPathUriSelectorWithLine() {
+        URI uri = URI.create("classpath:/io/cucumber/junit/platform/engine/feature-with-outline.feature?line=20");
+        DiscoverySelector resource = selectUri(uri);
+        EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
+        resolver.resolveSelectors(discoveryRequest, testDescriptor);
+        List<? extends TestDescriptor> tests = testDescriptor.getDescendants().stream()
+            .filter(TestDescriptor::isTest)
+            .collect(Collectors.toList());
+        assertEquals(1, tests.size());
     }
 
     @Test


### PR DESCRIPTION
## Summary
Support `line` query parameter in `UriSelector`. 

Allows the use of a `line` query parameter when using the `UriSelector`:
  - `classpath:/com/example/example.feature?line=20`
  - `file:/path/to/com/example/example.feature?line=20`

This can be used by IDE creators and users to select a file in a feature file
and easily convert it to something the `CucumberTestEngine` can discover
and execute.

Any `TestDescriptor` that matches the line *and* its descendents will be
included in the discovery result. Note that this differs from the `FeaturePath`
specification. When using `classpath:/com/example/example.feature:20` only
pickles are matched. The query parameter also allows the selection of
scenario (outlines), rules, example sections and whole features.

The the dot-feature-colon-line-number format of `FeaturePath` is
intentionally not reused. As we are using URIs and not encumbered by legacy
input formats we can use the proper abstractions here.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
