### PR TITLE
bug: on windows machine you can't determine the resource uri of inner packages

### DIFF
--- a/core/src/main/java/io/cucumber/core/resource/ClasspathSupport.java
+++ b/core/src/main/java/io/cucumber/core/resource/ClasspathSupport.java
@@ -85,7 +85,7 @@ public final class ClasspathSupport {
     }
 
     static URI determineClasspathResourceUri(Path baseDir, String basePackagePath, Path resource) {
-        String subPackageName = baseDir.relativize(resource.getParent()).toString();
+        String subPackageName = baseDir.relativize(resource.getParent()).toString().replacAll("\\","/");
         String resourceName = resource.getFileName().toString();
         String classpathResourcePath = of(basePackagePath, subPackageName, resourceName)
             .filter(value -> !value.isEmpty()) // default package .


### PR DESCRIPTION
when running from windows machine  relativize method return the path of sub packages as the native windows seperator path config \
so when you try to build uri app crash.
 i can give example from my own env:

[Utils] [ERROR] [Error] java.lang.IllegalArgumentException: Illegal character in opaque part at index 23: classpath:features/Casb\ActivitiesIntake/CASB-****-********permission_changesTo_delta_API.feature
	at java.base/java.net.URI.create(URI.java:906)

you can see that the seperator change between Casb folder and ActivitiesIntake folder

can you please fix that issue?(it's actually a bug, on windows machine you cant determine the resource uri of inner packages) 
i suggest also a fix to that problem on line 88 (  .replacAll("\\","/"); ) but you migh want to do something smarter

thanks

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

<!--- Provide a general summary description of your changes -->

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
