### PR TITLE
[Java] Add @ParameterType(useRegexpMatchAsStrongTypeHint=true/false)

### DIFF
--- a/java/src/main/java/io/cucumber/java/GlueAdaptor.java
+++ b/java/src/main/java/io/cucumber/java/GlueAdaptor.java
@@ -43,7 +43,8 @@ final class GlueAdaptor {
             String name = parameterType.name();
             boolean useForSnippets = parameterType.useForSnippets();
             boolean preferForRegexMatch = parameterType.preferForRegexMatch();
-            glue.addParameterType(new JavaParameterTypeDefinition(name, pattern, method, useForSnippets, preferForRegexMatch, lookup));
+            boolean useRegexpMatchAsStrongTypeHint = parameterType.useRegexpMatchAsStrongTypeHint();
+            glue.addParameterType(new JavaParameterTypeDefinition(name, pattern, method, useForSnippets, preferForRegexMatch, useRegexpMatchAsStrongTypeHint, lookup));
         } else if (annotationType.equals(DataTableType.class)) {
             DataTableType dataTableType = (DataTableType) annotation;
             glue.addDataTableType(new JavaDataTableTypeDefinition(method, lookup, dataTableType.replaceWithEmptyString()));

--- a/java/src/main/java/io/cucumber/java/JavaParameterTypeDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaParameterTypeDefinition.java
@@ -14,7 +14,7 @@ class JavaParameterTypeDefinition extends AbstractGlueDefinition implements Para
 
     private final ParameterType<Object> parameterType;
 
-    JavaParameterTypeDefinition(String name, String pattern, Method method, boolean useForSnippets, boolean preferForRegexpMatch, Lookup lookup) {
+    JavaParameterTypeDefinition(String name, String pattern, Method method, boolean useForSnippets, boolean preferForRegexpMatch, boolean useRegexpMatchAsStrongTypeHint, Lookup lookup) {
         super(requireValidMethod(method), lookup);
         this.parameterType = new ParameterType<>(
             name.isEmpty() ? method.getName() : name,
@@ -22,7 +22,8 @@ class JavaParameterTypeDefinition extends AbstractGlueDefinition implements Para
             this.method.getGenericReturnType(),
             this::execute,
             useForSnippets,
-            preferForRegexpMatch
+            preferForRegexpMatch,
+            useRegexpMatchAsStrongTypeHint
         );
     }
 

--- a/java/src/main/java/io/cucumber/java/ParameterType.java
+++ b/java/src/main/java/io/cucumber/java/ParameterType.java
@@ -76,4 +76,20 @@ public @interface ParameterType {
      * @see io.cucumber.cucumberexpressions.ParameterType#useForSnippets()
      */
     boolean useForSnippets() default false;
+
+    /**
+     * Indicates whether or not this parameter provides a strong type hint when considering a
+     * regular expression match. If so, the type hint provided by the method arguments will be
+     * ignored. If not, when both type hints are in agreement, this parameter types transformer
+     * will be used. Otherwise parameter transformation for a regular expression match will be
+     * handled by {@link DefaultParameterTransformer}.
+     *
+     * Note: This value currently defaults to true but will default to false in
+     * the next major release.
+     *
+     * @return true if this parameter type provides a type hint when considering a regular
+     * expression match
+     */
+    @API(status = API.Status.EXPERIMENTAL)
+    boolean useRegexpMatchAsStrongTypeHint() default true;
 }

--- a/java/src/test/java/io/cucumber/java/GlueAdaptorTest.java
+++ b/java/src/test/java/io/cucumber/java/GlueAdaptorTest.java
@@ -140,6 +140,9 @@ public class GlueAdaptorTest {
             () -> assertThat(dataTableTypeDefinition, notNullValue()),
             () -> assertThat(parameterTypeDefinition.parameterType().getRegexps(), is(singletonList("pattern"))),
             () -> assertThat(parameterTypeDefinition.parameterType().getName(), is("name")),
+            () -> assertThat(parameterTypeDefinition.parameterType().preferForRegexpMatch(), is(true)),
+            () -> assertThat(parameterTypeDefinition.parameterType().useForSnippets(), is(true)),
+            () -> assertThat(parameterTypeDefinition.parameterType().useRegexpMatchAsStrongTypeHint(), is(false)),
             () -> assertThat(afterStepHook, notNullValue()),
             () -> assertThat(beforeStepHook, notNullValue()),
             () -> assertThat(afterHook, notNullValue()),
@@ -174,7 +177,7 @@ public class GlueAdaptorTest {
         return "data_table_type";
     }
 
-    @ParameterType(value = "pattern", name = "name")
+    @ParameterType(value = "pattern", name = "name", preferForRegexMatch = true, useForSnippets = true, useRegexpMatchAsStrongTypeHint = false)
     public String parameter_type(String fromValue) {
         return "parameter_type";
     }

--- a/java/src/test/java/io/cucumber/java/JavaParameterTypeDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaParameterTypeDefinitionTest.java
@@ -33,7 +33,7 @@ class JavaParameterTypeDefinitionTest {
     @Test
     void can_define_parameter_type_converters_with_one_capture_group() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_one_capture_group_to_string", String.class);
-        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "(.*)", method, false, false, lookup);
+        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup);
         registry.defineParameterType(definition.parameterType());
         Expression cucumberExpression = new ExpressionFactory(registry).createExpression("{convert_one_capture_group_to_string}");
         List<Argument<?>> test = cucumberExpression.match("test");
@@ -47,7 +47,7 @@ class JavaParameterTypeDefinitionTest {
     @Test
     void can_define_parameter_type_converters_with_two_capture_groups() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_two_capture_group_to_string", String.class, String.class);
-        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "([^ ]*) ([^ ]*)", method, false, false, lookup);
+        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "([^ ]*) ([^ ]*)", method, false, false, false, lookup);
         registry.defineParameterType(definition.parameterType());
         Expression cucumberExpression = new ExpressionFactory(registry).createExpression("{convert_two_capture_group_to_string}");
         List<Argument<?>> test = cucumberExpression.match("test test");
@@ -61,7 +61,7 @@ class JavaParameterTypeDefinitionTest {
     @Test
     void can_define_parameter_type_converters_with_var_args() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_varargs_capture_group_to_string", String[].class);
-        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "([^ ]*) ([^ ]*)", method, false, false, lookup);
+        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "([^ ]*) ([^ ]*)", method, false, false, false, lookup);
         registry.defineParameterType(definition.parameterType());
         Expression cucumberExpression = new ExpressionFactory(registry).createExpression("{convert_varargs_capture_group_to_string}");
         List<Argument<?>> test = cucumberExpression.match("test test");
@@ -75,7 +75,7 @@ class JavaParameterTypeDefinitionTest {
     @Test
     void arguments_must_match_captured_groups() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_two_capture_group_to_string", String.class, String.class);
-        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", ".*", method, false, false, lookup);
+        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", ".*", method, false, false, false, lookup);
         registry.defineParameterType(definition.parameterType());
         Expression cucumberExpression = new ExpressionFactory(registry).createExpression("{convert_two_capture_group_to_string}");
         List<Argument<?>> test = cucumberExpression.match("test");
@@ -86,7 +86,7 @@ class JavaParameterTypeDefinitionTest {
     @Test
     void converter_must_have_return_type() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_capture_group_to_void", String.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, lookup));
+        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
     }
 
     public void convert_capture_group_to_void(String all) {
@@ -95,7 +95,7 @@ class JavaParameterTypeDefinitionTest {
     @Test
     void converter_may_have_non_generic_return_type() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_capture_group_to_optional_string", String.class);
-        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "(.*)", method, false, false, lookup);
+        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup);
         registry.defineParameterType(definition.parameterType());
         Expression cucumberExpression = new ExpressionFactory(registry).createExpression("{convert_capture_group_to_optional_string}");
         List<Argument<?>> args = cucumberExpression.match("convert_capture_group_to_optional_string");
@@ -109,7 +109,7 @@ class JavaParameterTypeDefinitionTest {
     @Test
     void converter_must_have_at_least_one_argument() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_nothing_to_string");
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, lookup));
+        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
     }
 
     public String convert_nothing_to_string() {
@@ -119,7 +119,7 @@ class JavaParameterTypeDefinitionTest {
     @Test
     void converter_must_have_string_arguments() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("converts_object_to_string", Object.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, lookup));
+        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
     }
 
     public String converts_object_to_string(Object other) {
@@ -129,7 +129,7 @@ class JavaParameterTypeDefinitionTest {
     @Test
     void converter_must_have_all_string_arguments() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("converts_objects_to_string", String.class, Object.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, lookup));
+        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
     }
 
     public String converts_objects_to_string(String all, Object other) {


### PR DESCRIPTION
## Summary

Parameter types are registered with a regex. When a step definition is written
as a regular expression `cucumber-expressions` use the regex in the capture
group as a type hint.

When the type hint provided by the regex and the type hint provided by the
method (i.e. the types of its arguments) disagree about the type
`cucumber-expressions` prefers the hint provided by the regex.

When parameter types are declared with very simple regexes this may cause a
problem. For example:

```java
import io.cucumber.java.ParameterType;
import io.cucumber.java.en.Given;

public class StepDefinitions {

    private static class TypeA {}

    @ParameterType("\\w+")
    public TypeA typeA(String a) {
        return new TypeA();
    }

    @Given("a cucumber expression of {typeA}")
    public void an_object_of_type_a(TypeA a) {
        // works fine!
    }

    @Given("^a regular expression of (\\w+)$")
    public void an_object_of_type_b(String b) {
        // broken: will attempt to use the transformer for TypeA
    }
}
```

By using `@ParameterType(pattern="\\w+", useRegexpMatchAsStrongTypeHint=false)`
this behaviour can be changed to instead prefer the type hint from the method.

## Motivation and Context

https://github.com/cucumber/cucumber/pull/918#issuecomment-595591357

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
