### PR TITLE
[Java8] Fix dependency name typo

### DIFF
--- a/java8/README.md
+++ b/java8/README.md
@@ -1,7 +1,7 @@
 Cucumber Java8
 ==============
 
-Provides annotation based step definitions. To use add the `cucumber-java` dependency to your pom.xml:
+Provides annotation based step definitions. To use add the `cucumber-java8` dependency to your pom.xml:
 
 ```xml
 <dependencies>


### PR DESCRIPTION
The `README.md` for `cucumber-java8` informs the user:

    To use add the `cucumber-java` dependency

...whereas it should say...

    To use add the `cucumber-java8` dependency

That's all this PR fixes :)