### PR TITLE
[TestNG] Fix concurrent modification of events

### DIFF
--- a/testng/src/test/java/io/cucumber/testng/TestNGCucumberRunnerTest.java
+++ b/testng/src/test/java/io/cucumber/testng/TestNGCucumberRunnerTest.java
@@ -48,11 +48,8 @@ public class TestNGCucumberRunnerTest {
 
     @Test
     public void parse_error_propagated_to_testng_test_execution() {
-        testNGCucumberRunner = new TestNGCucumberRunner(ParseError.class);
         try {
-            Object[][] scenarios = testNGCucumberRunner.provideScenarios(); // a CucumberException is caught
-            PickleWrapper pickleWrapper = (PickleWrapper) scenarios[0][0];
-            pickleWrapper.getPickle();
+            testNGCucumberRunner = new TestNGCucumberRunner(ParseError.class);
             Assert.fail("CucumberException not thrown");
         } catch (FeatureParserException e) {
             assertEquals(e.getMessage(), "Failed to parse resource at: classpath:io/cucumber/error/parse-error.feature");


### PR DESCRIPTION
When a TestNG suite with `parallel="methods"` is executed TestNG will invoke
all `@DataProvider` annotated methods. Because these data providers also emit
the `TestRunStarted` event this event is emitted twice concurrently. These
events collide in the `CanonicalOrderEventPublisher` resulting in a concurrent
modification that inserts a null element rather then either of the events.

By moving the start of the test execution to the constructor we ensure that
test execution is always started serially. Additionally this ensures that it is
impossible to emit a `TestRunFinished` event without also emitting a
`TestRunStarted` event.

This comes at the cost of starting the execution as soon as the `@BeforeClass`
method is invoked. This will result in some apparent overhead as TestNG is
still preparing for execution.

Fixes: https://github.com/cucumber/cucumber-jvm/issues/1917

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
