### PR TITLE
[Gherkin] Fix NPE on empty table

### DIFF
--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesStep.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesStep.java
@@ -20,14 +20,14 @@ final class GherkinMessagesStep implements Step {
 
     GherkinMessagesStep(PickleStep pickleStep, GherkinDialect dialect, String previousGwtKeyWord, int stepLine, String keyword) {
         this.pickleStep = pickleStep;
-        this.argument = extractArgument(pickleStep);
+        this.argument = extractArgument(pickleStep, stepLine);
         this.keyWord = keyword;
         this.stepType = extractKeyWordType(keyWord, dialect);
         this.previousGwtKeyWord = previousGwtKeyWord;
         this.stepLine = stepLine;
     }
 
-    private StepType extractKeyWordType(String keyWord, GherkinDialect dialect) {
+    private static StepType extractKeyWordType(String keyWord, GherkinDialect dialect) {
         if (StepType.isAstrix(keyWord)) {
             return StepType.OTHER;
         }
@@ -49,7 +49,7 @@ final class GherkinMessagesStep implements Step {
         throw new IllegalStateException("Keyword " + keyWord + " was neither given, when, then, and, but nor *");
     }
 
-    private Argument extractArgument(PickleStep pickleStep) {
+    private static Argument extractArgument(PickleStep pickleStep, int stepLine) {
         PickleStepArgument argument = pickleStep.getArgument();
         if (argument.hasDocString()) {
             PickleDocString docString = argument.getDocString();

--- a/gherkin-messages/src/test/java/io/cucumber/core/gherkin/messages/FeatureParserTest.java
+++ b/gherkin-messages/src/test/java/io/cucumber/core/gherkin/messages/FeatureParserTest.java
@@ -1,6 +1,9 @@
 package io.cucumber.core.gherkin.messages;
 
+import io.cucumber.core.gherkin.DataTableArgument;
 import io.cucumber.core.gherkin.Feature;
+import io.cucumber.core.gherkin.Pickle;
+import io.cucumber.core.gherkin.Step;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -10,6 +13,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static java.nio.file.Files.readAllBytes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class FeatureParserTest {
@@ -30,6 +34,17 @@ class FeatureParserTest {
         String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/empty.feature")));
         Optional<Feature> feature = parser.parse(uri, source, UUID::randomUUID);
         assertFalse(feature.isPresent());
+    }
+
+    @Test
+    void empty_table_is_parsed() throws IOException {
+        URI uri = URI.create("classpath:com/example.feature");
+        String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/empty-table.feature")));
+        Feature feature = parser.parse(uri, source, UUID::randomUUID).get();
+        Pickle pickle = feature.getPickles().get(0);
+        Step step = pickle.getSteps().get(0);
+        DataTableArgument argument = (DataTableArgument) step.getArgument();
+        assertEquals(5, argument.getLine());
     }
 
 }

--- a/gherkin-messages/src/test/resources/io/cucumber/core/gherkin/messages/empty-table.feature
+++ b/gherkin-messages/src/test/resources/io/cucumber/core/gherkin/messages/empty-table.feature
@@ -1,0 +1,5 @@
+Feature: Empty table
+
+  Scenario: This is valid Gherkin
+    Given an empty list
+      |

--- a/gherkin-vintage/src/main/java/io/cucumber/core/gherkin/vintage/GherkinVintageDataTableArgument.java
+++ b/gherkin-vintage/src/main/java/io/cucumber/core/gherkin/vintage/GherkinVintageDataTableArgument.java
@@ -11,9 +11,15 @@ final class GherkinVintageDataTableArgument implements DataTableArgument {
     private final CellView cells;
     private final int line;
 
-    GherkinVintageDataTableArgument(PickleTable table) {
+    GherkinVintageDataTableArgument(PickleTable table, int lineHint) {
         this.cells = new CellView(table);
-        this.line = table.getLocation().getLine();
+        // Work around for broken table.getLocation.
+        // TODO: Deprecate DataTableArgument.getLine
+        if (table.getRows().size() > 0 && table.getRows().get(0).getCells().size() > 0) {
+            this.line = table.getLocation().getLine();
+        } else {
+            this.line = lineHint;
+        }
     }
 
     @Override

--- a/gherkin-vintage/src/test/java/io/cucumber/core/gherkin/vintage/FeatureParserTest.java
+++ b/gherkin-vintage/src/test/java/io/cucumber/core/gherkin/vintage/FeatureParserTest.java
@@ -1,6 +1,9 @@
 package io.cucumber.core.gherkin.vintage;
 
+import io.cucumber.core.gherkin.DataTableArgument;
 import io.cucumber.core.gherkin.Feature;
+import io.cucumber.core.gherkin.Pickle;
+import io.cucumber.core.gherkin.Step;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -10,13 +13,15 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static java.nio.file.Files.readAllBytes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class FeatureParserTest {
 
+    private final GherkinVintageFeatureParser parser = new GherkinVintageFeatureParser();
+
     @Test
     void empty_feature_file_is_parsed_but_produces_no_feature() throws IOException {
-        GherkinVintageFeatureParser parser = new GherkinVintageFeatureParser();
         URI uri = URI.create("classpath:com/example.feature");
         String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/vintage/empty.feature")));
         Optional<Feature> feature = parser.parse(uri, source, UUID::randomUUID);
@@ -25,11 +30,21 @@ class FeatureParserTest {
 
     @Test
     void feature_file_without_pickles_is_parsed_but_produces_no_feature() throws IOException {
-        GherkinVintageFeatureParser parser = new GherkinVintageFeatureParser();
         URI uri = URI.create("classpath:com/example.feature");
         String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/vintage/empty.feature")));
         Optional<Feature> feature = parser.parse(uri, source, UUID::randomUUID);
         assertFalse(feature.isPresent());
+    }
+
+    @Test
+    void empty_table_is_parsed() throws IOException {
+        URI uri = URI.create("classpath:com/example.feature");
+        String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/vintage/empty-table.feature")));
+        Feature feature = parser.parse(uri, source, UUID::randomUUID).get();
+        Pickle pickle = feature.getPickles().get(0);
+        Step step = pickle.getSteps().get(0);
+        DataTableArgument argument = (DataTableArgument) step.getArgument();
+        assertEquals(5, argument.getLine());
     }
 
 }

--- a/gherkin-vintage/src/test/resources/io/cucumber/core/gherkin/vintage/empty-table.feature
+++ b/gherkin-vintage/src/test/resources/io/cucumber/core/gherkin/vintage/empty-table.feature
@@ -1,0 +1,5 @@
+Feature: Empty table
+
+  Scenario: This is valid Gherkin
+    Given an empty list
+      |


### PR DESCRIPTION
Parsing the feature below results in an NPE because Gherkin v5 uses the location
of the first cell as the location of the table. Because there is no cell, there
is no location. In this case we fall back to using the line of the step + 1.

```gherkin
Feature: Empty table

  Scenario: This is valid Gherkin
    Given an empty list
      |
```

Fixes: https://github.com/cucumber/cucumber-jvm/issues/1912

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).