### PR TITLE
[All] Fix typo in snippet generator message

### DIFF
--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/UndefinedStepException.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/UndefinedStepException.java
@@ -34,7 +34,7 @@ final class UndefinedStepException extends IncompleteExecutionException {
         if (snippets.isEmpty()) {
             return;
         }
-        sb.append(". You can implement it using tne snippet(s) below:\n\n");
+        sb.append(". You can implement it using the snippet(s) below:\n\n");
         sb.append(snippets.stream().collect(joining("\n---\n", "", "\n")));
     }
 

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/TestCaseResultObserverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/TestCaseResultObserverTest.java
@@ -209,7 +209,7 @@ class TestCaseResultObserverTest {
             observer::assertTestCasePassed
         );
         assertThat(exception.getMessage(), is("" +
-            "The step \"mocked\" is undefined. You can implement it using tne snippet(s) below:\n" +
+            "The step \"mocked\" is undefined. You can implement it using the snippet(s) below:\n" +
             "\n" +
             "mocked snippet 1\n" +
             "---\n" +

--- a/junit/src/main/java/io/cucumber/junit/UndefinedStepException.java
+++ b/junit/src/main/java/io/cucumber/junit/UndefinedStepException.java
@@ -45,7 +45,7 @@ final class UndefinedStepException extends RuntimeException {
         if (snippets.isEmpty()) {
             return;
         }
-        sb.append(". You can implement it using tne snippet(s) below:\n\n");
+        sb.append(". You can implement it using the snippet(s) below:\n\n");
         sb.append(String.join("\n", snippets));
     }
 

--- a/junit/src/test/java/io/cucumber/junit/JUnitReporterWithStepNotificationsTest.java
+++ b/junit/src/test/java/io/cucumber/junit/JUnitReporterWithStepNotificationsTest.java
@@ -250,7 +250,7 @@ class JUnitReporterWithStepNotificationsTest {
         Failure pickleFailure = failureArgumentCaptor.getValue();
         assertThat(pickleFailure.getDescription(), is(equalTo(pickleRunner.getDescription())));
         assertThat(pickleFailure.getException().getMessage(), is("" +
-            "The step \"step name\" is undefined. You can implement it using tne snippet(s) below:\n" +
+            "The step \"step name\" is undefined. You can implement it using the snippet(s) below:\n" +
             "\n" +
             "some snippet"
         ));
@@ -288,7 +288,7 @@ class JUnitReporterWithStepNotificationsTest {
         Failure pickleFailure = failureArgumentCaptor.getValue();
         assertThat(pickleFailure.getDescription(), is(equalTo(pickleRunner.getDescription())));
         assertThat(pickleFailure.getException().getMessage(), is("" +
-            "The step \"step name\" is undefined. You can implement it using tne snippet(s) below:\n" +
+            "The step \"step name\" is undefined. You can implement it using the snippet(s) below:\n" +
             "\n" +
             "some snippet"
         ));

--- a/testng/src/main/java/io/cucumber/testng/UndefinedStepException.java
+++ b/testng/src/main/java/io/cucumber/testng/UndefinedStepException.java
@@ -36,7 +36,7 @@ final class UndefinedStepException extends SkipException {
         if (snippets.isEmpty()) {
             return;
         }
-        sb.append(". You can implement it using tne snippet(s) below:\n\n");
+        sb.append(". You can implement it using the snippet(s) below:\n\n");
         sb.append(snippets.stream().collect(joining("\n---\n", "", "\n")));
     }
 

--- a/testng/src/test/java/io/cucumber/testng/TestCaseResultObserverTest.java
+++ b/testng/src/test/java/io/cucumber/testng/TestCaseResultObserverTest.java
@@ -112,7 +112,7 @@ public class TestCaseResultObserverTest {
         SkipException skipException = expectThrows(SkipException.class, resultListener::assertTestCasePassed);
         assertThat(skipException.isSkip(), is(true));
         assertThat(skipException.getMessage(), is("" +
-            "The step \"some step\" is undefined. You can implement it using tne snippet(s) below:\n" +
+            "The step \"some step\" is undefined. You can implement it using the snippet(s) below:\n" +
             "\n" +
             "stub snippet\n"
         ));
@@ -133,7 +133,7 @@ public class TestCaseResultObserverTest {
         SkipException skipException = expectThrows(SkipException.class, resultListener::assertTestCasePassed);
         assertThat(skipException.isSkip(), is(false));
         assertThat(skipException.getMessage(), is("" +
-            "The step \"some step\" is undefined. You can implement it using tne snippet(s) below:\n" +
+            "The step \"some step\" is undefined. You can implement it using the snippet(s) below:\n" +
             "\n" +
             "stub snippet\n"
         ));


### PR DESCRIPTION
The frequently seen snippet generator message contains a typo:

>[ERROR]   The step "I am a new customer" is undefined. You can implement it using _**tne**_ snippet(s) below:

This PR replaces `tne` with `the` wherever the above message appears in the code.