### PR TITLE
[JUnit Platform] Map tags to exclusive resources

### DIFF
--- a/junit-platform-engine/README.md
+++ b/junit-platform-engine/README.md
@@ -115,13 +115,55 @@ tasks {
 
 ## Parallel execution ## 
 
-By default, Cucumber tests are run sequentially in a single thread. Running
+By default, Cucumber runs tests sequentially in a single thread. Running
 tests in parallel is available as an opt-in feature. To enable parallel
-execution, set the set the `cucumber.execution.parallel.enabled` configuration
+execution, set the `cucumber.execution.parallel.enabled` configuration
 parameter to `true`, e.g. in `junit-platform.properties`.
 
 Cucumber supports JUnits `ParallelExecutionConfigurationStrategy` see the
 configuration options below.
+
+### Exclusive Resources ###
+
+Using exclusive resources it is possible to control which scenarios will
+not run concurrently with other scenarios that use the same resource.
+ 
+Cucumber tags can be mapped to exclusive resources. A resource can be
+either locked with a read-write-lock, or a read lock.  
+  
+For example:
+ 
+ 
+```gherkin
+Feature: Exclusive resources
+
+ @my-tag-ab-rw
+ Scenario: first example
+   Given this reads and writes resource a
+   And this reads and writes resource b
+   When it is executed it will   
+   Then it will not be executed concurrently with the second example
+
+ @my-tag-a-r
+ Scenario: second example
+   Given this reads resource a
+   When it is executed it will
+   Then it will not be executed concurrently with the first example
+
+```
+ 
+With this configuration: 
+ 
+```
+cucumber.execution.exclusive-resources.my-tag-ab-rw.read-write=resource-a,resource-b
+cucumber.execution.exclusive-resources.my-tag-a-r.read=resource-a
+```
+ 
+The first scenario tagged with `@my-tag-ab-rw` will lock resource `a` and `b`
+with a read-write lock and will not be concurrently executed with the second
+scenario that locks resource `a` with a read lock.
+
+Note: The `@` is not included.
 
 ## Configuration Options ##
 
@@ -130,41 +172,48 @@ can be supplied see the JUnit documentation [4.5. Configuration Parameters](http
 For documentation see [Constants](src/main/java/io/cucumber/junit/platform/engine/Constants.java).
 
 ```
-cucumber.ansi-colors.disabled=                          # true or false. default: false                     
+cucumber.ansi-colors.disabled=                                # true or false. default: false                     
+      
+cucumber.filter.tags=                                         # a cucumber tag expression. 
+                                                              # only matching scenarios are executed. 
+                                                              # example: @integration and not @disabled
+      
+cucumber.glue=                                                # comma separated package names. 
+                                                              # example: com.example.glue  
+      
+cucumber.plugin=                                              # comma separated plugin strings. 
+                                                              # example: pretty, json:path/to/report.json
+      
+cucumber.object-factory=                                      # object factory class name.
+                                                              # example: com.example.MyObjectFactory
+      
+cucumber.snippet-type=                                        # underscore or camelcase. 
+                                                              # default: underscore
+      
+cucumber.execution.dry-run=                                   # true or false. 
+                                                              # default: false
+       
+cucumber.execution.parallel.enabled=                          # true or false. 
+                                                              # default: false
+      
+cucumber.execution.parallel.config.strategy=                  # dynamic, fixed or custom. 
+                                                              # default: dynamic
+      
+cucumber.execution.parallel.config.fixed.parallelism=         # positive integer. 
+                                                              # example: 4 
+      
+cucumber.execution.parallel.config.dynamic.factor=            # positive double.
+                                                              # default: 1.0
+      
+cucumber.execution.parallel.config.custom.class=              # class name. 
+                                                              # example: com.example.MyCustomParallelStrategy
 
-cucumber.filter.tags=                                   # a cucumber tag expression. 
-                                                        # only matching scenarios are executed. 
-                                                        # example: @integration and not @disabled
+cucumber.execution.exclusive-resources.<tag-name>.read-write= # a comma seperated list of strings
+                                                              # example: resource-a, resource-b 
+     
+cucumber.execution.exclusive-resources.<tag-name>.read=       # a comma seperated list of strings
+                                                              # example: resource-a, resource-b
 
-cucumber.glue=                                          # comma separated package names. 
-                                                        # example: com.example.glue  
-
-cucumber.plugin=                                        # comma separated plugin strings. 
-                                                        # example: pretty, json:path/to/report.json
-
-cucumber.object-factory=                                # object factory class name.
-                                                        # example: com.example.MyObjectFactory
-
-cucumber.snippet-type=                                  # underscore or camelcase. 
-                                                        # default: underscore
-
-cucumber.execution.dry-run=                             # true or false. 
-                                                        # default: false
- 
-cucumber.execution.parallel.enabled=                    # true or false. 
-                                                        # default: false
-
-cucumber.execution.parallel.config.strategy=            # dynamic, fixed or custom. 
-                                                        # default: dynamic
-
-cucumber.execution.parallel.config.fixed.parallelism=   # positive integer. 
-                                                        # example: 4 
-
-cucumber.execution.parallel.config.dynamic.factor=      # positive double.
-                                                        # default: 1.0
-
-cucumber.execution.parallel.config.custom.class=        # class name. 
-                                                        # example: com.example.MyCustomParallelStrategy
 ```
 
 ## Supported Discovery Selectors and Filters ## 
@@ -189,7 +238,7 @@ The `UriSelector` supports URI's with a `line` query parameter:
 Any `TestDescriptor` that matches the line *and* its descendents will be 
 included in the discovery result.
 
-## Tags
+## Tags ##
 
 Cucumber tags are mapped to JUnit tags. Note that the `@` symbol is not part of
 the JUnit tag. So the scenarios below are tagged with `Smoke` and `Sanity`. 

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -29,6 +29,51 @@ public final class Constants {
      */
     public static final String EXECUTION_DRY_RUN_PROPERTY_NAME = io.cucumber.core.options.Constants.EXECUTION_DRY_RUN_PROPERTY_NAME;
 
+    static final String EXECUTION_EXCLUSIVE_RESOURCES_PREFIX = "cucumber.execution.exclusive-resources.";
+    static final String READ_WRITE_SUFFIX = ".read-write";
+    static final String READ_SUFFIX = ".read";
+
+    /**
+     * Tag replacement pattern for the exclusive resource templates: {@value}
+     *
+     * @see #EXECUTION_EXCLUSIVE_RESOURCES_READ_WRITE_TEMPLATE
+     */
+    public static final String EXECUTION_EXCLUSIVE_RESOURCES_TAG_TEMPLATE_VARIABLE = "<tag-name>";
+
+    /**
+     * Property template used to describe a mapping of tags to exclusive resources: {@value}
+     * <p>
+     * This maps a tag to a resource with a read-write lock.
+     * <p>
+     * For example given these properties:
+     * <pre> {@code
+     * cucumber.execution.exclusive-resources.my-tag-ab-rw.read-write=resource-a,resource-b
+     * cucumber.execution.exclusive-resources.my-tag-a-r.read=resource-a
+     * }
+     * </pre>
+     * A scenario tagged with {@code @my-tag-ab-rw} will lock
+     * resource {@code a} and {@code b} for reading and writing
+     * and will not be concurrently executed with other scenarios
+     * tagged with {@code @my-tag-ab-rw} as well as scenarios tagged
+     * with {@code @my-tag-a-r}.
+     * However a scenarios tagged with {@code @my-tag-a-r} will be concurrently
+     * executed with other scenarios with the same tag.
+     *
+     * @see <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution-synchronization">Junit 5 User Guide - Synchronization</a>
+     */
+    public static final String EXECUTION_EXCLUSIVE_RESOURCES_READ_WRITE_TEMPLATE =
+        EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + EXECUTION_EXCLUSIVE_RESOURCES_TAG_TEMPLATE_VARIABLE + READ_WRITE_SUFFIX;
+
+    /**
+     * Property template used to describe a mapping of tags to exclusive resources: {@value}
+     * <p>
+     * This maps a tag to a resource with a read lock.
+     *
+     * @see #EXECUTION_EXCLUSIVE_RESOURCES_READ_WRITE_TEMPLATE
+     */
+    public static final String EXECUTION_EXCLUSIVE_RESOURCES_READ_TEMPLATE =
+        EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + EXECUTION_EXCLUSIVE_RESOURCES_TAG_TEMPLATE_VARIABLE + READ_SUFFIX;
+
     /**
      * Property name used to set tag filter: {@value}
      * <p>

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
@@ -33,7 +33,7 @@ class DiscoverySelectorResolver {
     }
 
     private void resolve(EngineDiscoveryRequest request, CucumberEngineDescriptor engineDescriptor, Predicate<String> packageFilter) {
-        FeatureResolver featureResolver = createFeatureResolver(engineDescriptor, packageFilter);
+        FeatureResolver featureResolver = createFeatureResolver(request.getConfigurationParameters(), engineDescriptor, packageFilter);
 
         request.getSelectorsByType(ClasspathRootSelector.class).forEach(featureResolver::resolveClasspathRoot);
         request.getSelectorsByType(ClasspathResourceSelector.class).forEach(featureResolver::resolveClasspathResource);

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
@@ -12,6 +12,7 @@ import io.cucumber.core.gherkin.Scenario;
 import io.cucumber.core.gherkin.ScenarioOutline;
 import io.cucumber.core.resource.ClassLoaders;
 import io.cucumber.core.resource.ResourceScanner;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.ClassSelector;
@@ -47,14 +48,16 @@ final class FeatureResolver {
 
     private final CucumberEngineDescriptor engineDescriptor;
     private final Predicate<String> packageFilter;
+    private final ConfigurationParameters parameters;
 
-    private FeatureResolver(CucumberEngineDescriptor engineDescriptor, Predicate<String> packageFilter) {
+    private FeatureResolver(ConfigurationParameters parameters, CucumberEngineDescriptor engineDescriptor, Predicate<String> packageFilter) {
+        this.parameters = parameters;
         this.engineDescriptor = engineDescriptor;
         this.packageFilter = packageFilter;
     }
 
-    static FeatureResolver createFeatureResolver(CucumberEngineDescriptor engineDescriptor, Predicate<String> packageFilter) {
-        return new FeatureResolver(engineDescriptor, packageFilter);
+    static FeatureResolver createFeatureResolver(ConfigurationParameters parameters, CucumberEngineDescriptor engineDescriptor, Predicate<String> packageFilter) {
+        return new FeatureResolver(parameters, engineDescriptor, packageFilter);
     }
 
     private static URI stripQuery(URI uri) {
@@ -199,6 +202,7 @@ final class FeatureResolver {
             (Scenario node, TestDescriptor parent) -> {
                 Pickle pickle = feature.getPickleAt(node);
                 TestDescriptor descriptor = new PickleDescriptor(
+                    parameters,
                     source.scenarioSegment(parent.getUniqueId(), node),
                     getNameOrKeyWord(node),
                     source.nodeSource(node),
@@ -237,6 +241,7 @@ final class FeatureResolver {
             (Example node, TestDescriptor parent) -> {
                 Pickle pickle = feature.getPickleAt(node);
                 PickleDescriptor descriptor = new PickleDescriptor(
+                    parameters,
                     source.exampleSegment(parent.getUniqueId(), node),
                     getNameOrKeyWord(node),
                     source.nodeSource(node),

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/PickleDescriptor.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/PickleDescriptor.java
@@ -3,29 +3,51 @@ package io.cucumber.junit.platform.engine;
 import io.cucumber.core.gherkin.Pickle;
 import io.cucumber.core.resource.ClasspathSupport;
 import io.cucumber.tagexpressions.Expression;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.config.PrefixedConfigurationParameters;
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.descriptor.ClasspathResourceSource;
+import org.junit.platform.engine.support.hierarchical.ExclusiveResource;
 import org.junit.platform.engine.support.hierarchical.Node;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_EXCLUSIVE_RESOURCES_PREFIX;
+import static io.cucumber.junit.platform.engine.Constants.READ_SUFFIX;
+import static io.cucumber.junit.platform.engine.Constants.READ_WRITE_SUFFIX;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toCollection;
+import static org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode;
 
 class PickleDescriptor extends AbstractTestDescriptor implements Node<CucumberEngineExecutionContext> {
 
     private final Pickle pickleEvent;
+    private final Set<TestTag> tags;
+    private final Set<ExclusiveResource> exclusiveResources = new LinkedHashSet<>(0);
 
-    PickleDescriptor(UniqueId uniqueId, String name, TestSource source, Pickle pickleEvent) {
+    PickleDescriptor(ConfigurationParameters parameters, UniqueId uniqueId, String name, TestSource source, Pickle pickleEvent) {
         super(uniqueId, name, source);
         this.pickleEvent = pickleEvent;
+        this.tags = getTags(pickleEvent);
+        this.tags.forEach(tag -> {
+                ExclusiveResourceOptions exclusiveResourceOptions = new ExclusiveResourceOptions(parameters, tag);
+                exclusiveResourceOptions.exclusiveReadWriteResource()
+                    .map(resource -> new ExclusiveResource(resource, LockMode.READ_WRITE))
+                    .forEach(exclusiveResources::add);
+                exclusiveResourceOptions.exclusiveReadResource()
+                    .map(resource -> new ExclusiveResource(resource, LockMode.READ))
+                    .forEach(exclusiveResources::add);
+            }
+        );
     }
 
     @Override
@@ -60,6 +82,10 @@ class PickleDescriptor extends AbstractTestDescriptor implements Node<CucumberEn
      */
     @Override
     public Set<TestTag> getTags() {
+        return tags;
+    }
+
+    private Set<TestTag> getTags(Pickle pickleEvent) {
         return pickleEvent.getTags().stream()
             .map(tag -> tag.substring(1))
             .filter(TestTag::isValid)
@@ -76,4 +102,33 @@ class PickleDescriptor extends AbstractTestDescriptor implements Node<CucumberEn
             .map(ClasspathSupport::packageNameOfResource);
     }
 
+    @Override
+    public Set<ExclusiveResource> getExclusiveResources() {
+        return exclusiveResources;
+    }
+
+    private static final class ExclusiveResourceOptions {
+
+        private final ConfigurationParameters parameters;
+
+        ExclusiveResourceOptions(ConfigurationParameters parameters, TestTag tag) {
+            this.parameters = new PrefixedConfigurationParameters(
+                parameters,
+                EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + tag.getName()
+            );
+        }
+
+        public Stream<String> exclusiveReadWriteResource() {
+            return parameters.get(READ_WRITE_SUFFIX, s -> Arrays.stream(s.split(","))
+                .map(String::trim))
+                .orElse(Stream.empty());
+        }
+
+        public Stream<String> exclusiveReadResource() {
+            return parameters.get(READ_SUFFIX, s -> Arrays.stream(s.split(","))
+                .map(String::trim))
+                .orElse(Stream.empty());
+        }
+
+    }
 }

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
@@ -2,16 +2,22 @@ package io.cucumber.junit.platform.engine;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.hierarchical.ExclusiveResource;
+import org.junit.platform.engine.support.hierarchical.ExclusiveResource.LockMode;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 
 import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME_PREFIX;
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_EXCLUSIVE_RESOURCES_PREFIX;
+import static io.cucumber.junit.platform.engine.Constants.READ_SUFFIX;
+import static io.cucumber.junit.platform.engine.Constants.READ_WRITE_SUFFIX;
 import static io.cucumber.junit.platform.engine.FeatureResolver.createFeatureResolver;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
@@ -25,6 +31,7 @@ import static org.junit.platform.engine.support.descriptor.ClasspathResourceSour
 import static org.junit.platform.engine.support.descriptor.FilePosition.from;
 
 class FeatureResolverTest {
+
     private final String featurePath = "io/cucumber/junit/platform/engine/feature-with-outline.feature";
     private final String featureSegmentValue = CLASSPATH_SCHEME_PREFIX + featurePath;
     private CucumberEngineDescriptor testDescriptor;
@@ -32,9 +39,16 @@ class FeatureResolverTest {
 
     @BeforeEach
     void before() {
+
+        ConfigurationParameters configurationParameters = new MapConfigurationParameters(
+            new HashMap<String, String>() {{
+                put(EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + "ResourceA" + READ_WRITE_SUFFIX, "resource-a");
+                put(EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + "ResourceAReadOnly" + READ_SUFFIX, "resource-a");
+            }});
+        EmptyEngineDiscoveryRequest request = new EmptyEngineDiscoveryRequest(configurationParameters);
         id = UniqueId.forEngine(new CucumberTestEngine().getId());
         testDescriptor = new CucumberEngineDescriptor(id);
-        FeatureResolver featureResolver = createFeatureResolver(testDescriptor, aPackage -> true);
+        FeatureResolver featureResolver = createFeatureResolver(request.getConfigurationParameters(), testDescriptor, aPackage -> true);
         featureResolver.resolveClasspathResource(selectClasspathResource(featurePath));
     }
 
@@ -56,7 +70,7 @@ class FeatureResolverTest {
         TestDescriptor scenario = getScenario();
         assertEquals("A scenario", scenario.getDisplayName());
         assertEquals(
-            asSet(create("FeatureTag"), create("ScenarioTag")),
+            asSet(create("FeatureTag"), create("ScenarioTag"), create("ResourceA"), create("ResourceAReadOnly")),
             scenario.getTags()
         );
         assertEquals(of(from(featurePath, from(5, 3))), scenario.getSource());
@@ -66,9 +80,15 @@ class FeatureResolverTest {
                 .append("scenario", "5"),
             scenario.getUniqueId()
         );
-
         PickleDescriptor pickleDescriptor = (PickleDescriptor) scenario;
         assertEquals(Optional.of("io.cucumber.junit.platform.engine"), pickleDescriptor.getPackage());
+        assertEquals(
+            asSet(
+                new ExclusiveResource("resource-a", LockMode.READ_WRITE),
+                new ExclusiveResource("resource-a", LockMode.READ)
+            ),
+            pickleDescriptor.getExclusiveResources()
+        );
     }
 
     @Test
@@ -111,7 +131,8 @@ class FeatureResolverTest {
         assertEquals(Optional.of("io.cucumber.junit.platform.engine"), pickleDescriptor.getPackage());
     }
 
-    private Set<TestTag> asSet(TestTag... tags) {
+    @SafeVarargs
+    private static <T> Set<T> asSet(T... tags) {
         return new HashSet<>(asList(tags));
     }
 

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/MapConfigurationParameters.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/MapConfigurationParameters.java
@@ -10,7 +10,7 @@ class MapConfigurationParameters implements ConfigurationParameters {
 
     private final Map<String, String> parameters;
 
-    private MapConfigurationParameters(Map<String, String> parameters) {
+    MapConfigurationParameters(Map<String, String> parameters) {
         this.parameters = parameters;
     }
 

--- a/junit-platform-engine/src/test/resources/io/cucumber/junit/platform/engine/feature-with-outline.feature
+++ b/junit-platform-engine/src/test/resources/io/cucumber/junit/platform/engine/feature-with-outline.feature
@@ -1,7 +1,7 @@
 @FeatureTag
 Feature: A feature with scenario outlines
 
-  @ScenarioTag
+  @ScenarioTag @ResourceA  @ResourceAReadOnly
   Scenario: A scenario
     Given a scenario
     When it is executed


### PR DESCRIPTION
Using exclusive resources it is possible to control which scenarios will
not run concurrently with other scenarios that use the same resource.

Cucumber tags can be mapped to exclusive resources. A resource can be\
either locked with a read-write-lock, or a read lock.

For example:

```gherkin
Feature: Exclusive resources

 @my-tag-ab-rw
 Scenario: first example
   Given this reads and writes resource a
   And this reads and writes resource b
   When it is executed 
   Then it will not be executed concurrently with the second example

 @my-tag-a-r
 Scenario: second example
   Given this reads resource a
   When it is executed
   Then it will not be executed concurrently with the first example

```

With this configuration:

```
cucumber.execution.exclusive-resources.my-tag-ab-rw.read-write=resource-a,b
cucumber.execution.exclusive-resources.my-tag-a-r.read=a
```

The first scenario tagged with `@my-tag-ab-rw` will lock resource `a` and `b`
with a read-write lock and will not be concurrently executed with the second
scenario that locks resource `a` with a read lock.

Note: The `@` is not included.

Closes: https://github.com/cucumber/cucumber-jvm/issues/1903

![image](https://user-images.githubusercontent.com/6946919/79278570-3c568800-7eac-11ea-9e68-686e9c0a0f7a.png)

In this example the first two scenarios are tagged with a read lock on some resource and execute concurrently, the other scenarios have a read-write lock and execute sequentially. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
