### PR TITLE
[All] Remove Jackson from `cucumber-jvm` parent pom

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <project.Automatic-Module-Name>io.cucumber.core</project.Automatic-Module-Name>
+        <jackson-databind.version>2.10.2</jackson-databind.version>
         <jsoup.version>1.12.2</jsoup.version>
         <xmlunit.version>2.6.3</xmlunit.version>
         <webbit.version>0.4.15</webbit.version>
@@ -115,6 +116,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/docstring/pom.xml
+++ b/docstring/pom.xml
@@ -12,6 +12,7 @@
     <name>Cucumber-JVM: Docstring</name>
 
     <properties>
+        <jackson-databind.version>2.10.2</jackson-databind.version>
         <project.Automatic-Module-Name>io.cucumber.docstring</project.Automatic-Module-Name>
     </properties>
 
@@ -33,6 +34,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/java-calculator-junit5/pom.xml
+++ b/examples/java-calculator-junit5/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <project.Automatic-Module-Name>io.cucumber.examples.junit5</project.Automatic-Module-Name>
+        <jackson-databind.version>2.10.2</jackson-databind.version>
     </properties>
 
     <dependencies>
@@ -39,6 +40,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/java-calculator/pom.xml
+++ b/examples/java-calculator/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <project.Automatic-Module-Name>io.cucumber.examples.java</project.Automatic-Module-Name>
+        <jackson-databind.version>2.10.2</jackson-databind.version>
     </properties>
 
     <dependencies>
@@ -40,6 +41,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,6 +11,11 @@
     <packaging>jar</packaging>
     <name>Cucumber-JVM: Java</name>
 
+    <properties>
+        <project.Automatic-Module-Name>io.cucumber.java</project.Automatic-Module-Name>
+        <jackson-databind.version>2.10.2</jackson-databind.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.cucumber</groupId>
@@ -44,6 +49,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -114,7 +120,4 @@
         </plugins>
     </build>
 
-    <properties>
-        <project.Automatic-Module-Name>io.cucumber.java</project.Automatic-Module-Name>
-    </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,6 @@
         <junit-platform.version>1.6.0</junit-platform.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>3.2.4</mockito.version>
-        <jackson-databind.version>2.10.2</jackson-databind.version>
-
         <!--Maven plugins-->
         <groovy.version>2.5.9</groovy.version>
     </properties>
@@ -175,15 +173,6 @@
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-junit-platform-engine</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
-                <!-- Only ever include Jackson as test dependency
-                     This library gets security fixes faster then our release cycle -->
-                <scope>test</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The `cucumber-jvm` parent pom included `jackson-databind` in its dependency
management section. Because this is a test only dependency it was marked as
test scoped.

While not intended to function as a bill of materials people were and perhaps
still are using `cucumber-jvm` in this fashion. Removing `jackson-databind`
from the dependency management ensures that `cucumber-jvm` only manages
cucumber and test related dependencies.

While not safe, this does provide a modicum of safety.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
