### PR TITLE
[JUnit] Fix execution when JUnit v4.13 is used

### DIFF
--- a/junit/src/main/java/io/cucumber/junit/FeatureRunner.java
+++ b/junit/src/main/java/io/cucumber/junit/FeatureRunner.java
@@ -27,7 +27,7 @@ final class FeatureRunner extends ParentRunner<PickleRunner> {
     private Description description;
 
     FeatureRunner(CucumberFeature cucumberFeature, Filters filters, ThreadLocalRunnerSupplier runnerSupplier, JUnitOptions jUnitOptions) throws InitializationError {
-        super(null);
+        super((Class) null);
         this.cucumberFeature = cucumberFeature;
         buildFeatureElementRunners(filters, runnerSupplier, jUnitOptions);
     }

--- a/junit/src/main/java/io/cucumber/junit/PickleRunners.java
+++ b/junit/src/main/java/io/cucumber/junit/PickleRunners.java
@@ -45,7 +45,7 @@ final class PickleRunners {
         private Description description;
 
         WithStepDescriptions(RunnerSupplier runnerSupplier, PickleEvent pickleEvent, JUnitOptions jUnitOptions) throws InitializationError {
-            super(null);
+            super((Class) null);
             this.runnerSupplier = runnerSupplier;
             this.pickleEvent = pickleEvent;
             this.jUnitOptions = jUnitOptions;


### PR DESCRIPTION
## Summary

Fix execution issues if JUnit v4.13 is used at runtime instead of v4.12. Even if we do not update to v4.12, and cucumber users force update to v4.13.

## Details

Just the compile fixes due to additional constructors being added in JUnit v4.13.

## Motivation and Context

Something to do on the commute to work.

## How Has This Been Tested?

1. pom update to v4.13
2. mvn clean install (FAILS)
3. fix runtime issues
4. mvn clean install (PASSES)
5. revert pom to v4.12
6. mvn clean install (PASSES)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
