### PR TITLE
[JUnit] Add module-info for cucumber-junit-platform-engine

### DIFF
--- a/.m2/travis-ci-toolchains.xml
+++ b/.m2/travis-ci-toolchains.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>11</version>
+            <vendor>openjdk</vendor>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/local/lib/jvm/openjdk11</jdkHome>
+        </configuration>
+    </toolchain>
+</toolchains>

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,33 +3,37 @@ sudo: false
 
 cache:
   directories:
-  - "$HOME/.m2"
+    - "$HOME/.m2"
+
+install:
+  - mvn install -DskipTests=true -DskipITs=true -Dmaven.javadoc.skip=true -B -V --toolchains .m2/travis-ci-toolchains.xml
 
 jobs:
   include:
-  # 1.1 Semver check
-  - stage: test
-    jdk: openjdk8
-    script: mvn verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true
-    env: CHECK_SEMANTIC_VERSION=true
+    # 1.1 Semver check
+    - stage: test
+      jdk: openjdk11
+      script: mvn verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true --toolchains .m2/travis-ci-toolchains.xml
+      env: CHECK_SEMANTIC_VERSION=true
 
-  # 1.2 Check JDK 8,10,ea
-  - stage: test
-    jdk: openjdk8
-    script: mvn clean verify
-    after_success:
-      - mvn clean jacoco:prepare-agent test jacoco:report coveralls:report
-  - jdk: openjdk10
-    script: mvn -q verify
-  - jdk: openjdk11
-    script: mvn -q verify
+    # 1.2 Tests
+    - stage: test
+      jdk: openjdk11
+      script: mvn verify --toolchains .m2/travis-ci-toolchains.xml
+      env: VERIFY=true
 
-  # 1.3 Check javadoc. We need to use this version to properly detect errors.
-  - jdk: oraclejdk11
-    env: JAVADOC=true
-    script:
-    - mvn javadoc:jar
+      # 1.3 Coverage
+    - stage: test
+      jdk: openjdk11
+      script: mvn jacoco:prepare-agent verify jacoco:report coveralls:report --toolchains .m2/travis-ci-toolchains.xml
+      env: COVERAGE=true
+
+    # 1.4 Javadoc
+    - jdk: openjdk11
+      env: JAVADOC=true
+      script:
+        - mvn javadoc:jar --toolchains .m2/travis-ci-toolchains.xml
 
 branches:
   only:
-  - master
+    - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
  * [JUnit] Upgrade JUnit Platform from v1.5.2 to v1.6.0
- 
+ * [JUnit] Add module-info for `cucumber-junit-platform-engine` ([#1867](https://github.com/cucumber/cucumber-jvm/pull/1867) M.P. Korstanje, John Patrick)
+
 ### Deprecated
 
 ### Removed

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>cucumber-archetype</artifactId>
     <packaging>maven-archetype</packaging>
-    <name>cucumber-archetype</name>
+    <name>Cucumber JVM: Archetype</name>
     <description>Cucumber JVM: Maven Archetype</description>
 
     <!-- Not used by this module, but used by the integration tests of

--- a/core/src/main/java/io/cucumber/core/backend/Located.java
+++ b/core/src/main/java/io/cucumber/core/backend/Located.java
@@ -18,8 +18,8 @@ public interface Located {
      * <p>
      * Examples:
      * <ul>
-     *  <li> @{code com.example.StepDefinitions.given_an_example(io.cucumber.datatable.DataTable)>}</li>
-     *  <li> @{code com.example.StepDefinitions.<init>(StepDefinitions.java:9)>}</li>
+     *  <li> @{code com.example.StepDefinitions.given_an_example(io.cucumber.datatable.DataTable)}</li>
+     *  <li> @{code com.example.StepDefinitions.<init>(StepDefinitions.java:9)}</li>
      * </ul>
      *
      * @return The source line of the step definition.

--- a/junit-platform-engine/pom.xml
+++ b/junit-platform-engine/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -10,10 +11,6 @@
     <artifactId>cucumber-junit-platform-engine</artifactId>
     <packaging>jar</packaging>
     <name>Cucumber-JVM: JUnit Platform Engine</name>
-
-    <properties>
-        <project.Automatic-Module-Name>io.cucumber.junit.platform.engine</project.Automatic-Module-Name>
-    </properties>
 
     <profiles>
         <profile>
@@ -82,5 +79,30 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration combine.self="override">
+                    <!-- Ignore Automatic module name -->
+                    <archive>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/junit-platform-engine/src/main/java9/module-info.java
+++ b/junit-platform-engine/src/main/java9/module-info.java
@@ -1,0 +1,12 @@
+module io.cucumber.junit.platform.engine {
+    requires io.cucumber.core;
+
+    requires org.opentest4j;
+    requires org.junit.platform.commons;
+
+    requires transitive org.apiguardian.api;
+    requires transitive org.junit.platform.engine;
+
+    exports io.cucumber.junit.platform.engine;
+    provides org.junit.platform.engine.TestEngine with io.cucumber.junit.platform.engine.CucumberTestEngine;
+}

--- a/openejb/pom.xml
+++ b/openejb/pom.xml
@@ -74,7 +74,7 @@
 
     <!--
     Using source level 1.7 in combination with openejb-core results in 'An unknown compilation
-    error'. Use 1.6 instead and compile up to 1.7 to avoid this problem.
+    error'. Use 1.6 instead and compile up to avoid this problem.
      -->
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,15 @@
 
 
     <properties>
+        <!-- Tool chains, ect -->
+        <base.java.version>1.8</base.java.version>
+        <javadoc.java.version>8</javadoc.java.version>
+        <toolchain.vendor>openjdk</toolchain.vendor>
+        <toolchain.java.version>11</toolchain.java.version>
+
         <!--Semantic version -->
         <apiguardian-api.version>1.1.0</apiguardian-api.version>
+
         <!--Dependencies -->
         <cucumber-expressions.version>8.3.1</cucumber-expressions.version>
         <datatable.version>3.2.0</datatable.version>
@@ -266,13 +273,54 @@
                             </execution>
                         </executions>
                     </plugin>
-
                 </plugins>
             </build>
         </profile>
     </profiles>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <version>${toolchain.java.version}</version>
+                            <vendor>${toolchain.vendor}</vendor>
+                        </jdk>
+                    </toolchains>
+                </configuration>
+            </plugin>
+
+            <!-- enable Java 9,10,11 compilation -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>java9</id>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>java10</id>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>java11</id>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
                 <!-- Standard plugins - alphabetically -->
@@ -305,19 +353,84 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <source>${base.java.version}</source>
+                        <target>${base.java.version}</target>
+                    </configuration>
+                    <executions>
+                        <!-- for Java 9 -->
+                        <execution>
+                            <id>java9</id>
+                            <phase>none</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <release>9</release>
+                                <jdkToolchain>
+                                    <version>9</version>
+                                </jdkToolchain>
+                                <compileSourceRoots>
+                                    <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+                                </compileSourceRoots>
+                                <multiReleaseOutput>true</multiReleaseOutput>
+                            </configuration>
+                        </execution>
+
+                        <!-- for Java 10 -->
+                        <execution>
+                            <id>java10</id>
+                            <phase>none</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <release>10</release>
+                                <jdkToolchain>
+                                    <version>10</version>
+                                </jdkToolchain>
+                                <compileSourceRoots>
+                                    <compileSourceRoot>${project.basedir}/src/main/java10</compileSourceRoot>
+                                </compileSourceRoots>
+                                <multiReleaseOutput>true</multiReleaseOutput>
+                            </configuration>
+                        </execution>
+
+                        <!-- for Java 11 -->
+                        <execution>
+                            <id>java11</id>
+                            <phase>none</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <release>11</release>
+                                <jdkToolchain>
+                                    <version>11</version>
+                                </jdkToolchain>
+                                <compileSourceRoots>
+                                    <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
+                                </compileSourceRoots>
+                                <multiReleaseOutput>true</multiReleaseOutput>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
-                        <use>false</use>
                         <doclint>none</doclint>
-                        <source>8</source>
+                        <source>${javadoc.java.version}</source>
                         <excludePackageNames>io.cucumber.examples:org.springframework</excludePackageNames>
                         <links>
-                            <link>http://docs.oracle.com/javase/8/docs/api/</link>
                             <link>https://junit.org/junit4/javadoc/latest/</link>
                             <!-- javadoc plugin can't port docs for modularized code to
-                                 non-modularized code -->
+                               non-modularized code -->
                             <!-- <link>https://junit.org/junit5/docs/current/api/</link>-->
-                            <link>https://javadoc.io/doc/org.testng/testng/7.0.0/</link>
+                            <link>https://javadoc.io/doc/org.testng/testng/7.1.0/</link>
                         </links>
                         <groups>
                             <group>
@@ -357,6 +470,12 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.0.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-toolchains-plugin</artifactId>
+                    <version>1.1</version>
                 </plugin>
 
                 <!-- Semantic version check  -->
@@ -427,6 +546,15 @@
                     <groupId>org.eluder.coveralls</groupId>
                     <artifactId>coveralls-maven-plugin</artifactId>
                     <version>4.3.0</version>
+                    <!-- Include JAXB API directly to workaround coveralls-maven-plugin bug in Java 9+
+                         https://github.com/trautonen/coveralls-maven-plugin/issues/112 -->
+                    <dependencies>
+                        <dependency>
+                            <groupId>javax.xml.bind</groupId>
+                            <artifactId>jaxb-api</artifactId>
+                            <version>2.3.1</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Summary

Adds module-info for Cucumber Junit Platform Engine implementation.
This allows Java to ensure that all dependencies are available at
boot time.

To ensure backwards compatibility down to Java 8 we are using
multi-release jar files which will contain both Java 8 and
Java 9 class files.

To ensure the right JDK (OpenJDK 11) is used to build the project
the Maven Toolchains plugin will verify that this JDK is used.
This does require adding a `toolchains.xml` file to the `~/.m2/`
folder.

Example:

```xml
<?xml version="1.0" encoding="UTF8"?>
<toolchains>
    <toolchain>
        <type>jdk</type>
        <provides>
            <version>11</version>
            <vendor>openjdk</vendor>
        </provides>
        <configuration>
            <jdkHome>/path/to/openjdk11</jdkHome>
        </configuration>
    </toolchain>
</toolchains>
```