### PR TITLE
[Core] Print root cause of exceptions in glue definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ cache:
     - "$HOME/.m2"
 
 install:
-  - mvn install -DskipTests=true -DskipITs=true -Dmaven.javadoc.skip=true -B -V --toolchains .m2/travis-ci-toolchains.xml
+  - mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .m2/travis-ci-toolchains.xml
 
 jobs:
   include:
     # 1.1 Semver check
     - stage: test
       jdk: openjdk11
-      script: mvn verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true --toolchains .m2/travis-ci-toolchains.xml
+      script: mvn verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true -Darchetype.test.skip=true --toolchains .m2/travis-ci-toolchains.xml
       env: CHECK_SEMANTIC_VERSION=true
 
     # 1.2 Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
-
+ * [Core] Print root cause of exceptions thrown in datatable, parameter and docstring definitions ([#1872](https://github.com/cucumber/cucumber-jvm/pull/1872) M.P. Korstanje)
+ 
 ## [5.1.0] (2020-01-25)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
- * [Core] Print root cause of exceptions thrown in datatable, parameter and docstring definitions ([#1872](https://github.com/cucumber/cucumber-jvm/pull/1872) M.P. Korstanje)
+ * [Core] Print root cause of exceptions thrown in datatable, parameter and docstring definitions ([#1873](https://github.com/cucumber/cucumber-jvm/pull/1873) M.P. Korstanje)
  
 ## [5.1.0] (2020-01-25)
 

--- a/core/src/main/java/io/cucumber/core/backend/CucumberBackendException.java
+++ b/core/src/main/java/io/cucumber/core/backend/CucumberBackendException.java
@@ -1,5 +1,14 @@
 package io.cucumber.core.backend;
 
+import org.apiguardian.api.API;
+
+
+/**
+ * Thrown when the backend could not invoke some glue code. Not to be confused
+ * with {@link CucumberInvocationTargetException} which is thrown when the glue
+ * code throws an exception.
+ */
+@API(status = API.Status.STABLE)
 public class CucumberBackendException extends RuntimeException {
 
     public CucumberBackendException(String message) {

--- a/core/src/main/java/io/cucumber/core/backend/CucumberInvocationTargetException.java
+++ b/core/src/main/java/io/cucumber/core/backend/CucumberInvocationTargetException.java
@@ -1,8 +1,16 @@
 package io.cucumber.core.backend;
 
+import org.apiguardian.api.API;
+
 import java.lang.reflect.InvocationTargetException;
 
-public class CucumberInvocationTargetException extends RuntimeException   {
+/**
+ * Thrown when an exception was thrown by glue code. Not to be confused with
+ * {@link CucumberBackendException} which is thrown when the backend failed
+ * to invoke the glue.
+ */
+@API(status = API.Status.STABLE)
+public final class CucumberInvocationTargetException extends RuntimeException   {
 
     private final Located located;
     private final InvocationTargetException invocationTargetException;

--- a/pom.xml
+++ b/pom.xml
@@ -510,6 +510,21 @@
                                     <old>class io.cucumber.java8.AbstractDatatableElementTransformerDefinition</old>
                                     <justification>Internal API</justification>
                                 </item>
+                                <item>
+                                    <code>java.annotation.added</code>
+                                    <old>class io.cucumber.core.backend.CucumberBackendException</old>
+                                    <justification>Internal API promoted to public API</justification>
+                                </item>
+                                <item>
+                                    <code>java.annotation.added</code>
+                                    <old>class io.cucumber.core.backend.CucumberInvocationTargetException</old>
+                                    <justification>Internal API promoted to public API</justification>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.cucumber.core.backend.CucumberInvocationTargetException</old>
+                                    <justification>Internal API promoted to public API</justification>
+                                </item>
 
                                 <!-- Gherkin parser related -->
                                 <item>


### PR DESCRIPTION
## Summary
Exceptions thrown by parameter, datatable and docstring definitions
are swallowed leaving a stack trace ending with a rather puzzling
`CucumberInvocationTargetException`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
