### PR TITLE
[Core] UrlOutputStream uploads all data in one pass

### DIFF
--- a/core/src/main/java/io/cucumber/core/plugin/UrlOutputStream.java
+++ b/core/src/main/java/io/cucumber/core/plugin/UrlOutputStream.java
@@ -9,94 +9,97 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.newOutputStream;
 
 class UrlOutputStream extends OutputStream {
-    // Allow streaming, using a chunk size that is similar to a typical NDJSON
-    // message length
-    public static final int CHUNK_LENGTH = 256;
-    private final HttpURLConnection urlConnection;
-    private final OutputStream outputStream;
-
-    private String method;
-    private URL url;
-    private final Map<String, List<String>> requestHeaders;
+    private final CurlOption option;
+    private final Path temp;
+    private final OutputStream tempOutputStream;
 
     UrlOutputStream(CurlOption option) throws IOException {
-        this.method = option.getMethod().name();
-        this.url = option.getUri().toURL();
-
-        urlConnection = (HttpURLConnection) this.url.openConnection();
-        for (Entry<String, String> header : option.getHeaders()) {
-            urlConnection.setRequestProperty(header.getKey(), header.getValue());
-        }
-        urlConnection.setRequestMethod(this.method);
-        urlConnection.setDoOutput(true);
-        urlConnection.setChunkedStreamingMode(CHUNK_LENGTH);
-        urlConnection.setInstanceFollowRedirects(false);
-        requestHeaders = urlConnection.getRequestProperties();
-        outputStream = urlConnection.getOutputStream();
+        this.option = option;
+        this.temp = Files.createTempFile("cucumber", null);
+        this.tempOutputStream = newOutputStream(temp);
     }
 
     @Override
     public void write(byte[] buffer, int offset, int count) throws IOException {
-        outputStream.write(buffer, offset, count);
+        tempOutputStream.write(buffer, offset, count);
     }
 
     @Override
     public void write(byte[] buffer) throws IOException {
-        outputStream.write(buffer);
+        tempOutputStream.write(buffer);
     }
 
     @Override
     public void write(int b) throws IOException {
-        outputStream.write(b);
+        tempOutputStream.write(b);
     }
 
     @Override
     public void flush() throws IOException {
-        outputStream.flush();
+        tempOutputStream.flush();
     }
 
     @Override
     public void close() throws IOException {
-        outputStream.close();
-        int httpStatus = urlConnection.getResponseCode();
-        boolean redirect = httpStatus >= 300 && httpStatus < 400;
-        boolean error = httpStatus >= 400;
-        try (InputStream inputStream = error ? urlConnection.getErrorStream() : urlConnection.getInputStream()) {
-            Map<String, List<String>> responseHeaders = urlConnection.getHeaderFields();
-            try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream, UTF_8))) {
-                String responseBody = br.lines().collect(Collectors.joining(System.lineSeparator()));
-                if (error || redirect) {
-                    String message = generateCurlLikeMessage(this.method, this.url, this.requestHeaders, responseHeaders, responseBody, redirect);
-                    throw new IOException(message);
-                }
+        tempOutputStream.close();
+
+        URL url = option.getUri().toURL();
+        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+        for (Entry<String, String> header : option.getHeaders()) {
+            urlConnection.setRequestProperty(header.getKey(), header.getValue());
+        }
+        urlConnection.setInstanceFollowRedirects(true);
+        urlConnection.setRequestMethod(option.getMethod().name());
+        urlConnection.setDoOutput(true);
+        Map<String, List<String>> requestHeaders = urlConnection.getRequestProperties();
+        try (OutputStream outputStream = urlConnection.getOutputStream()) {
+            Files.copy(temp, outputStream);
+            handleResponse(urlConnection, requestHeaders);
+        }
+    }
+
+    private static void handleResponse(HttpURLConnection urlConnection, Map<String, List<String>> requestHeaders) throws IOException {
+        Map<String, List<String>> responseHeaders = urlConnection.getHeaderFields();
+        int responseCode = urlConnection.getResponseCode();
+        boolean success = 200 <= responseCode && responseCode < 300;
+
+        InputStream inputStream = urlConnection.getErrorStream() != null ? urlConnection.getErrorStream() : urlConnection.getInputStream();
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream, UTF_8))) {
+            String responseBody = br.lines().collect(Collectors.joining(System.lineSeparator()));
+            if (!success) {
+                String method = urlConnection.getRequestMethod();
+                URL url = urlConnection.getURL();
+                throw createCurlLikeException(method, url, requestHeaders, responseHeaders, responseBody);
             }
         }
     }
 
-    static String generateCurlLikeMessage(
+    static IOException createCurlLikeException(
         String method,
         URL url,
         Map<String, List<String>> requestHeaders,
         Map<String, List<String>> responseHeaders,
-        String responseBody,
-        boolean redirect) {
-        return String.format(
-            "%s:\n> %s %s\n%s%s\n%s",
-            redirect ? "HTTP redirect not supported" : "HTTP request failed",
+        String responseBody) {
+        return new IOException(String.format(
+            "%s:\n> %s %s%s%s%s",
+            "HTTP request failed",
             method,
             url,
             headersToString("> ", requestHeaders),
             headersToString("< ", responseHeaders),
             responseBody
-        );
+        ));
     }
 
     private static String headersToString(String prefix, Map<String, List<String>> headers) {
@@ -109,10 +112,12 @@ class UrlOutputStream extends OutputStream {
                 .map(value -> {
                     if (header.getKey() == null) {
                         return prefix + value;
+                    } else if (header.getValue() == null) {
+                        return prefix + header.getKey();
                     } else {
-                        return prefix + (header.getKey() + ": ") + value;
+                        return prefix + header.getKey() + ": " + value;
                     }
                 })
-            ).collect(Collectors.joining("\n"));
+            ).collect(Collectors.joining("\n", "", "\n"));
     }
 }


### PR DESCRIPTION
Chunked upload requires a connection to be kept alive for the duration
of the test execution. This is practically not feasible. So rather then
using chunked upload the output is written to a temporary file and then
uploaded all at once.
