### PR TITLE
[Java8] update to net.jodah:typetools:0.6.2

### DIFF
--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.Automatic-Module-Name>io.cucumber.java8</project.Automatic-Module-Name>
-        <typetools.version>0.6.1</typetools.version>
+        <typetools.version>0.6.2</typetools.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

Upgrade net.jodah:typetools from 0.6.1 to 0.6.2, which includes Automatic-Module-Name, that can be used for jpms.

## Details

Dependency update for java8 pom

## Motivation and Context

Getting Java Modules working for cucumber, so doing pr's for downstream projects.

## How Has This Been Tested?

mvn clean install

## Screenshots (if appropriate):

n/a/

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

- [ ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
