### PR TITLE
[Core] Escape spaces in resource name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+ *  [Core] Escape spaces in resource name ([#1874](https://github.com/cucumber/cucumber-jvm/pull/1874) M.P. Korstanje)
 
 ## [5.1.0] (2020-01-25)
 

--- a/core/src/main/java/io/cucumber/core/resource/ClasspathSupport.java
+++ b/core/src/main/java/io/cucumber/core/resource/ClasspathSupport.java
@@ -2,6 +2,7 @@ package io.cucumber.core.resource;
 
 import javax.lang.model.SourceVersion;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -133,7 +134,12 @@ public final class ClasspathSupport {
     }
 
     static URI classpathResourceUri(String classpathResourceName) {
-        return URI.create(CLASSPATH_SCHEME_PREFIX + classpathResourceName);
+        try {
+            // Unlike URI.create the constructor escapes reserved characters
+            return new URI(CLASSPATH_SCHEME, classpathResourceName, null);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
 
     public static URI rootPackageUri() {

--- a/core/src/test/java/io/cucumber/core/resource/ResourceScannerTest.java
+++ b/core/src/test/java/io/cucumber/core/resource/ResourceScannerTest.java
@@ -80,6 +80,13 @@ class ResourceScannerTest {
     }
 
     @Test
+    void scanForClasspathResourceWithSpaces() {
+        String resourceName = "io/cucumber/core/resource/test/spaces in name resource.txt";
+        List<URI> resources = resourceScanner.scanForClasspathResource(resourceName, aPackage -> true);
+        assertThat(resources, contains(URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")));
+    }
+
+    @Test
     void scanForClasspathPackageResource() {
         String resourceName = "io/cucumber/core/resource";
         List<URI> resources = resourceScanner.scanForClasspathResource(resourceName, aPackage -> true);

--- a/core/src/test/java/io/cucumber/core/resource/ResourceScannerTest.java
+++ b/core/src/test/java/io/cucumber/core/resource/ResourceScannerTest.java
@@ -28,7 +28,8 @@ class ResourceScannerTest {
         List<URI> resources = resourceScanner.scanForResourcesInClasspathRoot(classpathRoot, aPackage -> true);
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:resource.txt"),
-            URI.create("classpath:other-resource.txt")
+            URI.create("classpath:other-resource.txt"),
+            URI.create("classpath:spaces%20in%20name%20resource.txt")
         ));
     }
 
@@ -48,7 +49,8 @@ class ResourceScannerTest {
         List<URI> resources = resourceScanner.scanForResourcesInClasspathRoot(classpathRoot, aPackage -> true);
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:io/cucumber/core/resource/test/resource.txt"),
-            URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt")
+            URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt"),
+            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")
         ));
     }
 
@@ -58,7 +60,8 @@ class ResourceScannerTest {
         List<URI> resources = resourceScanner.scanForResourcesInPackage(basePackageName, aPackage -> true);
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:io/cucumber/core/resource/test/resource.txt"),
-            URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt")
+            URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt"),
+            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")
         ));
     }
 
@@ -68,7 +71,8 @@ class ResourceScannerTest {
         List<URI> resources = resourceScanner.scanForResourcesInPackage(basePackageName, aPackage -> true);
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:io/cucumber/core/resource/test/resource.txt"),
-            URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt")
+            URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt"),
+            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")
         ));
     }
 
@@ -92,7 +96,8 @@ class ResourceScannerTest {
         List<URI> resources = resourceScanner.scanForClasspathResource(resourceName, aPackage -> true);
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:io/cucumber/core/resource/test/resource.txt"),
-            URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt")
+            URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt"),
+            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")
         ));
     }
 
@@ -109,7 +114,8 @@ class ResourceScannerTest {
         List<URI> resources = resourceScanner.scanForResourcesPath(file.toPath());
         assertThat(resources, containsInAnyOrder(
             new File("src/test/resources/io/cucumber/core/resource/test/resource.txt").toURI(),
-            new File("src/test/resources/io/cucumber/core/resource/test/other-resource.txt").toURI()
+            new File("src/test/resources/io/cucumber/core/resource/test/other-resource.txt").toURI(),
+            new File("src/test/resources/io/cucumber/core/resource/test/spaces in name resource.txt").toURI()
         ));
     }
 
@@ -160,7 +166,8 @@ class ResourceScannerTest {
         List<URI> resources = resourceScanner.scanForResourcesUri(file.toURI());
         assertThat(resources, containsInAnyOrder(
             new File("src/test/resources/io/cucumber/core/resource/test/resource.txt").toURI(),
-            new File("src/test/resources/io/cucumber/core/resource/test/other-resource.txt").toURI()
+            new File("src/test/resources/io/cucumber/core/resource/test/other-resource.txt").toURI(),
+            new File("src/test/resources/io/cucumber/core/resource/test/spaces in name resource.txt").toURI()
         ));
     }
 
@@ -177,7 +184,8 @@ class ResourceScannerTest {
         List<URI> resources = resourceScanner.scanForResourcesUri(uri);
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:io/cucumber/core/resource/test/resource.txt"),
-            URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt")
+            URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt"),
+            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")
         ));
     }
 }


### PR DESCRIPTION
## Summary
`classpathResourceUri` used `URI.create` which assumes that the URI
to parse is a valid URI. This assumption doesnt hold when
transforming paths into URIs. Instead the URI constructor should be
used which does escaped reserved characters.

Closes #1872

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
