### PR TITLE
Create URI failed with features with spacebar

### DIFF
--- a/core/src/main/java/io/cucumber/core/resource/ClasspathSupport.java
+++ b/core/src/main/java/io/cucumber/core/resource/ClasspathSupport.java
@@ -133,7 +133,7 @@ public final class ClasspathSupport {
     }
 
     static URI classpathResourceUri(String classpathResourceName) {
-        return URI.create(CLASSPATH_SCHEME_PREFIX + classpathResourceName);
+        return URI.create(CLASSPATH_SCHEME_PREFIX + classpathResourceName).replace(" ","%20");
     }
 
     public static URI rootPackageUri() {


### PR DESCRIPTION
hi can you please fix the bug when try to create URI from feature with spacebar  

classpathResourceUri failed 
again its just hotfix.. if you have something smarter than i will be glad if you commit 

thanks

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

<!--- Provide a general summary description of your changes -->

## Details

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
