### PR TITLE
[Core] TestCaseState should be PASSED by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+ *  [Core] TestCaseState should be PASSED by default ([#1888](https://github.com/cucumber/cucumber-jvm/pull/1888) M.P. Korstanje)
+    * As a result  `Scenario.getState` will return `PASSED` rather then
+      `UNDEFINED` prior to the execution of the first step of a scenario.  
 
 ## [5.2.0] (2020-02-06)
 

--- a/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
@@ -14,7 +14,12 @@ public interface TestCaseState {
     Collection<String> getSourceTagNames();
 
     /**
-     * @return the <em>most severe</em> status of the Scenario's Steps.
+     * Returns the current status of this test case.
+     * <p>
+     * The test case status is calculate as the most severe status of the
+     * executed steps in the testcase so far.
+     *
+     * @return the current status of this test case
      */
     Status getStatus();
 

--- a/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
@@ -39,7 +39,7 @@ class TestCaseState implements io.cucumber.core.backend.TestCaseState {
     @Override
     public Status getStatus() {
         if (stepResults.isEmpty()) {
-            return Status.UNDEFINED;
+            return Status.PASSED;
         }
 
         Result mostSevereResult = max(stepResults, comparing(Result::getStatus));

--- a/core/src/test/java/io/cucumber/core/runner/TestCaseStateResultTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestCaseStateResultTest.java
@@ -59,8 +59,8 @@ class TestCaseStateResultTest {
     }
 
     @Test
-    void no_steps_is_undefined() {
-        assertThat(s.getStatus(), is(equalTo(UNDEFINED)));
+    void no_steps_is_passed() {
+        assertThat(s.getStatus(), is(equalTo(PASSED)));
     }
 
     @Test

--- a/java/src/main/java/io/cucumber/java/Scenario.java
+++ b/java/src/main/java/io/cucumber/java/Scenario.java
@@ -27,6 +27,14 @@ public final class Scenario {
         return delegate.getSourceTagNames();
     }
 
+    /**
+     * Returns the current status of this scenario.
+     * <p>
+     * The scenario status is calculate as the most severe status of the
+     * executed steps in the scenario so far.
+     *
+     * @return the current status of this scenario
+     */
     public Status getStatus() {
         return Status.valueOf(delegate.getStatus().name());
     }

--- a/java8/src/main/java/io/cucumber/java8/Scenario.java
+++ b/java8/src/main/java/io/cucumber/java8/Scenario.java
@@ -27,6 +27,14 @@ public final class Scenario {
         return delegate.getSourceTagNames();
     }
 
+    /**
+     * Returns the current status of this scenario.
+     * <p>
+     * The scenario status is calculate as the most severe status of the
+     * executed steps in the scenario so far.
+     *
+     * @return the current status of this scenario
+     */
     public Status getStatus() {
         return Status.valueOf(delegate.getStatus().name());
     }

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/TestCaseResultObserver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/TestCaseResultObserver.java
@@ -99,10 +99,6 @@ class TestCaseResultObserver implements AutoCloseable {
         }
 
         if (status.is(UNDEFINED)) {
-            if (suggestions.isEmpty()) {
-                // Empty scenario
-                return;
-            }
             throw new UndefinedStepException(suggestions);
         }
 

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/TestCaseResultObserverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/TestCaseResultObserverTest.java
@@ -221,7 +221,7 @@ class TestCaseResultObserverTest {
     @Test
     void empty() {
         bus.send(new TestCaseStarted(Instant.now(), testCase));
-        Result result = new Result(Status.UNDEFINED, Duration.ZERO, null);
+        Result result = new Result(Status.PASSED, Duration.ZERO, null);
         bus.send(new TestCaseFinished(Instant.now(), testCase, result));
         observer.assertTestCasePassed();
     }

--- a/testng/src/main/java/io/cucumber/testng/TestCaseResultObserver.java
+++ b/testng/src/main/java/io/cucumber/testng/TestCaseResultObserver.java
@@ -109,11 +109,6 @@ class TestCaseResultObserver implements AutoCloseable {
         }
 
         if (status.is(UNDEFINED)) {
-            if (suggestions.isEmpty()) {
-                // Empty scenario
-                return;
-            }
-
             throw new UndefinedStepException(suggestions, strict);
         }
 

--- a/testng/src/test/java/io/cucumber/testng/TestCaseResultObserverTest.java
+++ b/testng/src/test/java/io/cucumber/testng/TestCaseResultObserverTest.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 
 import static io.cucumber.plugin.event.Status.AMBIGUOUS;
 import static io.cucumber.plugin.event.Status.FAILED;
+import static io.cucumber.plugin.event.Status.PASSED;
 import static io.cucumber.plugin.event.Status.PENDING;
 import static io.cucumber.plugin.event.Status.SKIPPED;
 import static io.cucumber.plugin.event.Status.UNDEFINED;
@@ -142,7 +143,7 @@ public class TestCaseResultObserverTest {
     public void should_be_passed_for_empty_scenario() throws Throwable {
         TestCaseResultObserver resultListener = TestCaseResultObserver.observe(bus, false);
 
-        Result testCaseResult = new Result(UNDEFINED, ZERO, error);
+        Result testCaseResult = new Result(PASSED, ZERO, error);
         bus.send(new TestCaseFinished(now(), testCase, testCaseResult));
 
         resultListener.assertTestCasePassed();


### PR DESCRIPTION
Currently `TestCaseState` defaults to `Status.UNDEFINED` when no steps have
been executed. This is odd because the implementation otherwise collects the
most severe result. So the logical expectation would be that it would return
`Status.PASSED`

```java
@Override
public Status getStatus() {
    if (stepResults.isEmpty()) {
        return Status.UNDEFINED;
    }

    Result mostSevereResult = max(stepResults, comparing(Result::getStatus));
    return Status.valueOf(mostSevereResult.getStatus().name());
}
```

As a result the `TestCaseResultObserver` in `junit-platform-engine` and
`testng` needs to check if an undefined scenario was empty or not. This means
our abstraction is rather leaky.

```java
if (status.is(UNDEFINED)) {
    if (suggestions.isEmpty()) {
        // Empty scenario
        return;
     }
    throw new UndefinedStepException(suggestions, strict);
}
```

By stating that the empty test is passed by default and making `TestCaseState`
default to `Status.PASSED` we resolve this complexity. As a result  `Scenario.getState` will return `PASSED` rather then `UNDEFINED` prior to the execution of the first step of a scenario.

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
