### PR TITLE
[Spring] Deprecate cucumber.xml and implied context configuration

### DIFF
--- a/spring/README.md
+++ b/spring/README.md
@@ -1,7 +1,8 @@
 Cucumber Spring
 ===============
 
-Use Cucumber Spring to manage state between steps and for scenarios.
+Use Cucumber Spring to share state between steps in a scenario and access the
+spring application context.
 
 Add the `cucumber-spring` dependency to your `pom.xml`:
 
@@ -18,136 +19,141 @@ Add the `cucumber-spring` dependency to your `pom.xml`:
 </dependencies>
 ```
 
-## Annotation Based Configuration
-
-For your own classes:
-
-* Add a `@Component` annotation to each of the classes `cucumber-spring` should
-manage.
-```java
-package com.example.app;
-
-import org.springframework.stereotype.Component;
-
-@Component
-public class Belly {
-    private int cukes = 0;
-
-    public void setCukes(int cukes) {
-        this.cukes = cukes;
-    }
-
-    public int getCukes() {
-        return cukes;
-    }
-}
-```
-* Add the location of your classes to the `@ComponentScan` of your (test)
-configuration:
-
-```java
-package com.example.app;
-
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@ComponentScan("com.example.app")
-public class Config {
-    // the rest of your configuration
-}
-```
-
-For classes from other frameworks:
-
-* You will have to explicitly register them as Beans in your (test) configuration:
-
-```java
-package com.example.app;
-
-import com.example.other.framework.SomeOtherService;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
-
-@Configuration
-@ComponentScan("com.example.app")
-public class TestConfig {
-    @Bean
-    public SomeOtherService someOtherService() {
-        // return an instance of some other service
-    }
-}
-```
+## Configuring the Test Application Context
 
 To make Cucumber aware of your test configuration you can annotate a
 configuration class with `@CucumberContextConfiguration` and with one of the
 following annotations: `@ContextConfiguration`, `@ContextHierarchy` or
 `@BootstrapWith`. If you are using SpringBoot, you can annotate configuration
-class with `@SpringBootTest(classes = TestConfig.class)`.
+class with `@SpringBootTest`.
 
 For example:
 ```java
 import com.example.app;
+
 import org.springframework.boot.test.context.SpringBootTest;
+
 import io.cucumber.spring.CucumberContextConfiguration;
 
-@SpringBootTest(classes = TestConfig.class)
 @CucumberContextConfiguration
-public class SomeServiceStepDefinitions {
-
+@SpringBootTest(classes = TestConfig.class)
+public class CucumberSpringConfiguration {
 
 }
 ```
 
-Now you can use the registered beans by autowiring them where you need them.
+Note: Cucumber Spring uses Springs `TestContextManager` framework internally.
+As a result a single Cucumber scenario will mostly behave like a JUnit test.
 
-For example:
+For more information configuring Spring tests see:
+ - [Spring Framework Documentation - Testing](https://docs.spring.io/spring-framework/docs/current/spring-framework-reference/testing.html)
+ - [Spring Boot Features - Testing](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-testing)
+
+## Accessing the application context
+
+Components from the application context can be accessed by autowiring.
+Annotate a field in your step definition class with `@Autowired`. 
+
 ```java
-import com.example.app;
-import org.springframework.beans.factory.annotation.Autowired;
+package com.example.app;
 
-public class SomeServiceStepDefinitions {
-    
-    @Autowired
-    SomeService someService;
+public class MyStepDefinitions {
 
-    @Autowired
-    SomeOtherService someOtherService;
+   @Autowired
+   private MyService myService;
 
-    // the rest of your step definitions
+   @Given("feed back is requested from my service")
+   public void feed_back_is_requested(){
+      myService.requestFeedBack();
+   }
 }
 ```
 
-### The Application Context & Cucumber Glue Scope
+## Sharing State 
 
-Cucumber Spring creates an application context. This application context is
-shared between scenarios.
+Cucumber Spring creates an application context and using Springs
+`TestContextManager` framework internally. All scenarios as well as all other
+tests (e.g. JUnit) that use the same context configuration will share one
+instance of the Spring application. This avoids an expensive startup time.
 
-To prevent sharing state between scenarios, beans containing glue code
+### Sharing state between steps
+
+To prevent sharing test state between scenarios, beans containing glue code
 (i.e. step definitions, hooks, ect) are bound to the `cucumber-glue` scope.
 
-The `cucumber-glue` scope starts prior to a scenario and end after a scenario.
-Beans in this scope are created prior to a scenario execution and disposed at
-the end of it.
+The `cucumber-glue` scope starts prior to a scenario and ends after a scenario.
+All beans in this scope will be created before a scenario execution and
+disposed at the end of it.
 
-Changing a Spring bean's scope to `SCOPE_CUCUMBER_GLUE` will bind its lifecycle
-to the `cucumber-glue` scope.
+By using the `CucumberTestContext.SCOPE_CUCUMBER_GLUE` additional components
+can be added to the glue scope. These components can be used to safely share
+state between scenarios. 
 
 ```java
+package com.example.app;
+
 import org.springframework.stereotype.Component;
 import org.springframework.context.annotation.Scope;
-import static io.cucumber.spring.CucumberTestContext.SCOPE_CUCUMBER_GLUE;
+import static io.cucumber.spring.CucumberTestContext;
 
 @Component
-@Scope(SCOPE_CUCUMBER_GLUE)
-public class MyComponent {
+@Scope(CucumberTestContext.SCOPE_CUCUMBER_GLUE)
+public class TestUserInformation {
+
+    private User testUser;
+
+    public void setTestUser(User testUser) {
+        this.testUser = testUser;
+    }
+
+    public User getTestUser() {
+        return testUser;
+    }
+
 }
 ```
 
+The glue scoped component can then be autowired into a step definition:
+
+```java
+package com.example.app;
+
+public class UserStepDefinitions {
+
+   @Autowired
+   private UserService userService;
+
+   @Autowired
+   private TestUserInformation testUserInformation;
+
+   @Given("there is a user")
+   public void there_is_as_user() {
+      User testUser = userService.createUser();
+      testUserInformation.setTestUser(testUser);
+   }
+}
+
+public class PurchaseStepDefinitions {
+
+   @Autowired
+   private PurchaseService purchaseService;
+
+   @Autowired
+   private TestUserInformation testUserInformation;
+
+   @When("the user makes a purchase")
+   public void the_user_makes_a_purchase(){
+      Order order = ....
+      User user = testUserInformation.getTestUser();
+      purchaseService.purchase(user, order);
+   }
+}
+```
+
+### Dirtying the application context
+
 If your tests do dirty the application context you can add `@DirtiesContext` to 
-your test configuration.
+your test configuration. 
 
 ```java
 package com.example.app;
@@ -156,28 +162,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import io.cucumber.spring.CucumberContextConfiguration;
+
+@CucumberContextConfiguration
 @SpringBootTest(classes = TestConfig.class)
 @DirtiesContext
-public class SomeServiceStepDefinitions {
+public class CucumberSpringConfiguration {
+   
+}
+```
+```java
+package com.example.app;
 
-    @Autowired
-    private Belly belly; // Each scenario have a new instance of Belly
-    
-    [...]
-    
+public class MyStepDefinitions {
+
+   @Autowired
+   private MyService myService;  // Each scenario have a new instance of MyService
+
 }
 ```
 
-### XML Configuration
-
-If you are using xml based configuration, you can to register the beans in a
-`cucumber.xml` file:
-
-```xml
-<bean class="com.example.app.MyService"/>
-<bean class="com.example.lib.SomeOtherService"/>
-```
-
-Annotate a configuration class with 
-`@ContextConfiguration("classpath:cucumber.xml")`
-
+Note: Using `@DirtiesContext` in combination with parallel execution will lead
+to undefined behaviour.

--- a/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
+++ b/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
@@ -305,6 +305,7 @@ class SpringFactoryTest {
         );
     }
 
+    @CucumberContextConfiguration
     @ContextConfiguration("classpath:cucumber.xml")
     public static class WithSpringAnnotations {
 
@@ -338,8 +339,23 @@ class SpringFactoryTest {
         assertDoesNotThrow(factory::stop);
     }
 
+    @CucumberContextConfiguration
     @ContextConfiguration()
     public static class WithEmptySpringAnnotations {
+
+    }
+    @Test
+    void shouldBeStoppableWhenFacedWithMissingContextConfiguration() {
+        final ObjectFactory factory = new SpringFactory();
+        factory.addClass(WithoutContextConfiguration.class);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, factory::start);
+        assertThat(exception.getMessage(), containsString("Failed to load ApplicationContext"));
+        assertDoesNotThrow(factory::stop);
+    }
+
+    @CucumberContextConfiguration
+    public static class WithoutContextConfiguration {
 
     }
 }

--- a/spring/src/test/java/io/cucumber/spring/annotationconfig/RunCucumberContextConfigurationTest.java
+++ b/spring/src/test/java/io/cucumber/spring/annotationconfig/RunCucumberContextConfigurationTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
+    strict = true,
     glue = {"io.cucumber.spring.annotationconfig"},
     features = {"classpath:io/cucumber/spring/annotationContextConfiguration.feature"}
 )

--- a/spring/src/test/java/io/cucumber/spring/contextcaching/ContextCachingSteps.java
+++ b/spring/src/test/java/io/cucumber/spring/contextcaching/ContextCachingSteps.java
@@ -2,13 +2,14 @@ package io.cucumber.spring.contextcaching;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.hamcrest.MatcherAssert;
+import io.cucumber.spring.CucumberContextConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@CucumberContextConfiguration
 @ContextConfiguration(classes = {ContextConfig.class})
 public class ContextCachingSteps {
 

--- a/spring/src/test/java/io/cucumber/spring/contextcaching/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/contextcaching/RunCucumberTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
+    strict = true,
     features = {"classpath:io/cucumber/spring/contextCaching.feature"}
 )
 public class RunCucumberTest {

--- a/spring/src/test/java/io/cucumber/spring/contextconfig/BellyStepDefinitions.java
+++ b/spring/src/test/java/io/cucumber/spring/contextconfig/BellyStepDefinitions.java
@@ -1,6 +1,7 @@
 package io.cucumber.spring.contextconfig;
 
 import io.cucumber.java.en.Then;
+import io.cucumber.spring.CucumberContextConfiguration;
 import io.cucumber.spring.beans.Belly;
 import io.cucumber.spring.beans.BellyBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@CucumberContextConfiguration
 @ContextConfiguration("classpath:cucumber.xml")
 public class BellyStepDefinitions {
 

--- a/spring/src/test/java/io/cucumber/spring/contextconfig/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/contextconfig/RunCucumberTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
+    strict = true,
     glue = {
         "io.cucumber.spring.contextconfig",
         "io.cucumber.spring.commonglue",

--- a/spring/src/test/java/io/cucumber/spring/contexthierarchyconfig/WithContextHierarchyAnnotation.java
+++ b/spring/src/test/java/io/cucumber/spring/contexthierarchyconfig/WithContextHierarchyAnnotation.java
@@ -1,10 +1,12 @@
 package io.cucumber.spring.contexthierarchyconfig;
 
+import io.cucumber.spring.CucumberContextConfiguration;
 import io.cucumber.spring.beans.DummyComponent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 
+@CucumberContextConfiguration
 @ContextHierarchy({
     @ContextConfiguration("classpath:cucumber2.xml"),
     @ContextConfiguration("classpath:cucumber.xml")

--- a/spring/src/test/java/io/cucumber/spring/dirtiescontextconfig/DirtiesContextBellyStepDefinitions.java
+++ b/spring/src/test/java/io/cucumber/spring/dirtiescontextconfig/DirtiesContextBellyStepDefinitions.java
@@ -2,6 +2,7 @@ package io.cucumber.spring.dirtiescontextconfig;
 
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
+import io.cucumber.spring.CucumberContextConfiguration;
 import io.cucumber.spring.beans.Belly;
 import io.cucumber.spring.beans.BellyBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +11,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@CucumberContextConfiguration
 @ContextConfiguration("classpath:cucumber.xml")
 @DirtiesContext
 public class DirtiesContextBellyStepDefinitions {

--- a/spring/src/test/java/io/cucumber/spring/dirtiescontextconfig/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/dirtiescontextconfig/RunCucumberTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
+    strict = true,
     glue = {"io.cucumber.spring.dirtiescontextconfig"},
     features = {"classpath:io/cucumber/spring/dirtyCukes.feature"}
 )

--- a/spring/src/test/java/io/cucumber/spring/metaconfig/dirties/DirtiesContextBellyMetaStepDefinitions.java
+++ b/spring/src/test/java/io/cucumber/spring/metaconfig/dirties/DirtiesContextBellyMetaStepDefinitions.java
@@ -2,12 +2,14 @@ package io.cucumber.spring.metaconfig.dirties;
 
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
+import io.cucumber.spring.CucumberContextConfiguration;
 import io.cucumber.spring.beans.Belly;
 import io.cucumber.spring.beans.BellyBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@CucumberContextConfiguration
 @DirtiesMetaConfiguration
 public class DirtiesContextBellyMetaStepDefinitions {
 

--- a/spring/src/test/java/io/cucumber/spring/metaconfig/dirties/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/metaconfig/dirties/RunCucumberTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
+    strict = true,
     glue = {"io.cucumber.spring.metaconfig.dirties"},
     features = {"classpath:io/cucumber/spring/dirtyCukesWithMetaConfiguration.feature"}
 )

--- a/spring/src/test/java/io/cucumber/spring/metaconfig/general/BellyMetaStepDefinitions.java
+++ b/spring/src/test/java/io/cucumber/spring/metaconfig/general/BellyMetaStepDefinitions.java
@@ -1,12 +1,14 @@
 package io.cucumber.spring.metaconfig.general;
 
 import io.cucumber.java.en.Then;
+import io.cucumber.spring.CucumberContextConfiguration;
 import io.cucumber.spring.beans.Belly;
 import io.cucumber.spring.beans.BellyBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@CucumberContextConfiguration
 @MetaConfiguration
 public class BellyMetaStepDefinitions {
 

--- a/spring/src/test/java/io/cucumber/spring/metaconfig/general/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/metaconfig/general/RunCucumberTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
+    strict = true,
     glue = {
         "io.cucumber.spring.metaconfig.general",
         "io.cucumber.spring.commonglue",

--- a/spring/src/test/java/io/cucumber/spring/threading/ThreadingStepDefinitions.java
+++ b/spring/src/test/java/io/cucumber/spring/threading/ThreadingStepDefinitions.java
@@ -3,6 +3,7 @@ package io.cucumber.spring.threading;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import io.cucumber.spring.CucumberContextConfiguration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 
@@ -16,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+@CucumberContextConfiguration
 @WebAppConfiguration
 @ContextConfiguration("classpath:cucumber.xml")
 public class ThreadingStepDefinitions {

--- a/spring/src/test/java/io/cucumber/spring/webappconfig/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/webappconfig/RunCucumberTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
+    strict = true,
     glue = {"io.cucumber.spring.webappconfig"},
     features = {"classpath:io/cucumber/spring/springWebContextInjection.feature"}
 )

--- a/spring/src/test/java/io/cucumber/spring/webappconfig/SpringInjectionStepDefinitions.java
+++ b/spring/src/test/java/io/cucumber/spring/webappconfig/SpringInjectionStepDefinitions.java
@@ -3,6 +3,7 @@ package io.cucumber.spring.webappconfig;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import io.cucumber.spring.CucumberContextConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -15,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@CucumberContextConfiguration
 @WebAppConfiguration
 @ContextConfiguration("classpath:cucumber.xml")
 public class SpringInjectionStepDefinitions {


### PR DESCRIPTION
The prefered way to use `cucumber-spring` is to annotate a class
with both `@CucumberContextConfiguration` and a Spring context
configuration annotation such as `@ContextConfiguration`,
`@SpringBootTest`, ect.

Cucumber currently supports the discovery of context
configuration on any step defintion class. This requires a
significant amount of code and intimate knowledge of the
Spring Framework.
By restricting this too only classes annotated with
`@CucumberContextConfiguration` we can remove this complexity and
simply pass the annotated class to Spring `TestContextManager`
framework.

If no context configuration is available Cucumber currently also
support reading the application context from a magical
`cucumber.xml` file or should none exist an empty application
context.
Both these fallback strategies tend to hide user errors. And
removing them will provide more clarity and also remove
a nuggest of complexity.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
