### PR TITLE
[Core] Deprecate multiple tag arguments in @CucumberOptions

### DIFF
--- a/core/src/main/java/io/cucumber/core/options/CucumberOptionsAnnotationParser.java
+++ b/core/src/main/java/io/cucumber/core/options/CucumberOptionsAnnotationParser.java
@@ -4,6 +4,8 @@ import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.feature.FeatureWithLines;
 import io.cucumber.core.feature.GluePath;
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
 import io.cucumber.core.snippets.SnippetType;
 
 import java.nio.file.Path;
@@ -15,6 +17,9 @@ import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME_PREFIX
 import static java.util.Objects.requireNonNull;
 
 public final class CucumberOptionsAnnotationParser {
+
+    private final Logger log = LoggerFactory.getLogger(CucumberOptionsAnnotationParser.class);
+
     private boolean featuresSpecified = false;
     private boolean overridingGlueSpecified = false;
     private OptionsProvider optionsProvider;
@@ -87,8 +92,15 @@ public final class CucumberOptionsAnnotationParser {
     }
 
     private void addTags(CucumberOptions options, RuntimeOptionsBuilder args) {
-        for (String tags : options.tags()) {
-            args.addTagFilter(tags);
+        String[] tags = options.tags();
+        if (tags.length > 1) {
+            log.warn(() -> "" +
+                "Passing multiple tags through @CucumberOptions is deprecated.\n" +
+                "Please use a single tag expressions e.g: @CucumberOptions(tags=\"(@cucumber or @pickle) and not @salad\")"
+            );
+        }
+        for (String tagExpression : tags) {
+            args.addTagFilter(tagExpression);
         }
     }
 


### PR DESCRIPTION
Passing multiple tags through `@CucumberOptions` has confusing
semantics. Using a single tag expressions clears up any confusion and
harmonizes `@CucumberOptions` with `cucumber.filter.tags`.

For example:
```java
@CucumberOptions(tags="(@cucumber or @pickle) and not @salad")
```
```properties
cucumber.filter.tags="(@cucumber or @pickle) and not @salad"
```
Partial fix for: #1948
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).