### PR TITLE
[Spring] Do not reuse generic application context between scenarios

### DIFF
--- a/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
+++ b/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
@@ -22,12 +22,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.ContextConfiguration;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -323,6 +325,21 @@ class SpringFactoryTest {
         public String getProperty() {
             return property;
         }
+
+    }
+
+    @Test
+    void shouldBeStoppableWhenFacedWithInvalidConfiguration() {
+        final ObjectFactory factory = new SpringFactory();
+        factory.addClass(WithEmptySpringAnnotations.class);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, factory::start);
+        assertThat(exception.getMessage(), containsString("DelegatingSmartContextLoader was unable to detect defaults"));
+        assertDoesNotThrow(factory::stop);
+    }
+
+    @ContextConfiguration()
+    public static class WithEmptySpringAnnotations {
 
     }
 }

--- a/spring/src/test/java/io/cucumber/spring/TestContextAdaptorTest.java
+++ b/spring/src/test/java/io/cucumber/spring/TestContextAdaptorTest.java
@@ -3,8 +3,15 @@ package io.cucumber.spring;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.GenericApplicationContext;
 
+import static io.cucumber.spring.TestContextAdaptor.createApplicationContextAdaptor;
+import static io.cucumber.spring.TestContextAdaptor.createClassPathXmlApplicationContextAdaptor;
+import static io.cucumber.spring.TestContextAdaptor.createGenericApplicationContextAdaptor;
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TestContextAdaptorTest {
 
@@ -17,13 +24,37 @@ class TestContextAdaptorTest {
         GenericApplicationContext context = new GenericApplicationContext();
         context.setAllowBeanDefinitionOverriding(false);
 
-        TestContextAdaptor adaptor1 = TestContextAdaptor.createApplicationContextAdaptor(context, asList(GlueClass.class, GlueClass.class));
+        TestContextAdaptor adaptor1 = createApplicationContextAdaptor(context, asList(GlueClass.class, GlueClass.class));
         adaptor1.start();
-        GlueCodeContext.getInstance().start();
         GlueClass instance1 = adaptor1.getInstance(GlueClass.class);
         assertNotNull(instance1);
         adaptor1.stop();
-        GlueCodeContext.getInstance().stop();
+    }
+
+    @Test
+    void xmlApplicationContextCanBeReUsedBetweenScenarios() {
+        String[] configLocations = {"cucumber.xml"};
+        TestContextAdaptor adaptor1 = createClassPathXmlApplicationContextAdaptor(configLocations, asList(GlueClass.class, GlueClass.class));
+        adaptor1.start();
+        GlueClass instance1 = adaptor1.getInstance(GlueClass.class);
+        assertNotNull(instance1);
+        adaptor1.stop();
+
+        adaptor1.start();
+        GlueClass instance2 = adaptor1.getInstance(GlueClass.class);
+        assertNotNull(instance2);
+        assertNotSame(instance1, instance2);
+        adaptor1.stop();
+    }
+
+    @Test
+    void configurableApplicationContextCanNotBeReused() {
+        TestContextAdaptor adaptor = createGenericApplicationContextAdaptor(asList(GlueClass.class, GlueClass.class));
+        adaptor.start();
+        adaptor.stop();
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, adaptor::start);
+        assertThat(exception.getMessage(), containsString("GenericApplicationContext does not support multiple refresh attempts"));
     }
 
 }


### PR DESCRIPTION
When neither a glue class with a spring context configuration could be found
nor a `cucumber.xml` file exists `cucumber-spring` will fall back to a
`GenericApplicationContext` to facilitate dependency injection.

The current implementation tries to reuse this application context between
scenarios. This requires refreshing the context which can only be done once.
So it's not possible to reuse the `GenericApplicationContext` and a new one
should be created for each scenario.

## Motivation and Context

https://stackoverflow.com/questions/60445228/cucumber-5-0-0-and-springboot-multiple-scenarios-in-one-feature-file

## How Has This Been Tested?

Because `cucumber.xml` and the `GenericApplicationContext` are fallback methods it is very hard to test these individually.  Had to test these manually using:

https://github.com/mpkorstanje/cucumber-spring-1905

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
