### PR TITLE
[Core] Include all fields in JsonFormatters failure feature

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -137,6 +137,33 @@
                     </archive>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>io.cucumber:gherkin</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>gherkin</pattern>
+                                    <shadedPattern>io.cucumber.core.internal.gherkin</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/core/src/main/java/io/cucumber/core/stepexpression/StepExpressionFactory.java
+++ b/core/src/main/java/io/cucumber/core/stepexpression/StepExpressionFactory.java
@@ -102,7 +102,7 @@ public final class StepExpressionFactory {
     private CucumberException registerTypeInConfiguration(String expressionString, UndefinedParameterTypeException e) {
         return new CucumberException(format("" +
                 "Could not create a cucumber expression for '%s'.\n" +
-                "It appears you did not register parameter type.",
+                "It appears you did not register a parameter type.",
             expressionString
         ), e);
     }

--- a/core/src/test/java/io/cucumber/core/stepexpression/StepExpressionFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/stepexpression/StepExpressionFactoryTest.java
@@ -97,7 +97,7 @@ class StepExpressionFactoryTest {
         );
         assertThat(exception.getMessage(), is("" +
             "Could not create a cucumber expression for 'Given a {unknownParameterType}'.\n" +
-            "It appears you did not register parameter type."
+            "It appears you did not register a parameter type."
 
         ));
         assertThat(events, iterableWithSize(1));


### PR DESCRIPTION
Consumers of the json output expect all fields to be present. To avoid
breaking consumers we include all fields in the dummy feature that is
generated when cucumber fails to execute.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
