### PR TITLE
[Core] fix for DefaultSummaryPrinterTest on Windows

### DIFF
--- a/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
@@ -16,8 +16,8 @@ import java.util.UUID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Instant.ofEpochSecond;
 import static java.util.Collections.singletonList;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.text.IsEqualCompressingWhiteSpace.equalToCompressingWhiteSpace;
 
 class DefaultSummaryPrinterTest {
 

--- a/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
@@ -27,7 +27,6 @@ class DefaultSummaryPrinterTest {
         Clock.fixed(ofEpochSecond(0), ZoneId.of("UTC")),
         UUID::randomUUID
     );
-    private final String LINE_ENDING = System.lineSeparator();
 
     @BeforeEach
     void setup() {
@@ -56,18 +55,18 @@ class DefaultSummaryPrinterTest {
             bus.getInstant()
         ));
 
-        assertThat(new String(out.toByteArray(), UTF_8), is("" +
-            LINE_ENDING +
-            "0 Scenarios" + LINE_ENDING +
-            "0 Steps" + LINE_ENDING +
-            "0m0.000s" + LINE_ENDING +
-            LINE_ENDING +
-                LINE_ENDING +
-            "You can implement missing steps with the snippets below:" + LINE_ENDING +
-            LINE_ENDING +
-            "snippet" + LINE_ENDING +
-            LINE_ENDING +
-            LINE_ENDING
+        assertThat(new String(out.toByteArray(), UTF_8), equalToCompressingWhiteSpace("" +
+            "\n" +
+            "0 Scenarios\n" +
+            "0 Steps\n" +
+            "0m0.000s\n" +
+            "\n" +
+            "\n" +
+            "You can implement missing steps with the snippets below:\n" +
+            "\n" +
+            "snippet\n" +
+            "\n" +
+            "\n"
         ));
 
     }

--- a/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
@@ -27,6 +27,7 @@ class DefaultSummaryPrinterTest {
         Clock.fixed(ofEpochSecond(0), ZoneId.of("UTC")),
         UUID::randomUUID
     );
+    private final String LINE_ENDING = System.lineSeparator();
 
     @BeforeEach
     void setup() {
@@ -56,17 +57,17 @@ class DefaultSummaryPrinterTest {
         ));
 
         assertThat(new String(out.toByteArray(), UTF_8), is("" +
-            "\n" +
-            "0 Scenarios\n" +
-            "0 Steps\n" +
-            "0m0.000s\n" +
-            "\n" +
-            "\n" +
-            "You can implement missing steps with the snippets below:\n" +
-            "\n" +
-            "snippet\n" +
-            "\n" +
-            "\n"
+            LINE_ENDING +
+            "0 Scenarios" + LINE_ENDING +
+            "0 Steps" + LINE_ENDING +
+            "0m0.000s" + LINE_ENDING +
+            LINE_ENDING +
+                LINE_ENDING +
+            "You can implement missing steps with the snippets below:" + LINE_ENDING +
+            LINE_ENDING +
+            "snippet" + LINE_ENDING +
+            LINE_ENDING +
+            LINE_ENDING
         ));
 
     }


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Fix for the test DefaultSummaryPrinterTest which assumed LF only line endings but fails on Windows

## Details

Used System.lineSeparator() to determine the line ending to use in the expectation.

## Motivation and Context

The test fails on Windows.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->
The change is in a test.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
The change is local to one unit test.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue).
https://github.com/cucumber/cucumber-jvm/issues/1956
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I've added tests for my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
