### PR TITLE
[Core] CLI should search classpath root by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] (In Git)
 
 ### Added
+ *  [Core] CLI should search classpath root by default ([#1889](https://github.com/cucumber/cucumber-jvm/pull/1889) M.P. Korstanje)
 
 ### Changed
 

--- a/core/src/main/java/io/cucumber/core/cli/Main.java
+++ b/core/src/main/java/io/cucumber/core/cli/Main.java
@@ -54,6 +54,8 @@ public class Main {
 
         RuntimeOptions runtimeOptions = new CommandlineOptionsParser()
             .parse(argv)
+            .addDefaultGlueIfAbsent()
+            .addDefaultFeaturePathIfAbsent()
             .addDefaultFormatterIfAbsent()
             .addDefaultSummaryPrinterIfAbsent()
             .build(systemOptions);

--- a/core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
+++ b/core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
@@ -17,6 +17,8 @@ import java.util.TreeSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static io.cucumber.core.resource.ClasspathSupport.rootPackageUri;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 
@@ -64,6 +66,17 @@ public final class RuntimeOptions implements
         }
     }
 
+    void addDefaultGlueIfAbsent() {
+        if (glue.isEmpty()) {
+            glue.add(rootPackageUri());
+        }
+    }
+
+    void addDefaultFeaturePathIfAbsent() {
+        if (featurePaths.isEmpty()) {
+            featurePaths.add(FeatureWithLines.create(rootPackageUri(), emptyList()));
+        }
+    }
     public int getCount() {
         return count;
     }

--- a/core/src/main/java/io/cucumber/core/options/RuntimeOptionsBuilder.java
+++ b/core/src/main/java/io/cucumber/core/options/RuntimeOptionsBuilder.java
@@ -32,6 +32,8 @@ public final class RuntimeOptionsBuilder {
     private Class<? extends ObjectFactory> parsedObjectFactoryClass = null;
     private boolean addDefaultSummaryPrinterIfAbsent;
     private boolean addDefaultFormatterIfAbsent;
+    private boolean addDefaultGlueIfAbsent;
+    private boolean addDefaultFeaturePathIfAbsent;
 
     public RuntimeOptionsBuilder addRerun(Collection<FeatureWithLines> featureWithLines) {
         if (parsedRerunPaths == null) {
@@ -134,6 +136,14 @@ public final class RuntimeOptionsBuilder {
             runtimeOptions.addDefaultSummaryPrinterIfAbsent();
         }
 
+        if (addDefaultGlueIfAbsent) {
+            runtimeOptions.addDefaultGlueIfAbsent();
+        }
+
+        if (addDefaultFeaturePathIfAbsent) {
+            runtimeOptions.addDefaultFeaturePathIfAbsent();
+        }
+
         return runtimeOptions;
     }
 
@@ -204,6 +214,17 @@ public final class RuntimeOptionsBuilder {
         this.addDefaultFormatterIfAbsent = true;
         return this;
     }
+
+    public RuntimeOptionsBuilder addDefaultGlueIfAbsent() {
+        this.addDefaultGlueIfAbsent = true;
+        return this;
+    }
+
+    public RuntimeOptionsBuilder addDefaultFeaturePathIfAbsent() {
+        this.addDefaultFeaturePathIfAbsent = true;
+        return this;
+    }
+
 
     public void setObjectFactoryClass(Class<? extends ObjectFactory> objectFactoryClass) {
         this.parsedObjectFactoryClass = objectFactoryClass;

--- a/core/src/main/resources/io/cucumber/core/options/USAGE.txt
+++ b/core/src/main/resources/io/cucumber/core/options/USAGE.txt
@@ -6,8 +6,10 @@ Options:
                                            Defaults to 1.
 
   -g, --glue PATH                          Package to load glue code (step
-                                           definitions, hooks and plugins) from.
-                                           E.g: com.example.app
+                                           definitions, hooks and plugins) from
+                                           e.g: com.example.app. When not
+                                           provided Cucumber will search the
+                                           classpath.
 
   -p, --[add-]plugin PLUGIN[:PATH_OR_URL]  Register a plugin.
                                            Built-in formatter PLUGIN types:
@@ -69,6 +71,9 @@ Options:
                                            META-INF/services/io.cucumber.core.backend.ObjectFactory
 
 Feature path examples:
+                                           When no feature path is provided
+                                           cucumber will scan the classpath root
+                                           and its sub directories.
 
   <path>                                   Load the files with the extension
                                            ".feature" for the directory <path>

--- a/core/src/test/java/io/cucumber/core/options/RuntimeOptionsTest.java
+++ b/core/src/test/java/io/cucumber/core/options/RuntimeOptionsTest.java
@@ -35,6 +35,7 @@ import java.util.regex.Pattern;
 
 import static io.cucumber.core.options.Constants.FILTER_TAGS_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.OPTIONS_PROPERTY_NAME;
+import static io.cucumber.core.resource.ClasspathSupport.rootPackageUri;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
@@ -734,6 +735,24 @@ class RuntimeOptionsTest {
         assertThat(options.getFeaturePaths(), emptyCollectionOf(URI.class));
     }
 
+    @Test
+    void scans_class_path_root_for_glue_by_default() {
+        RuntimeOptions options = new CommandlineOptionsParser()
+            .parse()
+            .addDefaultGlueIfAbsent()
+            .build();
+        assertThat(options.getGlue(), is(singletonList(rootPackageUri())));
+    }
+
+    @Test
+    void scans_class_path_root_for_features_by_default() {
+        RuntimeOptions options = new CommandlineOptionsParser()
+            .parse()
+            .addDefaultFeaturePathIfAbsent()
+            .build();
+        assertThat(options.getFeaturePaths(), is(singletonList(rootPackageUri())));
+        assertThat(options.getLineFilters(), is(emptyMap()));
+    }
 
     public static final class AwareFormatter implements StrictAware, ColorAware, EventListener {
 

--- a/picocontainer/pom.xml
+++ b/picocontainer/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -66,13 +67,14 @@
                         </goals>
                         <configuration>
                             <target>
-                                <echo message="Running CLI test for picocontainer" />
-                                <java classname="io.cucumber.core.cli.Main" fork="true" failonerror="true" newenvironment="true" maxmemory="512m" classpathref="maven.test.classpath">
-                                    <arg value="--plugin" />
-                                    <arg value="progress" />
-                                    <arg value="--glue" />
-                                    <arg value="io.cucumber.picocontainer" />
-                                    <arg value="${basedir}/src/test/resources/io/cucumber/picocontainer" />
+                                <echo message="Running CLI test for picocontainer"/>
+                                <java classname="io.cucumber.core.cli.Main"
+                                      fork="true"
+                                      failonerror="true"
+                                      newenvironment="true"
+                                      maxmemory="512m"
+                                      classpathref="maven.test.classpath"
+                                >
                                 </java>
                             </target>
                         </configuration>


### PR DESCRIPTION
The Cucumber CLI is rather complex to use. To work correctly it needs both
a `--glue` parameter in the form of a package name and a location of a feature
file in form of a classpath uri or path. As a result people often configure
Cucumber incorrectly and are left wondering why their features or glue can not
be found.

This can be simplified as shown by the Cucumber Platform Engine which defaults
to the classpath root and the JUnit and TestNG runners which default to the
package of the runner class.

So it makes sense to do the same with the CLI.

Assuming the following project layout the CLI can discover and execute
all features without needing additional arguments.

```
├── pom.xml
├── src
│   ├── main
│   │   └── java
│   │       └── com/example/Application.java
│   └── test
│       ├── java
│       │   └── com/example/StepDefinitions.java
│       └── resources
│           └── com/example/example.feature
```

This can be done with a single maven command:

```
mvn exec:java                                  \
    -Dexec.classpathScope=test                 \
    -Dexec.mainClass=io.cucumber.core.cli.Main
```

Additional benefits can be found in the fact that IDEA often can't work out
which package should be used as glue and does not provide it. The Cucumber Eclipse
plugin on the other hand always defaults to the class path root.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
