### PR TITLE
[Java8] Show error message when used on Java 12+

### DIFF
--- a/java8/src/main/java/io/cucumber/java8/AbstractGlueDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/AbstractGlueDefinition.java
@@ -1,6 +1,7 @@
 package io.cucumber.java8;
 
 import io.cucumber.core.backend.ScenarioScoped;
+import net.jodah.typetools.TypeResolver;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -41,5 +42,19 @@ abstract class AbstractGlueDefinition implements ScenarioScoped {
                 "Expected single 'accept' method on body class, found '%s'", acceptMethods));
         }
         return acceptMethods.get(0);
+    }
+
+    Class<?>[] resolveRawArguments(Class<?> bodyClass, Class<?> body) {
+        Class<?>[] rawArguments = TypeResolver.resolveRawArguments(bodyClass, body);
+        for (Class<?> aClass : rawArguments) {
+            if (TypeResolver.Unknown.class.equals(aClass)) {
+                throw new IllegalStateException("" +
+                    "Could resolve the return type of the lambda at " + location.getFileName() + ":" + location.getLineNumber() + "\n" +
+                    "This version of cucumber-java8 is not compatible with Java 12+\n" +
+                    "See: https://github.com/cucumber/cucumber-jvm/issues/1817"
+                );
+            }
+        }
+        return rawArguments;
     }
 }

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableCellDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableCellDefinition.java
@@ -2,7 +2,6 @@ package io.cucumber.java8;
 
 import io.cucumber.core.backend.DataTableTypeDefinition;
 import io.cucumber.datatable.DataTableType;
-import net.jodah.typetools.TypeResolver;
 
 final class Java8DataTableCellDefinition extends AbstractDatatableElementTransformerDefinition implements DataTableTypeDefinition {
 
@@ -10,7 +9,7 @@ final class Java8DataTableCellDefinition extends AbstractDatatableElementTransfo
 
     Java8DataTableCellDefinition(String[] emptyPatterns, DataTableCellDefinitionBody<?> body) {
         super(body, new Exception().getStackTrace()[3], emptyPatterns);
-        Class<?> returnType = TypeResolver.resolveRawArguments(DataTableCellDefinitionBody.class, body.getClass())[0];
+        Class<?> returnType = resolveRawArguments(DataTableCellDefinitionBody.class, body.getClass())[0];
         this.dataTableType = new DataTableType(
             returnType,
             (String cell) -> execute(replaceEmptyPatternsWithEmptyString(cell))

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableDefinition.java
@@ -4,8 +4,6 @@ import io.cucumber.core.backend.DataTableTypeDefinition;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.datatable.DataTableType;
 
-import static net.jodah.typetools.TypeResolver.resolveRawArguments;
-
 final class Java8DataTableDefinition extends AbstractDatatableElementTransformerDefinition implements DataTableTypeDefinition {
 
     private final DataTableType dataTableType;

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableEntryDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableEntryDefinition.java
@@ -5,8 +5,6 @@ import io.cucumber.datatable.DataTableType;
 
 import java.util.Map;
 
-import static net.jodah.typetools.TypeResolver.resolveRawArguments;
-
 final class Java8DataTableEntryDefinition extends AbstractDatatableElementTransformerDefinition implements DataTableTypeDefinition {
 
     private final DataTableType dataTableType;

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableRowDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableRowDefinition.java
@@ -5,8 +5,6 @@ import io.cucumber.datatable.DataTableType;
 
 import java.util.List;
 
-import static net.jodah.typetools.TypeResolver.resolveRawArguments;
-
 final class Java8DataTableRowDefinition extends AbstractDatatableElementTransformerDefinition implements DataTableTypeDefinition {
 
     private final DataTableType dataTableType;

--- a/java8/src/main/java/io/cucumber/java8/Java8DocStringTypeDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DocStringTypeDefinition.java
@@ -4,8 +4,6 @@ import io.cucumber.core.backend.DocStringTypeDefinition;
 import io.cucumber.core.exception.CucumberException;
 import io.cucumber.docstring.DocStringType;
 
-import static net.jodah.typetools.TypeResolver.resolveRawArguments;
-
 final class Java8DocStringTypeDefinition extends AbstractGlueDefinition implements DocStringTypeDefinition {
 
     private final DocStringType docStringType;

--- a/java8/src/main/java/io/cucumber/java8/Java8StepDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8StepDefinition.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
-import static net.jodah.typetools.TypeResolver.resolveRawArguments;
 
 final class Java8StepDefinition extends AbstractGlueDefinition implements StepDefinition {
 

--- a/java8/src/main/java/io/cucumber/java8/LambdaTypeResolver.java
+++ b/java8/src/main/java/io/cucumber/java8/LambdaTypeResolver.java
@@ -26,9 +26,6 @@ final class LambdaTypeResolver implements TypeResolver {
     }
 
     public Type getType() {
-        if (net.jodah.typetools.TypeResolver.Unknown.class.equals(type)) {
-            return Object.class;
-        }
         return type;
     }
 


### PR DESCRIPTION
## Summary

Because of https://github.com/cucumber/cucumber-jvm/issues/1817 `cucumber-java8` can't resolve the argument types of step definitions,  parameter types and data table types. This results in a number of rather obscure behaviours. By adding a clear error message can avoid these behaviours.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
