### PR TITLE
[JUnit Platform] Support skipping scenarios with cucumber.filter.tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] (In Git)
 
 ### Added
+ * [JUnit Platform] Support skipping scenarios with `cucumber.filter.tags` ([#1899](https://github.com/cucumber/cucumber-jvm/pull/1899) M.P. Korstanje)
 
 ### Changed
 
@@ -16,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
- * [Junit] Sort discovered features (M.P. Korstanje)
+ * [JUnit Platform] Sort discovered features (M.P. Korstanje)
  * [All] Fix typo in snippet generator message ([#1894](https://github.com/cucumber/cucumber-jvm/pull/1894) Nat Ritmeyer)
  
 ## [5.3.0] (2020-02-13)
@@ -51,9 +52,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [5.1.2] (2020-01-27)
 
 ### Fixed
- * [JUnit] Build JUnit Platform Engine at Source level 8. (M.P. Korstanje)
+ * [JUnit Platform] Build JUnit Platform Engine at Source level 8. (M.P. Korstanje)
    - Entire project was build at source level 9 rather then only `module-info.java`
- * [JUnit] Require `io.cucumber.core.gherkin` as a module dependency. (M.P. Korstanje)
+ * [JUnit Platform] Require `io.cucumber.core.gherkin` as a module dependency. (M.P. Korstanje)
 
 ## [5.1.1] (2020-01-26)
 
@@ -69,8 +70,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  * [TestNG] Run scenarios in customized groups ([#1863](https://github.com/cucumber/cucumber-jvm/pull/1863) Konrad Maciaszczyk, M.P. Korstanje)
 
 ### Changed
- * [JUnit] Upgrade JUnit Platform from v1.5.2 to v1.6.0
- * [JUnit] Add module-info for `cucumber-junit-platform-engine` ([#1867](https://github.com/cucumber/cucumber-jvm/pull/1867) M.P. Korstanje, John Patrick)
+ * [JUnit Platform] Upgrade JUnit Platform from v1.5.2 to v1.6.0
+ * [JUnit Platform] Add module-info for `cucumber-junit-platform-engine` ([#1867](https://github.com/cucumber/cucumber-jvm/pull/1867) M.P. Korstanje, John Patrick)
 
 ### Fixed
  * [Java/Java8] Fix NPE in AbstractDatatableElementTransformerDefinition ([#1865](https://github.com/cucumber/cucumber-jvm/pull/1865) Florin Slevoaca, M.P. Korstanje)
@@ -93,7 +94,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
  * [Core] Fixed Illegal character error on Windows ([#1849](https://github.com/cucumber/cucumber-jvm/issues/1849) M.P. Korstanje)
- * [JUnit] Annotate `@Cucumber` with `@Testable` to facilitate discovery by IDEs (M.P. Korstanje)
+ * [JUnit Platform] Annotate `@Cucumber` with `@Testable` to facilitate discovery by IDEs (M.P. Korstanje)
  
 ### Deprecated 
 
@@ -114,20 +115,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  * [Core] Support Gherkin Rule keyword ([##1804](https://github.com/cucumber/cucumber-jvm/issues/#1804), [#1840](https://github.com/cucumber/cucumber-jvm/issues/1840) M.P. Korstanje, Aslak Hellesøy)
    - Opt-in by adding `cucumber-gherkin-messages` dependency
    - Not supported by JSON and HTML formatter.
- * [JUnit] Support `line` query parameter in `UriSelector` ([#1845](https://github.com/cucumber/cucumber-jvm/issues/1845) M.P. Korstanje)
+ * [JUnit Platform] Support `line` query parameter in `UriSelector` ([#1845](https://github.com/cucumber/cucumber-jvm/issues/1845) M.P. Korstanje)
  * [Core] Include default gherkin version in version.properties ([#1847](https://github.com/cucumber/cucumber-jvm/issues/1847) David Goss)
 
 ### Changed
  * [Core] Throw exception when multiple object factories are found ([#1832](https://github.com/cucumber/cucumber-jvm/issues/1832) M.P. Korstanje)
  * [Core] Print warning when using --non-strict ([#1835](https://github.com/cucumber/cucumber-jvm/issues/1835) M.P. Korstanje)
  * [Core] Throw exception when multiple object factories are found ([#1832](https://github.com/cucumber/cucumber-jvm/issues/1832) M.P. Korstanje)
- * [JUnit] Do not include @ in TestTags ([#1825](https://github.com/cucumber/cucumber-jvm/issues/1825) M.P. Korstanje)
+ * [JUnit Platform] Do not include @ in TestTags ([#1825](https://github.com/cucumber/cucumber-jvm/issues/1825) M.P. Korstanje)
 
 ### Fixed
- * [JUnit] Map `SKIPPED` to `TestAbortedException` (M.P. Korstanje)
- * [JUnit] Send events to configured Plugins (M.P. Korstanje)
- * [JUnit] Fix concurrent modification of event queue (M.P. Korstanje)
- * [JUnit] Mark `Constants` as part of the public API (M.P. Korstanje)
+ * [JUnit Platform] Map `SKIPPED` to `TestAbortedException` (M.P. Korstanje)
+ * [JUnit Platform] Send events to configured Plugins (M.P. Korstanje)
+ * [JUnit Platform] Fix concurrent modification of event queue (M.P. Korstanje)
+ * [JUnit Platform] Mark `Constants` as part of the public API (M.P. Korstanje)
  * [Core] DataTable does not support Kotlin Collection types ([#1838](https://github.com/cucumber/cucumber-jvm/issues/1838) Marit Van Dijk, M.P. Korstanje)
      - DataTable types for `X` and `? extends X` are now considered identical.
  * [Core] Ignore class load error while class scanning ([#1843](https://github.com/cucumber/cucumber-jvm/issues/1843), [#1844](https://github.com/cucumber/cucumber-jvm/issues/1844) M.P. Korstanje)
@@ -158,7 +159,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    - Add `DefaultDataTableCellTransformer` alternative for `TypeRegistry.setDefaultDataTableCellTransformer`
  * [Core] Limited support for classpath scanning in SpringBoot jars ([#1821](https://github.com/cucumber/cucumber-jvm/pull/1821) M.P. Korstanje)
    - Enables scanning of glue and features in `BOOT-INF/classes`.
- * [JUnit] Implement Cucumber as a Junit Platform Engine ([#1530](https://github.com/cucumber/cucumber-jvm/pull/1530), [#1824](https://github.com/cucumber/cucumber-jvm/pull/1824) M.P. Korstanje)
+ * [JUnit Platform] Implement Cucumber as a Junit Platform Engine ([#1530](https://github.com/cucumber/cucumber-jvm/pull/1530), [#1824](https://github.com/cucumber/cucumber-jvm/pull/1824) M.P. Korstanje)
    
 ### Changed
  * [Core] Indent write events in PrettyFormatter ([#1809](https://github.com/cucumber/cucumber-jvm/pull/1809) Alexandre Monterroso)

--- a/core/src/main/java/io/cucumber/core/options/Constants.java
+++ b/core/src/main/java/io/cucumber/core/options/Constants.java
@@ -98,10 +98,11 @@ public final class Constants {
     /**
      * Property name used to set tag filter: {@value}
      * <p>
-     * Filters features based on the provided tag expression e.g:
-     * {@code @Integration and not @Ignored}.
+     * Filters scenarios based on the provided tag expression e.g:
+     * {@code @Integration and not @Ignored}. Scenarios that do not
+     * match the expression are not executed.
      * <p>
-     * By default no features are filtered
+     * By default all scenarios are executed
      */
     public static final String FILTER_TAGS_PROPERTY_NAME = "cucumber.filter.tags";
 

--- a/core/src/main/java/io/cucumber/core/resource/PathScanner.java
+++ b/core/src/main/java/io/cucumber/core/resource/PathScanner.java
@@ -37,13 +37,13 @@ class PathScanner {
         return CloseablePath.open(uri);
     }
 
-    void findResourcesForPath(Path baseDir, Predicate<Path> filter, Function<Path, Consumer<Path>> consumer) {
-        if (!exists(baseDir)) {
-            throw new IllegalArgumentException("baseDir must exist: " + baseDir);
+    void findResourcesForPath(Path path, Predicate<Path> filter, Function<Path, Consumer<Path>> consumer) {
+        if (!exists(path)) {
+            throw new IllegalArgumentException("path must exist: " + path);
         }
 
         try {
-            walkFileTree(baseDir, new ResourceFileVisitor(filter, consumer.apply(baseDir)));
+            walkFileTree(path, new ResourceFileVisitor(filter, consumer.apply(path)));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/core/src/test/java/io/cucumber/core/runtime/FeaturePathFeatureSupplierTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/FeaturePathFeatureSupplierTest.java
@@ -65,7 +65,7 @@ class FeaturePathFeatureSupplierTest {
             IllegalArgumentException.class,
             supplier::get
         );
-        assertThat(exception.getMessage(), containsString("baseDir must exist"));
+        assertThat(exception.getMessage(), containsString("path must exist"));
     }
 
     @Test

--- a/junit-platform-engine/README.md
+++ b/junit-platform-engine/README.md
@@ -131,16 +131,40 @@ For documentation see [Constants](src/main/java/io/cucumber/junit/platform/engin
 
 ```
 cucumber.ansi-colors.disabled=                          # true or false. default: true                     
-cucumber.glue=                                          # comma separated package names. example: com.example.glue  
-cucumber.plugin=                                        # comma separated plugin strings. example: pretty, json:path/to/report.json
-cucumber.object-factory=                                # object factory class name. example: com.example.MyObjectFactory
-cucumber.snippet-type=                                  # underscore or camelcase. default: underscore
-cucumber.execution.dry-run=                             # true or false. default: false 
-cucumber.execution.parallel.enabled=                    # true or false. default: false
-cucumber.execution.parallel.config.strategy=            # dynamic, fixed or custom. default: dynamic
-cucumber.execution.parallel.config.fixed.parallelism=   # positive integer. example: 4 
-cucumber.execution.parallel.config.dynamic.factor=      # positive double. default: 1.0
-cucumber.execution.parallel.config.custom.class=        # class name. example: com.example.MyCustomParallelStrategy
+
+cucumber.filter.tags=                                   # a cucumber tag expression. 
+                                                        # only matching scenarios are executed. 
+                                                        # example: @integration and not @disabled
+
+cucumber.glue=                                          # comma separated package names. 
+                                                        # example: com.example.glue  
+
+cucumber.plugin=                                        # comma separated plugin strings. 
+                                                        # example: pretty, json:path/to/report.json
+
+cucumber.object-factory=                                # object factory class name.
+                                                        # example: com.example.MyObjectFactory
+
+cucumber.snippet-type=                                  # underscore or camelcase. 
+                                                        # default: underscore
+
+cucumber.execution.dry-run=                             # true or false. 
+                                                        # default: false
+ 
+cucumber.execution.parallel.enabled=                    # true or false. 
+                                                        # default: false
+
+cucumber.execution.parallel.config.strategy=            # dynamic, fixed or custom. 
+                                                        # default: dynamic
+
+cucumber.execution.parallel.config.fixed.parallelism=   # positive integer. 
+                                                        # example: 4 
+
+cucumber.execution.parallel.config.dynamic.factor=      # positive double.
+                                                        # default: 1.0
+
+cucumber.execution.parallel.config.custom.class=        # class name. 
+                                                        # example: com.example.MyCustomParallelStrategy
 ```
 
 ## Supported Discovery Selectors and Filters ## 
@@ -199,3 +223,13 @@ For further information See the relevant documentation on how to select tags:
 * [Gradle: Test Grouping](https://docs.gradle.org/current/userguide/java_testing.html#test_grouping)
 * [JUnit 5 Console Launcher: Options](https://junit.org/junit5/docs/current/user-guide/#running-tests-console-launcher-options)
 * [JUnit 5 Tag Expression](https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions)
+
+### @Disabled
+
+It is possible to recreate JUnit Jupiter's `@Disabled` functionality by
+setting the `cucumber.filter.tags=not @Disabled` property<sup>1</sup>. Any scenarios 
+tagged with `@Disabled` will be skipped. See [Configuration Options](#configuration-options)
+for more information. 
+
+1. Do note that this is a [Cucumber Tag Expression](https://cucumber.io/docs/cucumber/api/#tags)
+rather then a JUnit5 tag expression.

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -30,6 +30,18 @@ public final class Constants {
     public static final String EXECUTION_DRY_RUN_PROPERTY_NAME = io.cucumber.core.options.Constants.EXECUTION_DRY_RUN_PROPERTY_NAME;
 
     /**
+     * Property name used to set tag filter: {@value}
+     * <p>
+     * Filters scenarios based on the provided tag expression e.g:
+     * {@code @Integration and not @Ignored}. Scenarios
+     * that did not match the expression will be rendered by JUnit
+     * as skipped.
+     * <p>
+     * By default all scenarios are executed
+     */
+    public static final String FILTER_TAGS_PROPERTY_NAME = io.cucumber.core.options.Constants.FILTER_TAGS_PROPERTY_NAME;
+
+    /**
      * Property name to set the glue path: {@value}
      * <p>
      * A comma separated list of a classpath uri or package name e.g.:

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineExecutionContext.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineExecutionContext.java
@@ -37,12 +37,13 @@ public final class CucumberEngineExecutionContext implements EngineExecutionCont
     private static final Logger logger = LoggerFactory.getLogger(CucumberEngineExecutionContext.class);
     private final RunnerSupplier runnerSupplier;
     private final EventBus bus;
+    private final CucumberEngineOptions options;
 
     CucumberEngineExecutionContext(ConfigurationParameters configurationParameters) {
 
         Supplier<ClassLoader> classLoader = CucumberEngineExecutionContext.class::getClassLoader;
         logger.debug(() -> "Parsing options");
-        CucumberEngineOptions options = new CucumberEngineOptions(configurationParameters);
+        options = new CucumberEngineOptions(configurationParameters);
         ObjectFactoryServiceLoader objectFactoryServiceLoader = new ObjectFactoryServiceLoader(options);
         this.bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
         TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(classLoader, options);
@@ -59,6 +60,10 @@ public final class CucumberEngineExecutionContext implements EngineExecutionCont
             BackendSupplier backendSupplier = new BackendServiceLoader(classLoader, objectFactorySupplier);
             this.runnerSupplier = new SingletonRunnerSupplier(options, bus, backendSupplier, objectFactorySupplier, typeRegistryConfigurerSupplier);
         }
+    }
+
+    CucumberEngineOptions getOptions() {
+        return options;
     }
 
     void startTestRun() {

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
@@ -6,6 +6,8 @@ import io.cucumber.core.options.ObjectFactoryParser;
 import io.cucumber.core.options.PluginOption;
 import io.cucumber.core.options.SnippetTypeParser;
 import io.cucumber.core.snippets.SnippetType;
+import io.cucumber.tagexpressions.Expression;
+import io.cucumber.tagexpressions.TagExpressionParser;
 import org.junit.platform.engine.ConfigurationParameters;
 
 import java.net.URI;
@@ -17,6 +19,7 @@ import java.util.stream.Collectors;
 import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME_PREFIX;
 import static io.cucumber.junit.platform.engine.Constants.ANSI_COLORS_DISABLED_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.EXECUTION_DRY_RUN_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.FILTER_TAGS_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.OBJECT_FACTORY_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME;
@@ -47,6 +50,14 @@ class CucumberEngineOptions implements
             .map(pluginOption -> (Plugin) pluginOption)
             .collect(Collectors.toList()))
             .orElse(Collections.emptyList());
+    }
+
+    public Expression tagFilter() {
+        return new TagExpressionParser()
+            .parse(configurationParameters
+                .get(FILTER_TAGS_PROPERTY_NAME)
+                .orElse("")
+            );
     }
 
     @Override
@@ -88,7 +99,7 @@ class CucumberEngineOptions implements
             .orElse(null);
     }
 
-    boolean isParallelExecutionEnabled(){
+    boolean isParallelExecutionEnabled() {
         return configurationParameters
             .get(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, Boolean::parseBoolean)
             .orElse(false);

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/PickleDescriptor.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/PickleDescriptor.java
@@ -46,7 +46,7 @@ class PickleDescriptor extends AbstractTestDescriptor implements Node<CucumberEn
         if (expression.evaluate(tags)) {
             return SkipResult.doNotSkip();
         }
-        return SkipResult.skip("Disabled because '" + expression + "' did not match");
+        return SkipResult.skip("'" + Constants.FILTER_TAGS_PROPERTY_NAME + "=" + expression + "' did not match this scenario");
     }
 
     /**

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/PickleDescriptor.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/PickleDescriptor.java
@@ -2,6 +2,7 @@ package io.cucumber.junit.platform.engine;
 
 import io.cucumber.core.gherkin.Pickle;
 import io.cucumber.core.resource.ClasspathSupport;
+import io.cucumber.tagexpressions.Expression;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
@@ -11,6 +12,7 @@ import org.junit.platform.engine.support.hierarchical.Node;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -35,6 +37,16 @@ class PickleDescriptor extends AbstractTestDescriptor implements Node<CucumberEn
     public CucumberEngineExecutionContext execute(CucumberEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor) {
         context.runTestCase(pickleEvent);
         return context;
+    }
+
+    @Override
+    public SkipResult shouldBeSkipped(CucumberEngineExecutionContext context) {
+        List<String> tags = pickleEvent.getTags();
+        Expression expression = context.getOptions().tagFilter();
+        if (expression.evaluate(tags)) {
+            return SkipResult.doNotSkip();
+        }
+        return SkipResult.skip("Disabled because '" + expression + "' did not match");
     }
 
     /**

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
@@ -60,7 +60,7 @@ class CucumberTestEngineTest {
             .execute();
         assertEquals(1, result.testEvents().count());
         assertEquals(1, result.testEvents().skipped().count());
-        assertEquals(Optional.of("Disabled because '( @Integration and not ( @Disabled ) )' did not match"), result.testEvents()
+        assertEquals(Optional.of("'cucumber.filter.tags=( @Integration and not ( @Disabled ) )' did not match this scenario"), result.testEvents()
             .skipped()
             .map(event -> event.getPayload().get()) // replace with flatMap when above java 9
             .findFirst());

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
@@ -93,7 +93,7 @@ class DiscoverySelectorResolverTest {
         DiscoverySelector resource = selectClasspathRoots(singleton(classpathRoot)).get(0);
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
-        assertEquals(5, testDescriptor.getChildren().size());
+        assertEquals(6, testDescriptor.getChildren().size());
     }
 
     @Test
@@ -177,7 +177,7 @@ class DiscoverySelectorResolverTest {
         DiscoverySelector resource = selectDirectory("src/test/resources/io/cucumber/junit/platform/engine");
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
-        assertEquals(4, testDescriptor.getChildren().size());
+        assertEquals(5, testDescriptor.getChildren().size());
     }
 
     @Test
@@ -185,7 +185,7 @@ class DiscoverySelectorResolverTest {
         DiscoverySelector resource = selectPackage("io.cucumber.junit.platform.engine");
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
-        assertEquals(4, testDescriptor.getChildren().size());
+        assertEquals(5, testDescriptor.getChildren().size());
     }
 
     @Test
@@ -276,7 +276,7 @@ class DiscoverySelectorResolverTest {
         DiscoverySelector resource = selectClass(RunCucumberTest.class);
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
-        assertEquals(4, testDescriptor.getChildren().size());
+        assertEquals(5, testDescriptor.getChildren().size());
     }
 
     private Optional<UniqueId> selectSomePickle(DiscoverySelector resource) {

--- a/junit-platform-engine/src/test/resources/io/cucumber/junit/platform/engine/disabled.feature
+++ b/junit-platform-engine/src/test/resources/io/cucumber/junit/platform/engine/disabled.feature
@@ -1,0 +1,7 @@
+Feature: A feature with some work in progress
+
+  @Disabled
+  Scenario: A disabled scenario
+    Given a single scenario
+    When it is executed
+    Then nothing else happens

--- a/junit-platform-engine/src/test/resources/junit-platform.properties
+++ b/junit-platform-engine/src/test/resources/junit-platform.properties
@@ -1,1 +1,2 @@
 cucumber.glue=io.cucumber.junit.platform.engine
+cucumber.filter.tags=not @Disabled


### PR DESCRIPTION
The JUnit Platform supports skipping tests. For example in JUnit Jupiter a
test can be annotated with `@Disabled`. This test will be marked as skipped.

Cucumber scenarios do not have annotations nor is there any support to disable
specific scenarios. A typical work around with Cucumber JUnit 4 integration was
to set a permanent tag filter for `not @Disabled` in `@CucumberOptions`.

This wasn't possible with the JUnit Platform yet. By adding the
`cucumber.filter.tags` property it becomes possible to recreate JUnit Jupiter's
`@Disabled` functionality.
By setting `cucumber.filter.tags=not @Disabled` property any scenarios tagged
with `@Disabled` will be skipped.

Note that contrary to JUnit 4 skipped scenarios are not removed from the test
hierarchy. This is entirely intentional and a result of the way the JUnit
Platform supports skipping tests.

![image](https://user-images.githubusercontent.com/6946919/74935983-91fd3f80-53e9-11ea-8c41-e16e15e3f27f.png)

When skipped the JUnit Platform will also include the reason why the scenario was skipped.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
