### PR TITLE
[Java] Fix NPE in AbstractDatatableElementTransformerDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
-
+ * [Java] Fix NPE in AbstractDatatableElementTransformerDefinition ([#1865](https://github.com/cucumber/cucumber-jvm/pull/1865) Florin Slevoaca, M.P. Korstanje, ) 
+ 
 ## [5.0.0] (2020-01-16) - [Release Notes](release-notes/v5.0.0.md)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
- * [Java] Fix NPE in AbstractDatatableElementTransformerDefinition ([#1865](https://github.com/cucumber/cucumber-jvm/pull/1865) Florin Slevoaca, M.P. Korstanje, ) 
+ * [Java/Java8] Fix NPE in AbstractDatatableElementTransformerDefinition ([#1865](https://github.com/cucumber/cucumber-jvm/pull/1865) Florin Slevoaca, M.P. Korstanje)
+ * [Core] Fix collision when using `Datatable.asMaps` ([cucumber/cucumber#877](https://github.com/cucumber/cucumber/pull/877) M.P. Korstanje)
  
 ## [5.0.0] (2020-01-16) - [Release Notes](release-notes/v5.0.0.md)
 

--- a/java/src/main/java/io/cucumber/java/AbstractDatatableElementTransformerDefinition.java
+++ b/java/src/main/java/io/cucumber/java/AbstractDatatableElementTransformerDefinition.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import static io.cucumber.datatable.DataTable.create;
 import static java.util.stream.Collectors.toList;
 
-public class AbstractDatatableElementTransformerDefinition extends AbstractGlueDefinition {
+class AbstractDatatableElementTransformerDefinition extends AbstractGlueDefinition {
     private final String[] emptyPatterns;
 
     AbstractDatatableElementTransformerDefinition(Method method, Lookup lookup, String[] emptyPatterns) {

--- a/java/src/test/java/io/cucumber/java/JavaDataTableTypeDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDataTableTypeDefinitionTest.java
@@ -84,7 +84,7 @@ class JavaDataTableTypeDefinitionTest {
         Method method = JavaDataTableTypeDefinitionTest.class.getMethod("converts_table_entry_to_string", Map.class);
         JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookup, new String[]{"[empty]"});
         assertThat(definition.dataTableType().transform(emptyTable.asLists()),
-            is(singletonList("converts_table_entry_to_string={=d, a=}")));
+            is(singletonList("converts_table_entry_to_string={a=, =d}")));
     }
 
     public String converts_table_entry_to_string(Map<String, String> entry) {

--- a/java/src/test/java/io/cucumber/java/JavaDefaultDataTableCellTransformerDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDefaultDataTableCellTransformerDefinitionTest.java
@@ -39,6 +39,14 @@ class JavaDefaultDataTableCellTransformerDefinitionTest {
         assertThat(transformed, is("transform_string_to_type="));
     }
 
+    @Test
+    void can_transform_null_while_using_replacement_patterns() throws Throwable {
+        Method method = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("transform_string_to_type", String.class, Type.class);
+        JavaDefaultDataTableCellTransformerDefinition definition = new JavaDefaultDataTableCellTransformerDefinition(method, lookup, new String[]{"[empty]"});
+        Object transformed = definition.tableCellByTypeTransformer().transform(null, String.class);
+        assertThat(transformed, is("transform_string_to_type=null"));
+    }
+
     public Object transform_string_to_type(String fromValue, Type toValueType) {
         return "transform_string_to_type=" + fromValue;
     }

--- a/java/src/test/java/io/cucumber/java/JavaDefaultDataTableEntryTransformerDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDefaultDataTableEntryTransformerDefinitionTest.java
@@ -78,7 +78,7 @@ class JavaDefaultDataTableEntryTransformerDefinitionTest {
             () -> definition.tableEntryByTypeTransformer().transform(fromValue, String.class, cellTransformer)
         );
 
-        assertThat(exception.getMessage(), is("After replacing [empty] and [blank] with empty strings the datatable entry contains duplicate keys: {[blank]=b, [empty]=a}"));
+        assertThat(exception.getMessage(), is("After replacing [empty] and [blank] with empty strings the datatable entry contains duplicate keys: {[empty]=a, [blank]=b}"));
     }
 
     public <T> T correct_method(Map<String, String> fromValue, Type toValueType) {

--- a/java/src/test/java/io/cucumber/java/JavaDefaultDataTableEntryTransformerDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDefaultDataTableEntryTransformerDefinitionTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -54,8 +54,19 @@ class JavaDefaultDataTableEntryTransformerDefinitionTest {
     }
 
     @Test
+    void transforms_nulls_with_correct_method() throws Throwable {
+        Map<String, String> fromValue = singletonMap("key", null);
+        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("correct_method", Map.class, Type.class);
+        JavaDefaultDataTableEntryTransformerDefinition definition =
+            new JavaDefaultDataTableEntryTransformerDefinition(method, lookup, false, new String[]{"[empty]"});
+
+        assertThat(definition.tableEntryByTypeTransformer()
+            .transform(fromValue, String.class, cellTransformer), is("key=null"));
+    }
+
+    @Test
     void throws_for_multiple_empties_with_correct_method() throws Throwable {
-        Map<String, String> fromValue = new HashMap<>();
+        Map<String, String> fromValue = new LinkedHashMap<>();
         fromValue.put("[empty]", "a");
         fromValue.put("[blank]", "b");
         Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("correct_method", Map.class, Type.class);

--- a/java8/src/main/java/io/cucumber/java8/AbstractDatatableElementTransformerDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/AbstractDatatableElementTransformerDefinition.java
@@ -3,12 +3,12 @@ package io.cucumber.java8;
 import io.cucumber.datatable.DataTable;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import static io.cucumber.datatable.DataTable.create;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 
 public class AbstractDatatableElementTransformerDefinition extends AbstractGlueDefinition {
     private final String[] emptyPatterns;
@@ -34,14 +34,19 @@ public class AbstractDatatableElementTransformerDefinition extends AbstractGlueD
     }
 
     Map<String, String> replaceEmptyPatternsWithEmptyString(Map<String, String> fromValue) {
-        return fromValue.entrySet().stream()
-            .collect(toMap(
-                entry -> replaceEmptyPatternsWithEmptyString(entry.getKey()),
-                entry -> replaceEmptyPatternsWithEmptyString(entry.getValue()),
-                (s, s2) -> {
-                    throw createDuplicateKeyAfterReplacement(fromValue);
-                }
-            ));
+        Map<String, String> replacement = new LinkedHashMap<>();
+
+        fromValue.forEach((String key, String value) -> {
+            String potentiallyEmptyKey = replaceEmptyPatternsWithEmptyString(key);
+            String potentiallyEmptyValue = replaceEmptyPatternsWithEmptyString(value);
+
+            if (replacement.containsKey(potentiallyEmptyKey)) {
+                throw createDuplicateKeyAfterReplacement(fromValue);
+            }
+            replacement.put(potentiallyEmptyKey, potentiallyEmptyValue);
+        });
+
+        return replacement;
     }
 
     private IllegalArgumentException createDuplicateKeyAfterReplacement(Map<String, String> fromValue) {
@@ -57,7 +62,7 @@ public class AbstractDatatableElementTransformerDefinition extends AbstractGlueD
 
     String replaceEmptyPatternsWithEmptyString(String t) {
         for (String emptyPattern : emptyPatterns) {
-            if (t.equals(emptyPattern)) {
+            if (emptyPattern.equals(t)) {
                 return "";
             }
         }

--- a/java8/src/main/java/io/cucumber/java8/AbstractDatatableElementTransformerDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/AbstractDatatableElementTransformerDefinition.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import static io.cucumber.datatable.DataTable.create;
 import static java.util.stream.Collectors.toList;
 
-public class AbstractDatatableElementTransformerDefinition extends AbstractGlueDefinition {
+class AbstractDatatableElementTransformerDefinition extends AbstractGlueDefinition {
     private final String[] emptyPatterns;
 
     AbstractDatatableElementTransformerDefinition(Object body, StackTraceElement location, String[] emptyPatterns) {

--- a/java8/src/test/java/io/cucumber/java8/LambdaStepDefinitions.java
+++ b/java8/src/test/java/io/cucumber/java8/LambdaStepDefinitions.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -58,6 +59,7 @@ public class LambdaStepDefinitions implements io.cucumber.java8.En {
             List<Person> people = peopleTable.asList(Person.class);
             assertEquals("Hellesøy", people.get(0).last);
             assertEquals("", people.get(1).last);
+            assertNull(people.get(3).last);
         });
 
         Integer alreadyHadThisManyCukes = 1;

--- a/java8/src/test/resources/io/cucumber/java8/lambda-step-definitions.feature
+++ b/java8/src/test/resources/io/cucumber/java8/lambda-step-definitions.feature
@@ -21,6 +21,7 @@ Feature: Java8
       | Aslak  | Hellesøy |
       | Plato  | [blank]  |
       | Donald | Duck     |
+      | Toto   |          |
     And A string generic that is not a data table
 
   Scenario: using method references

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <apiguardian-api.version>1.1.0</apiguardian-api.version>
         <!--Dependencies -->
         <cucumber-expressions.version>8.3.1</cucumber-expressions.version>
-        <datatable.version>3.2.0</datatable.version>
+        <datatable.version>3.2.1</datatable.version>
         <tag-expressions.version>2.0.4</tag-expressions.version>
         <messages.version>9.0.3</messages.version>
         <gherkin-vintage.version>5.2.0</gherkin-vintage.version>
@@ -382,6 +382,17 @@
                                 </versionIncreaseAllows>
                             </revapi.semver.ignore>
                             <revapi.ignore>
+                                <item>
+                                    <code>java.class.visibilityReduced</code>
+                                    <old>class io.cucumber.java.AbstractDatatableElementTransformerDefinition</old>
+                                    <justification>Internal API</justification>
+                                </item>
+                                <item>
+                                    <code>java.class.visibilityReduced</code>
+                                    <old>class io.cucumber.java8.AbstractDatatableElementTransformerDefinition</old>
+                                    <justification>Internal API</justification>
+                                </item>
+
                                 <!-- Gherkin parser related -->
                                 <item>
                                     <code>java.class.externalClassExposedInAPI</code>


### PR DESCRIPTION
## Summary

When using

```
@DataTableType(replaceWithEmptyString={"[blank]"})
public List convertDataTable(DataTable dataTable) {
   return new ArrayList();
}
```

In combination with a table containing empty (now null cells)

```
    | test |
    |      |
```

An NPE would be thrown while checking the null cell against the
replacement pattern.

Fixes #1864

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Include https://github.com/cucumber/cucumber/pull/877