### PR TITLE
[Spring] Note that CucumberContextConfiguration is glue

### DIFF
--- a/spring/README.md
+++ b/spring/README.md
@@ -22,7 +22,7 @@ Add the `cucumber-spring` dependency to your `pom.xml`:
 ## Configuring the Test Application Context
 
 To make Cucumber aware of your test configuration you can annotate a
-configuration class with `@CucumberContextConfiguration` and with one of the
+configuration class on your glue path with `@CucumberContextConfiguration` and with one of the
 following annotations: `@ContextConfiguration`, `@ContextHierarchy` or
 `@BootstrapWith`. If you are using SpringBoot, you can annotate configuration
 class with `@SpringBootTest`.


### PR DESCRIPTION
With the recent deprecation of the use of `cucumber.xml` I migrated a project over to use the new CucumberContextConfiguration. In doing so I found a small gap in the docs - it's assumed that the config class annotated with `@ CucumberContextConfiguration` will be on the glue path. In my project I set the `cucumber.glue` option to point at a particular package, and since  my new CucumberContextConfiguration class wasn't initially on the glue path I was getting the following error:

```
io.cucumber.core.backend.CucumberBackendException: Error creating bean with name 'com.example.foobar.glue.Steps': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.example.foobar.glue.Steps]: No default constructor found; nested exception is java.lang.NoSuchMethodException: com.example.foobar.glue.Steps.<init>()
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'com.example.foobar.glue.Steps': Instantiation of bean failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.example.foobar.glue.Steps]: No default constructor found; nested exception is java.lang.NoSuchMethodException: com.example.foobar.glue.Steps.<init>()
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.example.foobar.glue.Steps]: No default constructor found; nested exception is java.lang.NoSuchMethodException: com.example.foobar.glue.Steps.<init>()
Caused by: java.lang.NoSuchMethodException: com.example.foobar.glue.Steps.<init>()
```

(`No default constructor found` because I'm using constructor injection)

The solution was to move the class annotated with `@CucumberContextConfiguration` to somewhere on the `cucumber.glue` path. As such, I've added a mention of this necessity to the spring readme. Hopefully it'll save others similar confusion :)
