### PR TITLE
[Java] Invoke static methods without instantiating target object

### DIFF
--- a/java/src/main/java/io/cucumber/java/AbstractGlueDefinition.java
+++ b/java/src/main/java/io/cucumber/java/AbstractGlueDefinition.java
@@ -4,13 +4,14 @@ import io.cucumber.core.backend.Located;
 import io.cucumber.core.backend.Lookup;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 import static java.util.Objects.requireNonNull;
 
 abstract class AbstractGlueDefinition implements Located {
 
     protected final Method method;
-    protected final Lookup lookup;
+    private final Lookup lookup;
     private String fullFormat;
 
     AbstractGlueDefinition(Method method, Lookup lookup) {
@@ -34,4 +35,12 @@ abstract class AbstractGlueDefinition implements Located {
         }
         return fullFormat;
     }
+
+    final Object invokeMethod(Object... args) {
+        if (Modifier.isStatic(method.getModifiers())) {
+            return Invoker.invokeStatic(this, method, args);
+        }
+        return Invoker.invoke(this, lookup.getInstance(method.getDeclaringClass()), method, args);
+    }
+
 }

--- a/java/src/main/java/io/cucumber/java/Invoker.java
+++ b/java/src/main/java/io/cucumber/java/Invoker.java
@@ -19,8 +19,16 @@ final class Invoker {
         return invoke(null, annotation, expressionMethod);
     }
 
+    static Object invokeStatic(Located located, Method method, Object... args) {
+        return doInvoke(located, null, method, args);
+    }
+
     static Object invoke(Located located, Object target, Method method, Object... args) {
         Method targetMethod = targetMethod(target, method);
+        return doInvoke(located, target, targetMethod, args);
+    }
+
+    private static Object doInvoke(Located located, Object target, Method targetMethod, Object[] args) {
         boolean accessible = targetMethod.isAccessible();
         try {
             targetMethod.setAccessible(true);

--- a/java/src/main/java/io/cucumber/java/JavaDataTableTypeDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaDataTableTypeDefinition.java
@@ -71,28 +71,36 @@ class JavaDataTableTypeDefinition extends AbstractDatatableElementTransformerDef
         if (DataTable.class.equals(parameterType)) {
             return new DataTableType(
                 returnType,
-                (DataTable table) -> execute(replaceEmptyPatternsWithEmptyString(table))
+                (DataTable table) -> invokeMethod(
+                    replaceEmptyPatternsWithEmptyString(table)
+                )
             );
         }
 
         if (List.class.equals(parameterType)) {
             return new DataTableType(
                 returnType,
-                (List<String> row) -> execute(replaceEmptyPatternsWithEmptyString(row))
+                (List<String> row) -> invokeMethod(
+                    replaceEmptyPatternsWithEmptyString(row)
+                )
             );
         }
 
         if (Map.class.equals(parameterType)) {
             return new DataTableType(
                 returnType,
-                (Map<String, String> entry) -> execute(replaceEmptyPatternsWithEmptyString(entry))
+                (Map<String, String> entry) -> invokeMethod(
+                    replaceEmptyPatternsWithEmptyString(entry)
+                )
             );
         }
 
         if (String.class.equals(parameterType)) {
             return new DataTableType(
                 returnType,
-                (String cell) -> execute(replaceEmptyPatternsWithEmptyString(cell))
+                (String cell) -> invokeMethod(
+                    replaceEmptyPatternsWithEmptyString(cell)
+                )
             );
         }
 
@@ -102,10 +110,6 @@ class JavaDataTableTypeDefinition extends AbstractDatatableElementTransformerDef
     @Override
     public DataTableType dataTableType() {
         return dataTableType;
-    }
-
-    private Object execute(Object arg) {
-        return Invoker.invoke(this, lookup.getInstance(method.getDeclaringClass()), method, arg);
     }
 
 }

--- a/java/src/main/java/io/cucumber/java/JavaDefaultDataTableCellTransformerDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaDefaultDataTableCellTransformerDefinition.java
@@ -16,7 +16,7 @@ class JavaDefaultDataTableCellTransformerDefinition extends AbstractDatatableEle
     JavaDefaultDataTableCellTransformerDefinition(Method method, Lookup lookup, String[] emptyPatterns) {
         super(requireValidMethod(method), lookup, emptyPatterns);
         this.transformer = (cellValue, toValueType) ->
-            execute(replaceEmptyPatternsWithEmptyString(cellValue), toValueType);
+            invokeMethod(replaceEmptyPatternsWithEmptyString(cellValue), toValueType);
     }
 
     private static Method requireValidMethod(Method method) {
@@ -52,10 +52,6 @@ class JavaDefaultDataTableCellTransformerDefinition extends AbstractDatatableEle
     @Override
     public TableCellByTypeTransformer tableCellByTypeTransformer() {
         return transformer;
-    }
-
-    private Object execute(String fromValue, Type toValueType) {
-        return Invoker.invoke(this, lookup.getInstance(method.getDeclaringClass()), method, fromValue, toValueType);
     }
 
 }

--- a/java/src/main/java/io/cucumber/java/JavaDefaultDataTableEntryTransformerDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaDefaultDataTableEntryTransformerDefinition.java
@@ -98,7 +98,7 @@ class JavaDefaultDataTableEntryTransformerDefinition extends AbstractDatatableEl
         } else {
             args = new Object[]{fromValue, toValueType};
         }
-        return Invoker.invoke(this, lookup.getInstance(method.getDeclaringClass()), method, args);
+        return invokeMethod(args);
     }
 
 }

--- a/java/src/main/java/io/cucumber/java/JavaDocStringTypeDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaDocStringTypeDefinition.java
@@ -18,7 +18,7 @@ class JavaDocStringTypeDefinition extends AbstractGlueDefinition implements DocS
         this.docStringType = new DocStringType(
             this.method.getReturnType(),
             contentType.isEmpty() ? method.getName() : contentType,
-            this::execute
+            this::invokeMethod
         );
     }
 
@@ -48,11 +48,6 @@ class JavaDocStringTypeDefinition extends AbstractGlueDefinition implements DocS
             .addSignature("public JsonNode json(String content)")
             .addNote("Note: JsonNode is an example of the class you want to convert content to")
             .build();
-    }
-
-
-    private Object execute(String content) {
-        return Invoker.invoke(this, lookup.getInstance(method.getDeclaringClass()), method, content);
     }
 
     @Override

--- a/java/src/main/java/io/cucumber/java/JavaHookDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaHookDefinition.java
@@ -13,13 +13,11 @@ final class JavaHookDefinition extends AbstractGlueDefinition implements HookDef
 
     private final String tagExpression;
     private final int order;
-    private final Lookup lookup;
 
     JavaHookDefinition(Method method, String tagExpression, int order, Lookup lookup) {
         super(requireValidMethod(method), lookup);
         this.tagExpression = requireNonNull(tagExpression, "tag-expression may not be null");
         this.order = order;
-        this.lookup = lookup;
     }
 
     private static Method requireValidMethod(Method method) {
@@ -58,7 +56,7 @@ final class JavaHookDefinition extends AbstractGlueDefinition implements HookDef
             args = new Object[0];
         }
 
-        Invoker.invoke(this, lookup.getInstance(method.getDeclaringClass()), method, args);
+        invokeMethod(args);
     }
 
     @Override

--- a/java/src/main/java/io/cucumber/java/JavaParameterTypeDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaParameterTypeDefinition.java
@@ -78,7 +78,7 @@ class JavaParameterTypeDefinition extends AbstractGlueDefinition implements Para
             args = captureGroups;
         }
 
-        return Invoker.invoke(this, lookup.getInstance(method.getDeclaringClass()), method, args);
+        return invokeMethod(args);
     }
 
 }

--- a/java/src/main/java/io/cucumber/java/JavaStepDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaStepDefinition.java
@@ -10,8 +10,8 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 final class JavaStepDefinition extends AbstractGlueDefinition implements StepDefinition {
-    private final String expression;
 
+    private final String expression;
     private final List<ParameterInfo> parameterInfos;
 
     JavaStepDefinition(Method method,
@@ -24,7 +24,7 @@ final class JavaStepDefinition extends AbstractGlueDefinition implements StepDef
 
     @Override
     public void execute(Object[] args) {
-        Invoker.invoke(this, lookup.getInstance(method.getDeclaringClass()), method, args);
+        invokeMethod(args);
     }
 
     @Override

--- a/java/src/test/java/io/cucumber/java/JavaDataTableTypeDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDataTableTypeDefinitionTest.java
@@ -25,6 +25,13 @@ class JavaDataTableTypeDefinitionTest {
         }
     };
 
+    private final Lookup lookupForStaticMethod = new Lookup() {
+        @Override
+        public <T> T getInstance(Class<T> glueClass) {
+            throw new IllegalArgumentException("should not be invoked");
+        }
+    };
+
     private final DataTable dataTable = DataTable.create(asList(
         asList("a", "b"),
         asList("c", "d")
@@ -171,5 +178,18 @@ class JavaDataTableTypeDefinitionTest {
     public String converts_map_of_objects_to_string(Map<Object, Object> entry) {
         return "converts_map_of_objects_to_string=" + entry;
     }
+
+    @Test
+    void static_methods_are_invoked_without_a_body() throws NoSuchMethodException {
+        Method method = JavaDataTableTypeDefinitionTest.class.getMethod("static_convert_data_table_to_string", DataTable.class);
+        JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookupForStaticMethod, new String[0]);
+        assertThat(definition.dataTableType().transform(dataTable.asLists()), is("static_convert_data_table_to_string=[[a, b], [c, d]]"));
+    }
+
+    public static String static_convert_data_table_to_string(DataTable table) {
+        return "static_convert_data_table_to_string=" + table.cells();
+    }
+
+
 
 }


### PR DESCRIPTION
Allows glue annotations to be used on static methods. This allows for
example `@DataTableType` to be used on the type it creates.

```

public class TestBean {
    private String stringOne;
    private String stringTwo;

    [...]

    @DataTableType
    public static TestBean makeTestBean(Map<String, String> row) {
        return new TestBean(
                row.get("ItemOne"),
                row.get("ItemTwo")
        );
    }
}
```

Fixes #1950

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
