### PR TITLE
[Core] Include default gherkin version in version.properties

### DIFF
--- a/core/src/main/resources/io/cucumber/core/version.properties
+++ b/core/src/main/resources/io/cucumber/core/version.properties
@@ -1,2 +1,2 @@
 cucumber-jvm.version=${parent.version}
-gherkin.version=${gherkin.version}
+gherkin.version=${gherkin-messages.version}

--- a/core/src/main/resources/io/cucumber/core/version.properties
+++ b/core/src/main/resources/io/cucumber/core/version.properties
@@ -1,2 +1,2 @@
 cucumber-jvm.version=${parent.version}
-gherkin.version=${gherkin-messages.version}
+gherkin.version=${gherkin-vintage.version}

--- a/core/src/main/resources/io/cucumber/core/version.properties
+++ b/core/src/main/resources/io/cucumber/core/version.properties
@@ -1,1 +1,2 @@
 cucumber-jvm.version=${parent.version}
+gherkin.version=${gherkin.version}


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Expose the gherkin version in `version.properties`, so it can be picked up from the classpath by other code.

## Details



## Motivation and Context

A bit more context in https://github.com/cucumber/cucumber/issues/779#issuecomment-561220566, but I am specifically targeting the IDEA autocompletion support for Rule/Example grammar.

I am opening this now for more of a steer, as I can see that with #1804 and others we now have multiple Gherkin versions so this would no longer be valid, and I'm not sure what the best way to achieve this kind of feature detection would be now - or if it's the right thing to do at all.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

(Sorry, meant to open this as a draft)