### PR TITLE
[Build] Automatically format code with spotless

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ end_of_line = lf
 charset = utf-8
 insert_final_newline = true
 
-[*.{java, xml}]
+[*.xml]
 indent_style = space
 indent_size = 4
 

--- a/.spotless/eclipse-formatter-settings.xml
+++ b/.spotless/eclipse-formatter-settings.xml
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="18">
+    <profile kind="CodeFormatterProfile" name="Cucumber" version="18">
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_before_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_switch_case_expressions" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="48"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_multiplicative_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_logical_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_annotation_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_loop_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_abstract_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_type_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_additive_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiplicative_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_switch_case_expressions" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_shift_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_relational_operator" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_after_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_if_then_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_default" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_between_different_tags" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression_chain" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_additive_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_shift_operator" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_bitwise_operator" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_code_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_bitwise_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_not_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="separate_lines_if_wrapped"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_lambda_body_block_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_logical_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_bitwise_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_relational_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_tag_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_string_concatenation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_logical_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_statement_group_in_switch" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_shift_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_enum_declaration_on_one_line" value="one_line_never"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_multiplicative_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_additive_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_string_concatenation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_code_block" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_relational_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_string_concatenation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+    </profile>
+</profiles>

--- a/.spotless/intelij-idea.importorder
+++ b/.spotless/intelij-idea.importorder
@@ -1,0 +1,6 @@
+# Organize import order using Intelij IDEA defaults
+# Escaped hashes sort static methods last: https://github.com/diffplug/spotless/issues/306
+1=
+2=javax
+3=java
+4=\#

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
     # 1.2 Tests
     - stage: test
       jdk: openjdk11
-      script: mvn verify --toolchains .m2/travis-ci-toolchains.xml
+      script: mvn verify -P-spotless-apply --toolchains .m2/travis-ci-toolchains.xml
       env: VERIFY=true
 
       # 1.3 Coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,37 @@
 ## About to contribute?
 
-We appreciate that. But before you do, please learn our basic rules:
+We appreciate that. Do keep the following in mind: 
 
-* This is not a support or discussion forum. If you have a question, please ask
-  it on [The Cukes Google Group](http://groups.google.com/group/cukes).
-* Do you have a feature request? Then don't expect it to be implemented unless
-  you or someone else sends a [pull request](https://help.github.com/articles/using-pull-requests).
-* Reporting a bug? We need to know what java/ruby/node.js etc. runtime you have,
-  and what jar/gem/npm package versions you are using. Bugs with 
-  [pull requests](https://help.github.com/articles/using-pull-requests) get
-  fixed quicker. Some bugs may never be fixed.
-* You have to tell us how to reproduce a bug. Bonus point for a 
-  [pull request](https://help.github.com/articles/using-pull-requests) with a
-  failing test that reproduces the bug.
-* Want to paste some code or output? Put \`\`\` on a line above and below your 
-  code/output. See 
-  [Github Flavored Markdown](https://help.github.com/articles/github-flavored-markdown)'s 
-  *Fenced Code Blocks* for details.
-* We love [pull requests](https://help.github.com/articles/using-pull-requests), 
-  but if you don't have a test to go with it we probably won't merge it.
 * Before making significant contribution consider discussing the outline of 
   your solution first. This may avoid a duplication of efforts.
+* When you send a [pull requests](https://help.github.com/articles/using-pull-requests), 
+  please include tests to go along with it.
+* Want to paste some code or output? Put \`\`\` on a line above and below your 
+  code/output. See [Github Flavored Markdown](https://help.github.com/articles/github-flavored-markdown)'s 
+  *Fenced Code Blocks* for details.
+
+## Formatting Java
+
+To automatically format the java source code run
+
+```
+mvn spotless:apply
+```
+
+To configure Intelij IDEA/Eclipse use the configuration files in `.spotless/`.
+
+## Formatting XML, Gherkin, ect
+
+* UTF-8 file encoding <sup>+</sup>
+* LF (UNIX) line endings <sup>+</sup>
+* 4 Space indent (no tabs) <sup>+</sup>
+  * XML
+  * Java
+* 2 Space indent (no tabs) <sup>+</sup>
+  * Gherkin
+
+`+` These are set automatically if you use an editor/IDE that supports 
+[EditorConfig](http://editorconfig.org/#download).
 
 ## Building Cucumber-JVM
 
@@ -52,28 +63,3 @@ the appropriate file extension for that language as well.
 ### Eclipse
 
 Just load the root `pom.xml`
-
-## Contributing
-
-To contribute to Cucumber-JVM you need a JDK, Maven and Git to get the code. You
-also need to set your IDE/text editor to use:
-
-* UTF-8 file encoding <sup>+</sup>
-* LF (UNIX) line endings <sup>+</sup>
-* No wildcard imports
-* Curly brace on same line as block
-* 4 Space indent (no tabs) <sup>+</sup>
-  * Java
-  * XML
-* 2 Space indent (no tabs) <sup>+</sup>
-  * Gherkin
-
-`+` These are set automatically if you use an editor/IDE that supports 
-[EditorConfig](http://editorconfig.org/#download).
-
-Please do *not* add @author tags - this project embraces collective code 
-ownership. If you want to know who wrote some code, look in git. When you are
-done, send a [pull request](http://help.github.com/send-pull-requests/).
-If we get a pull request where an entire file is changed because of 
-insignificant whitespace changes we cannot see what you have changed, and your
-contribution might get rejected.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Cucumber-JVM also integrates with all the popular
 Please ask on 
  * [The Cukes Google Group](http://groups.google.com/group/cukes).
  * [CucumberBDD Slack](https://cucumberbdd-slack-invite.herokuapp.com/) <sup>[direct link](https://cucumberbdd.slack.com/)</sup>
+
 ## Bugs and Feature requests
 
 You can register bugs and feature requests in the 

--- a/cdi2/src/main/java/io/cucumber/cdi2/Cdi2Factory.java
+++ b/cdi2/src/main/java/io/cucumber/cdi2/Cdi2Factory.java
@@ -6,7 +6,9 @@ import org.apiguardian.api.API;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.se.SeContainer;
 import javax.enterprise.inject.se.SeContainerInitializer;
+import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Unmanaged;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,7 +59,9 @@ public final class Cdi2Factory implements ObjectFactory {
         }
         final Instance<T> selected = container.select(type);
         if (selected.isUnsatisfied()) {
-            final Unmanaged.UnmanagedInstance<T> value = new Unmanaged<>(container.getBeanManager(), type).newInstance();
+            BeanManager beanManager = container.getBeanManager();
+            Unmanaged<T> unmanaged = new Unmanaged<>(beanManager, type);
+            Unmanaged.UnmanagedInstance<T> value = unmanaged.newInstance();
             value.produce();
             value.inject();
             value.postConstruct();

--- a/cdi2/src/test/java/io/cucumber/cdi2/Cdi2FactoryTest.java
+++ b/cdi2/src/test/java/io/cucumber/cdi2/Cdi2FactoryTest.java
@@ -23,10 +23,10 @@ class Cdi2FactoryTest {
         factory.start();
         final BellyStepDefinitions o1 = factory.getInstance(BellyStepDefinitions.class);
         final CdiBellyStepDefinitions cdiStep = factory.getInstance(CdiBellyStepDefinitions.class);
-        assertAll("Checking CDIBellyStepdefs",
-            () -> assertThat(cdiStep.getClass(), not(is(CdiBellyStepDefinitions.class))), // it is a CDI proxy
-            () -> assertThat(cdiStep.getClass().getSuperclass(), is(CdiBellyStepDefinitions.class))
-        );
+        assertAll(
+            // assert that it is is a CDI proxy
+            () -> assertThat(cdiStep.getClass(), not(is(CdiBellyStepDefinitions.class))),
+            () -> assertThat(cdiStep.getClass().getSuperclass(), is(CdiBellyStepDefinitions.class)));
         factory.stop();
 
         // Scenario 2
@@ -34,11 +34,10 @@ class Cdi2FactoryTest {
         final BellyStepDefinitions o2 = factory.getInstance(BellyStepDefinitions.class);
         factory.stop();
 
-        assertAll("Checking BellyStepdefs",
+        assertAll(
             () -> assertThat(o1, is(notNullValue())),
             () -> assertThat(o1, is(not(equalTo(o2)))),
-            () -> assertThat(o2, is(not(equalTo(o1))))
-        );
+            () -> assertThat(o2, is(not(equalTo(o1)))));
     }
 
 }

--- a/compatibility/src/test/java/io/cucumber/compatibility/CompatibilityTest.java
+++ b/compatibility/src/test/java/io/cucumber/compatibility/CompatibilityTest.java
@@ -44,17 +44,16 @@ public class CompatibilityTest {
 
         try {
             Runtime.builder()
-                .withRuntimeOptions(new RuntimeOptionsBuilder()
-                    .addGlue(testCase.getGlue())
-                    .addFeature(testCase.getFeature())
-                    .build())
-                .withAdditionalPlugins(
-                    new MessageFormatter(new FileOutputStream(outputNdjson)),
-                    new HtmlFormatter(new FileOutputStream(outputHtml)),
-                    new JsonFormatter(new FileOutputStream(outputJson))
-                )
-                .build()
-                .run();
+                    .withRuntimeOptions(new RuntimeOptionsBuilder()
+                            .addGlue(testCase.getGlue())
+                            .addFeature(testCase.getFeature())
+                            .build())
+                    .withAdditionalPlugins(
+                        new MessageFormatter(new FileOutputStream(outputNdjson)),
+                        new HtmlFormatter(new FileOutputStream(outputHtml)),
+                        new JsonFormatter(new FileOutputStream(outputJson)))
+                    .build()
+                    .run();
         } catch (Exception ignored) {
 
         }
@@ -65,12 +64,13 @@ public class CompatibilityTest {
         Map<String, List<GeneratedMessageV3>> expectedEnvelopes = openEnvelopes(expected);
         Map<String, List<GeneratedMessageV3>> actualEnvelopes = openEnvelopes(actual);
 
-        // exception: Java step definitions are not in a predictable order because
-        // Class#getMethods() does not return a predictable order.
+        // exception: Java step definitions are not in a predictable order
+        // because Class#getMethods() does not return a predictable order.
         sortStepDefinitions(expectedEnvelopes);
         sortStepDefinitions(actualEnvelopes);
 
-        // exception: Cucumber JVM can't execute when there are unknown-parameter-types
+        // exception: Cucumber JVM can't execute when there are
+        // unknown-parameter-types
         if ("unknown-parameter-type".equals(testCase.getId())) {
             expectedEnvelopes.remove("testCase");
             expectedEnvelopes.remove("testCaseStarted");
@@ -79,19 +79,16 @@ public class CompatibilityTest {
             expectedEnvelopes.remove("testCaseFinished");
         }
 
-        expectedEnvelopes.forEach((messageType, expectedMessages) ->
-            assertThat(
-                actualEnvelopes,
-                hasEntry(is(messageType), containsInRelativeOrder(aComparableMessage(expectedMessages)))
-            )
-        );
+        expectedEnvelopes.forEach((messageType, expectedMessages) -> assertThat(
+            actualEnvelopes,
+            hasEntry(is(messageType), containsInRelativeOrder(aComparableMessage(expectedMessages)))));
     }
 
     private static List<Messages.Envelope> readAllMessages(Path output) throws IOException {
         List<Messages.Envelope> expectedEnvelopes = new ArrayList<>();
         InputStream input = Files.newInputStream(output);
         new NdjsonToMessageIterable(input)
-            .forEach(expectedEnvelopes::add);
+                .forEach(expectedEnvelopes::add);
         return expectedEnvelopes;
     }
 
@@ -99,11 +96,11 @@ public class CompatibilityTest {
     private static <T> Map<String, List<T>> openEnvelopes(List<? extends GeneratedMessageV3> actual) {
         Map<String, List<T>> map = new LinkedHashMap<>();
         actual.forEach(envelope -> envelope.getAllFields()
-            .forEach((fieldDescriptor, value) -> {
-                String jsonName = fieldDescriptor.getJsonName();
-                map.putIfAbsent(jsonName, new ArrayList<>());
-                map.get(jsonName).add((T) value);
-            }));
+                .forEach((fieldDescriptor, value) -> {
+                    String jsonName = fieldDescriptor.getJsonName();
+                    map.putIfAbsent(jsonName, new ArrayList<>());
+                    map.get(jsonName).add((T) value);
+                }));
         return map;
     }
 
@@ -119,10 +116,10 @@ public class CompatibilityTest {
         }
     }
 
-    private static List<Matcher<? super GeneratedMessageV3>> aComparableMessage(List<GeneratedMessageV3> expectedMessages) {
-        return expectedMessages.stream()
-            .map(AComparableMessage::new)
-            .collect(Collectors.toList());
+    private static List<Matcher<? super GeneratedMessageV3>> aComparableMessage(List<GeneratedMessageV3> messages) {
+        return messages.stream()
+                .map(AComparableMessage::new)
+                .collect(Collectors.toList());
     }
 
 }

--- a/compatibility/src/test/java/io/cucumber/compatibility/attachments/Attachments.java
+++ b/compatibility/src/test/java/io/cucumber/compatibility/attachments/Attachments.java
@@ -46,7 +46,6 @@ public class Attachments {
         scenario.attach(bytes, mediaType, null);
     }
 
-
     @When("a JPEG image is attached")
     public void aJPEGImageIsAttached() throws IOException {
         Path path = Paths.get("src/test/resources/features/attachments/cucumber-growing-on-vine.jpg");

--- a/compatibility/src/test/java/io/cucumber/compatibility/matchers/AComparableMessage.java
+++ b/compatibility/src/test/java/io/cucumber/compatibility/matchers/AComparableMessage.java
@@ -50,7 +50,8 @@ public class AComparableMessage extends TypeSafeDiagnosingMatcher<GeneratedMessa
                     expected.add(hasEntry(is(fieldName), isA(expectedValue.getClass())));
                     break;
 
-                // exception: the CCK expects source references but java can not provide them
+                // exception: the CCK expects source references but java can not
+                // provide them
                 case "sourceReference":
                     expected.add(not(hasKey(is(fieldName))));
                     break;
@@ -64,6 +65,8 @@ public class AComparableMessage extends TypeSafeDiagnosingMatcher<GeneratedMessa
                 case "testCaseId":
                 case "testStepId":
                 case "testCaseStartedId":
+                    expected.add(hasEntry(is(fieldName), isA(String.class)));
+                    break;
                 // exception: protocolVersion can vary
                 case "protocolVersion":
                     expected.add(hasEntry(is(fieldName), isA(String.class)));
@@ -76,6 +79,9 @@ public class AComparableMessage extends TypeSafeDiagnosingMatcher<GeneratedMessa
                 // exception: timestamps and durations are not predictable
                 case "timestamp":
                 case "duration":
+                    expected.add(hasEntry(is(fieldName), isA(expectedValue.getClass())));
+                    break;
+
                 // exception: Mata fields depend on the platform
                 case "implementation":
                 case "runtime":
@@ -101,9 +107,9 @@ public class AComparableMessage extends TypeSafeDiagnosingMatcher<GeneratedMessa
         if (value instanceof List) {
             List<?> values = (List<?>) value;
             List<Matcher<? super Object>> allComparableValues = values.stream()
-                .map(o -> aComparableValue(o, depth))
-                .map(o -> (Matcher<? super Object>) o)
-                .collect(Collectors.toList());
+                    .map(o -> aComparableValue(o, depth))
+                    .map(o -> (Matcher<? super Object>) o)
+                    .collect(Collectors.toList());
             return contains(allComparableValues);
         }
 
@@ -145,10 +151,10 @@ public class AComparableMessage extends TypeSafeDiagnosingMatcher<GeneratedMessa
     private static Map<String, Object> asMapOfJsonNameToField(GeneratedMessageV3 envelope) {
         Map<String, Object> map = new LinkedHashMap<>();
         envelope.getAllFields()
-            .forEach((fieldDescriptor, value) -> {
-                String jsonName = fieldDescriptor.getJsonName();
-                map.put(jsonName, value);
-            });
+                .forEach((fieldDescriptor, value) -> {
+                    String jsonName = fieldDescriptor.getJsonName();
+                    map.put(jsonName, value);
+                });
         return map;
     }
 

--- a/core/src/main/java/cucumber/api/cli/Main.java
+++ b/core/src/main/java/cucumber/api/cli/Main.java
@@ -19,9 +19,11 @@ public class Main {
     /**
      * Launches the Cucumber-JVM command line.
      *
-     * @param argv        runtime options. See details in the {@code io.cucumber.core.options.Usage.txt} resource.
-     * @param classLoader classloader used to load the runtime
-     * @return 0 if execution was successful, 1 if it was not (test failures)
+     * @param  argv        runtime options. See details in the
+     *                     {@code io.cucumber.core.options.Usage.txt} resource.
+     * @param  classLoader classloader used to load the runtime
+     * @return             0 if execution was successful, 1 if it was not (test
+     *                     failures)
      */
     public static byte run(String[] argv, ClassLoader classLoader) {
         log.warn(() -> "You are using deprecated Main class. Please use io.cucumber.core.cli.Main");

--- a/core/src/main/java/io/cucumber/core/api/TypeRegistry.java
+++ b/core/src/main/java/io/cucumber/core/api/TypeRegistry.java
@@ -9,7 +9,8 @@ import io.cucumber.docstring.DocStringType;
 import org.apiguardian.api.API;
 
 /**
- * The type registry records defines parameter types, data table types and docstring transformers.
+ * The type registry records defines parameter types, data table types and
+ * docstring transformers.
  */
 @API(status = API.Status.STABLE)
 public interface TypeRegistry {

--- a/core/src/main/java/io/cucumber/core/api/TypeRegistryConfigurer.java
+++ b/core/src/main/java/io/cucumber/core/api/TypeRegistryConfigurer.java
@@ -5,18 +5,22 @@ import org.apiguardian.api.API;
 import java.util.Locale;
 
 /**
- * The type registry configurer allows to configure a new type registry and the locale.
+ * The type registry configurer allows to configure a new type registry and the
+ * locale.
  *
- * @deprecated Please use annotation based configuration.
- * See <a href="https://github.com/cucumber/cucumber-jvm/blob/master/examples/java-calculator/src/test/java/io/cucumber/examples/java/ShoppingSteps.java">Annotation based example</a>
- * See <a href="https://github.com/cucumber/cucumber-jvm/blob/master/examples/java8-calculator/src/test/java/io/cucumber/examples/java8/ShoppingSteps.java">Lambda based example</a>
+ * @deprecated Please use annotation based configuration. See <a href=
+ *             "https://github.com/cucumber/cucumber-jvm/blob/master/examples/java-calculator/src/test/java/io/cucumber/examples/java/ShoppingSteps.java">Annotation
+ *             based example</a> See <a href=
+ *             "https://github.com/cucumber/cucumber-jvm/blob/master/examples/java8-calculator/src/test/java/io/cucumber/examples/java8/ShoppingSteps.java">Lambda
+ *             based example</a>
  */
 @API(status = API.Status.STABLE)
 @Deprecated
 public interface TypeRegistryConfigurer {
 
     /**
-     * @return The locale to use, or null when language from feature file should be used.
+     * @return The locale to use, or null when language from feature file should
+     *         be used.
      */
     default Locale locale() {
         return null;

--- a/core/src/main/java/io/cucumber/core/backend/Backend.java
+++ b/core/src/main/java/io/cucumber/core/backend/Backend.java
@@ -9,7 +9,8 @@ import java.util.List;
 public interface Backend {
 
     /**
-     * Invoked once before all features. This is where steps and hooks should be loaded.
+     * Invoked once before all features. This is where steps and hooks should be
+     * loaded.
      *
      * @param glue      Glue that provides the steps to be executed.
      * @param gluePaths The locations for the glue to be loaded.
@@ -17,10 +18,10 @@ public interface Backend {
     void loadGlue(Glue glue, List<URI> gluePaths);
 
     /**
-     * Invoked before a new scenario starts. Implementations should do any necessary
-     * setup of new, isolated state here. Additional scenario scoped step definitions
-     * can be loaded here. These step definitions should implement
-     * {@link ScenarioScoped}
+     * Invoked before a new scenario starts. Implementations should do any
+     * necessary setup of new, isolated state here. Additional scenario scoped
+     * step definitions can be loaded here. These step definitions should
+     * implement {@link ScenarioScoped}
      */
     void buildWorld();
 

--- a/core/src/main/java/io/cucumber/core/backend/Container.java
+++ b/core/src/main/java/io/cucumber/core/backend/Container.java
@@ -10,8 +10,8 @@ public interface Container {
      * <p>
      * Invoked after creation but before {@link ObjectFactory#start()}.
      *
-     * @param glueClass glue class to add to the text context.
-     * @return should always return true, should be ignored.
+     * @param  glueClass glue class to add to the text context.
+     * @return           should always return true, should be ignored.
      */
     boolean addClass(Class<?> glueClass);
 

--- a/core/src/main/java/io/cucumber/core/backend/CucumberBackendException.java
+++ b/core/src/main/java/io/cucumber/core/backend/CucumberBackendException.java
@@ -2,7 +2,6 @@ package io.cucumber.core.backend;
 
 import org.apiguardian.api.API;
 
-
 /**
  * Thrown when the backend could not invoke some glue code. Not to be confused
  * with {@link CucumberInvocationTargetException} which is thrown when the glue

--- a/core/src/main/java/io/cucumber/core/backend/CucumberInvocationTargetException.java
+++ b/core/src/main/java/io/cucumber/core/backend/CucumberInvocationTargetException.java
@@ -6,8 +6,8 @@ import java.lang.reflect.InvocationTargetException;
 
 /**
  * Thrown when an exception was thrown by glue code. Not to be confused with
- * {@link CucumberBackendException} which is thrown when the backend failed
- * to invoke the glue.
+ * {@link CucumberBackendException} which is thrown when the backend failed to
+ * invoke the glue.
  */
 @API(status = API.Status.STABLE)
 public final class CucumberInvocationTargetException extends RuntimeException {

--- a/core/src/main/java/io/cucumber/core/backend/Glue.java
+++ b/core/src/main/java/io/cucumber/core/backend/Glue.java
@@ -21,7 +21,9 @@ public interface Glue {
 
     void addDefaultParameterTransformer(DefaultParameterTransformerDefinition defaultParameterTransformer);
 
-    void addDefaultDataTableEntryTransformer(DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer);
+    void addDefaultDataTableEntryTransformer(
+            DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer
+    );
 
     void addDefaultDataTableCellTransformer(DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer);
 

--- a/core/src/main/java/io/cucumber/core/backend/Located.java
+++ b/core/src/main/java/io/cucumber/core/backend/Located.java
@@ -6,9 +6,9 @@ import org.apiguardian.api.API;
 public interface Located {
 
     /**
-     * @param stackTraceElement The location of the step.
-     * @return Return true if this matches the location. This is used to filter
-     * stack traces.
+     * @param  stackTraceElement The location of the step.
+     * @return                   Return true if this matches the location. This
+     *                           is used to filter stack traces.
      */
     boolean isDefinedAt(StackTraceElement stackTraceElement);
 
@@ -18,8 +18,10 @@ public interface Located {
      * <p>
      * Examples:
      * <ul>
-     *  <li> @{code com.example.StepDefinitions.given_an_example(io.cucumber.datatable.DataTable)}</li>
-     *  <li> @{code com.example.StepDefinitions.<init>(StepDefinitions.java:9)}</li>
+     * <li>@{code
+     * com.example.StepDefinitions.given_an_example(io.cucumber.datatable.DataTable)}</li>
+     * <li>@{code
+     * com.example.StepDefinitions.<init>(StepDefinitions.java:9)}</li>
      * </ul>
      *
      * @return The source line of the step definition.

--- a/core/src/main/java/io/cucumber/core/backend/Lookup.java
+++ b/core/src/main/java/io/cucumber/core/backend/Lookup.java
@@ -8,9 +8,9 @@ public interface Lookup {
     /**
      * Provides an instance of a glue class.
      *
-     * @param glueClass type of instance to be created.
-     * @param <T>       type of Glue class
-     * @return new instance of type T
+     * @param  glueClass type of instance to be created.
+     * @param  <T>       type of Glue class
+     * @return           new instance of type T
      */
     <T> T getInstance(Class<T> glueClass);
 

--- a/core/src/main/java/io/cucumber/core/backend/ParameterInfo.java
+++ b/core/src/main/java/io/cucumber/core/backend/ParameterInfo.java
@@ -11,8 +11,8 @@ public interface ParameterInfo {
      * Returns the type of this parameter. This type is used to provide a hint
      * to cucumber expressions to resolve anonymous parameter types.
      * <p>
-     * Should always return the same value as {@link TypeResolver#resolve()}
-     * but may not throw any exceptions. May return {@code Object.class} when no
+     * Should always return the same value as {@link TypeResolver#resolve()} but
+     * may not throw any exceptions. May return {@code Object.class} when no
      * information is available.
      *
      * @return the type of this parameter.
@@ -27,8 +27,8 @@ public interface ParameterInfo {
     boolean isTransposed();
 
     /**
-     * Returns a type resolver. The type provided by this resolver is used
-     * to convert data table and doc string arguments to a java object.
+     * Returns a type resolver. The type provided by this resolver is used to
+     * convert data table and doc string arguments to a java object.
      *
      * @return a type resolver
      */

--- a/core/src/main/java/io/cucumber/core/backend/Pending.java
+++ b/core/src/main/java/io/cucumber/core/backend/Pending.java
@@ -1,6 +1,5 @@
 package io.cucumber.core.backend;
 
-
 import org.apiguardian.api.API;
 
 import java.lang.annotation.ElementType;
@@ -9,9 +8,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Any exception class annotated with this annotation will be treated as a "pending" exception.
- * That is - if the exception is thrown from a step definition or hook, the scenario's status will
- * be pending instead of failed.
+ * Any exception class annotated with this annotation will be treated as a
+ * "pending" exception. That is - if the exception is thrown from a step
+ * definition or hook, the scenario's status will be pending instead of failed.
  */
 @API(status = API.Status.STABLE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/io/cucumber/core/backend/ScenarioScoped.java
+++ b/core/src/main/java/io/cucumber/core/backend/ScenarioScoped.java
@@ -4,8 +4,8 @@ package io.cucumber.core.backend;
  * Marks a glue class as being scenario scoped.
  * <p>
  * Instances of scenario scoped glue can not be used between scenarios and will
- * be removed from the glue. This is useful when the glue holds a reference to
- * a scenario scoped object (e.g. a method closure).
+ * be removed from the glue. This is useful when the glue holds a reference to a
+ * scenario scoped object (e.g. a method closure).
  */
 public interface ScenarioScoped {
 

--- a/core/src/main/java/io/cucumber/core/backend/Snippet.java
+++ b/core/src/main/java/io/cucumber/core/backend/Snippet.java
@@ -10,16 +10,17 @@ import java.util.Map;
 public interface Snippet {
 
     /**
-     * @return a {@link java.text.MessageFormat} template used to generate a snippet. The template can access the
-     * following variables:
-     * <ul>
-     * <li>{0} : Step Keyword</li>
-     * <li>{1} : Value of {@link #escapePattern(String)}</li>
-     * <li>{2} : Function name</li>
-     * <li>{3} : Value of {@link #arguments(Map)}</li>
-     * <li>{4} : Regexp hint comment</li>
-     * <li>{5} : value of {@link #tableHint()} if the step has a table</li>
-     * </ul>
+     * @return a {@link java.text.MessageFormat} template used to generate a
+     *         snippet. The template can access the following variables:
+     *         <ul>
+     *         <li>{0} : Step Keyword</li>
+     *         <li>{1} : Value of {@link #escapePattern(String)}</li>
+     *         <li>{2} : Function name</li>
+     *         <li>{3} : Value of {@link #arguments(Map)}</li>
+     *         <li>{4} : Regexp hint comment</li>
+     *         <li>{5} : value of {@link #tableHint()} if the step has a
+     *         table</li>
+     *         </ul>
      */
     MessageFormat template();
 
@@ -29,17 +30,19 @@ public interface Snippet {
     String tableHint();
 
     /**
-     * Constructs a string representation of the arguments a step definition should accept. The arguments are
-     * provided a map of (suggested) names and types. The arguments are ordered by their position.
+     * Constructs a string representation of the arguments a step definition
+     * should accept. The arguments are provided a map of (suggested) names and
+     * types. The arguments are ordered by their position.
      *
-     * @param arguments ordered pairs of names and types
-     * @return a string representation of the arguments
+     * @param  arguments ordered pairs of names and types
+     * @return           a string representation of the arguments
      */
     String arguments(Map<String, Type> arguments);
 
     /**
-     * @param pattern the computed pattern that will match an undefined step
-     * @return an escaped representation of the pattern, if escaping is necessary.
+     * @param  pattern the computed pattern that will match an undefined step
+     * @return         an escaped representation of the pattern, if escaping is
+     *                 necessary.
      */
     String escapePattern(String pattern);
 

--- a/core/src/main/java/io/cucumber/core/backend/StepDefinition.java
+++ b/core/src/main/java/io/cucumber/core/backend/StepDefinition.java
@@ -8,12 +8,13 @@ import java.util.List;
 public interface StepDefinition extends Located {
 
     /**
-     * Invokes the step definition. The method should raise a Throwable
-     * if the invocation fails, which will cause the step to fail.
+     * Invokes the step definition. The method should raise a Throwable if the
+     * invocation fails, which will cause the step to fail.
      *
-     * @param args The arguments for the step
+     * @param  args                              The arguments for the step
      * @throws CucumberBackendException          of a failure to invoke the step
-     * @throws CucumberInvocationTargetException in case of a failure in the step.
+     * @throws CucumberInvocationTargetException in case of a failure in the
+     *                                           step.
      */
     void execute(Object[] args) throws CucumberBackendException, CucumberInvocationTargetException;
 
@@ -23,7 +24,8 @@ public interface StepDefinition extends Located {
     List<ParameterInfo> parameterInfos();
 
     /**
-     * @return the pattern associated with this instance. Used for error reporting only.
+     * @return the pattern associated with this instance. Used for error
+     *         reporting only.
      */
     String getPattern();
 

--- a/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
@@ -28,9 +28,9 @@ public interface TestCaseState {
      */
     boolean isFailed();
 
-
     /**
      * Attach data to the report(s).
+     * 
      * <pre>
      * {@code
      * // Attach a screenshot. See your UI automation tool's docs for
@@ -43,7 +43,9 @@ public interface TestCaseState {
      * {@code mediaType} must be provided. For example: {@code text/plain},
      * {@code image/png}, {@code text/html;charset=utf-8}.
      * <p>
-     * Media types are defined in <a href= https://tools.ietf.org/html/rfc7231#section-3.1.1.1>RFC 7231 Section 3.1.1.1</a>.
+     * Media types are defined in <a href=
+     * https://tools.ietf.org/html/rfc7231#section-3.1.1.1>RFC 7231 Section
+     * 3.1.1.1</a>.
      *
      * @param data      what to attach, for example an image.
      * @param mediaType what is the data?
@@ -55,7 +57,7 @@ public interface TestCaseState {
      * @param data      what to attach, for example html.
      * @param mediaType what is the data?
      * @param name      attachment name
-     * @see #attach(byte[], String, String)
+     * @see             #attach(byte[], String, String)
      */
     void attach(String data, String mediaType, String name);
 
@@ -63,7 +65,7 @@ public interface TestCaseState {
      * Outputs some text into the report.
      *
      * @param text what to put in the report.
-     * @see #attach(byte[], String, String)
+     * @see        #attach(byte[], String, String)
      */
     void log(String text);
 
@@ -83,9 +85,9 @@ public interface TestCaseState {
     URI getUri();
 
     /**
-     * @return the line in the feature file of the Scenario. If this is a Scenario
-     * from Scenario Outlines this will return the line of the example row in
-     * the Scenario Outline.
+     * @return the line in the feature file of the Scenario. If this is a
+     *         Scenario from Scenario Outlines this will return the line of the
+     *         example row in the Scenario Outline.
      */
     Integer getLine();
 

--- a/core/src/main/java/io/cucumber/core/backend/TypeResolver.java
+++ b/core/src/main/java/io/cucumber/core/backend/TypeResolver.java
@@ -5,8 +5,8 @@ import org.apiguardian.api.API;
 import java.lang.reflect.Type;
 
 /**
- * Allows lazy resolution and validation of the type of a data table or
- * doc string argument.
+ * Allows lazy resolution and validation of the type of a data table or doc
+ * string argument.
  */
 @API(status = API.Status.STABLE)
 public interface TypeResolver {
@@ -21,7 +21,7 @@ public interface TypeResolver {
      * When the {@link Object} type is returned no transform will be applied to
      * the data table or doc string.
      *
-     * @return a type
+     * @return                  a type
      * @throws RuntimeException when the type could not adequately be determined
      */
     Type resolve() throws RuntimeException;

--- a/core/src/main/java/io/cucumber/core/cli/Main.java
+++ b/core/src/main/java/io/cucumber/core/cli/Main.java
@@ -37,31 +37,33 @@ public class Main {
     /**
      * Launches the Cucumber-JVM command line.
      *
-     * @param argv        runtime options. See details in the {@code cucumber.api.cli.Usage.txt} resource.
-     * @param classLoader classloader used to load the runtime
-     * @return 0 if execution was successful, 1 if it was not (test failures)
+     * @param  argv        runtime options. See details in the
+     *                     {@code cucumber.api.cli.Usage.txt} resource.
+     * @param  classLoader classloader used to load the runtime
+     * @return             0 if execution was successful, 1 if it was not (test
+     *                     failures)
      */
     public static byte run(String[] argv, ClassLoader classLoader) {
         RuntimeOptions propertiesFileOptions = new CucumberPropertiesParser()
-            .parse(CucumberProperties.fromPropertiesFile())
-            .build();
+                .parse(CucumberProperties.fromPropertiesFile())
+                .build();
 
         RuntimeOptions environmentOptions = new CucumberPropertiesParser()
-            .parse(CucumberProperties.fromEnvironment())
-            .build(propertiesFileOptions);
+                .parse(CucumberProperties.fromEnvironment())
+                .build(propertiesFileOptions);
 
         RuntimeOptions systemOptions = new CucumberPropertiesParser()
-            .parse(CucumberProperties.fromSystemProperties())
-            .build(environmentOptions);
+                .parse(CucumberProperties.fromSystemProperties())
+                .build(environmentOptions);
 
         CommandlineOptionsParser commandlineOptionsParser = new CommandlineOptionsParser(System.out);
         RuntimeOptions runtimeOptions = commandlineOptionsParser
-            .parse(argv)
-            .addDefaultGlueIfAbsent()
-            .addDefaultFeaturePathIfAbsent()
-            .addDefaultFormatterIfAbsent()
-            .addDefaultSummaryPrinterIfAbsent()
-            .build(systemOptions);
+                .parse(argv)
+                .addDefaultGlueIfAbsent()
+                .addDefaultFeaturePathIfAbsent()
+                .addDefaultFormatterIfAbsent()
+                .addDefaultSummaryPrinterIfAbsent()
+                .build(systemOptions);
 
         Optional<Byte> exitStatus = commandlineOptionsParser.exitStatus();
         if (exitStatus.isPresent()) {
@@ -69,9 +71,9 @@ public class Main {
         }
 
         final Runtime runtime = Runtime.builder()
-            .withRuntimeOptions(runtimeOptions)
-            .withClassLoader(() -> classLoader)
-            .build();
+                .withRuntimeOptions(runtimeOptions)
+                .withClassLoader(() -> classLoader)
+                .build();
 
         runtime.run();
         return runtime.exitStatus();

--- a/core/src/main/java/io/cucumber/core/eventbus/AbstractEventPublisher.java
+++ b/core/src/main/java/io/cucumber/core/eventbus/AbstractEventPublisher.java
@@ -40,14 +40,14 @@ public abstract class AbstractEventPublisher implements EventPublisher {
     protected <T> void send(T event) {
         if (handlers.containsKey(Event.class) && event instanceof Event) {
             for (EventHandler handler : handlers.get(Event.class)) {
-                //noinspection unchecked: protected by registerHandlerFor
+                // noinspection unchecked: protected by registerHandlerFor
                 handler.receive(event);
             }
         }
 
         if (handlers.containsKey(event.getClass())) {
             for (EventHandler handler : handlers.get(event.getClass())) {
-                //noinspection unchecked: protected by registerHandlerFor
+                // noinspection unchecked: protected by registerHandlerFor
                 handler.receive(event);
             }
         }

--- a/core/src/main/java/io/cucumber/core/exception/CompositeCucumberException.java
+++ b/core/src/main/java/io/cucumber/core/exception/CompositeCucumberException.java
@@ -19,8 +19,8 @@ public final class CompositeCucumberException extends CucumberException {
 
     public String getMessage() {
         return super.getMessage() + this.causes.stream()
-            .map(e -> String.format("  %s(%s)", e.getClass().getName(), e.getMessage()))
-            .collect(Collectors.joining("\n", "\n", ""));
+                .map(e -> String.format("  %s(%s)", e.getClass().getName(), e.getMessage()))
+                .collect(Collectors.joining("\n", "\n", ""));
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/feature/Encoding.java
+++ b/core/src/main/java/io/cucumber/core/feature/Encoding.java
@@ -18,7 +18,8 @@ import static java.util.Locale.ROOT;
 final class Encoding {
 
     private static final Pattern COMMENT_OR_EMPTY_LINE_PATTERN = Pattern.compile("^\\s*#|^\\s*$");
-    private static final Pattern ENCODING_PATTERN = Pattern.compile("^\\s*#\\s*encoding\\s*:\\s*([0-9a-zA-Z\\-]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ENCODING_PATTERN = Pattern.compile("^\\s*#\\s*encoding\\s*:\\s*([0-9a-zA-Z\\-]+)",
+        Pattern.CASE_INSENSITIVE);
     private static final String DEFAULT_ENCODING = UTF_8.name();
     private static final String UTF_8_BOM = "\uFEFF";
 
@@ -39,10 +40,9 @@ final class Encoding {
         char[] buffer = new char[2 * 1024];
         final StringBuilder out = new StringBuilder();
         try (
-            InputStream is = resource.getInputStream();
-            InputStreamReader in = new InputStreamReader(is, encoding);
-            BufferedReader reader = new BufferedReader(in);
-        ) {
+                InputStream is = resource.getInputStream();
+                InputStreamReader in = new InputStreamReader(is, encoding);
+                BufferedReader reader = new BufferedReader(in);) {
             int read;
             while ((read = reader.read(buffer, 0, buffer.length)) > 0) {
                 out.append(buffer, 0, read);

--- a/core/src/main/java/io/cucumber/core/feature/FeatureIdentifier.java
+++ b/core/src/main/java/io/cucumber/core/feature/FeatureIdentifier.java
@@ -25,7 +25,8 @@ public class FeatureIdentifier {
 
     public static URI parse(URI featureIdentifier) {
         if (!isFeature(featureIdentifier)) {
-            throw new IllegalArgumentException("featureIdentifier does not reference a single feature file: " + featureIdentifier);
+            throw new IllegalArgumentException(
+                "featureIdentifier does not reference a single feature file: " + featureIdentifier);
         }
         return featureIdentifier;
     }

--- a/core/src/main/java/io/cucumber/core/feature/FeatureParser.java
+++ b/core/src/main/java/io/cucumber/core/feature/FeatureParser.java
@@ -27,20 +27,19 @@ public final class FeatureParser {
         this.idGenerator = idGenerator;
     }
 
-
     public Optional<Feature> parseResource(Resource resource) {
         requireNonNull(resource);
         URI uri = resource.getUri();
         String source = read(resource);
-        ServiceLoader<io.cucumber.core.gherkin.FeatureParser> services =
-            ServiceLoader.load(io.cucumber.core.gherkin.FeatureParser.class);
+        ServiceLoader<io.cucumber.core.gherkin.FeatureParser> services = ServiceLoader
+                .load(io.cucumber.core.gherkin.FeatureParser.class);
         Iterator<io.cucumber.core.gherkin.FeatureParser> iterator = services.iterator();
         List<io.cucumber.core.gherkin.FeatureParser> parser = new ArrayList<>();
         while (iterator.hasNext()) {
             parser.add(iterator.next());
         }
-        Comparator<io.cucumber.core.gherkin.FeatureParser> version =
-            comparing(io.cucumber.core.gherkin.FeatureParser::version);
+        Comparator<io.cucumber.core.gherkin.FeatureParser> version = comparing(
+            io.cucumber.core.gherkin.FeatureParser::version);
         return Collections.max(parser, version).parse(uri, source, idGenerator);
     }
 
@@ -51,6 +50,5 @@ public final class FeatureParser {
             throw new CucumberException("Failed to read resource:" + resource.getUri(), e);
         }
     }
-
 
 }

--- a/core/src/main/java/io/cucumber/core/feature/FeaturePath.java
+++ b/core/src/main/java/io/cucumber/core/feature/FeaturePath.java
@@ -12,15 +12,15 @@ import static java.util.Objects.requireNonNull;
 /**
  * A feature path is a URI to a single feature file or directory of features.
  * <p>
- * This URI can either be absolute:
- * {@code scheme:/absolute/path/to.feature}, or relative to the
- * current working directory: {@code scheme:relative/path/to.feature}. In
- * either form, when the scheme is omitted {@code file} will be assumed.
+ * This URI can either be absolute: {@code scheme:/absolute/path/to.feature}, or
+ * relative to the current working directory:
+ * {@code scheme:relative/path/to.feature}. In either form, when the scheme is
+ * omitted {@code file} will be assumed.
  * <p>
  * On systems that use a {@code File.separatorChar} other then `{@code /}`
- * {@code File.separatorChar} can be used as a path separator. When
- * doing so when the scheme must be omitted: {@code path\to.feature}.
- * <em>It is recommended to use `{@code /}` as the path separator.</em>
+ * {@code File.separatorChar} can be used as a path separator. When doing so
+ * when the scheme must be omitted: {@code path\to.feature}. <em>It is
+ * recommended to use `{@code /}` as the path separator.</em>
  *
  * @see FeatureIdentifier
  * @see FeatureWithLines
@@ -61,7 +61,7 @@ public class FeaturePath {
 
     private static boolean nonStandardPathSeparatorInUse(String featureIdentifier) {
         return File.separatorChar != RESOURCE_SEPARATOR_CHAR
-            && featureIdentifier.contains(File.separator);
+                && featureIdentifier.contains(File.separator);
     }
 
     private static String replaceNonStandardPathSeparator(String featureIdentifier) {

--- a/core/src/main/java/io/cucumber/core/feature/FeatureWithLines.java
+++ b/core/src/main/java/io/cucumber/core/feature/FeatureWithLines.java
@@ -14,12 +14,12 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * Identifies either a directory containing feature files, a specific
- * feature or specific scenarios and examples (pickles) in a feature.
+ * Identifies either a directory containing feature files, a specific feature or
+ * specific scenarios and examples (pickles) in a feature.
  * <p>
  * The syntax of a a feature with lines defined as either a {@link FeaturePath}
- * or a {@link FeatureIdentifier} followed by a sequence of line
- * numbers each preceded by a colon.
+ * or a {@link FeatureIdentifier} followed by a sequence of line numbers each
+ * preceded by a colon.
  */
 public class FeatureWithLines implements Serializable {
 
@@ -77,8 +77,8 @@ public class FeatureWithLines implements Serializable {
 
     private static List<Integer> toInts(String[] strings) {
         return Arrays.stream(strings)
-            .map(Integer::parseInt)
-            .collect(Collectors.toList());
+                .map(Integer::parseInt)
+                .collect(Collectors.toList());
     }
 
     public static FeatureWithLines parse(String uri, Collection<Integer> lines) {
@@ -100,8 +100,10 @@ public class FeatureWithLines implements Serializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         FeatureWithLines that = (FeatureWithLines) o;
         return uri.equals(that.uri) && lines.equals(that.lines);
     }

--- a/core/src/main/java/io/cucumber/core/feature/GluePath.java
+++ b/core/src/main/java/io/cucumber/core/feature/GluePath.java
@@ -18,16 +18,16 @@ import static java.util.Objects.requireNonNull;
 /**
  * The glue path is a class path URI to a package.
  * <p>
- * The glue path can be written as either a package name: {@code com.example.app},
- * a path {@code com/example/app} or uri {@code classpath:com/example/app}.
+ * The glue path can be written as either a package name:
+ * {@code com.example.app}, a path {@code com/example/app} or uri
+ * {@code classpath:com/example/app}.
  * <p>
- * On file system with a path separator other then `{@code /}` {@code com\example\app}
- * is also a valid glue path.
+ * On file system with a path separator other then `{@code /}`
+ * {@code com\example\app} is also a valid glue path.
  * <p>
  * It is recommended to always use the package name form.
  */
 public class GluePath {
-
 
     private GluePath() {
 
@@ -60,7 +60,7 @@ public class GluePath {
 
     private static boolean nonStandardPathSeparatorInUse(String featureIdentifier) {
         return File.separatorChar != RESOURCE_SEPARATOR_CHAR
-            && featureIdentifier.contains(File.separator);
+                && featureIdentifier.contains(File.separator);
     }
 
     private static String replaceNonStandardPathSeparator(String featureIdentifier) {
@@ -77,7 +77,9 @@ public class GluePath {
 
         if (uri.getScheme() == null) {
             try {
-                return new URI(CLASSPATH_SCHEME, schemeSpecificPart.startsWith("/") ? schemeSpecificPart : "/" + schemeSpecificPart, uri.getFragment());
+                return new URI(CLASSPATH_SCHEME,
+                    schemeSpecificPart.startsWith("/") ? schemeSpecificPart : "/" + schemeSpecificPart,
+                    uri.getFragment());
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException(e.getMessage(), e);
             }
@@ -92,13 +94,14 @@ public class GluePath {
 
     private static boolean isProbablyPackage(String gluePath) {
         return gluePath.contains(PACKAGE_SEPARATOR_STRING)
-            && !gluePath.contains(RESOURCE_SEPARATOR_STRING);
+                && !gluePath.contains(RESOURCE_SEPARATOR_STRING);
     }
 
     private static boolean isValidIdentifier(String schemeSpecificPart) {
         for (String part : schemeSpecificPart.split("/")) {
             for (int i = 0; i < part.length(); i++) {
-                if (i == 0 && !isJavaIdentifierStart(part.charAt(i)) || (i != 0 && !isJavaIdentifierPart(part.charAt(i)))) {
+                if (i == 0 && !isJavaIdentifierStart(part.charAt(i))
+                        || (i != 0 && !isJavaIdentifierPart(part.charAt(i)))) {
                     return false;
                 }
             }

--- a/core/src/main/java/io/cucumber/core/filter/TagPredicate.java
+++ b/core/src/main/java/io/cucumber/core/filter/TagPredicate.java
@@ -11,7 +11,6 @@ import java.util.function.Predicate;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
-
 final class TagPredicate implements Predicate<Pickle> {
 
     private final List<Expression> expressions = new ArrayList<>();
@@ -38,7 +37,7 @@ final class TagPredicate implements Predicate<Pickle> {
 
         List<String> tags = pickle.getTags();
         return expressions.stream()
-            .allMatch(expression -> expression.evaluate(tags));
+                .allMatch(expression -> expression.evaluate(tags));
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/logging/LoggerFactory.java
+++ b/core/src/main/java/io/cucumber/core/logging/LoggerFactory.java
@@ -11,7 +11,8 @@ import static java.util.Objects.requireNonNull;
  * Cucumber uses the Java Logging APIs from {@link java.util.logging} (JUL).
  * <p>
  * See the {@link java.util.logging.LogManager} for configuration options or use
- * the <a href="https://www.slf4j.org/legacy.html#jul-to-slf4j">JUL to SLF4J Bridge</a>
+ * the <a href="https://www.slf4j.org/legacy.html#jul-to-slf4j">JUL to SLF4J
+ * Bridge</a>
  */
 public final class LoggerFactory {
 
@@ -32,8 +33,8 @@ public final class LoggerFactory {
     /**
      * Get a {@link Logger}
      *
-     * @param clazz the class for which to get the logger
-     * @return the logger
+     * @param  clazz the class for which to get the logger
+     * @return       the logger
      */
     public static Logger getLogger(Class<?> clazz) {
         requireNonNull(clazz, "Class must not be null");

--- a/core/src/main/java/io/cucumber/core/options/CommandlineOptionsParser.java
+++ b/core/src/main/java/io/cucumber/core/options/CommandlineOptionsParser.java
@@ -37,7 +37,8 @@ public final class CommandlineOptionsParser {
 
     private static final Logger log = LoggerFactory.getLogger(CommandlineOptionsParser.class);
 
-    private static final String VERSION = ResourceBundle.getBundle("io.cucumber.core.version").getString("cucumber-jvm.version");
+    private static final String VERSION = ResourceBundle.getBundle("io.cucumber.core.version")
+            .getString("cucumber-jvm.version");
     // IMPORTANT! Make sure USAGE.txt is always uptodate if this class changes.
     private static final String USAGE_RESOURCE = "/io/cucumber/core/options/USAGE.txt";
 
@@ -185,9 +186,8 @@ public final class CommandlineOptionsParser {
 
     private String loadUsageText() {
         try (
-            InputStream usageResourceStream = CommandlineOptionsParser.class.getResourceAsStream(USAGE_RESOURCE);
-            BufferedReader br = new BufferedReader(new InputStreamReader(usageResourceStream, UTF_8))
-        ) {
+                InputStream usageResourceStream = CommandlineOptionsParser.class.getResourceAsStream(USAGE_RESOURCE);
+                BufferedReader br = new BufferedReader(new InputStreamReader(usageResourceStream, UTF_8))) {
             return br.lines().collect(joining(System.lineSeparator()));
         } catch (Exception e) {
             return "Could not load usage text: " + e.toString();
@@ -196,10 +196,10 @@ public final class CommandlineOptionsParser {
 
     private int findWidest(List<GherkinDialect> dialects, Function<GherkinDialect, String> getNativeName) {
         return dialects.stream()
-            .map(getNativeName)
-            .mapToInt(String::length)
-            .max()
-            .orElse(0);
+                .map(getNativeName)
+                .mapToInt(String::length)
+                .max()
+                .orElse(0);
     }
 
     private void printDialect(GherkinDialect dialect, int widestLanguage, int widestName, int widestNativeName) {
@@ -249,8 +249,8 @@ public final class CommandlineOptionsParser {
         codeKeywordList.remove("* ");
 
         List<String> codeWords = codeKeywordList.stream()
-            .map(keyword -> keyword.replaceAll("[\\s',!]", ""))
-            .collect(Collectors.toList());
+                .map(keyword -> keyword.replaceAll("[\\s',!]", ""))
+                .collect(Collectors.toList());
 
         addKeywordRow(table, key + " (code)", codeWords);
     }

--- a/core/src/main/java/io/cucumber/core/options/Constants.java
+++ b/core/src/main/java/io/cucumber/core/options/Constants.java
@@ -5,8 +5,8 @@ import io.cucumber.core.runtime.ObjectFactoryServiceLoader;
 public final class Constants {
 
     /**
-     * Property name used to disable ansi colors in the output (not supported
-     * by all terminals): {@value}
+     * Property name used to disable ansi colors in the output (not supported by
+     * all terminals): {@value}
      * <p>
      * Ansi colors are enabled by default.
      */
@@ -38,7 +38,8 @@ public final class Constants {
     /**
      * Property name used to set execution order: {@value}
      * <p>
-     * Valid values are {@code lexical}, {@code reverse}, {@code random} or {@code random:[seed]}.
+     * Valid values are {@code lexical}, {@code reverse}, {@code random} or
+     * {@code random:[seed]}.
      * <p>
      * By default features are executed in lexical file name order
      */
@@ -69,18 +70,18 @@ public final class Constants {
      * <p>
      * A comma separated list of:
      * <ul>
-     * <li>{@code path/to/dir}  - Load the files with the extension ".feature" for the
-     * directory {@code path} and its sub directories.
-     * <li>{@code path/name.feature} - Load the feature file {@code path/name.feature}
-     * from the file system.</li>
+     * <li>{@code path/to/dir} - Load the files with the extension ".feature"
+     * for the directory {@code path} and its sub directories.
+     * <li>{@code path/name.feature} - Load the feature file
+     * {@code path/name.feature} from the file system.</li>
      * <li>{@code classpath:path/name.feature} - Load the feature file
      * {@code path/name.feature} from the classpath.</li>
-     * <li>{@code path/name.feature:3:9} - Load the scenarios on line 3 and line 9 in
-     * the file {@code path/name.feature}.</li>
-     * <li>{@code @path/file} - Load {@code path/file} from the file system and parse
-     * feature paths.</li>
-     * <li>{@code @classpath:path/file} - Load {@code path/file} from the classpath and
+     * <li>{@code path/name.feature:3:9} - Load the scenarios on line 3 and line
+     * 9 in the file {@code path/name.feature}.</li>
+     * <li>{@code @path/file} - Load {@code path/file} from the file system and
      * parse feature paths.</li>
+     * <li>{@code @classpath:path/file} - Load {@code path/file} from the
+     * classpath and parse feature paths.</li>
      * </ul>
      *
      * @see io.cucumber.core.feature.FeatureWithLines
@@ -99,8 +100,8 @@ public final class Constants {
      * Property name used to set tag filter: {@value}
      * <p>
      * Filters scenarios based on the provided tag expression e.g:
-     * {@code @Integration and not @Ignored}. Scenarios that do not
-     * match the expression are not executed.
+     * {@code @Integration and not @Ignored}. Scenarios that do not match the
+     * expression are not executed.
      * <p>
      * By default all scenarios are executed
      */
@@ -143,13 +144,14 @@ public final class Constants {
      * <li>testng</li>
      * </ul>
      * <p>
-     * {@code PLUGIN} can also be a fully qualified class name, allowing registration
-     * of 3rd party plugins.
+     * {@code PLUGIN} can also be a fully qualified class name, allowing
+     * registration of 3rd party plugins.
      */
     public static final String PLUGIN_PROPERTY_NAME = "cucumber.plugin";
 
     /**
-     * Property name to control naming convention for generated snippets: {@value}
+     * Property name to control naming convention for generated snippets:
+     * {@value}
      * <p>
      * Valid values are {@code underscore} or {@code camelcase}.
      * <p>

--- a/core/src/main/java/io/cucumber/core/options/CucumberOptionsAnnotationParser.java
+++ b/core/src/main/java/io/cucumber/core/options/CucumberOptionsAnnotationParser.java
@@ -28,7 +28,8 @@ public final class CucumberOptionsAnnotationParser {
     public RuntimeOptionsBuilder parse(Class<?> clazz) {
         RuntimeOptionsBuilder args = new RuntimeOptionsBuilder();
 
-        for (Class<?> classWithOptions = clazz; hasSuperClass(classWithOptions); classWithOptions = classWithOptions.getSuperclass()) {
+        for (Class<?> classWithOptions = clazz; hasSuperClass(
+            classWithOptions); classWithOptions = classWithOptions.getSuperclass()) {
             CucumberOptions options = requireNonNull(optionsProvider).getOptions(classWithOptions);
 
             if (options != null) {
@@ -80,7 +81,8 @@ public final class CucumberOptionsAnnotationParser {
 
     private void addStrict(CucumberOptions options, RuntimeOptionsBuilder args) {
         if (!options.strict()) {
-            throw new CucumberException("@CucumberOptions(strict=false) is no longer supported. Please use strict=true");
+            throw new CucumberException(
+                "@CucumberOptions(strict=false) is no longer supported. Please use strict=true");
         }
     }
 
@@ -166,7 +168,6 @@ public final class CucumberOptionsAnnotationParser {
         String className = clazz.getName();
         return className.substring(0, Math.max(0, className.lastIndexOf('.')));
     }
-
 
     public interface OptionsProvider {
 

--- a/core/src/main/java/io/cucumber/core/options/CucumberProperties.java
+++ b/core/src/main/java/io/cucumber/core/options/CucumberProperties.java
@@ -39,7 +39,8 @@ public final class CucumberProperties {
     }
 
     public static Map<String, String> fromPropertiesFile() {
-        InputStream resourceAsStream = CucumberProperties.class.getResourceAsStream("/" + CUCUMBER_PROPERTIES_FILE_NAME);
+        InputStream resourceAsStream = CucumberProperties.class
+                .getResourceAsStream("/" + CUCUMBER_PROPERTIES_FILE_NAME);
         if (resourceAsStream == null) {
             log.debug(() -> CUCUMBER_PROPERTIES_FILE_NAME + " file did not exist");
             return Collections.emptyMap();
@@ -113,18 +114,18 @@ public final class CucumberProperties {
             String keyString = (String) key;
 
             String uppercase = keyString
-                .replace(".", "_")
-                .replace("-", "_")
-                .toUpperCase(Locale.ENGLISH);
+                    .replace(".", "_")
+                    .replace("-", "_")
+                    .toUpperCase(Locale.ENGLISH);
             String upperCaseMatch = super.get(uppercase);
             if (upperCaseMatch != null) {
                 return upperCaseMatch;
             }
 
             String lowercase = keyString
-                .replace(".", "_")
-                .replace("-", "_")
-                .toLowerCase(Locale.ENGLISH);
+                    .replace(".", "_")
+                    .replace("-", "_")
+                    .toLowerCase(Locale.ENGLISH);
             String lowerValue = super.get(lowercase);
             if (lowerValue != null)
                 return lowerValue;

--- a/core/src/main/java/io/cucumber/core/options/CucumberPropertiesParser.java
+++ b/core/src/main/java/io/cucumber/core/options/CucumberPropertiesParser.java
@@ -39,99 +39,91 @@ public final class CucumberPropertiesParser {
         parse(properties,
             ANSI_COLORS_DISABLED_PROPERTY_NAME,
             Boolean::parseBoolean,
-            builder::setMonochrome
-        );
+            builder::setMonochrome);
 
         parse(properties,
             EXECUTION_DRY_RUN_PROPERTY_NAME,
             Boolean::parseBoolean,
-            builder::setDryRun
-        );
+            builder::setDryRun);
 
         parse(properties,
             EXECUTION_LIMIT_PROPERTY_NAME,
             Integer::parseInt,
-            builder::setCount
-        );
+            builder::setCount);
 
         parse(properties,
             EXECUTION_ORDER_PROPERTY_NAME,
             PickleOrderParser::parse,
-            builder::setPickleOrder
-        );
+            builder::setPickleOrder);
 
         parse(properties,
             EXECUTION_STRICT_PROPERTY_NAME,
             Boolean::parseBoolean,
-            CucumberPropertiesParser::errorOnNonStrict
-        );
+            CucumberPropertiesParser::errorOnNonStrict);
 
         parseAll(properties,
             FEATURES_PROPERTY_NAME,
             splitAndThenFlatMap(CucumberPropertiesParser::parseFeatureFile),
-            builder::addFeature
-        );
+            builder::addFeature);
         parseAll(properties,
             FEATURES_PROPERTY_NAME,
             splitAndMap(CucumberPropertiesParser::parseRerunFile),
-            builder::addRerun
-        );
+            builder::addRerun);
 
         parse(properties,
             FILTER_NAME_PROPERTY_NAME,
             Pattern::compile,
-            builder::addNameFilter
-        );
+            builder::addNameFilter);
 
         parse(properties,
             FILTER_TAGS_PROPERTY_NAME,
             Function.identity(),
-            builder::addTagFilter
-        );
+            builder::addTagFilter);
 
         parseAll(properties,
             GLUE_PROPERTY_NAME,
             splitAndMap(GluePath::parse),
-            builder::addGlue
-        );
+            builder::addGlue);
 
         parse(properties,
             OBJECT_FACTORY_PROPERTY_NAME,
             ObjectFactoryParser::parseObjectFactory,
-            builder::setObjectFactoryClass
-        );
+            builder::setObjectFactoryClass);
 
         parseAll(properties,
             PLUGIN_PROPERTY_NAME,
             splitAndMap(Function.identity()),
-            builder::addPluginName
-        );
+            builder::addPluginName);
 
         parse(properties,
             SNIPPET_TYPE_PROPERTY_NAME,
             SnippetTypeParser::parseSnippetType,
-            builder::setSnippetType
-        );
+            builder::setSnippetType);
         parse(properties,
             WIP_PROPERTY_NAME,
             Boolean::parseBoolean,
-            builder::setWip
-        );
+            builder::setWip);
 
         return builder;
     }
 
-    private <T> void parse(Map<String, String> properties, String propertyName, Function<String, T> parser, Consumer<T> setter) {
+    private <T> void parse(
+            Map<String, String> properties, String propertyName, Function<String, T> parser, Consumer<T> setter
+    ) {
         parseAll(properties, propertyName, parser.andThen(Collections::singletonList), setter);
     }
 
     private static void errorOnNonStrict(Boolean strict) {
         if (!strict) {
-            throw new CucumberException(EXECUTION_STRICT_PROPERTY_NAME + "=false is no longer effective. Please use =true (the default) or remove this property");
+            throw new CucumberException(EXECUTION_STRICT_PROPERTY_NAME
+                    + "=false is no longer effective. Please use =true (the default) or remove this property");
         }
     }
 
-    private <T> void parseAll(Map<String, String> properties, String propertyName, Function<String, Collection<T>> parser, Consumer<T> setter) {
+    private <T> void parseAll(
+            Map<String, String> properties, String propertyName, Function<String, Collection<T>> parser,
+            Consumer<T> setter
+    ) {
         String property = properties.get(propertyName);
         if (property == null || property.isEmpty()) {
             return;
@@ -146,10 +138,10 @@ public final class CucumberPropertiesParser {
 
     private static <T> Function<String, Collection<T>> splitAndThenFlatMap(Function<String, Stream<T>> parse) {
         return combined -> stream(combined.split(","))
-            .map(String::trim)
-            .filter(part -> !part.isEmpty())
-            .flatMap(parse)
-            .collect(toList());
+                .map(String::trim)
+                .filter(part -> !part.isEmpty())
+                .flatMap(parse)
+                .collect(toList());
     }
 
     private static Stream<FeatureWithLines> parseFeatureFile(String property) {
@@ -161,10 +153,10 @@ public final class CucumberPropertiesParser {
 
     private static <T> Function<String, Collection<T>> splitAndMap(Function<String, T> parse) {
         return combined -> stream(combined.split(","))
-            .map(String::trim)
-            .filter(part -> !part.isEmpty())
-            .map(parse)
-            .collect(toList());
+                .map(String::trim)
+                .filter(part -> !part.isEmpty())
+                .map(parse)
+                .collect(toList());
     }
 
     private static Collection<FeatureWithLines> parseRerunFile(String property) {

--- a/core/src/main/java/io/cucumber/core/options/ObjectFactoryParser.java
+++ b/core/src/main/java/io/cucumber/core/options/ObjectFactoryParser.java
@@ -14,10 +14,12 @@ public final class ObjectFactoryParser {
         try {
             objectFactoryClass = Class.forName(cucumberObjectFactory);
         } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException(String.format("Could not load object factory class for '%s'", cucumberObjectFactory), e);
+            throw new IllegalArgumentException(
+                String.format("Could not load object factory class for '%s'", cucumberObjectFactory), e);
         }
         if (!ObjectFactory.class.isAssignableFrom(objectFactoryClass)) {
-            throw new IllegalArgumentException(String.format("Object factory class '%s' was not a subclass of '%s'", objectFactoryClass, ObjectFactory.class));
+            throw new IllegalArgumentException(String.format("Object factory class '%s' was not a subclass of '%s'",
+                objectFactoryClass, ObjectFactory.class));
         }
         return (Class<? extends ObjectFactory>) objectFactoryClass;
     }

--- a/core/src/main/java/io/cucumber/core/options/PluginOption.java
+++ b/core/src/main/java/io/cucumber/core/options/PluginOption.java
@@ -35,41 +35,46 @@ public class PluginOption implements Options.Plugin {
     private static final Logger log = LoggerFactory.getLogger(PluginOption.class);
 
     private static final Pattern PLUGIN_WITH_ARGUMENT_PATTERN = Pattern.compile("([^:]+):(.*)");
-    private static final HashMap<String, Supplier<Class<? extends Plugin>>> PLUGIN_CLASSES = new HashMap<String, Supplier<Class<? extends Plugin>>>() {{
-        put("default_summary", () -> DefaultSummaryPrinter.class);
-        put("html", () -> HtmlFormatter.class);
-        put("json", () -> JsonFormatter.class);
-        put("junit", () -> JUnitFormatter.class);
-        put("null_summary", () -> NullSummaryPrinter.class);
-        put("pretty", () -> PrettyFormatter.class);
-        put("progress", () -> ProgressFormatter.class);
-        put("message", () -> MessageFormatter.class);
-        put("rerun", () -> RerunFormatter.class);
-        put("summary", () -> DefaultSummaryPrinter.class);
-        put("testng", () -> TestNGFormatter.class);
-        put("timeline", () -> TimelineFormatter.class);
-        put("unused", () -> UnusedStepsSummaryPrinter.class);
-        put("usage", () -> UsageFormatter.class);
-        put("teamcity", () -> TeamCityPlugin.class);
-    }};
-
+    private static final HashMap<String, Supplier<Class<? extends Plugin>>> PLUGIN_CLASSES = new HashMap<String, Supplier<Class<? extends Plugin>>>() {
+        {
+            put("default_summary", () -> DefaultSummaryPrinter.class);
+            put("html", () -> HtmlFormatter.class);
+            put("json", () -> JsonFormatter.class);
+            put("junit", () -> JUnitFormatter.class);
+            put("null_summary", () -> NullSummaryPrinter.class);
+            put("pretty", () -> PrettyFormatter.class);
+            put("progress", () -> ProgressFormatter.class);
+            put("message", () -> MessageFormatter.class);
+            put("rerun", () -> RerunFormatter.class);
+            put("summary", () -> DefaultSummaryPrinter.class);
+            put("testng", () -> TestNGFormatter.class);
+            put("timeline", () -> TimelineFormatter.class);
+            put("unused", () -> UnusedStepsSummaryPrinter.class);
+            put("usage", () -> UsageFormatter.class);
+            put("teamcity", () -> TeamCityPlugin.class);
+        }
+    };
 
     // Replace IDEA plugin with TeamCity
-    private static final Set<String> INCOMPATIBLE_INTELLIJ_IDEA_PLUGIN_CLASSES = new HashSet<String>() {{
-        add("org.jetbrains.plugins.cucumber.java.run.CucumberJvmSMFormatter");
-        add("org.jetbrains.plugins.cucumber.java.run.CucumberJvm2SMFormatter");
-        add("org.jetbrains.plugins.cucumber.java.run.CucumberJvm3SMFormatter");
-        add("org.jetbrains.plugins.cucumber.java.run.CucumberJvm4SMFormatter");
-        add("org.jetbrains.plugins.cucumber.java.run.CucumberJvm5SMFormatter");
-    }};
+    private static final Set<String> INCOMPATIBLE_INTELLIJ_IDEA_PLUGIN_CLASSES = new HashSet<String>() {
+        {
+            add("org.jetbrains.plugins.cucumber.java.run.CucumberJvmSMFormatter");
+            add("org.jetbrains.plugins.cucumber.java.run.CucumberJvm2SMFormatter");
+            add("org.jetbrains.plugins.cucumber.java.run.CucumberJvm3SMFormatter");
+            add("org.jetbrains.plugins.cucumber.java.run.CucumberJvm4SMFormatter");
+            add("org.jetbrains.plugins.cucumber.java.run.CucumberJvm5SMFormatter");
+        }
+    };
 
     // Refuse plugins known to implement the old API
-    private static final Set<String> INCOMPATIBLE_PLUGIN_CLASSES = new HashSet<String>() {{
-        add("io.qameta.allure.cucumberjvm.AllureCucumberJvm");
-        add("io.qameta.allure.cucumber2jvm.AllureCucumber2Jvm");
-        add("io.qameta.allure.cucumber3jvm.AllureCucumber3Jvm");
-        add("io.qameta.allure.cucumber4jvm.AllureCucumber4Jvm");
-    }};
+    private static final Set<String> INCOMPATIBLE_PLUGIN_CLASSES = new HashSet<String>() {
+        {
+            add("io.qameta.allure.cucumberjvm.AllureCucumberJvm");
+            add("io.qameta.allure.cucumber2jvm.AllureCucumber2Jvm");
+            add("io.qameta.allure.cucumber3jvm.AllureCucumber3Jvm");
+            add("io.qameta.allure.cucumber4jvm.AllureCucumber4Jvm");
+        }
+    };
 
     private final String pluginString;
     private final Class<? extends Plugin> pluginClass;
@@ -111,7 +116,8 @@ public class PluginOption implements Options.Plugin {
             if (Plugin.class.isAssignableFrom(aClass)) {
                 return (Class<? extends Plugin>) aClass;
             }
-            throw new CucumberException("Couldn't load plugin class: " + className + ". It does not implement " + Plugin.class.getName());
+            throw new CucumberException(
+                "Couldn't load plugin class: " + className + ". It does not implement " + Plugin.class.getName());
         } catch (ClassNotFoundException | NoClassDefFoundError e) {
             throw new CucumberException("Couldn't load plugin class: " + className, e);
         }
@@ -133,12 +139,12 @@ public class PluginOption implements Options.Plugin {
     }
 
     boolean isFormatter() {
-        return EventListener.class.isAssignableFrom(pluginClass) || ConcurrentEventListener.class.isAssignableFrom(pluginClass);
+        return EventListener.class.isAssignableFrom(pluginClass)
+                || ConcurrentEventListener.class.isAssignableFrom(pluginClass);
     }
 
     boolean isSummaryPrinter() {
         return SummaryPrinter.class.isAssignableFrom(pluginClass);
     }
-
 
 }

--- a/core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
+++ b/core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
@@ -23,11 +23,11 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 
 public final class RuntimeOptions implements
-    io.cucumber.core.feature.Options,
-    io.cucumber.core.runner.Options,
-    io.cucumber.core.plugin.Options,
-    io.cucumber.core.filter.Options,
-    io.cucumber.core.backend.Options {
+        io.cucumber.core.feature.Options,
+        io.cucumber.core.runner.Options,
+        io.cucumber.core.plugin.Options,
+        io.cucumber.core.filter.Options,
+        io.cucumber.core.backend.Options {
 
     private final List<URI> glue = new ArrayList<>();
     private final List<String> tagExpressions = new ArrayList<>();
@@ -161,10 +161,10 @@ public final class RuntimeOptions implements
     @Override
     public List<URI> getFeaturePaths() {
         return unmodifiableList(featurePaths.stream()
-            .map(FeatureWithLines::uri)
-            .sorted()
-            .distinct()
-            .collect(Collectors.toList()));
+                .map(FeatureWithLines::uri)
+                .sorted()
+                .distinct()
+                .collect(Collectors.toList()));
     }
 
     void setFeaturePaths(List<FeatureWithLines> featurePaths) {

--- a/core/src/main/java/io/cucumber/core/options/RuntimeOptionsBuilder.java
+++ b/core/src/main/java/io/cucumber/core/options/RuntimeOptionsBuilder.java
@@ -145,8 +145,8 @@ public final class RuntimeOptionsBuilder {
 
     private boolean hasFeaturesWithLineFilters() {
         return parsedRerunPaths != null || !parsedFeaturePaths.stream()
-            .map(FeatureWithLines::lines)
-            .allMatch(Set::isEmpty);
+                .map(FeatureWithLines::lines)
+                .allMatch(Set::isEmpty);
     }
 
     public RuntimeOptionsBuilder setCount(int count) {
@@ -211,7 +211,6 @@ public final class RuntimeOptionsBuilder {
         this.addDefaultFeaturePathIfAbsent = true;
         return this;
     }
-
 
     public void setObjectFactoryClass(Class<? extends ObjectFactory> objectFactoryClass) {
         this.parsedObjectFactoryClass = objectFactoryClass;

--- a/core/src/main/java/io/cucumber/core/options/ShellWords.java
+++ b/core/src/main/java/io/cucumber/core/options/ShellWords.java
@@ -21,8 +21,8 @@ class ShellWords {
             } else {
                 String shellword = shellwordsMatcher.group();
                 if (shellword.startsWith("\"")
-                    && shellword.endsWith("\"")
-                    && shellword.length() > 2) {
+                        && shellword.endsWith("\"")
+                        && shellword.length() > 2) {
                     shellword = shellword.substring(1, shellword.length() - 1);
                 }
                 matchList.add(shellword);

--- a/core/src/main/java/io/cucumber/core/plugin/AnsiFormats.java
+++ b/core/src/main/java/io/cucumber/core/plugin/AnsiFormats.java
@@ -5,33 +5,42 @@ import java.util.Map;
 
 final class AnsiFormats implements Formats {
 
-    private static final Map<String, Format> formats = new HashMap<String, Format>() {{
-        put("undefined", new ColorFormat(AnsiEscapes.YELLOW));
-        put("undefined_arg", new ColorFormat(AnsiEscapes.YELLOW, AnsiEscapes.INTENSITY_BOLD)); // Never used, but avoids NPE in formatters.
-        put("unused", new ColorFormat(AnsiEscapes.YELLOW));
-        put("unused_arg", new ColorFormat(AnsiEscapes.YELLOW, AnsiEscapes.INTENSITY_BOLD));
-        put("pending", new ColorFormat(AnsiEscapes.YELLOW));
-        put("pending_arg", new ColorFormat(AnsiEscapes.YELLOW, AnsiEscapes.INTENSITY_BOLD));
-        put("executing", new ColorFormat(AnsiEscapes.GREY));
-        put("executing_arg", new ColorFormat(AnsiEscapes.GREY, AnsiEscapes.INTENSITY_BOLD));
-        put("failed", new ColorFormat(AnsiEscapes.RED));
-        put("failed_arg", new ColorFormat(AnsiEscapes.RED, AnsiEscapes.INTENSITY_BOLD));
-        put("ambiguous", new ColorFormat(AnsiEscapes.RED));
-        put("ambiguous_arg", new ColorFormat(AnsiEscapes.RED, AnsiEscapes.INTENSITY_BOLD));
-        put("passed", new ColorFormat(AnsiEscapes.GREEN));
-        put("passed_arg", new ColorFormat(AnsiEscapes.GREEN, AnsiEscapes.INTENSITY_BOLD));
-        put("outline", new ColorFormat(AnsiEscapes.CYAN));
-        put("outline_arg", new ColorFormat(AnsiEscapes.CYAN, AnsiEscapes.INTENSITY_BOLD));
-        put("skipped", new ColorFormat(AnsiEscapes.CYAN));
-        put("skipped_arg", new ColorFormat(AnsiEscapes.CYAN, AnsiEscapes.INTENSITY_BOLD));
-        put("comment", new ColorFormat(AnsiEscapes.GREY));
-        put("tag", new ColorFormat(AnsiEscapes.CYAN));
-        put("output", new ColorFormat(AnsiEscapes.BLUE));
-    }};
+    private static final Map<String, Format> formats = new HashMap<String, Format>() {
+        {
+            put("undefined", new ColorFormat(AnsiEscapes.YELLOW));
+            put("undefined_arg", new ColorFormat(AnsiEscapes.YELLOW, AnsiEscapes.INTENSITY_BOLD)); // Never
+                                                                                                   // used,
+                                                                                                   // but
+                                                                                                   // avoids
+                                                                                                   // NPE
+                                                                                                   // in
+                                                                                                   // formatters.
+            put("unused", new ColorFormat(AnsiEscapes.YELLOW));
+            put("unused_arg", new ColorFormat(AnsiEscapes.YELLOW, AnsiEscapes.INTENSITY_BOLD));
+            put("pending", new ColorFormat(AnsiEscapes.YELLOW));
+            put("pending_arg", new ColorFormat(AnsiEscapes.YELLOW, AnsiEscapes.INTENSITY_BOLD));
+            put("executing", new ColorFormat(AnsiEscapes.GREY));
+            put("executing_arg", new ColorFormat(AnsiEscapes.GREY, AnsiEscapes.INTENSITY_BOLD));
+            put("failed", new ColorFormat(AnsiEscapes.RED));
+            put("failed_arg", new ColorFormat(AnsiEscapes.RED, AnsiEscapes.INTENSITY_BOLD));
+            put("ambiguous", new ColorFormat(AnsiEscapes.RED));
+            put("ambiguous_arg", new ColorFormat(AnsiEscapes.RED, AnsiEscapes.INTENSITY_BOLD));
+            put("passed", new ColorFormat(AnsiEscapes.GREEN));
+            put("passed_arg", new ColorFormat(AnsiEscapes.GREEN, AnsiEscapes.INTENSITY_BOLD));
+            put("outline", new ColorFormat(AnsiEscapes.CYAN));
+            put("outline_arg", new ColorFormat(AnsiEscapes.CYAN, AnsiEscapes.INTENSITY_BOLD));
+            put("skipped", new ColorFormat(AnsiEscapes.CYAN));
+            put("skipped_arg", new ColorFormat(AnsiEscapes.CYAN, AnsiEscapes.INTENSITY_BOLD));
+            put("comment", new ColorFormat(AnsiEscapes.GREY));
+            put("tag", new ColorFormat(AnsiEscapes.CYAN));
+            put("output", new ColorFormat(AnsiEscapes.BLUE));
+        }
+    };
 
     public Format get(String key) {
         Format format = formats.get(key);
-        if (format == null) throw new NullPointerException("No format for key " + key);
+        if (format == null)
+            throw new NullPointerException("No format for key " + key);
         return format;
     }
 

--- a/core/src/main/java/io/cucumber/core/plugin/CanonicalEventOrder.java
+++ b/core/src/main/java/io/cucumber/core/plugin/CanonicalEventOrder.java
@@ -15,12 +15,11 @@ import java.util.List;
 import static java.util.Arrays.asList;
 
 /**
- * When pickles are executed in parallel events can be
- * produced with a partial ordering.
+ * When pickles are executed in parallel events can be produced with a partial
+ * ordering.
  * <p>
- * The canonical order is the order in which these events
- * would have been generated had cucumber executed these
- * pickles in a serial fashion.
+ * The canonical order is the order in which these events would have been
+ * generated had cucumber executed these pickles in a serial fashion.
  * <p>
  * In canonical order events are first ordered by type:
  * <ol>
@@ -66,8 +65,7 @@ final class CanonicalEventOrder implements Comparator<Event> {
             SnippetsSuggestedEvent.class,
             StepDefinedEvent.class,
             TestCaseEvent.class,
-            TestRunFinished.class
-        );
+            TestRunFinished.class);
 
         @Override
         public int compare(final Event a, final Event b) {
@@ -104,8 +102,7 @@ final class CanonicalEventOrder implements Comparator<Event> {
 
             int line = Integer.compare(
                 a.getTestCase().getLocation().getLine(),
-                b.getTestCase().getLocation().getLine()
-            );
+                b.getTestCase().getLocation().getLine());
             if (line != 0) {
                 return line;
             }

--- a/core/src/main/java/io/cucumber/core/plugin/DefaultSummaryPrinter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/DefaultSummaryPrinter.java
@@ -83,5 +83,4 @@ public final class DefaultSummaryPrinter implements SummaryPrinter, ColorAware, 
         stats.setMonochrome(monochrome);
     }
 
-
 }

--- a/core/src/main/java/io/cucumber/core/plugin/JUnitFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/JUnitFormatter.java
@@ -26,6 +26,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -129,8 +130,10 @@ public final class JUnitFormatter implements EventListener {
             Instant finished = event.getInstant();
             // set up a transformer
             rootElement.setAttribute("name", JUnitFormatter.class.getName());
-            rootElement.setAttribute("failures", String.valueOf(rootElement.getElementsByTagName("failure").getLength()));
-            rootElement.setAttribute("skipped", String.valueOf(rootElement.getElementsByTagName("skipped").getLength()));
+            rootElement.setAttribute("failures",
+                String.valueOf(rootElement.getElementsByTagName("failure").getLength()));
+            rootElement.setAttribute("skipped",
+                String.valueOf(rootElement.getElementsByTagName("skipped").getLength()));
             rootElement.setAttribute("errors", "0");
             rootElement.setAttribute("time", calculateTotalDurationString(Duration.between(started, finished)));
 
@@ -190,17 +193,16 @@ public final class JUnitFormatter implements EventListener {
 
         private String findRootNodeName(io.cucumber.plugin.event.TestCase testCase) {
             Location location = testCase.getLocation();
-            Predicate<Node> withLocation = candidate ->
-                location.equals(candidate.getLocation());
+            Predicate<Node> withLocation = candidate -> location.equals(candidate.getLocation());
             return parsedTestSources.get(testCase.getUri())
-                .stream()
-                .map(node -> node.findPathTo(withLocation))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .findFirst()
-                .map(nodes -> nodes.get(0))
-                .flatMap(Node::getName)
-                .orElse("Unknown");
+                    .stream()
+                    .map(node -> node.findPathTo(withLocation))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .findFirst()
+                    .map(nodes -> nodes.get(0))
+                    .flatMap(Node::getName)
+                    .orElse("Unknown");
         }
 
         private String calculateElementName(io.cucumber.plugin.event.TestCase testCase) {
@@ -226,7 +228,8 @@ public final class JUnitFormatter implements EventListener {
                 child = createFailure(doc, sb, result.getError().getMessage(), result.getError().getClass());
             } else if (status.is(Status.PENDING) || status.is(Status.UNDEFINED)) {
                 Throwable error = result.getError();
-                child = createFailure(doc, sb, "The scenario has pending or undefined step(s)", error == null ? Exception.class : error.getClass());
+                child = createFailure(doc, sb, "The scenario has pending or undefined step(s)",
+                    error == null ? Exception.class : error.getClass());
             } else if (status.is(Status.SKIPPED) && result.getError() != null) {
                 addStackTrace(sb, result);
                 child = createSkipped(doc, sb, printStackTrace(result.getError()));
@@ -274,8 +277,10 @@ public final class JUnitFormatter implements EventListener {
 
         private Element createElement(Document doc, StringBuilder sb, String elementType) {
             Element child = doc.createElement(elementType);
-            // the createCDATASection method seems to convert "\n" to "\r\n" on Windows, in case
-            // data originally contains "\r\n" line separators the result becomes "\r\r\n", which
+            // the createCDATASection method seems to convert "\n" to "\r\n" on
+            // Windows, in case
+            // data originally contains "\r\n" line separators the result
+            // becomes "\r\r\n", which
             // are displayed as double line breaks.
             String normalizedLineEndings = sb.toString().replace(System.lineSeparator(), "\n");
             child.appendChild(doc.createCDATASection(normalizedLineEndings));

--- a/core/src/main/java/io/cucumber/core/plugin/JsonFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/JsonFormatter.java
@@ -112,7 +112,7 @@ public final class JsonFormatter implements EventListener {
                 currentStepsList = (List<Map<String, Object>>) currentElementMap.get("steps");
             }
             currentStepOrHookMap = createTestStep(testStep);
-            //add beforeSteps list to current step
+            // add beforeSteps list to current step
             if (currentBeforeStepHookList.containsKey(before)) {
                 currentStepOrHookMap.put(before, currentBeforeStepHookList.get(before));
                 currentBeforeStepHookList.clear();
@@ -175,8 +175,7 @@ public final class JsonFormatter implements EventListener {
                     location.put("column", tag.getLocation().getColumn());
                     json.put("location", location);
                     return json;
-                }
-            ).collect(toList()));
+                }).collect(toList()));
 
         }
         return featureMap;
@@ -197,7 +196,8 @@ public final class JsonFormatter implements EventListener {
             testCaseMap.put("id", TestSourcesModel.calculateId(astNode));
             Scenario scenarioDefinition = TestSourcesModel.getScenarioDefinition(astNode);
             testCaseMap.put("keyword", scenarioDefinition.getKeyword());
-            testCaseMap.put("description", scenarioDefinition.getDescription() != null ? scenarioDefinition.getDescription() : "");
+            testCaseMap.put("description",
+                scenarioDefinition.getDescription() != null ? scenarioDefinition.getDescription() : "");
         }
         testCaseMap.put("steps", new ArrayList<Map<String, Object>>());
         if (!testCase.getTags().isEmpty()) {
@@ -409,7 +409,7 @@ public final class JsonFormatter implements EventListener {
 
     private String getDateTimeFromTimeStamp(Instant instant) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
-            .withZone(ZoneOffset.UTC);
+                .withZone(ZoneOffset.UTC);
         return formatter.format(instant);
     }
 
@@ -433,7 +433,8 @@ public final class JsonFormatter implements EventListener {
 
     private Map<String, Object> createEmbeddingMap(byte[] data, String mediaType, String name) {
         Map<String, Object> embedMap = new HashMap<>();
-        embedMap.put("mime_type", mediaType); // Should be media-type but not worth migrating for
+        embedMap.put("mime_type", mediaType); // Should be media-type but not
+                                              // worth migrating for
         embedMap.put("data", Base64.getEncoder().encodeToString(data));
         if (name != null) {
             embedMap.put("name", name);

--- a/core/src/main/java/io/cucumber/core/plugin/MessageFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/MessageFormatter.java
@@ -15,7 +15,7 @@ public final class MessageFormatter implements ConcurrentEventListener {
 
     private final Writer writer;
     private final JsonFormat.Printer jsonPrinter = JsonFormat.printer()
-        .omittingInsignificantWhitespace();
+            .omittingInsignificantWhitespace();
 
     public MessageFormatter(OutputStream outputStream) {
         this.writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
@@ -40,4 +40,3 @@ public final class MessageFormatter implements ConcurrentEventListener {
     }
 
 }
-

--- a/core/src/main/java/io/cucumber/core/plugin/PluginFactory.java
+++ b/core/src/main/java/io/cucumber/core/plugin/PluginFactory.java
@@ -28,8 +28,9 @@ import static java.util.Arrays.asList;
 /**
  * This class creates plugin instances from a String.
  * <p>
- * The String is of the form name[:output] where name is either a fully qualified class name or one of the built-in
- * short names. The output is optional for some plugins (and mandatory for some).
+ * The String is of the form name[:output] where name is either a fully
+ * qualified class name or one of the built-in short names. The output is
+ * optional for some plugins (and mandatory for some).
  *
  * @see Plugin for specific requirements
  */
@@ -37,14 +38,14 @@ public final class PluginFactory {
 
     private static final Logger log = LoggerFactory.getLogger(PluginFactory.class);
 
-    private final Class<?>[] CTOR_PARAMETERS = new Class<?>[]{
-        String.class,
-        File.class,
-        URI.class,
-        URL.class,
-        OutputStream.class,
-        // Deprecated
-        Appendable.class
+    private final Class<?>[] CTOR_PARAMETERS = new Class<?>[] {
+            String.class,
+            File.class,
+            URI.class,
+            URL.class,
+            OutputStream.class,
+            // Deprecated
+            Appendable.class
     };
 
     private String pluginUsingDefaultOut = null;
@@ -64,7 +65,8 @@ public final class PluginFactory {
         }
     }
 
-    private <T extends Plugin> T instantiate(String pluginString, Class<T> pluginClass, String argument) throws IOException, URISyntaxException {
+    private <T extends Plugin> T instantiate(String pluginString, Class<T> pluginClass, String argument)
+            throws IOException, URISyntaxException {
         Map<Class<?>, Constructor<T>> singleArgConstructors = findSingleArgConstructors(pluginClass);
         if (argument == null) {// No argument passed
             Constructor<T> outputStreamConstructor = singleArgConstructors.get(OutputStream.class);
@@ -76,14 +78,20 @@ public final class PluginFactory {
                 return newInstance(emptyConstructor);
             }
             if (!singleArgConstructors.isEmpty()) {
-                throw new CucumberException(String.format("You must supply an output argument to %s. Like so: %s:DIR|FILE|URL", pluginString, pluginString));
+                throw new CucumberException(String.format(
+                    "You must supply an output argument to %s. Like so: %s:DIR|FILE|URL", pluginString, pluginString));
             }
-            throw new CucumberException(String.format("%s must have at least one empty constructor or a constructor that declares a single parameter of one of: %s", pluginClass, asList(CTOR_PARAMETERS)));
+            throw new CucumberException(String.format(
+                "%s must have at least one empty constructor or a constructor that declares a single parameter of one of: %s",
+                pluginClass, asList(CTOR_PARAMETERS)));
         }
         if (singleArgConstructors.size() != 1) {
-            throw new CucumberException(String.format("%s must have exactly one constructor that declares a single parameter of one of: %s", pluginClass, asList(CTOR_PARAMETERS)));
+            throw new CucumberException(
+                String.format("%s must have exactly one constructor that declares a single parameter of one of: %s",
+                    pluginClass, asList(CTOR_PARAMETERS)));
         }
-        Map.Entry<Class<?>, Constructor<T>> singleArgConstructorEntry = singleArgConstructors.entrySet().iterator().next();
+        Map.Entry<Class<?>, Constructor<T>> singleArgConstructorEntry = singleArgConstructors.entrySet().iterator()
+                .next();
         Class<?> parameterType = singleArgConstructorEntry.getKey();
         Constructor<T> singleArgConstructor = singleArgConstructorEntry.getValue();
         return newInstance(singleArgConstructor, convert(argument, parameterType, pluginString, pluginClass));
@@ -118,8 +126,9 @@ public final class PluginFactory {
                 return defaultOut;
             } else {
                 throw new CucumberException("Only one plugin can use STDOUT, now both " +
-                    pluginUsingDefaultOut + " and " + pluginString + " use it. " +
-                    "If you use more than one plugin you must specify output path with " + pluginString + ":DIR|FILE|URL");
+                        pluginUsingDefaultOut + " and " + pluginString + " use it. " +
+                        "If you use more than one plugin you must specify output path with " + pluginString
+                        + ":DIR|FILE|URL");
             }
         } finally {
             defaultOut = null;
@@ -134,7 +143,8 @@ public final class PluginFactory {
         }
     }
 
-    private Object convert(String arg, Class<?> ctorArgClass, String pluginString, Class<?> pluginClass) throws IOException, URISyntaxException {
+    private Object convert(String arg, Class<?> ctorArgClass, String pluginString, Class<?> pluginClass)
+            throws IOException, URISyntaxException {
         if (ctorArgClass.equals(URI.class)) {
             return makeURL(arg).toURI();
         }
@@ -157,13 +167,16 @@ public final class PluginFactory {
 
         if (ctorArgClass.equals(Appendable.class)) {
             String recommendedParameters = Arrays.stream(CTOR_PARAMETERS)
-                .filter(c -> c != Appendable.class)
-                .map(Class::getName)
-                .collect(Collectors.joining(", "));
-            log.error(() -> String.format("The %s plugin class takes a java.lang.Appendable in its constructor, which is deprecated and will be removed in the next major release. It should be changed to accept one of %s", pluginClass.getName(), recommendedParameters));
+                    .filter(c -> c != Appendable.class)
+                    .map(Class::getName)
+                    .collect(Collectors.joining(", "));
+            log.error(() -> String.format(
+                "The %s plugin class takes a java.lang.Appendable in its constructor, which is deprecated and will be removed in the next major release. It should be changed to accept one of %s",
+                pluginClass.getName(), recommendedParameters));
             return new UTF8OutputStreamWriter(openStream(arg));
         }
-        throw new CucumberException(String.format("Cannot convert %s into a %s to pass to the %s plugin", arg, ctorArgClass, pluginString));
+        throw new CucumberException(
+            String.format("Cannot convert %s into a %s to pass to the %s plugin", arg, ctorArgClass, pluginString));
     }
 
     private static URL makeURL(String arg) throws MalformedURLException {
@@ -194,11 +207,11 @@ public final class PluginFactory {
             return new FileOutputStream(file);
         } catch (FileNotFoundException e) {
             throw new IllegalArgumentException(String.format("" +
-                "Couldn't create a file output stream for %s.\n" +
-                "Make sure the the file isn't a directory.\n" +
-                "The details are in the stack trace below:", file),
-                e
-            );
+                    "Couldn't create a file output stream for %s.\n" +
+                    "Make sure the the file isn't a directory.\n" +
+                    "The details are in the stack trace below:",
+                file),
+                e);
         }
     }
 

--- a/core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
@@ -88,12 +88,12 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
     private void preCalculateLocationIndent(TestCaseStarted event) {
         TestCase testCase = event.getTestCase();
         Integer longestStep = testCase.getTestSteps().stream()
-            .filter(PickleStepTestStep.class::isInstance)
-            .map(PickleStepTestStep.class::cast)
-            .map(PickleStepTestStep::getStep)
-            .map(step -> formatPlainStep(step.getKeyword(), step.getText()).length())
-            .max(Comparator.naturalOrder())
-            .orElse(0);
+                .filter(PickleStepTestStep.class::isInstance)
+                .map(PickleStepTestStep.class::cast)
+                .map(PickleStepTestStep::getStep)
+                .map(step -> formatPlainStep(step.getKeyword(), step.getText()).length())
+                .max(Comparator.naturalOrder())
+                .orElse(0);
 
         int scenarioLength = formatScenarioDefinition(testCase).length();
         commentStartIndex.put(testCase.getId(), max(longestStep, scenarioLength) + 1);
@@ -111,7 +111,8 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
         String definitionText = formatScenarioDefinition(testCase);
         String path = relativize(testCase.getUri()).getSchemeSpecificPart();
         String locationIndent = calculateLocationIndent(event.getTestCase(), SCENARIO_INDENT + definitionText);
-        out.println(SCENARIO_INDENT + definitionText + locationIndent + formatLocation(path + ":" + testCase.getLocation().getLine()));
+        out.println(SCENARIO_INDENT + definitionText + locationIndent
+                + formatLocation(path + ":" + testCase.getLocation().getLine()));
     }
 
     private void printStep(TestStepFinished event) {
@@ -120,7 +121,8 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
             String keyword = testStep.getStep().getKeyword();
             String stepText = testStep.getStep().getText();
             String status = event.getResult().getStatus().name().toLowerCase(ROOT);
-            String formattedStepText = formatStepText(keyword, stepText, formats.get(status), formats.get(status + "_arg"), testStep.getDefinitionArgument());
+            String formattedStepText = formatStepText(keyword, stepText, formats.get(status),
+                formats.get(status + "_arg"), testStep.getDefinitionArgument());
             String locationIndent = calculateLocationIndent(event.getTestCase(), formatPlainStep(keyword, stepText));
             out.println(STEP_INDENT + formattedStepText + locationIndent + formatLocation(testStep.getCodeLocation()));
         }
@@ -148,7 +150,8 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
     }
 
     private void printEmbedding(EmbedEvent event) {
-        String line = "Embedding " + event.getName() + " [" + event.getMediaType() + " " + event.getData().length + " bytes]";
+        String line = "Embedding " + event.getName() + " [" + event.getMediaType() + " " + event.getData().length
+                + " bytes]";
         out.println(STEP_SCENARIO_INDENT + line);
     }
 
@@ -197,21 +200,25 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
         return formats.get("comment").text("# " + location);
     }
 
-    String formatStepText(String keyword, String stepText, Format textFormat, Format argFormat, List<Argument> arguments) {
+    String formatStepText(
+            String keyword, String stepText, Format textFormat, Format argFormat, List<Argument> arguments
+    ) {
         int beginIndex = 0;
         StringBuilder result = new StringBuilder(textFormat.text(keyword));
         for (Argument argument : arguments) {
             // can be null if the argument is missing.
             if (argument.getValue() != null) {
                 int argumentOffset = argument.getStart();
-                // a nested argument starts before the enclosing argument ends; ignore it when formatting
+                // a nested argument starts before the enclosing argument ends;
+                // ignore it when formatting
                 if (argumentOffset < beginIndex) {
                     continue;
                 }
                 String text = stepText.substring(beginIndex, argumentOffset);
                 result.append(textFormat.text(text));
             }
-            // val can be null if the argument isn't there, for example @And("(it )?has something")
+            // val can be null if the argument isn't there, for example
+            // @And("(it )?has something")
             if (argument.getValue() != null) {
                 String text = stepText.substring(argument.getStart(), argument.getEnd());
                 result.append(argFormat.text(text));

--- a/core/src/main/java/io/cucumber/core/plugin/ProgressFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/ProgressFormatter.java
@@ -15,22 +15,26 @@ import java.util.Map;
 
 public final class ProgressFormatter implements ConcurrentEventListener, ColorAware {
 
-    private static final Map<Status, Character> CHARS = new HashMap<Status, Character>() {{
-        put(Status.PASSED, '.');
-        put(Status.UNDEFINED, 'U');
-        put(Status.PENDING, 'P');
-        put(Status.SKIPPED, '-');
-        put(Status.FAILED, 'F');
-        put(Status.AMBIGUOUS, 'A');
-    }};
-    private static final Map<Status, AnsiEscapes> ANSI_ESCAPES = new HashMap<Status, AnsiEscapes>() {{
-        put(Status.PASSED, AnsiEscapes.GREEN);
-        put(Status.UNDEFINED, AnsiEscapes.YELLOW);
-        put(Status.PENDING, AnsiEscapes.YELLOW);
-        put(Status.SKIPPED, AnsiEscapes.CYAN);
-        put(Status.FAILED, AnsiEscapes.RED);
-        put(Status.AMBIGUOUS, AnsiEscapes.RED);
-    }};
+    private static final Map<Status, Character> CHARS = new HashMap<Status, Character>() {
+        {
+            put(Status.PASSED, '.');
+            put(Status.UNDEFINED, 'U');
+            put(Status.PENDING, 'P');
+            put(Status.SKIPPED, '-');
+            put(Status.FAILED, 'F');
+            put(Status.AMBIGUOUS, 'A');
+        }
+    };
+    private static final Map<Status, AnsiEscapes> ANSI_ESCAPES = new HashMap<Status, AnsiEscapes>() {
+        {
+            put(Status.PASSED, AnsiEscapes.GREEN);
+            put(Status.UNDEFINED, AnsiEscapes.YELLOW);
+            put(Status.PENDING, AnsiEscapes.YELLOW);
+            put(Status.SKIPPED, AnsiEscapes.CYAN);
+            put(Status.FAILED, AnsiEscapes.RED);
+            put(Status.AMBIGUOUS, AnsiEscapes.RED);
+        }
+    };
 
     private final NiceAppendable out;
     private boolean monochrome = false;

--- a/core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
@@ -62,4 +62,3 @@ public final class RerunFormatter implements ConcurrentEventListener {
     }
 
 }
-

--- a/core/src/main/java/io/cucumber/core/plugin/TeamCityPlugin.java
+++ b/core/src/main/java/io/cucumber/core/plugin/TeamCityPlugin.java
@@ -52,21 +52,33 @@ public class TeamCityPlugin implements EventListener {
     private static final String TEAMCITY_PREFIX = "##teamcity";
 
     private static final String TEMPLATE_ENTER_THE_MATRIX = TEAMCITY_PREFIX + "[enteredTheMatrix timestamp = '%s']";
-    private static final String TEMPLATE_TEST_RUN_STARTED = TEAMCITY_PREFIX + "[testSuiteStarted timestamp = '%s' name = 'Cucumber']";
-    private static final String TEMPLATE_TEST_RUN_FINISHED = TEAMCITY_PREFIX + "[testSuiteFinished timestamp = '%s' name = 'Cucumber']";
+    private static final String TEMPLATE_TEST_RUN_STARTED = TEAMCITY_PREFIX
+            + "[testSuiteStarted timestamp = '%s' name = 'Cucumber']";
+    private static final String TEMPLATE_TEST_RUN_FINISHED = TEAMCITY_PREFIX
+            + "[testSuiteFinished timestamp = '%s' name = 'Cucumber']";
 
-    private static final String TEMPLATE_TEST_SUITE_STARTED = TEAMCITY_PREFIX + "[testSuiteStarted timestamp = '%s' locationHint = '%s' name = '%s']";
-    private static final String TEMPLATE_TEST_SUITE_FINISHED = TEAMCITY_PREFIX + "[testSuiteFinished timestamp = '%s' name = '%s']";
+    private static final String TEMPLATE_TEST_SUITE_STARTED = TEAMCITY_PREFIX
+            + "[testSuiteStarted timestamp = '%s' locationHint = '%s' name = '%s']";
+    private static final String TEMPLATE_TEST_SUITE_FINISHED = TEAMCITY_PREFIX
+            + "[testSuiteFinished timestamp = '%s' name = '%s']";
 
-    private static final String TEMPLATE_TEST_STARTED = TEAMCITY_PREFIX + "[testStarted timestamp = '%s' locationHint = '%s' captureStandardOutput = 'true' name = '%s']";
-    private static final String TEMPLATE_TEST_FINISHED = TEAMCITY_PREFIX + "[testFinished timestamp = '%s' duration = '%s' name = '%s']";
-    private static final String TEMPLATE_TEST_FAILED = TEAMCITY_PREFIX + "[testFailed timestamp = '%s' duration = '%s' message = '%s' details = '%s' name = '%s']";
-    private static final String TEMPLATE_TEST_IGNORED = TEAMCITY_PREFIX + "[testIgnored timestamp = '%s' duration = '%s' message = '%s' name = '%s']";
+    private static final String TEMPLATE_TEST_STARTED = TEAMCITY_PREFIX
+            + "[testStarted timestamp = '%s' locationHint = '%s' captureStandardOutput = 'true' name = '%s']";
+    private static final String TEMPLATE_TEST_FINISHED = TEAMCITY_PREFIX
+            + "[testFinished timestamp = '%s' duration = '%s' name = '%s']";
+    private static final String TEMPLATE_TEST_FAILED = TEAMCITY_PREFIX
+            + "[testFailed timestamp = '%s' duration = '%s' message = '%s' details = '%s' name = '%s']";
+    private static final String TEMPLATE_TEST_IGNORED = TEAMCITY_PREFIX
+            + "[testIgnored timestamp = '%s' duration = '%s' message = '%s' name = '%s']";
 
-    private static final String TEMPLATE_PROGRESS_COUNTING_STARTED = TEAMCITY_PREFIX + "[customProgressStatus testsCategory = 'Scenarios' count = '0' timestamp = '%s']";
-    private static final String TEMPLATE_PROGRESS_COUNTING_FINISHED = TEAMCITY_PREFIX + "[customProgressStatus testsCategory = '' count = '0' timestamp = '%s']";
-    private static final String TEMPLATE_PROGRESS_TEST_STARTED = TEAMCITY_PREFIX + "[customProgressStatus type = 'testStarted' timestamp = '%s']";
-    private static final String TEMPLATE_PROGRESS_TEST_FINISHED = TEAMCITY_PREFIX + "[customProgressStatus type = 'testFinished' timestamp = '%s']";
+    private static final String TEMPLATE_PROGRESS_COUNTING_STARTED = TEAMCITY_PREFIX
+            + "[customProgressStatus testsCategory = 'Scenarios' count = '0' timestamp = '%s']";
+    private static final String TEMPLATE_PROGRESS_COUNTING_FINISHED = TEAMCITY_PREFIX
+            + "[customProgressStatus testsCategory = '' count = '0' timestamp = '%s']";
+    private static final String TEMPLATE_PROGRESS_TEST_STARTED = TEAMCITY_PREFIX
+            + "[customProgressStatus type = 'testStarted' timestamp = '%s']";
+    private static final String TEMPLATE_PROGRESS_TEST_FINISHED = TEAMCITY_PREFIX
+            + "[customProgressStatus type = 'testFinished' timestamp = '%s']";
 
     private static final String TEMPLATE_ATTACH_WRITE_EVENT = TEAMCITY_PREFIX + "[message text='%s' status='NORMAL']";
 
@@ -126,15 +138,14 @@ public class TeamCityPlugin implements EventListener {
         String timestamp = extractTimeStamp(event);
 
         Location location = testCase.getLocation();
-        Predicate<Node> withLocation = candidate ->
-            location.equals(candidate.getLocation());
+        Predicate<Node> withLocation = candidate -> location.equals(candidate.getLocation());
         List<Node> path = parsedTestSources.get(uri)
-            .stream()
-            .map(node -> node.findPathTo(withLocation))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .findFirst()
-            .orElse(emptyList());
+                .stream()
+                .map(node -> node.findPathTo(withLocation))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst()
+                .orElse(emptyList());
 
         poppedNodes(path).forEach(node -> finishNode(timestamp, node));
         pushedNodes(path).forEach(node -> startNode(uri, timestamp, node));
@@ -186,7 +197,6 @@ public class TeamCityPlugin implements EventListener {
         return newStack.subList(currentStack.size(), newStack.size());
     }
 
-
     private void printTestStepStarted(TestStepStarted event) {
         String timestamp = extractTimeStamp(event);
         String name = extractName(event.getTestStep());
@@ -236,10 +246,12 @@ public class TeamCityPlugin implements EventListener {
         Status status = event.getResult().getStatus();
         switch (status) {
             case SKIPPED:
-                print(TEMPLATE_TEST_IGNORED, timeStamp, duration, error == null ? "Step skipped" : error.getMessage(), name);
+                print(TEMPLATE_TEST_IGNORED, timeStamp, duration, error == null ? "Step skipped" : error.getMessage(),
+                    name);
                 break;
             case PENDING:
-                print(TEMPLATE_TEST_IGNORED, timeStamp, duration, error == null ? "Step pending" : error.getMessage(), name);
+                print(TEMPLATE_TEST_IGNORED, timeStamp, duration, error == null ? "Step pending" : error.getMessage(),
+                    name);
                 break;
             case UNDEFINED:
                 PickleStepTestStep testStep = (PickleStepTestStep) event.getTestStep();
@@ -295,19 +307,16 @@ public class TeamCityPlugin implements EventListener {
         }
 
         snippets.stream()
-            .filter(snippet ->
-                snippet.getStepLocation().equals(testStep.getStep().getLocation()) &&
-                    snippet.getUri().equals(testStep.getUri())
-            )
-            .findFirst()
-            .ifPresent(event -> {
+                .filter(snippet -> snippet.getStepLocation().equals(testStep.getStep().getLocation()) &&
+                        snippet.getUri().equals(testStep.getUri()))
+                .findFirst()
+                .ifPresent(event -> {
                     builder.append("You can implement missing steps with the snippets below:\n");
                     event.getSnippets().forEach(snippet -> {
                         builder.append(snippet);
                         builder.append("\n");
                     });
-                }
-            );
+                });
         return builder.toString();
     }
 
@@ -338,7 +347,8 @@ public class TeamCityPlugin implements EventListener {
 
     private void handleEmbedEvent(EmbedEvent event) {
         String name = event.getName() == null ? "" : event.getName() + " ";
-        print(TEMPLATE_ATTACH_WRITE_EVENT, "Embed event: " + name + "[" + event.getMediaType() + " " + event.getData().length + " bytes]\n");
+        print(TEMPLATE_ATTACH_WRITE_EVENT,
+            "Embed event: " + name + "[" + event.getMediaType() + " " + event.getData().length + " bytes]\n");
     }
 
     private void handleWriteEvent(WriteEvent event) {
@@ -363,12 +373,12 @@ public class TeamCityPlugin implements EventListener {
             return "";
         }
         return source
-            .replace("|", "||")
-            .replace("'", "|'")
-            .replace("\n", "|n")
-            .replace("\r", "|r")
-            .replace("[", "|[")
-            .replace("]", "|]");
+                .replace("|", "||")
+                .replace("'", "|'")
+                .replace("\n", "|n")
+                .replace("\r", "|r")
+                .replace("[", "|[")
+                .replace("]", "|]");
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/plugin/TestNGFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/TestNGFormatter.java
@@ -27,6 +27,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -113,17 +114,16 @@ public final class TestNGFormatter implements EventListener {
 
     private String findRootNodeName(io.cucumber.plugin.event.TestCase testCase) {
         Location location = testCase.getLocation();
-        Predicate<Node> withLocation = candidate ->
-            candidate.getLocation().equals(location);
+        Predicate<Node> withLocation = candidate -> candidate.getLocation().equals(location);
         return parsedTestSources.get(testCase.getUri())
-            .stream()
-            .map(node -> node.findPathTo(withLocation))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .findFirst()
-            .map(nodes -> nodes.get(0))
-            .flatMap(Node::getName)
-            .orElse("Unknown");
+                .stream()
+                .map(node -> node.findPathTo(withLocation))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst()
+                .map(nodes -> nodes.get(0))
+                .flatMap(Node::getName)
+                .orElse("Unknown");
     }
 
     private void handleTestStepFinished(TestStepFinished event) {
@@ -241,11 +241,13 @@ public final class TestNGFormatter implements EventListener {
             if (failed != null) {
                 element.setAttribute("status", "FAIL");
                 String stacktrace = printStackTrace(failed.getError());
-                Element exception = createException(doc, failed.getError().getClass().getName(), stringBuilder.toString(), stacktrace);
+                Element exception = createException(doc, failed.getError().getClass().getName(),
+                    stringBuilder.toString(), stacktrace);
                 element.appendChild(exception);
             } else if (skipped != null) {
                 element.setAttribute("status", "FAIL");
-                Element exception = createException(doc, "The scenario has pending or undefined step(s)", stringBuilder.toString(), "The scenario has pending or undefined step(s)");
+                Element exception = createException(doc, "The scenario has pending or undefined step(s)",
+                    stringBuilder.toString(), "The scenario has pending or undefined step(s)");
                 element.appendChild(exception);
             } else {
                 element.setAttribute("status", "PASS");

--- a/core/src/main/java/io/cucumber/core/plugin/TestSourcesModel.java
+++ b/core/src/main/java/io/cucumber/core/plugin/TestSourcesModel.java
@@ -108,22 +108,20 @@ final class TestSourcesModel {
         String source = pathToReadEventMap.get(path).getSource();
 
         List<Messages.Envelope> sources = singletonList(
-            makeSourceEnvelope(source, path.toString())
-        );
+            makeSourceEnvelope(source, path.toString()));
 
         List<Messages.Envelope> envelopes = Gherkin.fromSources(
             sources,
             true,
             true,
             true,
-            () -> String.valueOf(UUID.randomUUID())
-        ).collect(toList());
+            () -> String.valueOf(UUID.randomUUID())).collect(toList());
 
         GherkinDocument gherkinDocument = envelopes.stream()
-            .filter(Messages.Envelope::hasGherkinDocument)
-            .map(Messages.Envelope::getGherkinDocument)
-            .findFirst()
-            .orElse(null);
+                .filter(Messages.Envelope::hasGherkinDocument)
+                .map(Messages.Envelope::getGherkinDocument)
+                .findFirst()
+                .orElse(null);
 
         pathToAstMap.put(path, gherkinDocument);
         Map<Integer, AstNode> nodeMap = new HashMap<>();
@@ -149,7 +147,9 @@ final class TestSourcesModel {
         }
     }
 
-    private void processBackgroundDefinition(Map<Integer, AstNode> nodeMap, Background background, AstNode currentParent) {
+    private void processBackgroundDefinition(
+            Map<Integer, AstNode> nodeMap, Background background, AstNode currentParent
+    ) {
         AstNode childNode = new AstNode(background, currentParent);
         nodeMap.put(background.getLocation().getLine(), childNode);
         for (Step step : background.getStepsList()) {
@@ -176,7 +176,9 @@ final class TestSourcesModel {
         }
     }
 
-    private void processScenarioOutlineExamples(Map<Integer, AstNode> nodeMap, Scenario scenarioOutline, AstNode parent) {
+    private void processScenarioOutlineExamples(
+            Map<Integer, AstNode> nodeMap, Scenario scenarioOutline, AstNode parent
+    ) {
         for (Examples examples : scenarioOutline.getExamplesList()) {
             AstNode examplesNode = new AstNode(examples, parent);
             TableRow headerRow = examples.getTableHeader();
@@ -215,11 +217,11 @@ final class TestSourcesModel {
     static Background getBackgroundForTestCase(AstNode astNode) {
         Feature feature = getFeatureForTestCase(astNode);
         return feature.getChildrenList()
-            .stream()
-            .filter(FeatureChild::hasBackground)
-            .map(FeatureChild::getBackground)
-            .findFirst()
-            .orElse(null);
+                .stream()
+                .filter(FeatureChild::hasBackground)
+                .map(FeatureChild::getBackground)
+                .findFirst()
+                .orElse(null);
     }
 
     private static Feature getFeatureForTestCase(AstNode astNode) {

--- a/core/src/main/java/io/cucumber/core/plugin/TimelineFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/TimelineFormatter.java
@@ -34,18 +34,18 @@ import static java.util.Locale.ROOT;
 
 public final class TimelineFormatter implements ConcurrentEventListener {
 
-    private static final String[] TEXT_ASSETS = new String[]{
-        "/io/cucumber/core/plugin/timeline/index.html",
-        "/io/cucumber/core/plugin/timeline/formatter.js",
-        "/io/cucumber/core/plugin/timeline/report.css",
-        "/io/cucumber/core/plugin/timeline/jquery-3.4.1.min.js",
-        "/io/cucumber/core/plugin/timeline/vis.min.css",
-        "/io/cucumber/core/plugin/timeline/vis.min.js",
-        "/io/cucumber/core/plugin/timeline/vis.override.css",
-        "/io/cucumber/core/plugin/timeline/chosen.jquery.min.js",
-        "/io/cucumber/core/plugin/timeline/chosen.min.css",
-        "/io/cucumber/core/plugin/timeline/chosen.override.css",
-        "/io/cucumber/core/plugin/timeline/chosen-sprite.png"
+    private static final String[] TEXT_ASSETS = new String[] {
+            "/io/cucumber/core/plugin/timeline/index.html",
+            "/io/cucumber/core/plugin/timeline/formatter.js",
+            "/io/cucumber/core/plugin/timeline/report.css",
+            "/io/cucumber/core/plugin/timeline/jquery-3.4.1.min.js",
+            "/io/cucumber/core/plugin/timeline/vis.min.css",
+            "/io/cucumber/core/plugin/timeline/vis.min.js",
+            "/io/cucumber/core/plugin/timeline/vis.override.css",
+            "/io/cucumber/core/plugin/timeline/chosen.jquery.min.js",
+            "/io/cucumber/core/plugin/timeline/chosen.min.css",
+            "/io/cucumber/core/plugin/timeline/chosen.override.css",
+            "/io/cucumber/core/plugin/timeline/chosen-sprite.png"
     };
 
     private final Map<String, TestData> allTests = new HashMap<>();
@@ -54,16 +54,17 @@ public final class TimelineFormatter implements ConcurrentEventListener {
     private final NiceAppendable reportJs;
     private final Map<URI, Collection<Node>> parsedTestSources = new HashMap<>();
 
-
     @SuppressWarnings("unused") // Used by PluginFactory
     public TimelineFormatter(final File reportDir) throws FileNotFoundException {
         reportDir.mkdirs();
         if (!reportDir.isDirectory()) {
-            throw new CucumberException(String.format("The %s needs an existing directory. Not a directory: %s", getClass().getName(), reportDir.getAbsolutePath()));
+            throw new CucumberException(String.format("The %s needs an existing directory. Not a directory: %s",
+                getClass().getName(), reportDir.getAbsolutePath()));
         }
 
         this.reportDir = reportDir;
-        this.reportJs = new NiceAppendable(new UTF8OutputStreamWriter(new FileOutputStream(new File(reportDir, "report.js"))));
+        this.reportJs = new NiceAppendable(
+            new UTF8OutputStreamWriter(new FileOutputStream(new File(reportDir, "report.js"))));
     }
 
     @Override
@@ -99,29 +100,33 @@ public final class TimelineFormatter implements ConcurrentEventListener {
         reportJs.println();
         appendAsJsonToJs(gson, reportJs, "timelineItems", allTests.values());
         reportJs.println();
-        //Need to sort groups by id, so can guarantee output of order in rendered timeline
+        // Need to sort groups by id, so can guarantee output of order in
+        // rendered timeline
         appendAsJsonToJs(gson, reportJs, "timelineGroups", new TreeMap<>(allGroups).values());
         reportJs.println();
         reportJs.append("});");
         reportJs.close();
         copyReportFiles();
 
-        // TODO: Enable this warning when cucumber-html-formatter is ready to be used
-//        System.err.println("" +
-//            "\n" +
-//            "****************************************\n" +
-//            "* WARNING: The timeline formatter will *\n" +
-//            "* be removed in cucumber-jvm 6.0.0 and *\n" +
-//            "* be replaced by the standalone        *\n" +
-//            "* cucumber-html-formatter.             *\n" +
-//            "****************************************\n");
+        // TODO: Enable this warning when cucumber-html-formatter is ready to be
+        // used
+        // System.err.println("" +
+        // "\n" +
+        // "****************************************\n" +
+        // "* WARNING: The timeline formatter will *\n" +
+        // "* be removed in cucumber-jvm 6.0.0 and *\n" +
+        // "* be replaced by the standalone *\n" +
+        // "* cucumber-html-formatter. *\n" +
+        // "****************************************\n");
     }
 
     private String getId(final TestCaseEvent testCaseEvent) {
         return testCaseEvent.getTestCase().getId().toString();
     }
 
-    private void appendAsJsonToJs(final Gson gson, final NiceAppendable out, final String pushTo, final Collection<?> content) {
+    private void appendAsJsonToJs(
+            final Gson gson, final NiceAppendable out, final String pushTo, final Collection<?> content
+    ) {
         out.append("CucumberHTML.").append(pushTo).append(".pushArray(");
         gson.toJson(content, out);
         out.append(");");
@@ -196,7 +201,7 @@ public final class TimelineFormatter implements ConcurrentEventListener {
         @SerializedName("group")
         final long threadId;
         @SerializedName("content")
-        final String content = ""; //Replaced in JS file
+        final String content = ""; // Replaced in JS file
         @SerializedName("tags")
         final String tags;
         @SerializedName("end")
@@ -217,17 +222,16 @@ public final class TimelineFormatter implements ConcurrentEventListener {
 
         private String findRootNodeName(TestCase testCase) {
             Location location = testCase.getLocation();
-            Predicate<Node> withLocation = candidate ->
-                candidate.getLocation().equals(location);
+            Predicate<Node> withLocation = candidate -> candidate.getLocation().equals(location);
             return parsedTestSources.get(testCase.getUri())
-                .stream()
-                .map(node -> node.findPathTo(withLocation))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .findFirst()
-                .map(nodes -> nodes.get(0))
-                .flatMap(Node::getName)
-                .orElse("Unknown");
+                    .stream()
+                    .map(node -> node.findPathTo(withLocation))
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .findFirst()
+                    .map(nodes -> nodes.get(0))
+                    .flatMap(Node::getName)
+                    .orElse("Unknown");
         }
 
         private String buildTagsValue(final TestCase testCase) {

--- a/core/src/main/java/io/cucumber/core/plugin/UrlOutputStream.java
+++ b/core/src/main/java/io/cucumber/core/plugin/UrlOutputStream.java
@@ -70,12 +70,14 @@ class UrlOutputStream extends OutputStream {
         }
     }
 
-    private static void handleResponse(HttpURLConnection urlConnection, Map<String, List<String>> requestHeaders) throws IOException {
+    private static void handleResponse(HttpURLConnection urlConnection, Map<String, List<String>> requestHeaders)
+            throws IOException {
         Map<String, List<String>> responseHeaders = urlConnection.getHeaderFields();
         int responseCode = urlConnection.getResponseCode();
         boolean success = 200 <= responseCode && responseCode < 300;
 
-        InputStream inputStream = urlConnection.getErrorStream() != null ? urlConnection.getErrorStream() : urlConnection.getInputStream();
+        InputStream inputStream = urlConnection.getErrorStream() != null ? urlConnection.getErrorStream()
+                : urlConnection.getInputStream();
         try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream, UTF_8))) {
             String responseBody = br.lines().collect(Collectors.joining(System.lineSeparator()));
             if (!success) {
@@ -87,11 +89,12 @@ class UrlOutputStream extends OutputStream {
     }
 
     static IOException createCurlLikeException(
-        String method,
-        URL url,
-        Map<String, List<String>> requestHeaders,
-        Map<String, List<String>> responseHeaders,
-        String responseBody) {
+            String method,
+            URL url,
+            Map<String, List<String>> requestHeaders,
+            Map<String, List<String>> responseHeaders,
+            String responseBody
+    ) {
         return new IOException(String.format(
             "%s:\n> %s %s%s%s%s",
             "HTTP request failed",
@@ -99,27 +102,26 @@ class UrlOutputStream extends OutputStream {
             url,
             headersToString("> ", requestHeaders),
             headersToString("< ", responseHeaders),
-            responseBody
-        ));
+            responseBody));
     }
 
     private static String headersToString(String prefix, Map<String, List<String>> headers) {
         return headers
-            .entrySet()
-            .stream()
-            .flatMap(header -> header
-                .getValue()
+                .entrySet()
                 .stream()
-                .map(value -> {
-                    if (header.getKey() == null) {
-                        return prefix + value;
-                    } else if (header.getValue() == null) {
-                        return prefix + header.getKey();
-                    } else {
-                        return prefix + header.getKey() + ": " + value;
-                    }
-                })
-            ).collect(Collectors.joining("\n", "", "\n"));
+                .flatMap(header -> header
+                        .getValue()
+                        .stream()
+                        .map(value -> {
+                            if (header.getKey() == null) {
+                                return prefix + value;
+                            } else if (header.getValue() == null) {
+                                return prefix + header.getKey();
+                            } else {
+                                return prefix + header.getKey() + ": " + value;
+                            }
+                        }))
+                .collect(Collectors.joining("\n", "", "\n"));
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/plugin/UsageFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/UsageFormatter.java
@@ -24,7 +24,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Formatter to measure performance of steps. Includes average and median step duration.
+ * Formatter to measure performance of steps. Includes average and median step
+ * duration.
  */
 public final class UsageFormatter implements Plugin, ConcurrentEventListener {
 
@@ -60,8 +61,7 @@ public final class UsageFormatter implements Plugin, ConcurrentEventListener {
         for (Map.Entry<String, List<StepContainer>> usageEntry : usageMap.entrySet()) {
             StepDefContainer stepDefContainer = new StepDefContainer(
                 usageEntry.getKey(),
-                createStepContainers(usageEntry.getValue())
-            );
+                createStepContainers(usageEntry.getValue()));
             stepDefContainers.add(stepDefContainer);
         }
 
@@ -72,7 +72,8 @@ public final class UsageFormatter implements Plugin, ConcurrentEventListener {
     private void addUsageEntry(Result result, PickleStepTestStep testStep) {
         List<StepContainer> stepContainers = usageMap.computeIfAbsent(testStep.getPattern(), k -> new ArrayList<>());
         StepContainer stepContainer = findOrCreateStepContainer(testStep.getStepText(), stepContainers);
-        StepDuration stepDuration = new StepDuration(result.getDuration(), testStep.getUri() + ":" + testStep.getStepLine());
+        StepDuration stepDuration = new StepDuration(result.getDuration(),
+            testStep.getUri() + ":" + testStep.getStepLine());
         stepContainer.getDurations().add(stepDuration);
     }
 
@@ -84,13 +85,13 @@ public final class UsageFormatter implements Plugin, ConcurrentEventListener {
     }
 
     private Gson gson() {
-        JsonSerializer<Duration> durationJsonSerializer = (duration, returnVal, jsonSerializationContext) ->
-            new JsonPrimitive((double) duration.getNano() / NANOS_PER_SECOND);
+        JsonSerializer<Duration> durationJsonSerializer = (duration, returnVal,
+                jsonSerializationContext) -> new JsonPrimitive((double) duration.getNano() / NANOS_PER_SECOND);
 
         return new GsonBuilder()
-            .registerTypeAdapter(Duration.class, durationJsonSerializer)
-            .setPrettyPrinting()
-            .create();
+                .registerTypeAdapter(Duration.class, durationJsonSerializer)
+                .setPrettyPrinting()
+                .create();
     }
 
     private StepContainer findOrCreateStepContainer(String stepNameWithArgs, List<StepContainer> stepContainers) {

--- a/core/src/main/java/io/cucumber/core/resource/ClasspathScanner.java
+++ b/core/src/main/java/io/cucumber/core/resource/ClasspathScanner.java
@@ -39,9 +39,9 @@ public final class ClasspathScanner {
 
     public <T> List<Class<? extends T>> scanForSubClassesInPackage(String packageName, Class<T> parentClass) {
         return scanForClassesInPackage(packageName, isSubClassOf(parentClass))
-            .stream()
-            .map(aClass -> (Class<? extends T>) aClass.asSubclass(parentClass))
-            .collect(toList());
+                .stream()
+                .map(aClass -> (Class<? extends T>) aClass.asSubclass(parentClass))
+                .collect(toList());
     }
 
     private List<Class<?>> scanForClassesInPackage(String packageName, Predicate<Class<?>> classFilter) {
@@ -61,10 +61,10 @@ public final class ClasspathScanner {
 
     private List<Class<?>> findClassesForUris(List<URI> baseUris, String packageName, Predicate<Class<?>> classFilter) {
         return baseUris.stream()
-            .map(baseUri -> findClassesForUri(baseUri, packageName, classFilter))
-            .flatMap(Collection::stream)
-            .distinct()
-            .collect(toList());
+                .map(baseUri -> findClassesForUri(baseUri, packageName, classFilter))
+                .flatMap(Collection::stream)
+                .distinct()
+                .collect(toList());
     }
 
     private List<Class<?>> findClassesForUri(URI baseUri, String packageName, Predicate<Class<?>> classFilter) {
@@ -72,8 +72,7 @@ public final class ClasspathScanner {
         pathScanner.findResourcesForUri(
             baseUri,
             path -> isNotModuleInfo(path) && isNotPackageInfo(path) && isClassFile(path),
-            processClassFiles(packageName, classFilter, classes::add)
-        );
+            processClassFiles(packageName, classFilter, classes::add));
         return classes;
     }
 
@@ -89,15 +88,17 @@ public final class ClasspathScanner {
         return file.getFileName().toString().endsWith(CLASS_FILE_SUFFIX);
     }
 
-    private Function<Path, Consumer<Path>> processClassFiles(String basePackageName,
-                                                             Predicate<Class<?>> classFilter,
-                                                             Consumer<Class<?>> classConsumer) {
+    private Function<Path, Consumer<Path>> processClassFiles(
+            String basePackageName,
+            Predicate<Class<?>> classFilter,
+            Consumer<Class<?>> classConsumer
+    ) {
         return baseDir -> classFile -> {
             String fqn = determineFullyQualifiedClassName(baseDir, basePackageName, classFile);
             try {
                 Optional.of(getClassLoader().loadClass(fqn))
-                    .filter(classFilter)
-                    .ifPresent(classConsumer);
+                        .filter(classFilter)
+                        .ifPresent(classConsumer);
             } catch (ClassNotFoundException | NoClassDefFoundError e) {
                 log.debug(e, () -> "Failed to load class " + fqn);
             }

--- a/core/src/main/java/io/cucumber/core/resource/ClasspathSupport.java
+++ b/core/src/main/java/io/cucumber/core/resource/ClasspathSupport.java
@@ -1,6 +1,7 @@
 package io.cucumber.core.resource;
 
 import javax.lang.model.SourceVersion;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -38,7 +39,7 @@ public final class ClasspathSupport {
             return;
         }
         boolean valid = stream(DOT_PATTERN.split(packageName))
-            .allMatch(SourceVersion::isName);
+                .allMatch(SourceVersion::isName);
         if (!valid) {
             throw new IllegalArgumentException("Invalid part(s) in package name: " + packageName);
         }
@@ -69,8 +70,8 @@ public final class ClasspathSupport {
     static String determinePackageName(Path baseDir, String basePackageName, Path classFile) {
         String subPackageName = determineSubpackageName(baseDir, classFile);
         return of(basePackageName, subPackageName)
-            .filter(value -> !value.isEmpty()) // default package
-            .collect(joining(PACKAGE_SEPARATOR_STRING));
+                .filter(value -> !value.isEmpty()) // default package
+                .collect(joining(PACKAGE_SEPARATOR_STRING));
     }
 
     private static String determineSubpackageName(Path baseDir, Path resource) {
@@ -83,8 +84,8 @@ public final class ClasspathSupport {
         String subPackageName = determineSubpackagePath(baseDir, resource);
         String resourceName = resource.getFileName().toString();
         String classpathResourcePath = of(basePackagePath, subPackageName, resourceName)
-            .filter(value -> !value.isEmpty()) // default package .
-            .collect(joining(RESOURCE_SEPARATOR_STRING));
+                .filter(value -> !value.isEmpty()) // default package .
+                .collect(joining(RESOURCE_SEPARATOR_STRING));
         return classpathResourceUri(classpathResourcePath);
     }
 
@@ -107,8 +108,8 @@ public final class ClasspathSupport {
         String subpackageName = determineSubpackageName(baseDir, classFile);
         String simpleClassName = determineSimpleClassName(classFile);
         return of(basePackageName, subpackageName, simpleClassName)
-            .filter(value -> !value.isEmpty()) // default package
-            .collect(joining(PACKAGE_SEPARATOR_STRING));
+                .filter(value -> !value.isEmpty()) // default package
+                .collect(joining(PACKAGE_SEPARATOR_STRING));
     }
 
     private static String determineSimpleClassName(Path classFile) {

--- a/core/src/main/java/io/cucumber/core/resource/JarUriFileSystemService.java
+++ b/core/src/main/java/io/cucumber/core/resource/JarUriFileSystemService.java
@@ -27,7 +27,7 @@ class JarUriFileSystemService {
     private static final Map<URI, AtomicInteger> referenceCount = new HashMap<>();
 
     private static CloseablePath open(URI jarUri, Function<FileSystem, Path> pathProvider)
-        throws IOException {
+            throws IOException {
         FileSystem fileSystem = openFileSystem(jarUri);
         Path path = pathProvider.apply(fileSystem);
         return CloseablePath.open(path, () -> closeFileSystem(jarUri));
@@ -101,14 +101,13 @@ class JarUriFileSystemService {
 
     private static CucumberException nestedJarEntriesAreUnsupported(URI uri) {
         return new CucumberException("" +
-            "The resource " + uri + " is located in a nested jar.\n" +
-            "\n" +
-            "This typically happens when trying to run Cucumber inside a Spring Boot Executable Jar.\n" +
-            "Cucumber currently doesn't support classpath scanning in nested jars.\n" +
-            "Feel free to send a pull request to make this possible!\n" +
-            "\n" +
-            "You can avoid this error by unpacking your application before executing."
-        );
+                "The resource " + uri + " is located in a nested jar.\n" +
+                "\n" +
+                "This typically happens when trying to run Cucumber inside a Spring Boot Executable Jar.\n" +
+                "Cucumber currently doesn't support classpath scanning in nested jars.\n" +
+                "Feel free to send a pull request to make this possible!\n" +
+                "\n" +
+                "You can avoid this error by unpacking your application before executing.");
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/resource/Resource.java
+++ b/core/src/main/java/io/cucumber/core/resource/Resource.java
@@ -13,9 +13,9 @@ public interface Resource {
      * Returns a uri representing this resource.
      * <p>
      * Resources on the classpath will have the form
-     * {@code classpath:com/example.feature} while resources on the file
-     * system will have the form {@code file:/path/to/example.feature}. Other
-     * resources will be represented by their exact uri.
+     * {@code classpath:com/example.feature} while resources on the file system
+     * will have the form {@code file:/path/to/example.feature}. Other resources
+     * will be represented by their exact uri.
      *
      * @return a uri representing this resource
      */

--- a/core/src/main/java/io/cucumber/core/resource/ResourceScanner.java
+++ b/core/src/main/java/io/cucumber/core/resource/ResourceScanner.java
@@ -34,9 +34,10 @@ public final class ResourceScanner<R> {
     private final Predicate<Path> canLoad;
     private final Function<Resource, Optional<R>> loadResource;
 
-    public ResourceScanner(Supplier<ClassLoader> classLoaderSupplier,
-                           Predicate<Path> canLoad,
-                           Function<Resource, Optional<R>> loadResource
+    public ResourceScanner(
+            Supplier<ClassLoader> classLoaderSupplier,
+            Predicate<Path> canLoad,
+            Function<Resource, Optional<R>> loadResource
     ) {
         this.classLoaderSupplier = classLoaderSupplier;
         this.canLoad = canLoad;
@@ -50,30 +51,33 @@ public final class ResourceScanner<R> {
         return findResourcesForUri(root, DEFAULT_PACKAGE_NAME, packageFilter, createResource);
     }
 
-    private List<R> findResourcesForUri(URI baseUri,
-                                        String basePackageName,
-                                        Predicate<String> packageFilter,
-                                        BiFunction<Path, Path, Resource> createResource) {
+    private List<R> findResourcesForUri(
+            URI baseUri,
+            String basePackageName,
+            Predicate<String> packageFilter,
+            BiFunction<Path, Path, Resource> createResource
+    ) {
         List<R> resources = new ArrayList<>();
         pathScanner.findResourcesForUri(
             baseUri,
             canLoad,
-            processResource(basePackageName, packageFilter, createResource, resources::add)
-        );
+            processResource(basePackageName, packageFilter, createResource, resources::add));
         return resources;
     }
 
-    private Function<Path, Consumer<Path>> processResource(String basePackageName,
-                                                           Predicate<String> packageFilter,
-                                                           BiFunction<Path, Path, Resource> createResource,
-                                                           Consumer<R> consumer) {
+    private Function<Path, Consumer<Path>> processResource(
+            String basePackageName,
+            Predicate<String> packageFilter,
+            BiFunction<Path, Path, Resource> createResource,
+            Consumer<R> consumer
+    ) {
         return baseDir -> path -> {
             String packageName = determinePackageName(baseDir, basePackageName, path);
             if (packageFilter.test(packageName)) {
                 createResource
-                    .andThen(loadResource)
-                    .apply(baseDir, path)
-                    .ifPresent(consumer);
+                        .andThen(loadResource)
+                        .apply(baseDir, path)
+                        .ifPresent(consumer);
             }
         };
     }
@@ -90,15 +94,17 @@ public final class ResourceScanner<R> {
         return this.classLoaderSupplier.get();
     }
 
-    private List<R> findResourcesForUris(List<URI> baseUris,
-                                         String basePackageName,
-                                         Predicate<String> packageFilter,
-                                         BiFunction<Path, Path, Resource> createResource) {
+    private List<R> findResourcesForUris(
+            List<URI> baseUris,
+            String basePackageName,
+            Predicate<String> packageFilter,
+            BiFunction<Path, Path, Resource> createResource
+    ) {
         return baseUris.stream()
-            .map(baseUri -> findResourcesForUri(baseUri, basePackageName, packageFilter, createResource))
-            .flatMap(Collection::stream)
-            .distinct()
-            .collect(toList());
+                .map(baseUri -> findResourcesForUri(baseUri, basePackageName, packageFilter, createResource))
+                .flatMap(Collection::stream)
+                .distinct()
+                .collect(toList());
     }
 
     public List<R> scanForClasspathResource(String resourceName, Predicate<String> packageFilter) {
@@ -115,8 +121,7 @@ public final class ResourceScanner<R> {
         pathScanner.findResourcesForPath(
             resourcePath,
             canLoad,
-            processResource(DEFAULT_PACKAGE_NAME, NULL_FILTER, createUriResource(), resources::add)
-        );
+            processResource(DEFAULT_PACKAGE_NAME, NULL_FILTER, createUriResource(), resources::add));
         return resources;
     }
 

--- a/core/src/main/java/io/cucumber/core/runner/AmbiguousStepDefinitionsException.java
+++ b/core/src/main/java/io/cucumber/core/runner/AmbiguousStepDefinitionsException.java
@@ -21,8 +21,8 @@ final class AmbiguousStepDefinitionsException extends Exception {
         requireNonNull(matches);
 
         return quoteText(step.getText()) + " matches more than one step definition:\n" + matches.stream()
-            .map(match -> "  " + quoteText(match.getPattern()) + " in " + match.getLocation())
-            .collect(joining("\n"));
+                .map(match -> "  " + quoteText(match.getPattern()) + " in " + match.getLocation())
+                .collect(joining("\n"));
     }
 
     private static String quoteText(String text) {

--- a/core/src/main/java/io/cucumber/core/runner/CamelCaseStringConverter.java
+++ b/core/src/main/java/io/cucumber/core/runner/CamelCaseStringConverter.java
@@ -44,8 +44,7 @@ class CamelCaseStringConverter {
     private static CucumberException createDuplicateKeyException(String key, String conflictingKey, String newKey) {
         return new CucumberException(String.format(
             "Failed to convert header '%s' to property name. '%s' also converted to '%s'",
-            key, conflictingKey, newKey
-        ));
+            key, conflictingKey, newKey));
     }
 
     private static String normalizeSpace(String originalHeaderName) {

--- a/core/src/main/java/io/cucumber/core/runner/CoreDefaultDataTableEntryTransformerDefinition.java
+++ b/core/src/main/java/io/cucumber/core/runner/CoreDefaultDataTableEntryTransformerDefinition.java
@@ -19,11 +19,14 @@ class CoreDefaultDataTableEntryTransformerDefinition implements DefaultDataTable
         this.transformer = delegate.headersToProperties() ? new ConvertingTransformer(transformer) : transformer;
     }
 
-    public static CoreDefaultDataTableEntryTransformerDefinition create(DefaultDataTableEntryTransformerDefinition definition) {
+    public static CoreDefaultDataTableEntryTransformerDefinition create(
+            DefaultDataTableEntryTransformerDefinition definition
+    ) {
         // Ideally we would avoid this by keeping the scenario scoped
         // glue in a different bucket from the globally scoped glue.
         if (definition instanceof ScenarioScoped) {
-            return new CoreDefaultDataTableEntryTransformerDefinition.ScenarioCoreDefaultDataTableEntryTransformerDefinition(definition);
+            return new CoreDefaultDataTableEntryTransformerDefinition.ScenarioCoreDefaultDataTableEntryTransformerDefinition(
+                definition);
         }
         return new CoreDefaultDataTableEntryTransformerDefinition(definition);
     }
@@ -48,7 +51,8 @@ class CoreDefaultDataTableEntryTransformerDefinition implements DefaultDataTable
         return delegate.getLocation();
     }
 
-    private static class ScenarioCoreDefaultDataTableEntryTransformerDefinition extends CoreDefaultDataTableEntryTransformerDefinition implements ScenarioScoped {
+    private static class ScenarioCoreDefaultDataTableEntryTransformerDefinition
+            extends CoreDefaultDataTableEntryTransformerDefinition implements ScenarioScoped {
 
         ScenarioCoreDefaultDataTableEntryTransformerDefinition(DefaultDataTableEntryTransformerDefinition delegate) {
             super(delegate);
@@ -66,7 +70,9 @@ class CoreDefaultDataTableEntryTransformerDefinition implements DefaultDataTable
         }
 
         @Override
-        public Object transform(Map<String, String> entryValue, Type toValueType, TableCellByTypeTransformer cellTransformer) throws Throwable {
+        public Object transform(
+                Map<String, String> entryValue, Type toValueType, TableCellByTypeTransformer cellTransformer
+        ) throws Throwable {
             return delegate.transform(converter.toCamelCase(entryValue), toValueType, cellTransformer);
         }
 

--- a/core/src/main/java/io/cucumber/core/runner/DefinitionArgument.java
+++ b/core/src/main/java/io/cucumber/core/runner/DefinitionArgument.java
@@ -62,8 +62,8 @@ final class DefinitionArgument implements Argument {
         private Group(io.cucumber.cucumberexpressions.Group group) {
             this.group = group;
             children = group.getChildren().stream()
-                .map(Group::new)
-                .collect(Collectors.toList());
+                    .map(Group::new)
+                    .collect(Collectors.toList());
         }
 
         @Override

--- a/core/src/main/java/io/cucumber/core/runner/DuplicateDefaultDataTableCellTransformers.java
+++ b/core/src/main/java/io/cucumber/core/runner/DuplicateDefaultDataTableCellTransformers.java
@@ -16,8 +16,8 @@ class DuplicateDefaultDataTableCellTransformers extends CucumberException {
 
     private static String createMessage(List<DefaultDataTableCellTransformerDefinition> definitions) {
         return "There may not be more then one default table cell transformers. Found:" + definitions.stream()
-            .map(Located::getLocation)
-            .collect(joining("\n - ", "\n - ", "\n"));
+                .map(Located::getLocation)
+                .collect(joining("\n - ", "\n - ", "\n"));
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/runner/DuplicateDefaultDataTableEntryTransformers.java
+++ b/core/src/main/java/io/cucumber/core/runner/DuplicateDefaultDataTableEntryTransformers.java
@@ -14,8 +14,8 @@ class DuplicateDefaultDataTableEntryTransformers extends CucumberException {
 
     private static String createMessage(List<CoreDefaultDataTableEntryTransformerDefinition> definitions) {
         return "There may not be more then one default data table entry. Found:" + definitions.stream()
-            .map(CoreDefaultDataTableEntryTransformerDefinition::getLocation)
-            .collect(joining("\n - ", "\n - ", "\n"));
+                .map(CoreDefaultDataTableEntryTransformerDefinition::getLocation)
+                .collect(joining("\n - ", "\n - ", "\n"));
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/runner/DuplicateDefaultParameterTransformers.java
+++ b/core/src/main/java/io/cucumber/core/runner/DuplicateDefaultParameterTransformers.java
@@ -15,8 +15,8 @@ class DuplicateDefaultParameterTransformers extends CucumberException {
 
     private static String createMessage(List<DefaultParameterTransformerDefinition> definitions) {
         return "There may not be more then one default parameter transformer. Found:" + definitions.stream()
-            .map(d -> d.getLocation())
-            .collect(joining("\n - ", "\n - ", "\n"));
+                .map(d -> d.getLocation())
+                .collect(joining("\n - ", "\n - ", "\n"));
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/runner/DuplicateStepDefinitionException.java
+++ b/core/src/main/java/io/cucumber/core/runner/DuplicateStepDefinitionException.java
@@ -17,8 +17,7 @@ final class DuplicateStepDefinitionException extends CucumberException {
 
         return String.format("Duplicate step definitions in %s and %s",
             a.getLocation(),
-            b.getLocation()
-        );
+            b.getLocation());
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/runner/HookDefinitionMatch.java
+++ b/core/src/main/java/io/cucumber/core/runner/HookDefinitionMatch.java
@@ -29,9 +29,9 @@ final class HookDefinitionMatch implements StepDefinitionMatch {
     private Throwable couldNotInvokeHook(CucumberBackendException e) {
         return new CucumberException(String.format("" +
                 "Could not invoke hook defined at '%s'.\n" +
-                "It appears there was a problem with the hook definition.", //TODO: Add doc URL
-            hookDefinition.getLocation()
-        ), e);
+                // TODO: Add doc URL
+                "It appears there was a problem with the hook definition.",
+            hookDefinition.getLocation()), e);
     }
 
     @Override

--- a/core/src/main/java/io/cucumber/core/runner/PickleStepDefinitionMatch.java
+++ b/core/src/main/java/io/cucumber/core/runner/PickleStepDefinitionMatch.java
@@ -82,23 +82,23 @@ class PickleStepDefinitionMatch extends Match implements StepDefinitionMatch {
         List<String> arguments = createArgumentsForErrorMessage();
         return new CucumberException(String.format(
             "Step [%s] is defined with %s parameters at '%s'.\n" +
-                "However, the gherkin step has %s arguments%sStep text: %s",
+                    "However, the gherkin step has %s arguments%sStep text: %s",
             stepDefinition.getPattern(),
             parameterCount,
             stepDefinition.getLocation(),
             arguments.size(),
             formatArguments(arguments),
-            step.getText()
-        ));
+            step.getText()));
     }
 
     private CucumberException registerDataTableTypeInConfiguration(Exception e) {
         return new CucumberException(String.format("" +
                 "Could not convert arguments for step [%s] defined at '%s'.\n" +
-                "It appears you did not register a data table type.", //TODO: Add doc URL
+                "It appears you did not register a data table type.", // TODO:
+                                                                      // Add doc
+                                                                      // URL
             stepDefinition.getPattern(),
-            stepDefinition.getLocation()
-        ), e);
+            stepDefinition.getLocation()), e);
     }
 
     private CucumberInvocationTargetException causedByCucumberInvocationTargetException(RuntimeException e) {
@@ -113,17 +113,18 @@ class PickleStepDefinitionMatch extends Match implements StepDefinitionMatch {
         return new CucumberException(String.format(
             "Could not convert arguments for step [%s] defined at '%s'.",
             stepDefinition.getPattern(),
-            stepDefinition.getLocation()
-        ), e);
+            stepDefinition.getLocation()), e);
     }
 
     private CucumberException couldNotInvokeArgumentConversion(CucumberBackendException e) {
         return new CucumberException(String.format("" +
                 "Could not convert arguments for step [%s] defined at '%s'.\n" +
-                "It appears there was a problem with a hook or transformer definition.", //TODO: Add doc URL
+                "It appears there was a problem with a hook or transformer definition.", // TODO:
+                                                                                         // Add
+                                                                                         // doc
+                                                                                         // URL
             stepDefinition.getPattern(),
-            stepDefinition.getLocation()
-        ), e);
+            stepDefinition.getLocation()), e);
     }
 
     private Throwable couldNotInvokeStep(CucumberBackendException e, List<Object> result) {
@@ -131,10 +132,12 @@ class PickleStepDefinitionMatch extends Match implements StepDefinitionMatch {
         return new CucumberException(String.format("" +
                 "Could not invoke step [%s] defined at '%s'.\n" +
                 "It appears there was a problem with the step definition.\n" +
-                "The converted arguments types were (" + argumentTypes + ")", //TODO: Add doc URL
+                "The converted arguments types were (" + argumentTypes + ")", // TODO:
+                                                                              // Add
+                                                                              // doc
+                                                                              // URL
             stepDefinition.getPattern(),
-            stepDefinition.getLocation()
-        ), e);
+            stepDefinition.getLocation()), e);
     }
 
     private StackTraceElement getStepLocation() {
@@ -163,8 +166,8 @@ class PickleStepDefinitionMatch extends Match implements StepDefinitionMatch {
 
     private String createArgumentTypes(List<Object> result) {
         return result.stream()
-            .map(o -> o == null ? "null" : o.getClass().getName())
-            .collect(Collectors.joining(", "));
+                .map(o -> o == null ? "null" : o.getClass().getName())
+                .collect(Collectors.joining(", "));
     }
 
     public String getPattern() {

--- a/core/src/main/java/io/cucumber/core/runner/PickleStepTestStep.java
+++ b/core/src/main/java/io/cucumber/core/runner/PickleStepTestStep.java
@@ -23,11 +23,13 @@ final class PickleStepTestStep extends TestStep implements io.cucumber.plugin.ev
         this(id, uri, step, Collections.emptyList(), Collections.emptyList(), definitionMatch);
     }
 
-    PickleStepTestStep(UUID id, URI uri,
-                       Step step,
-                       List<HookTestStep> beforeStepHookSteps,
-                       List<HookTestStep> afterStepHookSteps,
-                       PickleStepDefinitionMatch definitionMatch) {
+    PickleStepTestStep(
+            UUID id, URI uri,
+            Step step,
+            List<HookTestStep> beforeStepHookSteps,
+            List<HookTestStep> afterStepHookSteps,
+            PickleStepDefinitionMatch definitionMatch
+    ) {
         super(id, definitionMatch);
         this.uri = uri;
         this.step = step;

--- a/core/src/main/java/io/cucumber/core/runner/Runner.java
+++ b/core/src/main/java/io/cucumber/core/runner/Runner.java
@@ -35,7 +35,10 @@ public final class Runner {
     private final TypeRegistryConfigurer typeRegistryConfigurer;
     private List<SnippetGenerator> snippetGenerators;
 
-    public Runner(EventBus bus, Collection<? extends Backend> backends, ObjectFactory objectFactory, TypeRegistryConfigurer typeRegistryConfigurer, Options runnerOptions) {
+    public Runner(
+            EventBus bus, Collection<? extends Backend> backends, ObjectFactory objectFactory,
+            TypeRegistryConfigurer typeRegistryConfigurer, Options runnerOptions
+    ) {
         this.bus = bus;
         this.runnerOptions = runnerOptions;
         this.backends = backends;
@@ -59,7 +62,8 @@ public final class Runner {
             StepTypeRegistry stepTypeRegistry = createTypeRegistryForPickle(pickle);
             snippetGenerators = createSnippetGeneratorsForPickle(stepTypeRegistry);
 
-            buildBackendWorlds(); // Java8 step definitions will be added to the glue here
+            buildBackendWorlds(); // Java8 step definitions will be added to the
+                                  // glue here
 
             glue.prepareGlue(stepTypeRegistry);
 
@@ -83,10 +87,10 @@ public final class Runner {
 
     private List<SnippetGenerator> createSnippetGeneratorsForPickle(StepTypeRegistry stepTypeRegistry) {
         return backends.stream()
-            .map(Backend::getSnippet)
-            .filter(Objects::nonNull)
-            .map(s -> new SnippetGenerator(s, stepTypeRegistry.parameterTypeRegistry()))
-            .collect(Collectors.toList());
+                .map(Backend::getSnippet)
+                .filter(Objects::nonNull)
+                .map(s -> new SnippetGenerator(s, stepTypeRegistry.parameterTypeRegistry()))
+                .collect(Collectors.toList());
     }
 
     private void buildBackendWorlds() {
@@ -98,7 +102,8 @@ public final class Runner {
 
     private TestCase createTestCaseForPickle(Pickle pickle) {
         if (pickle.getSteps().isEmpty()) {
-            return new TestCase(bus.generateId(), emptyList(), emptyList(), emptyList(), pickle, runnerOptions.isDryRun());
+            return new TestCase(bus.generateId(), emptyList(), emptyList(), emptyList(), pickle,
+                runnerOptions.isDryRun());
         }
 
         List<PickleStepTestStep> testSteps = createTestStepsForPickleSteps(pickle);
@@ -121,7 +126,8 @@ public final class Runner {
             PickleStepDefinitionMatch match = matchStepToStepDefinition(pickle, step);
             List<HookTestStep> afterStepHookSteps = createAfterStepHooks(pickle.getTags());
             List<HookTestStep> beforeStepHookSteps = createBeforeStepHooks(pickle.getTags());
-            testSteps.add(new PickleStepTestStep(bus.generateId(), pickle.getUri(), step, beforeStepHookSteps, afterStepHookSteps, match));
+            testSteps.add(new PickleStepTestStep(bus.generateId(), pickle.getUri(), step, beforeStepHookSteps,
+                afterStepHookSteps, match));
         }
 
         return testSteps;
@@ -143,7 +149,8 @@ public final class Runner {
             }
             List<String> snippets = generateSnippetsForStep(step);
             if (!snippets.isEmpty()) {
-                bus.send(new SnippetsSuggestedEvent(bus.getInstant(), pickle.getUri(), pickle.getScenarioLocation(), step.getLocation(), snippets));
+                bus.send(new SnippetsSuggestedEvent(bus.getInstant(), pickle.getUri(), pickle.getScenarioLocation(),
+                    step.getLocation(), snippets));
             }
             return new UndefinedPickleStepDefinitionMatch(pickle.getUri(), step);
         } catch (AmbiguousStepDefinitionsException e) {
@@ -159,11 +166,13 @@ public final class Runner {
         return createTestStepsForHooks(tags, glue.getBeforeStepHooks(), HookType.BEFORE_STEP);
     }
 
-    private List<HookTestStep> createTestStepsForHooks(List<String> tags, Collection<CoreHookDefinition> hooks, HookType hookType) {
+    private List<HookTestStep> createTestStepsForHooks(
+            List<String> tags, Collection<CoreHookDefinition> hooks, HookType hookType
+    ) {
         return hooks.stream()
-            .filter(hook -> hook.matches(tags))
-            .map(hook -> new HookTestStep(bus.generateId(), hookType, new HookDefinitionMatch(hook)))
-            .collect(Collectors.toList());
+                .filter(hook -> hook.matches(tags))
+                .map(hook -> new HookTestStep(bus.generateId(), hookType, new HookDefinitionMatch(hook)))
+                .collect(Collectors.toList());
     }
 
     private List<String> generateSnippetsForStep(Step step) {

--- a/core/src/main/java/io/cucumber/core/runner/StackManipulation.java
+++ b/core/src/main/java/io/cucumber/core/runner/StackManipulation.java
@@ -39,7 +39,9 @@ final class StackManipulation {
         return newStackTraceLength;
     }
 
-    static Throwable removeFrameworkFramesAndAppendStepLocation(CucumberInvocationTargetException invocationException, StackTraceElement stepLocation) {
+    static Throwable removeFrameworkFramesAndAppendStepLocation(
+            CucumberInvocationTargetException invocationException, StackTraceElement stepLocation
+    ) {
         Located located = invocationException.getLocated();
         Throwable error = invocationException.getInvocationTargetExceptionCause();
         if (stepLocation == null) {

--- a/core/src/main/java/io/cucumber/core/runner/TestCase.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCase.java
@@ -35,11 +35,13 @@ final class TestCase implements io.cucumber.plugin.event.TestCase {
     private final List<HookTestStep> afterHooks;
     private final UUID id;
 
-    TestCase(UUID id, List<PickleStepTestStep> testSteps,
-             List<HookTestStep> beforeHooks,
-             List<HookTestStep> afterHooks,
-             Pickle pickle,
-             boolean dryRun) {
+    TestCase(
+            UUID id, List<PickleStepTestStep> testSteps,
+            List<HookTestStep> beforeHooks,
+            List<HookTestStep> afterHooks,
+            Pickle pickle,
+            boolean dryRun
+    ) {
         this.id = id;
         this.testSteps = testSteps;
         this.beforeHooks = beforeHooks;
@@ -48,8 +50,11 @@ final class TestCase implements io.cucumber.plugin.event.TestCase {
         this.dryRun = dryRun;
     }
 
-    private static Messages.TestCase.TestStep.StepMatchArgumentsList.StepMatchArgument.Group makeMessageGroup(Group group) {
-        Messages.TestCase.TestStep.StepMatchArgumentsList.StepMatchArgument.Group.Builder builder = Messages.TestCase.TestStep.StepMatchArgumentsList.StepMatchArgument.Group.newBuilder();
+    private static Messages.TestCase.TestStep.StepMatchArgumentsList.StepMatchArgument.Group makeMessageGroup(
+            Group group
+    ) {
+        Messages.TestCase.TestStep.StepMatchArgumentsList.StepMatchArgument.Group.Builder builder = Messages.TestCase.TestStep.StepMatchArgumentsList.StepMatchArgument.Group
+                .newBuilder();
         if (group == null) {
             return builder.build();
         }
@@ -63,10 +68,10 @@ final class TestCase implements io.cucumber.plugin.event.TestCase {
         }
 
         return builder
-            .addAllChildren(group.getChildren().stream()
-                .map(TestCase::makeMessageGroup)
-                .collect(toList()))
-            .build();
+                .addAllChildren(group.getChildren().stream()
+                        .map(TestCase::makeMessageGroup)
+                        .collect(toList()))
+                .build();
     }
 
     private static String toString(Throwable error) {
@@ -162,22 +167,20 @@ final class TestCase implements io.cucumber.plugin.event.TestCase {
 
     private void emitTestCaseMessage(EventBus bus) {
         bus.send(Messages.Envelope.newBuilder()
-            .setTestCase(Messages.TestCase.newBuilder()
-                .setId(id.toString())
-                .setPickleId(pickle.getId())
-                .addAllTestSteps(getTestSteps()
-                    .stream()
-                    .map(this::createTestStep)
-                    .collect(toList())
-                )
-            ).build()
-        );
+                .setTestCase(Messages.TestCase.newBuilder()
+                        .setId(id.toString())
+                        .setPickleId(pickle.getId())
+                        .addAllTestSteps(getTestSteps()
+                                .stream()
+                                .map(this::createTestStep)
+                                .collect(toList())))
+                .build());
     }
 
     private Messages.TestCase.TestStep createTestStep(TestStep testStep) {
         Messages.TestCase.TestStep.Builder testStepBuilder = Messages.TestCase.TestStep
-            .newBuilder()
-            .setId(testStep.getId().toString());
+                .newBuilder()
+                .setId(testStep.getId().toString());
 
         if (testStep instanceof HookTestStep) {
             HookTestStep hookTestStep = (HookTestStep) testStep;
@@ -185,22 +188,23 @@ final class TestCase implements io.cucumber.plugin.event.TestCase {
         } else if (testStep instanceof PickleStepTestStep) {
             PickleStepTestStep pickleStep = (PickleStepTestStep) testStep;
             testStepBuilder
-                .addAllStepDefinitionIds(singletonList(pickleStep.getId().toString()))
-                .setPickleStepId(pickleStep.getStep().getId())
-                .addStepMatchArgumentsLists(getStepMatchArguments(pickleStep));
+                    .addAllStepDefinitionIds(singletonList(pickleStep.getId().toString()))
+                    .setPickleStepId(pickleStep.getStep().getId())
+                    .addStepMatchArgumentsLists(getStepMatchArguments(pickleStep));
         }
 
         return testStepBuilder.build();
     }
 
     public Messages.TestCase.TestStep.StepMatchArgumentsList getStepMatchArguments(PickleStepTestStep pickleStep) {
-        Messages.TestCase.TestStep.StepMatchArgumentsList.Builder builder = Messages.TestCase.TestStep.StepMatchArgumentsList.newBuilder();
+        Messages.TestCase.TestStep.StepMatchArgumentsList.Builder builder = Messages.TestCase.TestStep.StepMatchArgumentsList
+                .newBuilder();
 
         pickleStep.getDefinitionArgument().forEach(arg -> builder
-            .addStepMatchArguments(Messages.TestCase.TestStep.StepMatchArgumentsList.StepMatchArgument.newBuilder()
-                .setParameterTypeName(arg.getParameterTypeName())
-                .setGroup(makeMessageGroup(arg.getGroup()))
-                .build()));
+                .addStepMatchArguments(Messages.TestCase.TestStep.StepMatchArgumentsList.StepMatchArgument.newBuilder()
+                        .setParameterTypeName(arg.getParameterTypeName())
+                        .setGroup(makeMessageGroup(arg.getGroup()))
+                        .build()));
 
         return builder.build();
     }
@@ -208,29 +212,32 @@ final class TestCase implements io.cucumber.plugin.event.TestCase {
     private void emitTestCaseStarted(EventBus bus, Instant start, UUID executionId) {
         bus.send(new TestCaseStarted(start, this));
         bus.send(Messages.Envelope.newBuilder()
-            .setTestCaseStarted(Messages.TestCaseStarted.newBuilder()
-                .setId(executionId.toString())
-                .setTestCaseId(id.toString())
-                .setTimestamp(javaInstantToTimestamp(start))
-                .build()
-            ).build());
+                .setTestCaseStarted(Messages.TestCaseStarted.newBuilder()
+                        .setId(executionId.toString())
+                        .setTestCaseId(id.toString())
+                        .setTimestamp(javaInstantToTimestamp(start))
+                        .build())
+                .build());
     }
 
-    private void emitTestCaseFinished(EventBus bus, UUID executionId, Instant stop, Duration duration, Status status, Result result) {
+    private void emitTestCaseFinished(
+            EventBus bus, UUID executionId, Instant stop, Duration duration, Status status, Result result
+    ) {
         bus.send(new TestCaseFinished(stop, this, result));
-        Messages.TestStepFinished.TestStepResult.Builder testResultBuilder = Messages.TestStepFinished.TestStepResult.newBuilder()
-            .setStatus(from(status))
-            .setDuration(javaDurationToDuration(duration));
+        Messages.TestStepFinished.TestStepResult.Builder testResultBuilder = Messages.TestStepFinished.TestStepResult
+                .newBuilder()
+                .setStatus(from(status))
+                .setDuration(javaDurationToDuration(duration));
 
         if (result.getError() != null) {
             testResultBuilder.setMessage(toString(result.getError()));
         }
 
         bus.send(Messages.Envelope.newBuilder()
-            .setTestCaseFinished(Messages.TestCaseFinished.newBuilder()
-                .setTestCaseStartedId(executionId.toString())
-                .setTimestamp(javaInstantToTimestamp(stop)))
-            .build());
+                .setTestCaseFinished(Messages.TestCaseFinished.newBuilder()
+                        .setTestCaseStartedId(executionId.toString())
+                        .setTimestamp(javaInstantToTimestamp(stop)))
+                .build());
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
@@ -68,53 +68,47 @@ class TestCaseState implements io.cucumber.core.backend.TestCaseState {
     public void attach(byte[] data, String mediaType, String name) {
         bus.send(new EmbedEvent(bus.getInstant(), testCase, data, mediaType, name));
         bus.send(Messages.Envelope.newBuilder()
-            .setAttachment(
-                Messages.Attachment.newBuilder()
-                    .setTestCaseStartedId(testExecutionId.toString())
-                    .setTestStepId(currentTestStepId.toString())
-                    .setBody(Base64.getEncoder().encodeToString(data))
-                    .setContentEncoding(ContentEncoding.BASE64)
-                    // Add file name to message protocol
-                    // https://github.com/cucumber/cucumber/issues/945
-                    .setMediaType(mediaType)
-            )
-            .build()
-        );
+                .setAttachment(
+                    Messages.Attachment.newBuilder()
+                            .setTestCaseStartedId(testExecutionId.toString())
+                            .setTestStepId(currentTestStepId.toString())
+                            .setBody(Base64.getEncoder().encodeToString(data))
+                            .setContentEncoding(ContentEncoding.BASE64)
+                            // Add file name to message protocol
+                            // https://github.com/cucumber/cucumber/issues/945
+                            .setMediaType(mediaType))
+                .build());
     }
 
     @Override
     public void attach(String data, String mediaType, String name) {
         bus.send(new EmbedEvent(bus.getInstant(), testCase, data.getBytes(UTF_8), mediaType, name));
         bus.send(Messages.Envelope.newBuilder()
-            .setAttachment(
-                Messages.Attachment.newBuilder()
-                    .setTestCaseStartedId(testExecutionId.toString())
-                    .setTestStepId(currentTestStepId.toString())
-                    .setBody(data)
-                    .setContentEncoding(ContentEncoding.IDENTITY)
-                    // Add file name to message protocol
-                    // https://github.com/cucumber/cucumber/issues/945
-                    .setMediaType(mediaType)
-            )
-            .build()
-        );
+                .setAttachment(
+                    Messages.Attachment.newBuilder()
+                            .setTestCaseStartedId(testExecutionId.toString())
+                            .setTestStepId(currentTestStepId.toString())
+                            .setBody(data)
+                            .setContentEncoding(ContentEncoding.IDENTITY)
+                            // Add file name to message protocol
+                            // https://github.com/cucumber/cucumber/issues/945
+                            .setMediaType(mediaType))
+                .build());
     }
 
     @Override
     public void log(String text) {
         bus.send(new WriteEvent(bus.getInstant(), testCase, text));
         bus.send(Messages.Envelope.newBuilder()
-            .setAttachment(
-                Messages.Attachment.newBuilder()
-                    .setTestCaseStartedId(testExecutionId.toString())
-                    .setTestStepId(currentTestStepId.toString())
-                    .setBody(text)
-                    .setContentEncoding(ContentEncoding.IDENTITY)
-                    .setMediaType("text/x.cucumber.log+plain")
-                    .build()
-            )
-            .build()
-        );
+                .setAttachment(
+                    Messages.Attachment.newBuilder()
+                            .setTestCaseStartedId(testExecutionId.toString())
+                            .setTestStepId(currentTestStepId.toString())
+                            .setBody(text)
+                            .setContentEncoding(ContentEncoding.IDENTITY)
+                            .setMediaType("text/x.cucumber.log+plain")
+                            .build())
+                .build());
     }
 
     @Override

--- a/core/src/main/java/io/cucumber/core/runner/TestStep.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestStep.java
@@ -25,10 +25,10 @@ import static java.time.Duration.ZERO;
 abstract class TestStep implements io.cucumber.plugin.event.TestStep {
 
     private static final String[] TEST_ABORTED_OR_SKIPPED_EXCEPTIONS = {
-        "org.junit.AssumptionViolatedException",
-        "org.junit.internal.AssumptionViolatedException",
-        "org.opentest4j.TestAbortedException",
-        "org.testng.SkipException",
+            "org.junit.AssumptionViolatedException",
+            "org.junit.internal.AssumptionViolatedException",
+            "org.opentest4j.TestAbortedException",
+            "org.testng.SkipException",
     };
 
     static {
@@ -75,16 +75,14 @@ abstract class TestStep implements io.cucumber.plugin.event.TestStep {
         return !result.getStatus().is(Status.PASSED);
     }
 
-
     private void emitTestStepStarted(TestCase testCase, EventBus bus, UUID textExecutionId, Instant startTime) {
         bus.send(new TestStepStarted(startTime, testCase, this));
         bus.send(Messages.Envelope.newBuilder()
-            .setTestStepStarted(Messages.TestStepStarted.newBuilder()
-                .setTestCaseStartedId(textExecutionId.toString())
-                .setTestStepId(id.toString())
-                .setTimestamp(javaInstantToTimestamp(startTime))
-            ).build()
-        );
+                .setTestStepStarted(Messages.TestStepStarted.newBuilder()
+                        .setTestCaseStartedId(textExecutionId.toString())
+                        .setTestStepId(id.toString())
+                        .setTimestamp(javaInstantToTimestamp(startTime)))
+                .build());
     }
 
     private Status executeStep(TestCaseState state, boolean skipSteps) throws Throwable {
@@ -125,24 +123,26 @@ abstract class TestStep implements io.cucumber.plugin.event.TestStep {
         return new Result(status, duration, error);
     }
 
-    private void emitTestStepFinished(TestCase testCase, EventBus bus, UUID textExecutionId, Instant stopTime, Duration duration, Result result) {
+    private void emitTestStepFinished(
+            TestCase testCase, EventBus bus, UUID textExecutionId, Instant stopTime, Duration duration, Result result
+    ) {
         bus.send(new TestStepFinished(stopTime, testCase, this, result));
-        Messages.TestStepFinished.TestStepResult.Builder builder = Messages.TestStepFinished.TestStepResult.newBuilder();
+        Messages.TestStepFinished.TestStepResult.Builder builder = Messages.TestStepFinished.TestStepResult
+                .newBuilder();
 
         if (result.getError() != null) {
             builder.setMessage(extractStackTrace(result.getError()));
         }
         Messages.TestStepFinished.TestStepResult testResult = builder.setStatus(from(result.getStatus()))
-            .setDuration(javaDurationToDuration(duration))
-            .build();
+                .setDuration(javaDurationToDuration(duration))
+                .build();
         bus.send(Messages.Envelope.newBuilder()
-            .setTestStepFinished(Messages.TestStepFinished.newBuilder()
-                .setTestCaseStartedId(textExecutionId.toString())
-                .setTestStepId(id.toString())
-                .setTimestamp(javaInstantToTimestamp(stopTime))
-                .setTestStepResult(testResult)
-            ).build()
-        );
+                .setTestStepFinished(Messages.TestStepFinished.newBuilder()
+                        .setTestCaseStartedId(textExecutionId.toString())
+                        .setTestStepId(id.toString())
+                        .setTimestamp(javaInstantToTimestamp(stopTime))
+                        .setTestStepResult(testResult))
+                .build());
     }
 
     private String extractStackTrace(Throwable error) {

--- a/core/src/main/java/io/cucumber/core/runner/TestStepResultStatus.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestStepResultStatus.java
@@ -8,14 +8,16 @@ import java.util.Map;
 
 class TestStepResultStatus {
 
-    private static final Map<Status, Messages.TestStepFinished.TestStepResult.Status> STATUS = new HashMap<Status, Messages.TestStepFinished.TestStepResult.Status>() {{
-        put(Status.FAILED, Messages.TestStepFinished.TestStepResult.Status.FAILED);
-        put(Status.PASSED, Messages.TestStepFinished.TestStepResult.Status.PASSED);
-        put(Status.UNDEFINED, Messages.TestStepFinished.TestStepResult.Status.UNDEFINED);
-        put(Status.PENDING, Messages.TestStepFinished.TestStepResult.Status.PENDING);
-        put(Status.SKIPPED, Messages.TestStepFinished.TestStepResult.Status.SKIPPED);
-        put(Status.AMBIGUOUS, Messages.TestStepFinished.TestStepResult.Status.AMBIGUOUS);
-    }};
+    private static final Map<Status, Messages.TestStepFinished.TestStepResult.Status> STATUS = new HashMap<Status, Messages.TestStepFinished.TestStepResult.Status>() {
+        {
+            put(Status.FAILED, Messages.TestStepFinished.TestStepResult.Status.FAILED);
+            put(Status.PASSED, Messages.TestStepFinished.TestStepResult.Status.PASSED);
+            put(Status.UNDEFINED, Messages.TestStepFinished.TestStepResult.Status.UNDEFINED);
+            put(Status.PENDING, Messages.TestStepFinished.TestStepResult.Status.PENDING);
+            put(Status.SKIPPED, Messages.TestStepFinished.TestStepResult.Status.SKIPPED);
+            put(Status.AMBIGUOUS, Messages.TestStepFinished.TestStepResult.Status.AMBIGUOUS);
+        }
+    };
 
     private TestStepResultStatus() {
     }

--- a/core/src/main/java/io/cucumber/core/runtime/BackendServiceLoader.java
+++ b/core/src/main/java/io/cucumber/core/runtime/BackendServiceLoader.java
@@ -12,15 +12,17 @@ import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
 /**
- * Supplies instances of {@link Backend} created by using a {@link ServiceLoader}
- * to locate instance of {@link BackendSupplier}.
+ * Supplies instances of {@link Backend} created by using a
+ * {@link ServiceLoader} to locate instance of {@link BackendSupplier}.
  */
 public final class BackendServiceLoader implements BackendSupplier {
 
     private final Supplier<ClassLoader> classLoaderSupplier;
     private final ObjectFactorySupplier objectFactorySupplier;
 
-    public BackendServiceLoader(Supplier<ClassLoader> classLoaderSupplier, ObjectFactorySupplier objectFactorySupplier) {
+    public BackendServiceLoader(
+            Supplier<ClassLoader> classLoaderSupplier, ObjectFactorySupplier objectFactorySupplier
+    ) {
         this.classLoaderSupplier = classLoaderSupplier;
         this.objectFactorySupplier = objectFactorySupplier;
     }
@@ -33,7 +35,8 @@ public final class BackendServiceLoader implements BackendSupplier {
     Collection<? extends Backend> get(Iterable<BackendProviderService> serviceLoader) {
         Collection<? extends Backend> backends = loadBackends(serviceLoader);
         if (backends.isEmpty()) {
-            throw new CucumberException("No backends were found. Please make sure you have a backend module on your CLASSPATH.");
+            throw new CucumberException(
+                "No backends were found. Please make sure you have a backend module on your CLASSPATH.");
         }
         return backends;
     }
@@ -46,6 +49,5 @@ public final class BackendServiceLoader implements BackendSupplier {
         }
         return backends;
     }
-
 
 }

--- a/core/src/main/java/io/cucumber/core/runtime/CucumberExecutionContext.java
+++ b/core/src/main/java/io/cucumber/core/runtime/CucumberExecutionContext.java
@@ -55,25 +55,20 @@ public final class CucumberExecutionContext {
             version = "unreleased";
         }
         bus.send(Envelope.newBuilder()
-            .setMeta(Messages.Meta.newBuilder()
-                .setProtocolVersion(Messages.class.getPackage().getImplementationVersion())
-                .setRuntime(Messages.Meta.Product.newBuilder()
-                    .setName(System.getProperty("java.vendor"))
-                    .setVersion(System.getProperty("java.version"))
-                )
-                .setImplementation(Messages.Meta.Product.newBuilder()
-                    .setName("cucumber-jvm")
-                    .setVersion(version)
-                )
-                .setOs(Messages.Meta.Product.newBuilder()
-                    .setName(System.getProperty("os.name"))
-                )
-                .setCpu(Messages.Meta.Product.newBuilder()
-                    .setName(System.getProperty("os.arch"))
-                )
-                .build())
-            .build()
-        );
+                .setMeta(Messages.Meta.newBuilder()
+                        .setProtocolVersion(Messages.class.getPackage().getImplementationVersion())
+                        .setRuntime(Messages.Meta.Product.newBuilder()
+                                .setName(System.getProperty("java.vendor"))
+                                .setVersion(System.getProperty("java.version")))
+                        .setImplementation(Messages.Meta.Product.newBuilder()
+                                .setName("cucumber-jvm")
+                                .setVersion(version))
+                        .setOs(Messages.Meta.Product.newBuilder()
+                                .setName(System.getProperty("os.name")))
+                        .setCpu(Messages.Meta.Product.newBuilder()
+                                .setName(System.getProperty("os.arch")))
+                        .build())
+                .build());
     }
 
     private void emitTestRunStarted() {
@@ -81,10 +76,9 @@ public final class CucumberExecutionContext {
         start = bus.getInstant();
         bus.send(new TestRunStarted(start));
         bus.send(Envelope.newBuilder()
-            .setTestRunStarted(Messages.TestRunStarted.newBuilder()
-                .setTimestamp(javaInstantToTimestamp(start)))
-            .build()
-        );
+                .setTestRunStarted(Messages.TestRunStarted.newBuilder()
+                        .setTimestamp(javaInstantToTimestamp(start)))
+                .build());
     }
 
     public void finishTestRun() {
@@ -108,20 +102,19 @@ public final class CucumberExecutionContext {
         Result result = new Result(
             cucumberException != null ? Status.FAILED : exitStatus.getStatus(),
             Duration.between(start, instant),
-            cucumberException
-        );
+            cucumberException);
         bus.send(new TestRunFinished(instant, result));
 
         Messages.TestRunFinished.Builder testRunFinished = Messages.TestRunFinished.newBuilder()
-            .setSuccess(exitStatus.isSuccess())
-            .setTimestamp(javaInstantToTimestamp(instant));
+                .setSuccess(exitStatus.isSuccess())
+                .setTimestamp(javaInstantToTimestamp(instant));
 
         if (cucumberException != null) {
             testRunFinished.setMessage(cucumberException.getMessage());
         }
         bus.send(Envelope.newBuilder()
-            .setTestRunFinished(testRunFinished)
-            .build());
+                .setTestRunFinished(testRunFinished)
+                .build());
     }
 
     public void beforeFeature(Feature feature) {

--- a/core/src/main/java/io/cucumber/core/runtime/FeaturePathFeatureSupplier.java
+++ b/core/src/main/java/io/cucumber/core/runtime/FeaturePathFeatureSupplier.java
@@ -20,7 +20,8 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.joining;
 
 /**
- * Supplies a list of features found on the the feature path provided to RuntimeOptions.
+ * Supplies a list of features found on the the feature path provided to
+ * RuntimeOptions.
  */
 public final class FeaturePathFeatureSupplier implements FeatureSupplier {
 
@@ -35,8 +36,7 @@ public final class FeaturePathFeatureSupplier implements FeatureSupplier {
         this.featureScanner = new ResourceScanner<>(
             classLoader,
             FeatureIdentifier::isFeature,
-            parser::parseResource
-        );
+            parser::parseResource);
     }
 
     @Override
@@ -47,7 +47,8 @@ public final class FeaturePathFeatureSupplier implements FeatureSupplier {
             if (featurePaths.isEmpty()) {
                 log.warn(() -> "Got no path to feature directory or feature file");
             } else {
-                log.warn(() -> "No features found at " + featurePaths.stream().map(URI::toString).collect(joining(", ")));
+                log.warn(
+                    () -> "No features found at " + featurePaths.stream().map(URI::toString).collect(joining(", ")));
             }
         }
         return features;
@@ -84,22 +85,22 @@ public final class FeaturePathFeatureSupplier implements FeatureSupplier {
 
             Map<String, Feature> existingFeatures = sourceToFeature.get(parsedFeature.getSource());
             if (existingFeatures != null) {
-                // Same contents but different file names was probably intentional
+                // Same contents but different file names was probably
+                // intentional
                 Feature existingFeature = existingFeatures.get(parsedFileName);
                 if (existingFeature != null) {
                     log.error(() -> "" +
-                        "Duplicate feature found: " +
-                        parsedFeature.getUri() + " was identical to " + existingFeature.getUri() + "\n" +
-                        "\n" +
-                        "This typically happens when you configure cucumber to look " +
-                        "for features in the root of your project.\nYour build tool " +
-                        "creates a copy of these features in a 'target' or 'build'" +
-                        "directory.\n" +
-                        "\n" +
-                        "If your features are on the class path consider using a class path URI.\n" +
-                        "For example: 'classpath:com/example/app.feature'\n" +
-                        "Otherwise you'll have to provide a more specific location"
-                    );
+                            "Duplicate feature found: " +
+                            parsedFeature.getUri() + " was identical to " + existingFeature.getUri() + "\n" +
+                            "\n" +
+                            "This typically happens when you configure cucumber to look " +
+                            "for features in the root of your project.\nYour build tool " +
+                            "creates a copy of these features in a 'target' or 'build'" +
+                            "directory.\n" +
+                            "\n" +
+                            "If your features are on the class path consider using a class path URI.\n" +
+                            "For example: 'classpath:com/example/app.feature'\n" +
+                            "Otherwise you'll have to provide a more specific location");
                     return;
                 }
             }

--- a/core/src/main/java/io/cucumber/core/runtime/ObjectFactoryServiceLoader.java
+++ b/core/src/main/java/io/cucumber/core/runtime/ObjectFactoryServiceLoader.java
@@ -23,7 +23,8 @@ public final class ObjectFactoryServiceLoader {
     }
 
     /**
-     * Loads an instance of {@link ObjectFactory} using the {@link ServiceLoader} mechanism.
+     * Loads an instance of {@link ObjectFactory} using the
+     * {@link ServiceLoader} mechanism.
      * <p>
      * Will load an instance of the class provided by
      * {@link Options#getObjectFactoryClass()}. If
@@ -65,7 +66,9 @@ public final class ObjectFactoryServiceLoader {
         return objectFactory;
     }
 
-    private static ObjectFactory loadSelectedObjectFactory(ServiceLoader<ObjectFactory> loader, Class<? extends ObjectFactory> objectFactoryClass) {
+    private static ObjectFactory loadSelectedObjectFactory(
+            ServiceLoader<ObjectFactory> loader, Class<? extends ObjectFactory> objectFactoryClass
+    ) {
         for (ObjectFactory objectFactory : loader) {
             if (objectFactoryClass.equals(objectFactory.getClass())) {
                 return objectFactory;
@@ -73,26 +76,25 @@ public final class ObjectFactoryServiceLoader {
         }
 
         throw new CucumberException("" +
-            "Could not find object factory " + objectFactoryClass.getName() + ".\n" +
-            "Cucumber uses SPI to discover object factory implementations.\n" +
-            "Has the class been registered with SPI and is it available on the classpath?"
-        );
+                "Could not find object factory " + objectFactoryClass.getName() + ".\n" +
+                "Cucumber uses SPI to discover object factory implementations.\n" +
+                "Has the class been registered with SPI and is it available on the classpath?");
     }
 
     private static String getMultipleObjectFactoryLogMessage(ObjectFactory... objectFactories) {
         String factoryNames = Stream.of(objectFactories)
-            .map(Object::getClass)
-            .map(Class::getName)
-            .collect(Collectors.joining(", "));
+                .map(Object::getClass)
+                .map(Class::getName)
+                .collect(Collectors.joining(", "));
 
         return "More than one Cucumber ObjectFactory was found in the classpath\n" +
-            "\n" +
-            "Found: " + factoryNames + "\n" +
-            "\n" +
-            "You may have included, for instance, cucumber-spring AND cucumber-guice as part of\n" +
-            "your dependencies. When this happens, Cucumber can't decide which to use.\n" +
-            "In order to enjoy dependency injection features, either remove the unnecessary dependencies" +
-            "from your classpath or use the `cucumber.object-factory` property or `@CucumberOptions(objectFactory=...)` to select one.\n";
+                "\n" +
+                "Found: " + factoryNames + "\n" +
+                "\n" +
+                "You may have included, for instance, cucumber-spring AND cucumber-guice as part of\n" +
+                "your dependencies. When this happens, Cucumber can't decide which to use.\n" +
+                "In order to enjoy dependency injection features, either remove the unnecessary dependencies" +
+                "from your classpath or use the `cucumber.object-factory` property or `@CucumberOptions(objectFactory=...)` to select one.\n";
     }
 
     /**
@@ -131,7 +133,9 @@ public final class ObjectFactoryServiceLoader {
                 instances.put(type, instance);
                 return instance;
             } catch (NoSuchMethodException e) {
-                throw new CucumberException(String.format("%s doesn't have an empty constructor. If you need dependency injection, put cucumber-picocontainer on the classpath", type), e);
+                throw new CucumberException(String.format(
+                    "%s doesn't have an empty constructor. If you need dependency injection, put cucumber-picocontainer on the classpath",
+                    type), e);
             } catch (Exception e) {
                 throw new CucumberException(String.format("Failed to instantiate %s", type), e);
             }

--- a/core/src/main/java/io/cucumber/core/runtime/Runtime.java
+++ b/core/src/main/java/io/cucumber/core/runtime/Runtime.java
@@ -51,13 +51,15 @@ public final class Runtime {
     private final PickleOrder pickleOrder;
     private final CucumberExecutionContext context;
 
-    private Runtime(final ExitStatus exitStatus,
-                    final CucumberExecutionContext context,
-                    final Predicate<Pickle> filter,
-                    final int limit,
-                    final FeatureSupplier featureSupplier,
-                    final ExecutorService executor,
-                    final PickleOrder pickleOrder) {
+    private Runtime(
+            final ExitStatus exitStatus,
+            final CucumberExecutionContext context,
+            final Predicate<Pickle> filter,
+            final int limit,
+            final FeatureSupplier featureSupplier,
+            final ExecutorService executor,
+            final PickleOrder pickleOrder
+    ) {
         this.filter = filter;
         this.context = context;
         this.limit = limit;
@@ -76,13 +78,13 @@ public final class Runtime {
         final List<Feature> features = featureSupplier.get();
         features.forEach(context::beforeFeature);
         final List<Future<?>> executingPickles = features.stream()
-            .flatMap(feature -> feature.getPickles().stream())
-            .filter(filter)
-            .collect(collectingAndThen(toList(),
-                list -> pickleOrder.orderPickles(list).stream()))
-            .limit(limit > 0 ? limit : Integer.MAX_VALUE)
-            .map(pickle -> executor.submit(execute(pickle)))
-            .collect(toList());
+                .flatMap(feature -> feature.getPickles().stream())
+                .filter(filter)
+                .collect(collectingAndThen(toList(),
+                    list -> pickleOrder.orderPickles(list).stream()))
+                .limit(limit > 0 ? limit : Integer.MAX_VALUE)
+                .map(pickle -> executor.submit(execute(pickle)))
+                .collect(toList());
 
         executor.shutdown();
 
@@ -155,15 +157,16 @@ public final class Runtime {
         }
 
         public Runtime build() {
-            final ObjectFactoryServiceLoader objectFactoryServiceLoader = new ObjectFactoryServiceLoader(runtimeOptions);
+            final ObjectFactoryServiceLoader objectFactoryServiceLoader = new ObjectFactoryServiceLoader(
+                runtimeOptions);
 
             final ObjectFactorySupplier objectFactorySupplier = runtimeOptions.isMultiThreaded()
-                ? new ThreadLocalObjectFactorySupplier(objectFactoryServiceLoader)
-                : new SingletonObjectFactorySupplier(objectFactoryServiceLoader);
+                    ? new ThreadLocalObjectFactorySupplier(objectFactoryServiceLoader)
+                    : new SingletonObjectFactorySupplier(objectFactoryServiceLoader);
 
             final BackendSupplier backendSupplier = this.backendSupplier != null
-                ? this.backendSupplier
-                : new BackendServiceLoader(this.classLoader, objectFactorySupplier);
+                    ? this.backendSupplier
+                    : new BackendServiceLoader(this.classLoader, objectFactorySupplier);
 
             final Plugins plugins = new Plugins(new PluginFactory(), runtimeOptions);
             for (final Plugin plugin : additionalPlugins) {
@@ -177,21 +180,24 @@ public final class Runtime {
                 plugins.setEventBusOnEventListenerPlugins(eventBus);
             }
 
-            final TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(classLoader, runtimeOptions);
+            final TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(
+                classLoader, runtimeOptions);
 
             final RunnerSupplier runnerSupplier = runtimeOptions.isMultiThreaded()
-                ? new ThreadLocalRunnerSupplier(runtimeOptions, eventBus, backendSupplier, objectFactorySupplier, typeRegistryConfigurerSupplier)
-                : new SingletonRunnerSupplier(runtimeOptions, eventBus, backendSupplier, objectFactorySupplier, typeRegistryConfigurerSupplier);
+                    ? new ThreadLocalRunnerSupplier(runtimeOptions, eventBus, backendSupplier, objectFactorySupplier,
+                        typeRegistryConfigurerSupplier)
+                    : new SingletonRunnerSupplier(runtimeOptions, eventBus, backendSupplier, objectFactorySupplier,
+                        typeRegistryConfigurerSupplier);
 
             final ExecutorService executor = runtimeOptions.isMultiThreaded()
-                ? Executors.newFixedThreadPool(runtimeOptions.getThreads(), new CucumberThreadFactory())
-                : new SameThreadExecutorService();
+                    ? Executors.newFixedThreadPool(runtimeOptions.getThreads(), new CucumberThreadFactory())
+                    : new SameThreadExecutorService();
 
             final FeatureParser parser = new FeatureParser(eventBus::generateId);
 
             final FeatureSupplier featureSupplier = this.featureSupplier != null
-                ? this.featureSupplier
-                : new FeaturePathFeatureSupplier(classLoader, runtimeOptions, parser);
+                    ? this.featureSupplier
+                    : new FeaturePathFeatureSupplier(classLoader, runtimeOptions, parser);
 
             final Predicate<Pickle> filter = new Filters(runtimeOptions);
             final int limit = runtimeOptions.getLimitCount();
@@ -229,7 +235,7 @@ public final class Runtime {
 
         @Override
         public void shutdown() {
-            //no-op
+            // no-op
         }
 
         @Override

--- a/core/src/main/java/io/cucumber/core/runtime/ScanningTypeRegistryConfigurerSupplier.java
+++ b/core/src/main/java/io/cucumber/core/runtime/ScanningTypeRegistryConfigurerSupplier.java
@@ -33,8 +33,7 @@ public final class ScanningTypeRegistryConfigurerSupplier implements TypeRegistr
         return reflections.instantiateExactlyOneSubclass(
             TypeRegistryConfigurer.class,
             options.getGlue(),
-            new DefaultTypeRegistryConfiguration()
-        );
+            new DefaultTypeRegistryConfiguration());
     }
 
     private static final class DefaultTypeRegistryConfiguration implements TypeRegistryConfigurer {
@@ -46,7 +45,7 @@ public final class ScanningTypeRegistryConfigurerSupplier implements TypeRegistr
 
         @Override
         public void configureTypeRegistry(io.cucumber.core.api.TypeRegistry typeRegistry) {
-            //noop
+            // noop
         }
 
     }
@@ -75,19 +74,21 @@ public final class ScanningTypeRegistryConfigurerSupplier implements TypeRegistr
 
         private <T> Collection<? extends T> instantiateSubclasses(Class<T> parentType, List<URI> packageNames) {
             return packageNames
-                .stream()
-                .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
-                .map(ClasspathSupport::packageName)
-                .map(basePackageName -> classFinder.scanForSubClassesInPackage(basePackageName, parentType))
-                .flatMap(Collection::stream)
-                .filter(Reflections::isInstantiable)
-                .map(Reflections::newInstance)
-                .collect(toSet());
+                    .stream()
+                    .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
+                    .map(ClasspathSupport::packageName)
+                    .map(basePackageName -> classFinder.scanForSubClassesInPackage(basePackageName, parentType))
+                    .flatMap(Collection::stream)
+                    .filter(Reflections::isInstantiable)
+                    .map(Reflections::newInstance)
+                    .collect(toSet());
         }
 
         static boolean isInstantiable(Class<?> clazz) {
-            boolean isNonStaticInnerClass = !Modifier.isStatic(clazz.getModifiers()) && clazz.getEnclosingClass() != null;
-            return Modifier.isPublic(clazz.getModifiers()) && !Modifier.isAbstract(clazz.getModifiers()) && !isNonStaticInnerClass;
+            boolean isNonStaticInnerClass = !Modifier.isStatic(clazz.getModifiers())
+                    && clazz.getEnclosingClass() != null;
+            return Modifier.isPublic(clazz.getModifiers()) && !Modifier.isAbstract(clazz.getModifiers())
+                    && !isNonStaticInnerClass;
         }
 
         private static <T> T newInstance(Class<? extends T> clazz) {
@@ -103,7 +104,6 @@ public final class ScanningTypeRegistryConfigurerSupplier implements TypeRegistr
                 throw new CucumberException(e);
             }
         }
-
 
     }
 

--- a/core/src/main/java/io/cucumber/core/runtime/SingletonRunnerSupplier.java
+++ b/core/src/main/java/io/cucumber/core/runtime/SingletonRunnerSupplier.java
@@ -19,10 +19,11 @@ public final class SingletonRunnerSupplier implements RunnerSupplier {
     private Runner runner;
 
     public SingletonRunnerSupplier(
-        Options runnerOptions,
-        EventBus eventBus,
-        BackendSupplier backendSupplier,
-        ObjectFactorySupplier objectFactorySupplier, TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier) {
+            Options runnerOptions,
+            EventBus eventBus,
+            BackendSupplier backendSupplier,
+            ObjectFactorySupplier objectFactorySupplier, TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier
+    ) {
         this.backendSupplier = backendSupplier;
         this.runnerOptions = runnerOptions;
         this.eventBus = eventBus;
@@ -44,8 +45,7 @@ public final class SingletonRunnerSupplier implements RunnerSupplier {
             backendSupplier.get(),
             objectFactorySupplier.get(),
             typeRegistryConfigurerSupplier.get(),
-            runnerOptions
-        );
+            runnerOptions);
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/runtime/TestCaseResultObserver.java
+++ b/core/src/main/java/io/cucumber/core/runtime/TestCaseResultObserver.java
@@ -50,11 +50,9 @@ public final class TestCaseResultObserver implements AutoCloseable {
 
     private void handleSnippetSuggestedEvent(SnippetsSuggestedEvent event) {
         snippetsPerStep.putIfAbsent(new StepLocation(
-                event.getUri(),
-                event.getStepLine()
-            ),
-            event.getSnippets()
-        );
+            event.getUri(),
+            event.getStepLine()),
+            event.getSnippets());
     }
 
     private void handleTestStepFinished(TestStepFinished event) {
@@ -75,9 +73,7 @@ public final class TestCaseResultObserver implements AutoCloseable {
         List<String> snippets = snippetsPerStep.get(
             new StepLocation(
                 pickleStepTestStep.getUri(),
-                pickleStepTestStep.getStepLine()
-            )
-        );
+                pickleStepTestStep.getStepLine()));
         suggestions.add(new Suggestion(stepText, snippets));
     }
 
@@ -86,10 +82,10 @@ public final class TestCaseResultObserver implements AutoCloseable {
     }
 
     public void assertTestCasePassed(
-        Supplier<Throwable> testCaseSkipped,
-        Function<Throwable, Throwable> testCaseSkippedWithException,
-        Function<List<Suggestion>, Throwable> testCaseWasUndefined,
-        Function<Throwable, Throwable> testCaseWasPending
+            Supplier<Throwable> testCaseSkipped,
+            Function<Throwable, Throwable> testCaseSkippedWithException,
+            Function<List<Suggestion>, Throwable> testCaseWasUndefined,
+            Function<Throwable, Throwable> testCaseWasPending
     ) {
         Status status = result.getStatus();
         if (status.is(PASSED)) {

--- a/core/src/main/java/io/cucumber/core/runtime/ThreadLocalObjectFactorySupplier.java
+++ b/core/src/main/java/io/cucumber/core/runtime/ThreadLocalObjectFactorySupplier.java
@@ -1,6 +1,5 @@
 package io.cucumber.core.runtime;
 
-
 import io.cucumber.core.backend.ObjectFactory;
 
 import static java.lang.ThreadLocal.withInitial;

--- a/core/src/main/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplier.java
+++ b/core/src/main/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplier.java
@@ -9,7 +9,8 @@ import java.time.Instant;
 import java.util.UUID;
 
 /**
- * Creates a distinct runner for each calling thread. Each runner has its own bus, backend- and glue-suppliers.
+ * Creates a distinct runner for each calling thread. Each runner has its own
+ * bus, backend- and glue-suppliers.
  * <p>
  * Each runners bus passes all events to the event bus of this supplier.
  */
@@ -24,11 +25,11 @@ public final class ThreadLocalRunnerSupplier implements RunnerSupplier {
     private final ThreadLocal<Runner> runners = ThreadLocal.withInitial(this::createRunner);
 
     public ThreadLocalRunnerSupplier(
-        Options runnerOptions,
-        EventBus sharedEventBus,
-        BackendSupplier backendSupplier,
-        ObjectFactorySupplier objectFactorySupplier,
-        TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier
+            Options runnerOptions,
+            EventBus sharedEventBus,
+            BackendSupplier backendSupplier,
+            ObjectFactorySupplier objectFactorySupplier,
+            TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier
     ) {
         this.runnerOptions = runnerOptions;
         this.sharedEventBus = SynchronizedEventBus.synchronize(sharedEventBus);
@@ -48,8 +49,7 @@ public final class ThreadLocalRunnerSupplier implements RunnerSupplier {
             backendSupplier.get(),
             objectFactorySupplier.get(),
             typeRegistryConfigurerSupplier.get(),
-            runnerOptions
-        );
+            runnerOptions);
     }
 
     private static final class LocalEventBus extends AbstractEventBus {

--- a/core/src/main/java/io/cucumber/core/snippets/SnippetGenerator.java
+++ b/core/src/main/java/io/cucumber/core/snippets/SnippetGenerator.java
@@ -20,9 +20,10 @@ import java.util.regex.Pattern;
 
 public final class SnippetGenerator {
 
-    @SuppressWarnings("RegExpRedundantEscape") // Android can't parse unescaped braces.
-    private static final ArgumentPattern[] DEFAULT_ARGUMENT_PATTERNS = new ArgumentPattern[]{
-        new ArgumentPattern(Pattern.compile("\\{.*?\\}"))
+    @SuppressWarnings("RegExpRedundantEscape") // Android can't parse unescaped
+                                               // braces.
+    private static final ArgumentPattern[] DEFAULT_ARGUMENT_PATTERNS = new ArgumentPattern[] {
+            new ArgumentPattern(Pattern.compile("\\{.*?\\}"))
     };
 
     private static final String REGEXP_HINT = "Write code here that turns the phrase above into concrete actions";
@@ -40,15 +41,15 @@ public final class SnippetGenerator {
         List<String> snippets = new ArrayList<>(generatedExpressions.size());
         FunctionNameGenerator functionNameGenerator = new FunctionNameGenerator(snippetType.joiner());
         for (GeneratedExpression expression : generatedExpressions) {
-            snippets.add(snippet.template().format(new String[]{
-                    sanitize(step.getType().isGivenWhenThen() ? step.getKeyword() : step.getPreviousGivenWhenThenKeyword()),
+            snippets.add(snippet.template().format(new String[] {
+                    sanitize(
+                        step.getType().isGivenWhenThen() ? step.getKeyword() : step.getPreviousGivenWhenThenKeyword()),
                     snippet.escapePattern(expression.getSource()),
                     functionName(expression.getSource(), functionNameGenerator),
                     snippet.arguments(arguments(step, expression.getParameterNames(), expression.getParameterTypes())),
                     REGEXP_HINT,
                     tableHint(step)
-                }
-            ));
+            }));
         }
 
         return snippets;
@@ -110,7 +111,7 @@ public final class SnippetGenerator {
             return name;
         }
 
-        for (int i = 1; ; i++) {
+        for (int i = 1;; i++) {
             if (!parameterNames.contains(name + i)) {
                 return name + i;
             }

--- a/core/src/main/java/io/cucumber/core/stepexpression/ArgumentMatcher.java
+++ b/core/src/main/java/io/cucumber/core/stepexpression/ArgumentMatcher.java
@@ -40,10 +40,10 @@ public final class ArgumentMatcher {
 
     private static List<List<String>> emptyCellsToNull(List<List<String>> cells) {
         return cells.stream()
-            .map(row -> row.stream()
-                .map(s -> s.isEmpty() ? null : s)
-                .collect(Collectors.toList()))
-            .collect(Collectors.toList());
+                .map(row -> row.stream()
+                        .map(s -> s.isEmpty() ? null : s)
+                        .collect(Collectors.toList()))
+                .collect(Collectors.toList());
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/stepexpression/StepExpressionFactory.java
+++ b/core/src/main/java/io/cucumber/core/stepexpression/StepExpressionFactory.java
@@ -42,19 +42,19 @@ public final class StepExpressionFactory {
             return createExpression(
                 stepDefinition.getPattern(),
                 stepDefinitionDoesNotTakeAnyParameter(stepDefinition),
-                false
-            );
+                false);
         }
 
         ParameterInfo parameterInfo = parameterInfos.get(parameterInfos.size() - 1);
         return createExpression(
             stepDefinition.getPattern(),
             parameterInfo.getTypeResolver()::resolve,
-            parameterInfo.isTransposed()
-        );
+            parameterInfo.isTransposed());
     }
 
-    private StepExpression createExpression(String expressionString, Supplier<Type> tableOrDocStringType, boolean transpose) {
+    private StepExpression createExpression(
+            String expressionString, Supplier<Type> tableOrDocStringType, boolean transpose
+    ) {
         requireNonNull(expressionString, "expressionString can not be null");
         requireNonNull(tableOrDocStringType, "tableOrDocStringType can not be null");
 
@@ -78,8 +78,7 @@ public final class StepExpressionFactory {
         return () -> {
             throw new CucumberException(format(
                 "step definition at %s does not take any parameters",
-                stepDefinition.getLocation()
-            ));
+                stepDefinition.getLocation()));
         };
     }
 
@@ -89,11 +88,10 @@ public final class StepExpressionFactory {
             expression = expressionFactory.createExpression(expressionString);
         } catch (UndefinedParameterTypeException e) {
             bus.send(Envelope.newBuilder()
-                .setUndefinedParameterType(UndefinedParameterType.newBuilder()
-                    .setExpression(expressionString)
-                    .setName(e.getUndefinedParameterTypeName()))
-                .build()
-            );
+                    .setUndefinedParameterType(UndefinedParameterType.newBuilder()
+                            .setExpression(expressionString)
+                            .setName(e.getUndefinedParameterTypeName()))
+                    .build());
             throw registerTypeInConfiguration(expressionString, e);
         }
         return expression;
@@ -103,8 +101,7 @@ public final class StepExpressionFactory {
         return new CucumberException(format("" +
                 "Could not create a cucumber expression for '%s'.\n" +
                 "It appears you did not register a parameter type.",
-            expressionString
-        ), e);
+            expressionString), e);
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/stepexpression/StepTypeRegistry.java
+++ b/core/src/main/java/io/cucumber/core/stepexpression/StepTypeRegistry.java
@@ -20,7 +20,6 @@ public final class StepTypeRegistry implements io.cucumber.core.api.TypeRegistry
 
     private final DocStringTypeRegistry docStringTypeRegistry;
 
-
     public StepTypeRegistry(Locale locale) {
         parameterTypeRegistry = new ParameterTypeRegistry(locale);
         dataTableTypeRegistry = new DataTableTypeRegistry(locale);
@@ -60,7 +59,9 @@ public final class StepTypeRegistry implements io.cucumber.core.api.TypeRegistry
     }
 
     @Override
-    public void setDefaultDataTableEntryTransformer(TableEntryByTypeTransformer defaultDataTableEntryByTypeTransformer) {
+    public void setDefaultDataTableEntryTransformer(
+            TableEntryByTypeTransformer defaultDataTableEntryByTypeTransformer
+    ) {
         dataTableTypeRegistry.setDefaultDataTableEntryTransformer(defaultDataTableEntryByTypeTransformer);
     }
 

--- a/core/src/test/java/io/cucumber/core/cli/MainDemo.java
+++ b/core/src/test/java/io/cucumber/core/cli/MainDemo.java
@@ -3,8 +3,8 @@ package io.cucumber.core.cli;
 public class MainDemo {
 
     public static void main(String[] args) {
-//        Main.main("--i18n");
-//        Main.main("--i18n", "help");
+        // Main.main("--i18n");
+        // Main.main("--i18n", "help");
         Main.main("--i18n", "tlh");
     }
 

--- a/core/src/test/java/io/cucumber/core/exception/CompositeCucumberExceptionTest.java
+++ b/core/src/test/java/io/cucumber/core/exception/CompositeCucumberExceptionTest.java
@@ -21,8 +21,7 @@ class CompositeCucumberExceptionTest {
         assertAll(
             () -> assertThat(expectedThrown.getMessage(), is(equalTo("There were 0 exceptions:\n"))),
             () -> assertThat(expectedThrown.getCause(), is(nullValue())),
-            () -> assertThat(expectedThrown.getCauses(), is(equalTo(causes)))
-        );
+            () -> assertThat(expectedThrown.getCauses(), is(equalTo(causes))));
     }
 
     @Test
@@ -30,10 +29,10 @@ class CompositeCucumberExceptionTest {
         final List<Throwable> causes = Collections.singletonList(new IllegalArgumentException());
         CompositeCucumberException expectedThrown = new CompositeCucumberException(causes);
         assertAll(
-            () -> assertThat(expectedThrown.getMessage(), is(equalTo("There were 1 exceptions:\n  java.lang.IllegalArgumentException(null)"))),
+            () -> assertThat(expectedThrown.getMessage(),
+                is(equalTo("There were 1 exceptions:\n  java.lang.IllegalArgumentException(null)"))),
             () -> assertThat(expectedThrown.getCause(), is(nullValue())),
-            () -> assertThat(expectedThrown.getCauses(), is(equalTo(causes)))
-        );
+            () -> assertThat(expectedThrown.getCauses(), is(equalTo(causes))));
     }
 
     @Test
@@ -41,10 +40,10 @@ class CompositeCucumberExceptionTest {
         final List<Throwable> causes = Arrays.asList(new IllegalArgumentException(), new RuntimeException());
         CompositeCucumberException expectedThrown = new CompositeCucumberException(causes);
         assertAll(
-            () -> assertThat(expectedThrown.getMessage(), is(equalTo("There were 2 exceptions:\n  java.lang.IllegalArgumentException(null)\n  java.lang.RuntimeException(null)"))),
+            () -> assertThat(expectedThrown.getMessage(), is(equalTo(
+                "There were 2 exceptions:\n  java.lang.IllegalArgumentException(null)\n  java.lang.RuntimeException(null)"))),
             () -> assertThat(expectedThrown.getCause(), is(nullValue())),
-            () -> assertThat(expectedThrown.getCauses(), is(equalTo(causes)))
-        );
+            () -> assertThat(expectedThrown.getCauses(), is(equalTo(causes))));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/exception/CucumberExceptionTest.java
+++ b/core/src/test/java/io/cucumber/core/exception/CucumberExceptionTest.java
@@ -16,8 +16,7 @@ class CucumberExceptionTest {
         CucumberException expectedThrown = new CucumberException(new RuntimeException());
         assertAll(
             () -> assertThat(expectedThrown.getMessage(), is(equalTo("java.lang.RuntimeException"))),
-            () -> assertThat(expectedThrown.getCause(), isA(RuntimeException.class))
-        );
+            () -> assertThat(expectedThrown.getCause(), isA(RuntimeException.class)));
     }
 
     @Test
@@ -25,8 +24,7 @@ class CucumberExceptionTest {
         CucumberException expectedThrown = new CucumberException((Throwable) null);
         assertAll(
             () -> assertThat(expectedThrown.getMessage(), is(nullValue())),
-            () -> assertThat(expectedThrown.getCause(), is(nullValue()))
-        );
+            () -> assertThat(expectedThrown.getCause(), is(nullValue())));
     }
 
     @Test
@@ -34,8 +32,7 @@ class CucumberExceptionTest {
         CucumberException expectedThrown = new CucumberException("message");
         assertAll(
             () -> assertThat(expectedThrown.getMessage(), is(equalTo("message"))),
-            () -> assertThat(expectedThrown.getCause(), is(nullValue()))
-        );
+            () -> assertThat(expectedThrown.getCause(), is(nullValue())));
     }
 
     @Test
@@ -43,8 +40,7 @@ class CucumberExceptionTest {
         CucumberException expectedThrown = new CucumberException((String) null);
         assertAll(
             () -> assertThat(expectedThrown.getMessage(), is(nullValue())),
-            () -> assertThat(expectedThrown.getCause(), is(nullValue()))
-        );
+            () -> assertThat(expectedThrown.getCause(), is(nullValue())));
     }
 
     @Test
@@ -52,8 +48,7 @@ class CucumberExceptionTest {
         CucumberException expectedThrown = new CucumberException("message", new RuntimeException());
         assertAll(
             () -> assertThat(expectedThrown.getMessage(), is(equalTo("message"))),
-            () -> assertThat(expectedThrown.getCause(), isA(RuntimeException.class))
-        );
+            () -> assertThat(expectedThrown.getCause(), isA(RuntimeException.class)));
     }
 
     @Test
@@ -61,8 +56,7 @@ class CucumberExceptionTest {
         CucumberException expectedThrown = new CucumberException(null, null);
         assertAll(
             () -> assertThat(expectedThrown.getMessage(), is(nullValue())),
-            () -> assertThat(expectedThrown.getCause(), is(nullValue()))
-        );
+            () -> assertThat(expectedThrown.getCause(), is(nullValue())));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/feature/EncodingTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/EncodingTest.java
@@ -20,13 +20,15 @@ class EncodingTest {
 
     @Test
     void test_utf8_bom_encode() throws RuntimeException, IOException {
-        when(resource.getInputStream()).thenReturn(new FileInputStream("src/test/resources/io/cucumber/core/feature/UTF_8_BOM_Encoded.feature"));
+        when(resource.getInputStream()).thenReturn(
+            new FileInputStream("src/test/resources/io/cucumber/core/feature/UTF_8_BOM_Encoded.feature"));
         assertFalse(Encoding.readFile(resource).startsWith("\uFEFF"), "UTF-8 BOM encoding not removed.");
     }
 
     @Test
     void test_utf8_encode() throws RuntimeException, IOException {
-        when(resource.getInputStream()).thenReturn(new FileInputStream("src/test/resources/io/cucumber/core/feature/UTF_8_Encoded.feature"));
+        when(resource.getInputStream())
+                .thenReturn(new FileInputStream("src/test/resources/io/cucumber/core/feature/UTF_8_Encoded.feature"));
         assertFalse(Encoding.readFile(resource).startsWith("\uFEFF"), "UTF-8 BOM encoding should not be present.");
     }
 

--- a/core/src/test/java/io/cucumber/core/feature/FeatureIdentifierTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/FeatureIdentifierTest.java
@@ -17,10 +17,9 @@ class FeatureIdentifierTest {
     void can_parse_feature_path_with_feature() {
         URI uri = FeatureIdentifier.parse(FeaturePath.parse("classpath:/path/to/file.feature"));
 
-        assertAll("Checking uri",
+        assertAll(
             () -> assertThat(uri.getScheme(), is(equalTo("classpath"))),
-            () -> assertThat(uri.getSchemeSpecificPart(), is(equalTo("/path/to/file.feature")))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is(equalTo("/path/to/file.feature"))));
     }
 
     @Test
@@ -28,8 +27,7 @@ class FeatureIdentifierTest {
         Executable testMethod = () -> FeatureIdentifier.parse(URI.create("classpath:/path/to/file.feature:10:40"));
         IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "featureIdentifier does not reference a single feature file: classpath:/path/to/file.feature:10:40"
-        )));
+            "featureIdentifier does not reference a single feature file: classpath:/path/to/file.feature:10:40")));
     }
 
     @Test
@@ -37,8 +35,7 @@ class FeatureIdentifierTest {
         Executable testMethod = () -> FeatureIdentifier.parse(URI.create("classpath:/path/to"));
         IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "featureIdentifier does not reference a single feature file: classpath:/path/to"
-        )));
+            "featureIdentifier does not reference a single feature file: classpath:/path/to")));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/feature/FeaturePathTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/FeaturePathTest.java
@@ -20,8 +20,7 @@ class FeaturePathTest {
     void can_parse_empty_feature_path() {
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> FeaturePath.parse("")
-        );
+            () -> FeaturePath.parse(""));
         assertThat(exception.getMessage(), is("featureIdentifier may not be empty"));
     }
 
@@ -30,8 +29,7 @@ class FeaturePathTest {
         URI uri = FeaturePath.parse("classpath:/");
         assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/")));
     }
 
     @Test
@@ -41,8 +39,7 @@ class FeaturePathTest {
 
         assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/")));
     }
 
     @Test
@@ -51,8 +48,7 @@ class FeaturePathTest {
 
         assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/path/to/file.feature"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/path/to/file.feature")));
     }
 
     @Test
@@ -61,8 +57,7 @@ class FeaturePathTest {
 
         assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/path/to"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/path/to")));
     }
 
     @Test
@@ -72,8 +67,7 @@ class FeaturePathTest {
 
         assertAll(
             () -> assertThat(uri.getScheme(), is("file")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/path/to/file.feature"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/path/to/file.feature")));
     }
 
     @Test
@@ -83,8 +77,7 @@ class FeaturePathTest {
 
         assertAll(
             () -> assertThat(uri.getScheme(), is("file")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/path/to"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/path/to")));
     }
 
     @Test
@@ -93,8 +86,7 @@ class FeaturePathTest {
 
         assertAll(
             () -> assertThat(uri.getScheme(), is("file")),
-            () -> assertThat(uri.getSchemeSpecificPart(), endsWith("path/to/file.feature"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), endsWith("path/to/file.feature")));
     }
 
     @Test
@@ -112,8 +104,7 @@ class FeaturePathTest {
 
         assertAll(
             () -> assertThat(uri.getScheme(), is("file")),
-            () -> assertThat(uri.getSchemeSpecificPart(), endsWith("path/to/file.feature"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), endsWith("path/to/file.feature")));
     }
 
     @Test
@@ -123,8 +114,7 @@ class FeaturePathTest {
 
         assertAll(
             () -> assertThat(uri.getScheme(), is("file")),
-            () -> assertThat(uri.getSchemeSpecificPart(), endsWith("path/to/file.feature"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), endsWith("path/to/file.feature")));
     }
 
     @Test
@@ -134,8 +124,7 @@ class FeaturePathTest {
 
         assertAll(
             () -> assertThat(uri.getScheme(), is(is("file"))),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/C:/path/to/file.feature"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/C:/path/to/file.feature")));
     }
 
     @Test
@@ -144,8 +133,7 @@ class FeaturePathTest {
 
         assertAll(
             () -> assertThat(uri.getScheme(), is(is("file"))),
-            () -> assertThat(uri.getSchemeSpecificPart(), endsWith("path/to the/file.feature"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), endsWith("path/to the/file.feature")));
     }
 
     @Test
@@ -155,8 +143,7 @@ class FeaturePathTest {
 
         assertAll(
             () -> assertThat(uri.getScheme(), is("file")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/C:/path/to/file.feature"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/C:/path/to/file.feature")));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/feature/FeatureWithLinesTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/FeatureWithLinesTest.java
@@ -18,8 +18,7 @@ class FeatureWithLinesTest {
 
         assertAll(
             () -> assertThat(featureWithLines.uri(), is(URI.create("classpath:example.feature"))),
-            () -> assertThat(featureWithLines.lines(), emptyCollectionOf(Integer.class))
-        );
+            () -> assertThat(featureWithLines.lines(), emptyCollectionOf(Integer.class)));
     }
 
     @Test
@@ -28,8 +27,7 @@ class FeatureWithLinesTest {
 
         assertAll(
             () -> assertThat(featureWithLines.uri(), is(URI.create("classpath:example.feature"))),
-            () -> assertThat(featureWithLines.lines(), contains(999))
-        );
+            () -> assertThat(featureWithLines.lines(), contains(999)));
     }
 
     @Test
@@ -38,8 +36,7 @@ class FeatureWithLinesTest {
 
         assertAll(
             () -> assertThat(featureWithLines.uri(), is(URI.create("classpath:example.feature"))),
-            () -> assertThat(featureWithLines.lines(), contains(999, 2000))
-        );
+            () -> assertThat(featureWithLines.lines(), contains(999, 2000)));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/feature/GluePathTest.java
+++ b/core/src/test/java/io/cucumber/core/feature/GluePathTest.java
@@ -19,20 +19,18 @@ class GluePathTest {
     void can_parse_empty_glue_path() {
         URI uri = GluePath.parse("");
 
-        assertAll("Checking uri",
+        assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/")));
     }
 
     @Test
     void can_parse_root_package() {
         URI uri = GluePath.parse("classpath:/");
 
-        assertAll("Checking uri",
+        assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/")));
     }
 
     @Test
@@ -40,50 +38,45 @@ class GluePathTest {
         // The eclipse plugin uses `classpath:` as the default
         URI uri = GluePath.parse("classpath:");
 
-        assertAll("Checking uri",
+        assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/")));
     }
 
     @Test
     void can_parse_classpath_form() {
         URI uri = GluePath.parse("classpath:com/example/app");
 
-        assertAll("Checking uri",
+        assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("com/example/app"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("com/example/app")));
     }
 
     @Test
     void can_parse_relative_path_form() {
         URI uri = GluePath.parse("com/example/app");
 
-        assertAll("Checking uri",
+        assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/com/example/app"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/com/example/app")));
     }
 
     @Test
     void can_parse_absolute_path_form() {
         URI uri = GluePath.parse("/com/example/app");
 
-        assertAll("Checking uri",
+        assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/com/example/app"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/com/example/app")));
     }
 
     @Test
     void can_parse_package_form() {
         URI uri = GluePath.parse("com.example.app");
 
-        assertAll("Checking uri",
+        assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is("/com/example/app"))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is("/com/example/app")));
     }
 
     @Test
@@ -91,8 +84,7 @@ class GluePathTest {
         Executable testMethod = () -> GluePath.parse("file:com/example/app");
         IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "The glue path must have a classpath scheme file:com/example/app"
-        )));
+            "The glue path must have a classpath scheme file:com/example/app")));
     }
 
     @Test
@@ -100,31 +92,28 @@ class GluePathTest {
         Executable testMethod = () -> GluePath.parse("01-examples");
         IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "The glue path contained invalid identifiers 01-examples"
-        )));
+            "The glue path contained invalid identifiers 01-examples")));
     }
 
     @Test
     void can_parse_windows_path_form() {
-        assumeTrue(File.separatorChar == '\\'); //Requires windows
+        assumeTrue(File.separatorChar == '\\'); // Requires windows
 
         URI uri = GluePath.parse("com\\example\\app");
 
-        assertAll("Checking uri",
+        assertAll(
             () -> assertThat(uri.getScheme(), is("classpath")),
-            () -> assertThat(uri.getSchemeSpecificPart(), is(equalTo("/com/example/app")))
-        );
+            () -> assertThat(uri.getSchemeSpecificPart(), is(equalTo("/com/example/app"))));
     }
 
     @Test
     void absolute_windows_path_form_is_not_valid() {
-        assumeTrue(File.separatorChar == '\\'); //Requires windows
+        assumeTrue(File.separatorChar == '\\'); // Requires windows
 
         Executable testMethod = () -> GluePath.parse("C:\\com\\example\\app");
         IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "The glue path must have a classpath scheme C:/com/example/app"
-        )));
+            "The glue path must have a classpath scheme C:/com/example/app")));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/filter/LinePredicateTest.java
+++ b/core/src/test/java/io/cucumber/core/filter/LinePredicateTest.java
@@ -19,14 +19,13 @@ class LinePredicateTest {
     private final Feature feature = TestFeatureParser.parse(
         "file:path/file.feature",
         "" +
-            "Feature: Test feature\n" +
-            "  Scenario Outline: Test scenario\n" +
-            "     Given I have 4 <thing> in my belly\n" +
-            "     Examples:\n" +
-            "       | thing    | \n" +
-            "       | cucumber | \n" +
-            "       | gherkin  | \n"
-    );
+                "Feature: Test feature\n" +
+                "  Scenario Outline: Test scenario\n" +
+                "     Given I have 4 <thing> in my belly\n" +
+                "     Examples:\n" +
+                "       | thing    | \n" +
+                "       | cucumber | \n" +
+                "       | gherkin  | \n");
     private final Pickle pickle = feature.getPickles().get(0);
 
     @Test
@@ -36,8 +35,7 @@ class LinePredicateTest {
         // but all pickles from path/file.feature shall also be executed.
         LinePredicate predicate = new LinePredicate(singletonMap(
             URI.create("file:another_path/file.feature"),
-            singletonList(8)
-        ));
+            singletonList(8)));
         assertTrue(predicate.test(pickle));
     }
 
@@ -45,8 +43,7 @@ class LinePredicateTest {
     void matches_pickles_for_any_line_in_predicate() {
         LinePredicate predicate = new LinePredicate(singletonMap(
             URI.create("file:path/file.feature"),
-            asList(2, 4)
-        ));
+            asList(2, 4)));
         assertTrue(predicate.test(pickle));
     }
 
@@ -54,8 +51,7 @@ class LinePredicateTest {
     void matches_pickles_on_scenario_location_of_the_pickle() {
         LinePredicate predicate = new LinePredicate(singletonMap(
             URI.create("file:path/file.feature"),
-            singletonList(2)
-        ));
+            singletonList(2)));
         assertTrue(predicate.test(pickle));
     }
 
@@ -63,8 +59,7 @@ class LinePredicateTest {
     void matches_pickles_on_example_location_of_the_pickle() {
         LinePredicate predicate = new LinePredicate(singletonMap(
             URI.create("file:path/file.feature"),
-            singletonList(6)
-        ));
+            singletonList(6)));
         assertTrue(predicate.test(pickle));
     }
 
@@ -72,8 +67,7 @@ class LinePredicateTest {
     void does_not_matches_pickles_not_on_any_line_of_the_predicate() {
         LinePredicate predicate = new LinePredicate(singletonMap(
             new File("path/file.feature").toURI(),
-            singletonList(4)
-        ));
+            singletonList(4)));
         assertFalse(predicate.test(pickle));
     }
 

--- a/core/src/test/java/io/cucumber/core/filter/NamePredicateTest.java
+++ b/core/src/test/java/io/cucumber/core/filter/NamePredicateTest.java
@@ -23,10 +23,9 @@ class NamePredicateTest {
 
     private Pickle createPickleWithName(String pickleName) {
         Feature feature = TestFeatureParser.parse("file:path/file.feature", "" +
-            "Feature: Test feature\n" +
-            "  Scenario: " + pickleName + "\n" +
-            "     Given I have 4 cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: " + pickleName + "\n" +
+                "     Given I have 4 cukes in my belly\n");
         return feature.getPickles().get(0);
     }
 

--- a/core/src/test/java/io/cucumber/core/filter/TagPredicateTest.java
+++ b/core/src/test/java/io/cucumber/core/filter/TagPredicateTest.java
@@ -21,11 +21,10 @@ class TagPredicateTest {
 
     private Pickle createPickleWithTags(String... tags) {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  " + String.join(" ", tags) + "\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  " + String.join(" ", tags) + "\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my belly\n");
         return feature.getPickles().get(0);
     }
 

--- a/core/src/test/java/io/cucumber/core/logging/LoggerFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/logging/LoggerFactoryTest.java
@@ -13,7 +13,6 @@ import java.util.logging.LogRecord;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
-
 class LoggerFactoryTest {
 
     private final Exception exception = new Exception();
@@ -67,7 +66,6 @@ class LoggerFactoryTest {
                 description.appendValue(throwable);
             }
 
-
             @Override
             protected boolean matchesSafely(LogRecord logRecord, Description description) {
                 description.appendText("error=");
@@ -78,8 +76,8 @@ class LoggerFactoryTest {
                 description.appendValue(logRecord.getThrown());
 
                 return Objects.equals(logRecord.getMessage(), message)
-                    && Objects.equals(logRecord.getLevel(), level)
-                    && Objects.equals(logRecord.getThrown(), throwable);
+                        && Objects.equals(logRecord.getLevel(), level)
+                        && Objects.equals(logRecord.getThrown(), throwable);
             }
         };
     }
@@ -107,7 +105,6 @@ class LoggerFactoryTest {
         logger.config(exception, () -> "Config");
         assertThat(logged, logRecord("Config", Level.CONFIG, exception));
     }
-
 
     @Test
     void debug() {

--- a/core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
@@ -101,28 +101,28 @@ class CommandlineOptionsParserTest {
     @Test
     void assigns_feature_paths() {
         RuntimeOptions options = parser
-            .parse("somewhere_else")
-            .build();
+                .parse("somewhere_else")
+                .build();
         assertThat(options.getFeaturePaths(), contains(new File("somewhere_else").toURI()));
     }
 
     @Test
     void strips_line_filters_from_feature_paths_and_put_them_among_line_filters() {
         RuntimeOptions options = parser
-            .parse("somewhere_else.feature:3")
-            .build();
+                .parse("somewhere_else.feature:3")
+                .build();
 
         assertAll(
             () -> assertThat(options.getFeaturePaths(), contains(new File("somewhere_else.feature").toURI())),
-            () -> assertThat(options.getLineFilters(), hasEntry(new File("somewhere_else.feature").toURI(), singleton(3)))
-        );
+            () -> assertThat(options.getLineFilters(),
+                hasEntry(new File("somewhere_else.feature").toURI(), singleton(3))));
     }
 
     @Test
     void select_multiple_lines_in_a_features() {
         RuntimeOptions options = parser
-            .parse("somewhere_else.feature:3:5")
-            .build();
+                .parse("somewhere_else.feature:3:5")
+                .build();
         assertThat(options.getFeaturePaths(), contains(new File("somewhere_else.feature").toURI()));
         Set<Integer> lines = new HashSet<>(asList(3, 5));
         assertThat(options.getLineFilters(), hasEntry(new File("somewhere_else.feature").toURI(), lines));
@@ -131,8 +131,8 @@ class CommandlineOptionsParserTest {
     @Test
     void combines_line_filters_from_repeated_features() {
         RuntimeOptions options = parser
-            .parse("classpath:somewhere_else.feature:3", "classpath:somewhere_else.feature:5")
-            .build();
+                .parse("classpath:somewhere_else.feature:3", "classpath:somewhere_else.feature:5")
+                .build();
         assertThat(options.getFeaturePaths(), contains(uri("classpath:somewhere_else.feature")));
         Set<Integer> lines = new HashSet<>(asList(3, 5));
         assertThat(options.getLineFilters(), hasEntry(uri("classpath:somewhere_else.feature"), lines));
@@ -145,24 +145,24 @@ class CommandlineOptionsParserTest {
     @Test
     void assigns_filters_from_tags() {
         RuntimeOptions options = parser
-            .parse("--tags", "@keep_this")
-            .build();
+                .parse("--tags", "@keep_this")
+                .build();
         assertThat(options.getTagExpressions(), contains("@keep_this"));
     }
 
     @Test
     void assigns_glue() {
         RuntimeOptions options = parser
-            .parse("--glue", "somewhere")
-            .build();
+                .parse("--glue", "somewhere")
+                .build();
         assertThat(options.getGlue(), contains(uri("classpath:/somewhere")));
     }
 
     @Test
     void creates_html_formatter() {
         RuntimeOptions options = parser
-            .parse("--plugin", "html:target/deeply/nested.html", "--glue", "somewhere")
-            .build();
+                .parse("--plugin", "html:target/deeply/nested.html", "--glue", "somewhere")
+                .build();
         Plugins plugins = new Plugins(new PluginFactory(), options);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
 
@@ -172,9 +172,9 @@ class CommandlineOptionsParserTest {
     @Test
     void creates_progress_formatter_as_default() {
         RuntimeOptions options = parser
-            .parse()
-            .addDefaultFormatterIfAbsent()
-            .build();
+                .parse()
+                .addDefaultFormatterIfAbsent()
+                .build();
         Plugins plugins = new Plugins(new PluginFactory(), options);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
 
@@ -184,9 +184,9 @@ class CommandlineOptionsParserTest {
     @Test
     void creates_default_summary_printer_when_no_summary_printer_plugin_is_specified() {
         RuntimeOptions options = parser
-            .parse("--plugin", "pretty")
-            .addDefaultSummaryPrinterIfAbsent()
-            .build();
+                .parse("--plugin", "pretty")
+                .addDefaultSummaryPrinterIfAbsent()
+                .build();
         Plugins plugins = new Plugins(new PluginFactory(), options);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
 
@@ -211,22 +211,22 @@ class CommandlineOptionsParserTest {
     @Test
     void creates_null_summary_printer() {
         RuntimeOptions options = parser
-            .parse("--plugin", "null_summary", "--glue", "somewhere")
-            .build();
+                .parse("--plugin", "null_summary", "--glue", "somewhere")
+                .build();
         Plugins plugins = new Plugins(new PluginFactory(), options);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
 
         assertAll(
             () -> assertThat(plugins.getPlugins(), hasItem(plugin("io.cucumber.core.plugin.NullSummaryPrinter"))),
-            () -> assertThat(plugins.getPlugins(), not(hasItem(plugin("io.cucumber.core.plugin.DefaultSummaryPrinter"))))
-        );
+            () -> assertThat(plugins.getPlugins(),
+                not(hasItem(plugin("io.cucumber.core.plugin.DefaultSummaryPrinter")))));
     }
 
     @Test
     void replaces_incompatible_intellij_idea_plugin() {
         RuntimeOptions options = parser
-            .parse("--plugin", "org.jetbrains.plugins.cucumber.java.run.CucumberJvm3SMFormatter")
-            .build();
+                .parse("--plugin", "org.jetbrains.plugins.cucumber.java.run.CucumberJvm3SMFormatter")
+                .build();
         Plugins plugins = new Plugins(new PluginFactory(), options);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
 
@@ -236,32 +236,32 @@ class CommandlineOptionsParserTest {
     @Test
     void assigns_wip() {
         RuntimeOptions options = parser
-            .parse("--wip")
-            .build();
+                .parse("--wip")
+                .build();
         assertThat(options.isWip(), is(true));
     }
 
     @Test
     void assigns_wip_short() {
         RuntimeOptions options = parser
-            .parse("-w")
-            .build();
+                .parse("-w")
+                .build();
         assertThat(options.isWip(), is(true));
     }
 
     @Test
     void default_wip() {
         RuntimeOptions options = parser
-            .parse()
-            .build();
+                .parse()
+                .build();
         assertThat(options.isWip(), is(false));
     }
 
     @Test
     void name_without_spaces_is_preserved() {
         RuntimeOptions options = parser
-            .parse("--name", "someName")
-            .build();
+                .parse("--name", "someName")
+                .build();
         Pattern actualPattern = options.getNameFilters().iterator().next();
         assertThat(actualPattern.pattern(), is("someName"));
     }
@@ -269,8 +269,8 @@ class CommandlineOptionsParserTest {
     @Test
     void name_with_spaces_is_preserved() {
         RuntimeOptions options = parser
-            .parse("--name", "some Name")
-            .build();
+                .parse("--name", "some Name")
+                .build();
         Pattern actualPattern = options.getNameFilters().iterator().next();
         assertThat(actualPattern.pattern(), is("some Name"));
     }
@@ -278,41 +278,40 @@ class CommandlineOptionsParserTest {
     @Test
     void combines_tag_filters_from_env_if_rerun_file_specified_in_cli() {
         RuntimeOptions runtimeOptions = parser
-            .parse("@src/test/resources/io/cucumber/core/options/runtime-options-rerun.txt")
-            .build();
+                .parse("@src/test/resources/io/cucumber/core/options/runtime-options-rerun.txt")
+                .build();
 
         RuntimeOptions options = new CucumberPropertiesParser()
-            .parse(singletonMap(FILTER_TAGS_PROPERTY_NAME, "@should_not_be_clobbered"))
-            .build(runtimeOptions);
+                .parse(singletonMap(FILTER_TAGS_PROPERTY_NAME, "@should_not_be_clobbered"))
+                .build(runtimeOptions);
 
         assertAll(
             () -> assertThat(options.getTagExpressions(), contains("@should_not_be_clobbered")),
-            () -> assertThat(options.getLineFilters(), hasEntry(new File("this/should/be/rerun.feature").toURI(), singleton(12)))
-        );
+            () -> assertThat(options.getLineFilters(),
+                hasEntry(new File("this/should/be/rerun.feature").toURI(), singleton(12))));
     }
 
     @Test
     void clobbers_line_filters_from_cli_if_tags_are_specified_in_env() {
         RuntimeOptions runtimeOptions = parser
-            .parse("file:path/to.feature")
-            .build();
+                .parse("file:path/to.feature")
+                .build();
 
         RuntimeOptions options = new CucumberPropertiesParser()
-            .parse(singletonMap(FILTER_TAGS_PROPERTY_NAME, "@should_not_be_clobbered"))
-            .build(runtimeOptions);
+                .parse(singletonMap(FILTER_TAGS_PROPERTY_NAME, "@should_not_be_clobbered"))
+                .build(runtimeOptions);
 
         assertAll(
             () -> assertThat(options.getTagExpressions(), contains("@should_not_be_clobbered")),
             () -> assertThat(options.getLineFilters(), is(emptyMap())),
-            () -> assertThat(options.getFeaturePaths(), contains(new File("path/to.feature").toURI()))
-        );
+            () -> assertThat(options.getFeaturePaths(), contains(new File("path/to.feature").toURI())));
     }
 
     @Test
     void fail_on_unsupported_options() {
         parser
-            .parse("-concreteUnsupportedOption", "somewhere", "somewhere_else")
-            .build();
+                .parse("-concreteUnsupportedOption", "somewhere", "somewhere_else")
+                .build();
         assertThat(output(), startsWith("Unknown option: -concreteUnsupportedOption"));
         assertThat(parser.exitStatus(), is(Optional.of((byte) 0x1)));
     }
@@ -320,24 +319,24 @@ class CommandlineOptionsParserTest {
     @Test
     void threads_default_1() {
         RuntimeOptions options = parser
-            .parse()
-            .build();
+                .parse()
+                .build();
         assertThat(options.getThreads(), is(1));
     }
 
     @Test
     void ensure_threads_param_is_used() {
         RuntimeOptions options = parser
-            .parse("--threads", "10")
-            .build();
+                .parse("--threads", "10")
+                .build();
         assertThat(options.getThreads(), is(10));
     }
 
     @Test
     void ensure_less_than_1_thread_is_not_allowed() {
         parser
-            .parse("--threads", "0")
-            .build();
+                .parse("--threads", "0")
+                .build();
         assertThat(output(), is("--threads must be > 0\n"));
         assertThat(parser.exitStatus(), is(Optional.of((byte) 0x1)));
     }
@@ -345,8 +344,8 @@ class CommandlineOptionsParserTest {
     @Test
     void set_monochrome_on_color_aware_formatters() {
         RuntimeOptions options = parser
-            .parse("--monochrome", "--plugin", AwareFormatter.class.getName())
-            .build();
+                .parse("--monochrome", "--plugin", AwareFormatter.class.getName())
+                .build();
         Plugins plugins = new Plugins(new PluginFactory(), options);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
 
@@ -357,8 +356,8 @@ class CommandlineOptionsParserTest {
     @Test
     void set_strict_on_strict_aware_formatters() {
         RuntimeOptions options = parser
-            .parse("--strict", "--plugin", AwareFormatter.class.getName())
-            .build();
+                .parse("--strict", "--plugin", AwareFormatter.class.getName())
+                .build();
         Plugins plugins = new Plugins(new PluginFactory(), options);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
 
@@ -370,78 +369,81 @@ class CommandlineOptionsParserTest {
     @Test
     void ensure_default_snippet_type_is_underscore() {
         RuntimeOptions runtimeOptions = parser
-            .parse()
-            .build();
+                .parse()
+                .build();
         RuntimeOptions options = new CucumberPropertiesParser()
-            .parse(properties)
-            .build(runtimeOptions);
+                .parse(properties)
+                .build(runtimeOptions);
         assertThat(options.getSnippetType(), is(SnippetType.UNDERSCORE));
     }
 
     @Test
     void order_type_default_none() {
         RuntimeOptions options = parser
-            .parse()
-            .build();
+                .parse()
+                .build();
         Pickle a = createPickle("file:path/file1.feature", "a");
         Pickle b = createPickle("file:path/file2.feature", "b");
         assertThat(options.getPickleOrder()
-            .orderPickles(Arrays.asList(a, b)), contains(a, b));
+                .orderPickles(Arrays.asList(a, b)),
+            contains(a, b));
     }
 
     private Pickle createPickle(String uri, String name) {
         Feature feature = TestFeatureParser.parse(uri, "" +
-            "Feature: Test feature\n" +
-            "  Scenario: " + name + "\n" +
-            "     Given I have 4 cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: " + name + "\n" +
+                "     Given I have 4 cukes in my belly\n");
         return feature.getPickles().get(0);
     }
 
     @Test
     void ensure_order_type_reverse_is_used() {
         RuntimeOptions options = parser
-            .parse("--order", "reverse")
-            .build();
+                .parse("--order", "reverse")
+                .build();
         Pickle a = createPickle("file:path/file1.feature", "a");
         Pickle b = createPickle("file:path/file2.feature", "b");
         assertThat(options.getPickleOrder()
-            .orderPickles(Arrays.asList(a, b)), contains(b, a));
+                .orderPickles(Arrays.asList(a, b)),
+            contains(b, a));
     }
 
     @Test
     void ensure_order_type_random_is_used() {
         parser
-            .parse("--order", "random")
-            .build();
+                .parse("--order", "random")
+                .build();
     }
 
     @Test
     void ensure_order_type_random_with_seed_is_used() {
         RuntimeOptions options = parser
-            .parse("--order", "random:5000")
-            .build();
+                .parse("--order", "random:5000")
+                .build();
         Pickle a = createPickle("file:path/file1.feature", "a");
         Pickle b = createPickle("file:path/file2.feature", "b");
         Pickle c = createPickle("file:path/file3.feature", "c");
         assertThat(options.getPickleOrder()
-            .orderPickles(Arrays.asList(a, b, c)), contains(c, a, b));
+                .orderPickles(Arrays.asList(a, b, c)),
+            contains(c, a, b));
     }
 
     @Test
     void ensure_invalid_ordertype_is_not_allowed() {
         Executable testMethod = () -> parser
-            .parse("--order", "invalid")
-            .build();
+                .parse("--order", "invalid")
+                .build();
         IllegalArgumentException actualThrown = assertThrows(IllegalArgumentException.class, testMethod);
-        assertThat(actualThrown.getMessage(), is(equalTo("Invalid order. Must be either reverse, random or random:<long>")));
+        assertThat(actualThrown.getMessage(),
+            is(equalTo("Invalid order. Must be either reverse, random or random:<long>")));
     }
 
     @Test
     void ensure_less_than_1_count_is_not_allowed() {
         parser
-            .parse("--count", "0")
-            .build();
+                .parse("--count", "0")
+                .build();
         assertThat(output(), is("--count must be > 0\n"));
         assertThat(parser.exitStatus(), is(Optional.of((byte) 0x1)));
     }
@@ -449,18 +451,18 @@ class CommandlineOptionsParserTest {
     @Test
     void scans_class_path_root_for_glue_by_default() {
         RuntimeOptions options = parser
-            .parse()
-            .addDefaultGlueIfAbsent()
-            .build();
+                .parse()
+                .addDefaultGlueIfAbsent()
+                .build();
         assertThat(options.getGlue(), is(singletonList(rootPackageUri())));
     }
 
     @Test
     void scans_class_path_root_for_features_by_default() {
         RuntimeOptions options = parser
-            .parse()
-            .addDefaultFeaturePathIfAbsent()
-            .build();
+                .parse()
+                .addDefaultFeaturePathIfAbsent()
+                .build();
         assertThat(options.getFeaturePaths(), is(singletonList(rootPackageUri())));
         assertThat(options.getLineFilters(), is(emptyMap()));
     }

--- a/core/src/test/java/io/cucumber/core/options/CucumberOptions.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberOptions.java
@@ -8,7 +8,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE})
+@Target({ ElementType.TYPE })
 public @interface CucumberOptions {
 
     boolean dryRun() default false;
@@ -25,11 +25,9 @@ public @interface CucumberOptions {
 
     String[] plugin() default {};
 
-
     boolean monochrome() default false;
 
     String[] name() default {};
-
 
     SnippetType snippets() default SnippetType.UNDERSCORE;
 

--- a/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
@@ -32,30 +32,28 @@ class CucumberOptionsAnnotationParserTest {
     @Test
     void create_without_options() {
         RuntimeOptions runtimeOptions = parser()
-            .parse(WithoutOptions.class)
-            .addDefaultSummaryPrinterIfAbsent()
-            .addDefaultFormatterIfAbsent()
-            .build();
+                .parse(WithoutOptions.class)
+                .addDefaultSummaryPrinterIfAbsent()
+                .addDefaultFormatterIfAbsent()
+                .build();
 
-        assertAll("Checking RuntimeOptions",
+        assertAll(
             () -> assertThat(runtimeOptions.getObjectFactoryClass(), is(nullValue())),
             () -> assertThat(runtimeOptions.getFeaturePaths(), contains(uri("classpath:/io/cucumber/core/options"))),
-            () -> assertThat(runtimeOptions.getGlue(), contains(uri("classpath:/io/cucumber/core/options")))
-        );
+            () -> assertThat(runtimeOptions.getGlue(), contains(uri("classpath:/io/cucumber/core/options"))));
 
         Plugins plugins = new Plugins(new PluginFactory(), runtimeOptions);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
 
-        assertAll("Checking Plugins",
+        assertAll(
             () -> assertThat(plugins.getPlugins(), hasSize(2)),
             () -> assertPluginExists(plugins.getPlugins(), "io.cucumber.core.plugin.ProgressFormatter"),
-            () -> assertPluginExists(plugins.getPlugins(), "io.cucumber.core.plugin.DefaultSummaryPrinter")
-        );
+            () -> assertPluginExists(plugins.getPlugins(), "io.cucumber.core.plugin.DefaultSummaryPrinter"));
     }
 
     private CucumberOptionsAnnotationParser parser() {
         return new CucumberOptionsAnnotationParser()
-            .withOptionsProvider(new CoreCucumberOptionsProvider());
+                .withOptionsProvider(new CoreCucumberOptionsProvider());
     }
 
     public static URI uri(String str) {
@@ -76,31 +74,29 @@ class CucumberOptionsAnnotationParserTest {
     void create_without_options_with_base_class_without_options() {
         Class<?> subClassWithMonoChromeTrueClass = WithoutOptionsWithBaseClassWithoutOptions.class;
         RuntimeOptions runtimeOptions = parser()
-            .parse(subClassWithMonoChromeTrueClass)
-            .addDefaultFormatterIfAbsent()
-            .addDefaultSummaryPrinterIfAbsent()
-            .build();
+                .parse(subClassWithMonoChromeTrueClass)
+                .addDefaultFormatterIfAbsent()
+                .addDefaultSummaryPrinterIfAbsent()
+                .build();
         Plugins plugins = new Plugins(new PluginFactory(), runtimeOptions);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
 
-        assertAll("Checking Plugins",
+        assertAll(
             () -> assertThat(runtimeOptions.getFeaturePaths(), contains(uri("classpath:/io/cucumber/core/options"))),
             () -> assertThat(runtimeOptions.getGlue(), contains(uri("classpath:/io/cucumber/core/options"))),
             () -> assertThat(plugins.getPlugins(), hasSize(2)),
             () -> assertPluginExists(plugins.getPlugins(), "io.cucumber.core.plugin.ProgressFormatter"),
-            () -> assertPluginExists(plugins.getPlugins(), "io.cucumber.core.plugin.DefaultSummaryPrinter")
-        );
+            () -> assertPluginExists(plugins.getPlugins(), "io.cucumber.core.plugin.DefaultSummaryPrinter"));
     }
 
     @Test
     void create_with_no_filters() {
         RuntimeOptions runtimeOptions = parser().parse(NoName.class).build();
 
-        assertAll("Checking RuntimeOptions",
+        assertAll(
             () -> assertTrue(runtimeOptions.getTagExpressions().isEmpty()),
             () -> assertTrue(runtimeOptions.getNameFilters().isEmpty()),
-            () -> assertTrue(runtimeOptions.getLineFilters().isEmpty())
-        );
+            () -> assertTrue(runtimeOptions.getLineFilters().isEmpty()));
     }
 
     @Test
@@ -111,10 +107,9 @@ class CucumberOptionsAnnotationParserTest {
         assertThat(filters.size(), is(equalTo(2)));
         Iterator<Pattern> iterator = filters.iterator();
 
-        assertAll("Checking Pattern",
+        assertAll(
             () -> assertThat(getRegexpPattern(iterator.next()), is(equalTo("name1"))),
-            () -> assertThat(getRegexpPattern(iterator.next()), is(equalTo("name2")))
-        );
+            () -> assertThat(getRegexpPattern(iterator.next()), is(equalTo("name2"))));
     }
 
     private String getRegexpPattern(Object pattern) {
@@ -142,9 +137,9 @@ class CucumberOptionsAnnotationParserTest {
     @Test
     void create_default_summary_printer_when_no_summary_printer_plugin_is_defined() {
         RuntimeOptions runtimeOptions = parser()
-            .parse(ClassWithNoSummaryPrinterPlugin.class)
-            .addDefaultSummaryPrinterIfAbsent()
-            .build();
+                .parse(ClassWithNoSummaryPrinterPlugin.class)
+                .addDefaultSummaryPrinterIfAbsent()
+                .build();
         Plugins plugins = new Plugins(new PluginFactory(), runtimeOptions);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
         assertPluginExists(plugins.getPlugins(), "io.cucumber.core.plugin.DefaultSummaryPrinter");
@@ -157,10 +152,9 @@ class CucumberOptionsAnnotationParserTest {
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
         List<Plugin> pluginList = plugins.getPlugins();
 
-        assertAll("Checking Plugin",
+        assertAll(
             () -> assertPluginExists(pluginList, "io.cucumber.core.plugin.HtmlFormatter"),
-            () -> assertPluginExists(pluginList, "io.cucumber.core.plugin.PrettyFormatter")
-        );
+            () -> assertPluginExists(pluginList, "io.cucumber.core.plugin.PrettyFormatter"));
     }
 
     @Test
@@ -174,39 +168,44 @@ class CucumberOptionsAnnotationParserTest {
     void create_with_glue() {
         RuntimeOptions runtimeOptions = parser().parse(ClassWithGlue.class).build();
 
-        assertThat(runtimeOptions.getGlue(), contains(uri("classpath:/app/features/user/registration"), uri("classpath:/app/features/hooks")));
+        assertThat(runtimeOptions.getGlue(),
+            contains(uri("classpath:/app/features/user/registration"), uri("classpath:/app/features/hooks")));
     }
 
     @Test
     void create_with_extra_glue() {
         RuntimeOptions runtimeOptions = parser().parse(ClassWithExtraGlue.class).build();
 
-        assertThat(runtimeOptions.getGlue(), contains(uri("classpath:/app/features/hooks"), uri("classpath:/io/cucumber/core/options")));
+        assertThat(runtimeOptions.getGlue(),
+            contains(uri("classpath:/app/features/hooks"), uri("classpath:/io/cucumber/core/options")));
 
     }
 
     @Test
     void create_with_extra_glue_in_subclass_of_extra_glue() {
         RuntimeOptions runtimeOptions = parser()
-            .parse(SubClassWithExtraGlueOfExtraGlue.class)
-            .build();
+                .parse(SubClassWithExtraGlueOfExtraGlue.class)
+                .build();
 
         assertThat(runtimeOptions.getGlue(),
-            contains(uri("classpath:/app/features/user/hooks"), uri("classpath:/app/features/hooks"), uri("classpath:/io/cucumber/core/options")));
+            contains(uri("classpath:/app/features/user/hooks"), uri("classpath:/app/features/hooks"),
+                uri("classpath:/io/cucumber/core/options")));
     }
 
     @Test
     void create_with_extra_glue_in_subclass_of_glue() {
         RuntimeOptions runtimeOptions = parser().parse(SubClassWithExtraGlueOfGlue.class).build();
 
-        assertThat(runtimeOptions.getGlue(), contains(uri("classpath:/app/features/user/hooks"), uri("classpath:/app/features/user/registration"), uri("classpath:/app/features/hooks")));
+        assertThat(runtimeOptions.getGlue(), contains(uri("classpath:/app/features/user/hooks"),
+            uri("classpath:/app/features/user/registration"), uri("classpath:/app/features/hooks")));
     }
 
     @Test
     void cannot_create_with_glue_and_extra_glue() {
         Executable testMethod = () -> parser().parse(ClassWithGlueAndExtraGlue.class).build();
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
-        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo("glue and extraGlue cannot be specified at the same time")));
+        assertThat("Unexpected exception message", actualThrown.getMessage(),
+            is(equalTo("glue and extraGlue cannot be specified at the same time")));
     }
 
     @CucumberOptions(snippets = SnippetType.CAMELCASE)
@@ -224,7 +223,7 @@ class CucumberOptionsAnnotationParserTest {
         // empty
     }
 
-    @CucumberOptions(name = {"name1", "name2"})
+    @CucumberOptions(name = { "name1", "name2" })
     private static class MultipleNames {
         // empty
     }
@@ -282,32 +281,36 @@ class CucumberOptionsAnnotationParserTest {
         // empty
     }
 
-    @CucumberOptions(junit = {"option1", "option2=value"})
+    @CucumberOptions(junit = { "option1", "option2=value" })
     private static class ClassWithJunitOption {
         // empty
     }
 
-    @CucumberOptions(glue = {"app.features.user.registration", "app.features.hooks"})
+    @CucumberOptions(glue = { "app.features.user.registration", "app.features.hooks" })
     private static class ClassWithGlue {
         // empty
     }
 
-    @CucumberOptions(extraGlue = {"app.features.hooks"})
+    @CucumberOptions(extraGlue = "app.features.hooks")
     private static class ClassWithExtraGlue {
         // empty
     }
 
-    @CucumberOptions(extraGlue = {"app.features.user.hooks"})
+    @CucumberOptions(extraGlue = "app.features.user.hooks")
     private static class SubClassWithExtraGlueOfExtraGlue extends ClassWithExtraGlue {
         // empty
     }
 
-    @CucumberOptions(extraGlue = {"app.features.user.hooks"})
+    @CucumberOptions(extraGlue = "app.features.user.hooks")
     private static class SubClassWithExtraGlueOfGlue extends ClassWithGlue {
         // empty
     }
 
-    @CucumberOptions(extraGlue = {"app.features.hooks"}, glue = {"app.features.user.registration"})
+    @CucumberOptions(
+            glue = "app.features.user.registration",
+            extraGlue = "app.features.hooks"
+
+    )
     private static class ClassWithGlueAndExtraGlue {
         // empty
     }

--- a/core/src/test/java/io/cucumber/core/options/CucumberPropertiesParserTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberPropertiesParserTest.java
@@ -57,18 +57,17 @@ class CucumberPropertiesParserTest {
         properties.put(Constants.FEATURES_PROPERTY_NAME, "classpath:com/example.feature");
         RuntimeOptions options = cucumberPropertiesParser.parse(properties).build();
         assertThat(options.getFeaturePaths(), contains(
-            URI.create("classpath:com/example.feature")
-        ));
+            URI.create("classpath:com/example.feature")));
     }
 
     @Test
     void should_parse_features_list() {
-        properties.put(Constants.FEATURES_PROPERTY_NAME, "classpath:com/example/app.feature, classpath:com/example/other.feature");
+        properties.put(Constants.FEATURES_PROPERTY_NAME,
+            "classpath:com/example/app.feature, classpath:com/example/other.feature");
         RuntimeOptions options = cucumberPropertiesParser.parse(properties).build();
         assertThat(options.getFeaturePaths(), contains(
             URI.create("classpath:com/example/app.feature"),
-            URI.create("classpath:com/example/other.feature")
-        ));
+            URI.create("classpath:com/example/other.feature")));
     }
 
     @Test
@@ -76,8 +75,7 @@ class CucumberPropertiesParserTest {
         properties.put(Constants.FILTER_NAME_PROPERTY_NAME, "Test.*");
         RuntimeOptions options = cucumberPropertiesParser.parse(properties).build();
         assertThat(options.getNameFilters().get(0).pattern(), equalTo(
-            "Test.*"
-        ));
+            "Test.*"));
     }
 
     @Test
@@ -85,8 +83,7 @@ class CucumberPropertiesParserTest {
         properties.put(Constants.FILTER_TAGS_PROPERTY_NAME, "@No and not @Never");
         RuntimeOptions options = cucumberPropertiesParser.parse(properties).build();
         assertThat(options.getTagExpressions(), contains(
-            "@No and not @Never"
-        ));
+            "@No and not @Never"));
     }
 
     @Test
@@ -94,8 +91,7 @@ class CucumberPropertiesParserTest {
         properties.put(Constants.GLUE_PROPERTY_NAME, "com.example.steps");
         RuntimeOptions options = cucumberPropertiesParser.parse(properties).build();
         assertThat(options.getGlue(), contains(
-            URI.create("classpath:/com/example/steps")
-        ));
+            URI.create("classpath:/com/example/steps")));
     }
 
     @Test
@@ -104,8 +100,7 @@ class CucumberPropertiesParserTest {
         RuntimeOptions options = cucumberPropertiesParser.parse(properties).build();
         assertThat(options.getGlue(), contains(
             URI.create("classpath:/com/example/app/steps"),
-            URI.create("classpath:/com/example/other/steps")
-        ));
+            URI.create("classpath:/com/example/other/steps")));
     }
 
     @Test
@@ -142,8 +137,7 @@ class CucumberPropertiesParserTest {
         properties.put(Constants.OBJECT_FACTORY_PROPERTY_NAME, "garbage");
         CucumberException exception = assertThrows(
             CucumberException.class,
-            () -> cucumberPropertiesParser.parse(properties).build()
-        );
+            () -> cucumberPropertiesParser.parse(properties).build());
         assertThat(exception.getMessage(), equalTo("Failed to parse 'cucumber.object-factory' with value 'garbage'"));
     }
 

--- a/core/src/test/java/io/cucumber/core/options/CucumberPropertiesTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberPropertiesTest.java
@@ -13,7 +13,8 @@ import static org.hamcrest.core.IsNull.nullValue;
 
 class CucumberPropertiesTest {
 
-    private final CucumberProperties.CucumberPropertiesMap env = new CucumberProperties.CucumberPropertiesMap(Collections.emptyMap());
+    private final CucumberProperties.CucumberPropertiesMap env = new CucumberProperties.CucumberPropertiesMap(
+        Collections.emptyMap());
 
     @BeforeEach
     void setup() {

--- a/core/src/test/java/io/cucumber/core/options/CurlOptionTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CurlOptionTest.java
@@ -39,8 +39,7 @@ class CurlOptionTest {
     public void must_provide_valid_method() {
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> CurlOption.parse("https://example.com -X NO-SUCH-METHOD")
-        );
+            () -> CurlOption.parse("https://example.com -X NO-SUCH-METHOD"));
         assertThat(exception.getMessage(), is("NO-SUCH-METHOD was not a http method"));
     }
 
@@ -53,7 +52,8 @@ class CurlOptionTest {
 
     @Test
     public void must_provide_valid_headers() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> CurlOption.parse("https://example.com -H 'Content-Type'"));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> CurlOption.parse("https://example.com -H 'Content-Type'"));
         assertThat(exception.getMessage(), is("'Content-Type' was not a valid header"));
     }
 
@@ -61,7 +61,8 @@ class CurlOptionTest {
     public void may_only_provide_one_url() {
         String uri = "https://example.com/path https://example.com/other/path";
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> CurlOption.parse(uri));
-        assertThat(exception.getMessage(), is("'https://example.com/path https://example.com/other/path' was not a valid curl command"));
+        assertThat(exception.getMessage(),
+            is("'https://example.com/path https://example.com/other/path' was not a valid curl command"));
     }
 
     @Test

--- a/core/src/test/java/io/cucumber/core/options/RerunFileTest.java
+++ b/core/src/test/java/io/cucumber/core/options/RerunFileTest.java
@@ -39,20 +39,20 @@ class RerunFileTest {
     void loads_features_specified_in_rerun_file() throws Exception {
         mockFileResource(
             "path/bar.feature:2\n" +
-                "path/foo.feature:4\n");
+                    "path/foo.feature:4\n");
 
         RuntimeOptions runtimeOptions = parser
-            .parse("@" + rerunPath)
-            .build();
+                .parse("@" + rerunPath)
+                .build();
 
         assertAll(
             () -> assertThat(runtimeOptions.getFeaturePaths(), contains(
                 new File("path/bar.feature").toURI(),
-                new File("path/foo.feature").toURI()
-            )),
-            () -> assertThat(runtimeOptions.getLineFilters(), hasEntry(new File("path/bar.feature").toURI(), singleton(2))),
-            () -> assertThat(runtimeOptions.getLineFilters(), hasEntry(new File("path/foo.feature").toURI(), singleton(4)))
-        );
+                new File("path/foo.feature").toURI())),
+            () -> assertThat(runtimeOptions.getLineFilters(),
+                hasEntry(new File("path/bar.feature").toURI(), singleton(2))),
+            () -> assertThat(runtimeOptions.getLineFilters(),
+                hasEntry(new File("path/foo.feature").toURI(), singleton(4))));
     }
 
     private void mockFileResource(String... contents) throws IOException {
@@ -66,13 +66,12 @@ class RerunFileTest {
         mockFileResource("");
 
         RuntimeOptions runtimeOptions = parser
-            .parse("@" + rerunPath)
-            .build();
+                .parse("@" + rerunPath)
+                .build();
 
         assertAll(
             () -> assertThat(runtimeOptions.getFeaturePaths(), hasSize(0)),
-            () -> assertThat(runtimeOptions.getLineFilters(), equalTo(emptyMap()))
-        );
+            () -> assertThat(runtimeOptions.getLineFilters(), equalTo(emptyMap())));
     }
 
     @Test
@@ -80,13 +79,12 @@ class RerunFileTest {
         mockFileResource("\n");
 
         RuntimeOptions runtimeOptions = parser
-            .parse("@" + rerunPath)
-            .build();
+                .parse("@" + rerunPath)
+                .build();
 
         assertAll(
             () -> assertThat(runtimeOptions.getFeaturePaths(), hasSize(0)),
-            () -> assertThat(runtimeOptions.getLineFilters(), equalTo(emptyMap()))
-        );
+            () -> assertThat(runtimeOptions.getLineFilters(), equalTo(emptyMap())));
     }
 
     @Test
@@ -94,13 +92,12 @@ class RerunFileTest {
         mockFileResource("\r");
 
         RuntimeOptions runtimeOptions = parser
-            .parse("@" + rerunPath)
-            .build();
+                .parse("@" + rerunPath)
+                .build();
 
         assertAll(
             () -> assertThat(runtimeOptions.getFeaturePaths(), hasSize(0)),
-            () -> assertThat(runtimeOptions.getLineFilters(), equalTo(emptyMap()))
-        );
+            () -> assertThat(runtimeOptions.getLineFilters(), equalTo(emptyMap())));
     }
 
     @Test
@@ -108,30 +105,30 @@ class RerunFileTest {
         mockFileResource("\r\n");
 
         RuntimeOptions runtimeOptions = parser
-            .parse("@" + rerunPath)
-            .build();
+                .parse("@" + rerunPath)
+                .build();
 
         assertAll(
             () -> assertThat(runtimeOptions.getFeaturePaths(), hasSize(0)),
-            () -> assertThat(runtimeOptions.getLineFilters(), equalTo(emptyMap()))
-        );
+            () -> assertThat(runtimeOptions.getLineFilters(), equalTo(emptyMap())));
     }
 
     @Test
     void last_new_line_is_optional() throws Exception {
         mockFileResource(
-            "classpath:path/bar.feature:2\nclasspath:path/foo.feature:4"
-        );
+            "classpath:path/bar.feature:2\nclasspath:path/foo.feature:4");
 
         RuntimeOptions runtimeOptions = parser
-            .parse("@" + rerunPath)
-            .build();
+                .parse("@" + rerunPath)
+                .build();
 
         assertAll(
-            () -> assertThat(runtimeOptions.getFeaturePaths(), contains(URI.create("classpath:path/bar.feature"), URI.create("classpath:path/foo.feature"))),
-            () -> assertThat(runtimeOptions.getLineFilters(), hasEntry(URI.create("classpath:path/bar.feature"), singleton(2))),
-            () -> assertThat(runtimeOptions.getLineFilters(), hasEntry(URI.create("classpath:path/foo.feature"), singleton(4)))
-        );
+            () -> assertThat(runtimeOptions.getFeaturePaths(),
+                contains(URI.create("classpath:path/bar.feature"), URI.create("classpath:path/foo.feature"))),
+            () -> assertThat(runtimeOptions.getLineFilters(),
+                hasEntry(URI.create("classpath:path/bar.feature"), singleton(2))),
+            () -> assertThat(runtimeOptions.getLineFilters(),
+                hasEntry(URI.create("classpath:path/foo.feature"), singleton(4))));
     }
 
     @Test
@@ -141,34 +138,34 @@ class RerunFileTest {
             "file:/home/users/mp/My%20Documents/tests/bar.feature:2\n");
 
         RuntimeOptions runtimeOptions = parser
-            .parse("@" + rerunPath)
-            .build();
+                .parse("@" + rerunPath)
+                .build();
 
         assertAll(
-            () -> assertThat(runtimeOptions.getFeaturePaths(), contains(URI.create("file:/home/users/mp/My%20Documents/tests/bar.feature"))),
-            () -> assertThat(runtimeOptions.getLineFilters(), hasEntry(URI.create("file:/home/users/mp/My%20Documents/tests/bar.feature"), singleton(2)))
-        );
+            () -> assertThat(runtimeOptions.getFeaturePaths(),
+                contains(URI.create("file:/home/users/mp/My%20Documents/tests/bar.feature"))),
+            () -> assertThat(runtimeOptions.getLineFilters(),
+                hasEntry(URI.create("file:/home/users/mp/My%20Documents/tests/bar.feature"), singleton(2))));
     }
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void understands_rerun_files_without_separation_in_rerun_filepath() throws Exception {
         mockFileResource(
-            "file:/home/users/mp/My%20Documents/tests/bar.feature:2file:/home/users/mp/My%20Documents/tests/foo.feature:4"
-        );
+            "file:/home/users/mp/My%20Documents/tests/bar.feature:2file:/home/users/mp/My%20Documents/tests/foo.feature:4");
 
         RuntimeOptions runtimeOptions = parser
-            .parse("@" + rerunPath)
-            .build();
+                .parse("@" + rerunPath)
+                .build();
 
         assertAll(
             () -> assertThat(runtimeOptions.getFeaturePaths(), contains(
                 URI.create("file:/home/users/mp/My%20Documents/tests/bar.feature"),
-                URI.create("file:/home/users/mp/My%20Documents/tests/foo.feature")
-            )),
-            () -> assertThat(runtimeOptions.getLineFilters(), hasEntry(URI.create("file:/home/users/mp/My%20Documents/tests/bar.feature"), singleton(2))),
-            () -> assertThat(runtimeOptions.getLineFilters(), hasEntry(URI.create("file:/home/users/mp/My%20Documents/tests/foo.feature"), singleton(4)))
-        );
+                URI.create("file:/home/users/mp/My%20Documents/tests/foo.feature"))),
+            () -> assertThat(runtimeOptions.getLineFilters(),
+                hasEntry(URI.create("file:/home/users/mp/My%20Documents/tests/bar.feature"), singleton(2))),
+            () -> assertThat(runtimeOptions.getLineFilters(),
+                hasEntry(URI.create("file:/home/users/mp/My%20Documents/tests/foo.feature"), singleton(4))));
     }
 
     @Test
@@ -176,21 +173,21 @@ class RerunFileTest {
         mockFileResource("file:path/bar.feature:2\n");
 
         RuntimeOptions options = parser
-            .parse("@" + rerunPath)
-            .build();
+                .parse("@" + rerunPath)
+                .build();
 
         assertAll(
             () -> assertThat(options.getFeaturePaths(), contains(new File("path/bar.feature").toURI())),
-            () -> assertThat(options.getLineFilters(), hasEntry(new File("path/bar.feature").toURI(), singleton(2)))
-        );
+            () -> assertThat(options.getLineFilters(), hasEntry(new File("path/bar.feature").toURI(), singleton(2))));
     }
 
     @Test
-    void strips_lines_from_rerun_file_from_cli_if_filters_are_specified_in_cucumber_options_property() throws IOException {
+    void strips_lines_from_rerun_file_from_cli_if_filters_are_specified_in_cucumber_options_property()
+            throws IOException {
         mockFileResource("file:path/file.feature:3\n");
         RuntimeOptions options = parser
-            .parse("@" + rerunPath)
-            .build();
+                .parse("@" + rerunPath)
+                .build();
         assertThat(options.getFeaturePaths(), contains(new File("path/file.feature").toURI()));
     }
 

--- a/core/src/test/java/io/cucumber/core/options/ShellWordsTest.java
+++ b/core/src/test/java/io/cucumber/core/options/ShellWordsTest.java
@@ -34,7 +34,8 @@ class ShellWordsTest {
 
     @Test
     void parses_both_single_and_double_quoted_strings() {
-        assertThat(ShellWords.parse("--name \"The Fox\" --fur 'Brown White'"), is(equalTo(asList("--name", "The Fox", "--fur", "Brown White"))));
+        assertThat(ShellWords.parse("--name \"The Fox\" --fur 'Brown White'"),
+            is(equalTo(asList("--name", "The Fox", "--fur", "Brown White"))));
     }
 
     @Test

--- a/core/src/test/java/io/cucumber/core/options/TestPluginOption.java
+++ b/core/src/test/java/io/cucumber/core/options/TestPluginOption.java
@@ -1,6 +1,5 @@
 package io.cucumber.core.options;
 
-
 public class TestPluginOption {
 
     public static PluginOption parse(String pluginArgumentPattern) {

--- a/core/src/test/java/io/cucumber/core/plugin/CanonicalEventOrderTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/CanonicalEventOrderTest.java
@@ -33,8 +33,10 @@ class CanonicalEventOrderTest {
     private final CanonicalEventOrder comparator = new CanonicalEventOrder();
     private final Event runStarted = new TestRunStarted(getInstant());
     private final Event testRead = new TestSourceRead(getInstant(), URI.create("file:path/to.feature"), "source");
-    private final Event testParsed = new TestSourceParsed(getInstant(), URI.create("file:path/to.feature"), Collections.emptyList());
-    private final Event suggested = new SnippetsSuggestedEvent(getInstant(), URI.create("file:path/to/1.feature"), 0, 0, Collections.emptyList());
+    private final Event testParsed = new TestSourceParsed(getInstant(), URI.create("file:path/to.feature"),
+        Collections.emptyList());
+    private final Event suggested = new SnippetsSuggestedEvent(getInstant(), URI.create("file:path/to/1.feature"), 0, 0,
+        Collections.emptyList());
     private final Event feature1Case1Started = createTestCaseEvent(URI.create("file:path/to/1.feature"), 1);
     private final Event feature1Case2Started = createTestCaseEvent(URI.create("file:path/to/1.feature"), 9);
     private final Event feature1Case3Started = createTestCaseEvent(URI.create("file:path/to/1.feature"), 11);
@@ -54,7 +56,7 @@ class CanonicalEventOrderTest {
 
     @Test
     void verifyTestRunStartedSortedCorrectly() {
-        assertAll("comparator CanonicalEventOrder",
+        assertAll(
             () -> assertThat(comparator.compare(runStarted, runStarted), equalTo(EQUAL_TO)),
             () -> assertThat(comparator.compare(runStarted, testRead), equalTo(LESS_THAN)),
             () -> assertThat(comparator.compare(runStarted, testParsed), equalTo(LESS_THAN)),
@@ -63,13 +65,12 @@ class CanonicalEventOrderTest {
             () -> assertThat(comparator.compare(runStarted, feature1Case2Started), equalTo(LESS_THAN)),
             () -> assertThat(comparator.compare(runStarted, feature1Case3Started), equalTo(LESS_THAN)),
             () -> assertThat(comparator.compare(runStarted, feature2Case1Started), equalTo(LESS_THAN)),
-            () -> assertThat(comparator.compare(runStarted, runFinished), equalTo(LESS_THAN))
-        );
+            () -> assertThat(comparator.compare(runStarted, runFinished), equalTo(LESS_THAN)));
     }
 
     @Test
     void verifyTestSourceReadSortedCorrectly() {
-        assertAll("comparator CanonicalEventOrder",
+        assertAll(
             () -> assertThat(comparator.compare(testRead, runStarted), equalTo(GREATER_THAN)),
             () -> assertThat(comparator.compare(testRead, testRead), equalTo(EQUAL_TO)),
             () -> assertThat(comparator.compare(testRead, testParsed), equalTo(LESS_THAN)),
@@ -78,13 +79,12 @@ class CanonicalEventOrderTest {
             () -> assertThat(comparator.compare(testRead, feature1Case2Started), equalTo(LESS_THAN)),
             () -> assertThat(comparator.compare(testRead, feature1Case3Started), equalTo(LESS_THAN)),
             () -> assertThat(comparator.compare(testRead, feature2Case1Started), equalTo(LESS_THAN)),
-            () -> assertThat(comparator.compare(testRead, runFinished), equalTo(LESS_THAN))
-        );
+            () -> assertThat(comparator.compare(testRead, runFinished), equalTo(LESS_THAN)));
     }
 
     @Test
     void verifyTestSourceParsedSortedCorrectly() {
-        assertAll("comparator CanonicalEventOrder",
+        assertAll(
             () -> assertThat(comparator.compare(testParsed, runStarted), equalTo(GREATER_THAN)),
             () -> assertThat(comparator.compare(testParsed, testRead), equalTo(GREATER_THAN)),
             () -> assertThat(comparator.compare(testParsed, testParsed), equalTo(EQUAL_TO)),
@@ -93,13 +93,12 @@ class CanonicalEventOrderTest {
             () -> assertThat(comparator.compare(testParsed, feature1Case2Started), equalTo(LESS_THAN)),
             () -> assertThat(comparator.compare(testParsed, feature1Case3Started), equalTo(LESS_THAN)),
             () -> assertThat(comparator.compare(testParsed, feature2Case1Started), equalTo(LESS_THAN)),
-            () -> assertThat(comparator.compare(testParsed, runFinished), equalTo(LESS_THAN))
-        );
+            () -> assertThat(comparator.compare(testParsed, runFinished), equalTo(LESS_THAN)));
     }
 
     @Test
     void verifySnippetsSuggestedSortedCorrectly() {
-        assertAll("comparator CanonicalEventOrder",
+        assertAll(
             () -> assertThat(comparator.compare(suggested, runStarted), equalTo(GREATER_THAN)),
             () -> assertThat(comparator.compare(suggested, testRead), equalTo(GREATER_THAN)),
             () -> assertThat(comparator.compare(suggested, testParsed), equalTo(GREATER_THAN)),
@@ -108,42 +107,38 @@ class CanonicalEventOrderTest {
             () -> assertThat(comparator.compare(suggested, feature1Case2Started), equalTo(LESS_THAN)),
             () -> assertThat(comparator.compare(suggested, feature1Case3Started), equalTo(LESS_THAN)),
             () -> assertThat(comparator.compare(suggested, feature2Case1Started), equalTo(LESS_THAN)),
-            () -> assertThat(comparator.compare(suggested, runFinished), equalTo(LESS_THAN))
-        );
+            () -> assertThat(comparator.compare(suggested, runFinished), equalTo(LESS_THAN)));
     }
 
     @Test
     void verifyTestCaseStartedSortedCorrectly() {
         final List<Event> greaterThan = Arrays.asList(runStarted, testRead, suggested);
         for (final Event e : greaterThan) {
-            assertAll("comparator CanonicalEventOrder",
+            assertAll(
                 () -> assertThat(comparator.compare(feature1Case1Started, e), equalTo(GREATER_THAN)),
                 () -> assertThat(comparator.compare(feature1Case2Started, e), equalTo(GREATER_THAN)),
                 () -> assertThat(comparator.compare(feature1Case3Started, e), equalTo(GREATER_THAN)),
-                () -> assertThat(comparator.compare(feature2Case1Started, e), equalTo(GREATER_THAN))
-            );
+                () -> assertThat(comparator.compare(feature2Case1Started, e), equalTo(GREATER_THAN)));
         }
 
         final List<Event> lessThan = Collections.singletonList(runFinished);
         for (final Event e : lessThan) {
-            assertAll("comparator CanonicalEventOrder",
+            assertAll(
                 () -> assertThat(comparator.compare(feature1Case1Started, e), equalTo(LESS_THAN)),
                 () -> assertThat(comparator.compare(feature1Case2Started, e), equalTo(LESS_THAN)),
                 () -> assertThat(comparator.compare(feature1Case3Started, e), equalTo(LESS_THAN)),
-                () -> assertThat(comparator.compare(feature2Case1Started, e), equalTo(LESS_THAN))
-            );
+                () -> assertThat(comparator.compare(feature2Case1Started, e), equalTo(LESS_THAN)));
         }
 
-        assertAll("comparator CanonicalEventOrder",
+        assertAll(
             () -> assertThat(comparator.compare(feature1Case1Started, feature1Case2Started), lessThan(EQUAL_TO)),
             () -> assertThat(comparator.compare(feature1Case2Started, feature1Case3Started), lessThan(EQUAL_TO)),
-            () -> assertThat(comparator.compare(feature1Case3Started, feature2Case1Started), lessThan(EQUAL_TO))
-        );
+            () -> assertThat(comparator.compare(feature1Case3Started, feature2Case1Started), lessThan(EQUAL_TO)));
     }
 
     @Test
     void verifyTestRunFinishedSortedCorrectly() {
-        assertAll("comparator CanonicalEventOrder",
+        assertAll(
             () -> assertThat(comparator.compare(runFinished, runStarted), equalTo(GREATER_THAN)),
             () -> assertThat(comparator.compare(runFinished, suggested), equalTo(GREATER_THAN)),
             () -> assertThat(comparator.compare(runFinished, testRead), equalTo(GREATER_THAN)),
@@ -152,8 +147,7 @@ class CanonicalEventOrderTest {
             () -> assertThat(comparator.compare(runFinished, feature1Case2Started), equalTo(GREATER_THAN)),
             () -> assertThat(comparator.compare(runFinished, feature1Case3Started), equalTo(GREATER_THAN)),
             () -> assertThat(comparator.compare(runFinished, feature2Case1Started), equalTo(GREATER_THAN)),
-            () -> assertThat(comparator.compare(runFinished, runFinished), equalTo(EQUAL_TO))
-        );
+            () -> assertThat(comparator.compare(runFinished, runFinished), equalTo(EQUAL_TO)));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
@@ -25,8 +25,7 @@ class DefaultSummaryPrinterTest {
     private final DefaultSummaryPrinter summaryPrinter = new DefaultSummaryPrinter(out);
     private final EventBus bus = new TimeServiceEventBus(
         Clock.fixed(ofEpochSecond(0), ZoneId.of("UTC")),
-        UUID::randomUUID
-    );
+        UUID::randomUUID);
 
     @BeforeEach
     void setup() {
@@ -40,34 +39,30 @@ class DefaultSummaryPrinterTest {
             URI.create("classpath:com/example.feature"),
             12,
             13,
-            singletonList("snippet")
-        ));
+            singletonList("snippet")));
 
         bus.send(new SnippetsSuggestedEvent(
             bus.getInstant(),
             URI.create("classpath:com/example.feature"),
             12,
             14,
-            singletonList("snippet")
-        ));
+            singletonList("snippet")));
 
         bus.send(new TestRunFinished(
-            bus.getInstant()
-        ));
+            bus.getInstant()));
 
         assertThat(new String(out.toByteArray(), UTF_8), equalToCompressingWhiteSpace("" +
-            "\n" +
-            "0 Scenarios\n" +
-            "0 Steps\n" +
-            "0m0.000s\n" +
-            "\n" +
-            "\n" +
-            "You can implement missing steps with the snippets below:\n" +
-            "\n" +
-            "snippet\n" +
-            "\n" +
-            "\n"
-        ));
+                "\n" +
+                "0 Scenarios\n" +
+                "0 Steps\n" +
+                "0m0.000s\n" +
+                "\n" +
+                "\n" +
+                "You can implement missing steps with the snippets below:\n" +
+                "\n" +
+                "snippet\n" +
+                "\n" +
+                "\n"));
 
     }
 

--- a/core/src/test/java/io/cucumber/core/plugin/FormatterSpy.java
+++ b/core/src/test/java/io/cucumber/core/plugin/FormatterSpy.java
@@ -15,7 +15,8 @@ public class FormatterSpy implements EventListener {
     private final EventHandler<TestCaseStarted> testCaseStartedHandler = event -> calls.append("TestCase started\n");
     private final EventHandler<TestCaseFinished> testCaseFinishedHandler = event -> calls.append("TestCase finished\n");
     private final EventHandler<TestStepStarted> testStepStartedHandler = event -> calls.append("  TestStep started\n");
-    private final EventHandler<TestStepFinished> testStepFinishedHandler = event -> calls.append("  TestStep finished\n");
+    private final EventHandler<TestStepFinished> testStepFinishedHandler = event -> calls
+            .append("  TestStep finished\n");
     private final EventHandler<TestRunFinished> runFinishHandler = event -> calls.append("TestRun finished\n");
 
     @Override

--- a/core/src/test/java/io/cucumber/core/plugin/HtmlFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/HtmlFormatterTest.java
@@ -23,29 +23,28 @@ class HtmlFormatterTest {
         formatter.setEventPublisher(bus);
 
         bus.send(Messages.Envelope.newBuilder()
-            .setTestRunStarted(Messages.TestRunStarted.newBuilder()
-                .setTimestamp(Messages.Timestamp.newBuilder()
-                    .setSeconds(10)
-                    .build())
-                .build())
-            .build());
+                .setTestRunStarted(Messages.TestRunStarted.newBuilder()
+                        .setTimestamp(Messages.Timestamp.newBuilder()
+                                .setSeconds(10)
+                                .build())
+                        .build())
+                .build());
 
         bus.send(
             Messages.Envelope.newBuilder()
-                .setTestRunFinished(Messages.TestRunFinished.newBuilder()
-                    .setTimestamp(Messages.Timestamp.newBuilder()
-                        .setSeconds(15)
-                        .build())
-                    .build())
-                .build());
+                    .setTestRunFinished(Messages.TestRunFinished.newBuilder()
+                            .setTimestamp(Messages.Timestamp.newBuilder()
+                                    .setSeconds(15)
+                                    .build())
+                            .build())
+                    .build());
 
         String html = new String(bytes.toByteArray(), UTF_8);
         assertThat(html, containsString("" +
-            "window.CUCUMBER_MESSAGES = [" +
-            "{\"testRunStarted\":{\"timestamp\":{\"seconds\":\"10\"}}}," +
-            "{\"testRunFinished\":{\"timestamp\":{\"seconds\":\"15\"}}}" +
-            "];"));
+                "window.CUCUMBER_MESSAGES = [" +
+                "{\"testRunStarted\":{\"timestamp\":{\"seconds\":\"10\"}}}," +
+                "{\"testRunFinished\":{\"timestamp\":{\"seconds\":\"15\"}}}" +
+                "];"));
     }
-
 
 }

--- a/core/src/test/java/io/cucumber/core/plugin/JUnitFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/JUnitFormatterTest.java
@@ -43,64 +43,77 @@ class JUnitFormatterTest {
 
     @Test
     void featureSimpleTest() throws Exception {
-        File report = runFeaturesWithJunitFormatter(singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_1.feature"));
-        assertXmlEqual(JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_1.report.xml"), report);
+        File report = runFeaturesWithJunitFormatter(
+            singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_1.feature"));
+        assertXmlEqual(
+            JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_1.report.xml"),
+            report);
     }
 
     private File runFeaturesWithJunitFormatter(final List<String> featurePaths) throws IOException {
         File report = File.createTempFile("cucumber-jvm-junit", "xml");
 
         RuntimeOptionsBuilder options = new RuntimeOptionsBuilder()
-            .addPluginName("junit:" + report.getAbsolutePath());
+                .addPluginName("junit:" + report.getAbsolutePath());
         featurePaths.forEach(s -> options.addFeature(FeatureWithLines.parse(s)));
 
         TestHelper.builder()
-            .withRuntimeArgs(options.build())
-            .withFeatures(features)
-            .withStepsToResult(stepsToResult)
-            .withStepsToLocation(stepsToLocation)
-            .withHooks(hooks)
-            .withHookLocations(hookLocations)
-            .withHookActions(hookActions)
-            .withTimeServiceType(TestHelper.TimeServiceType.FIXED_INCREMENT)
-            .withTimeServiceIncrement(ZERO)
-            .build()
-            .run();
+                .withRuntimeArgs(options.build())
+                .withFeatures(features)
+                .withStepsToResult(stepsToResult)
+                .withStepsToLocation(stepsToLocation)
+                .withHooks(hooks)
+                .withHookLocations(hookLocations)
+                .withHookActions(hookActions)
+                .withTimeServiceType(TestHelper.TimeServiceType.FIXED_INCREMENT)
+                .withTimeServiceIncrement(ZERO)
+                .build()
+                .run();
 
         return report;
     }
 
     private static void assertXmlEqual(Object expected, Object actual) {
         assertThat(actual, isIdenticalTo(expected).ignoreWhitespace());
-        assertThat(actual, valid(JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/surefire-test-report-3.0.xsd")));
+        assertThat(actual, valid(
+            JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/surefire-test-report-3.0.xsd")));
     }
 
     @Test
     void featureWithBackgroundTest() throws Exception {
-        File report = runFeaturesWithJunitFormatter(singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_2.feature"));
-        assertXmlEqual(JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_2.report.xml"), report);
+        File report = runFeaturesWithJunitFormatter(
+            singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_2.feature"));
+        assertXmlEqual(
+            JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_2.report.xml"),
+            report);
     }
 
     @Test
     void featureWithOutlineTest() throws Exception {
-        File report = runFeaturesWithJunitFormatter(singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_3.feature"));
-        assertXmlEqual(JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_3.report.xml"), report);
+        File report = runFeaturesWithJunitFormatter(
+            singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_3.feature"));
+        assertXmlEqual(
+            JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_3.report.xml"),
+            report);
     }
 
     @Test
     void featureSimpleStrictTest() throws Exception {
-        File report = runFeaturesWithJunitFormatter(singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_1.feature"));
-        assertXmlEqual(JUnitFormatterTest.class.getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_1_strict.report.xml"), report);
+        File report = runFeaturesWithJunitFormatter(
+            singletonList("classpath:io/cucumber/core/plugin//JUnitFormatterTest_1.feature"));
+        assertXmlEqual(JUnitFormatterTest.class
+                .getResourceAsStream("/io/cucumber/core/plugin/JUnitFormatterTest_1_strict.report.xml"),
+            report);
     }
 
     @Test
     void should_format_passed_scenario() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    Given first step\n" +
-                "    When second step\n" +
-                "    Then third step\n");
+                    "  Scenario: scenario name\n" +
+                    "    Given first step\n" +
+                    "    When second step\n" +
+                    "    Then third step\n");
         features.add(feature);
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
@@ -110,15 +123,16 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.003\">\n" +
-            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
-            "        <system-out><![CDATA[" +
-            "Given first step............................................................passed\n" +
-            "When second step............................................................passed\n" +
-            "Then third step.............................................................passed\n" +
-            "]]></system-out>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.003\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
+                "        <system-out><![CDATA[" +
+                "Given first step............................................................passed\n" +
+                "When second step............................................................passed\n" +
+                "Then third step.............................................................passed\n" +
+                "]]></system-out>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -126,16 +140,16 @@ class JUnitFormatterTest {
         final File report = File.createTempFile("cucumber-jvm-junit", ".xml");
         final JUnitFormatter formatter = createJUnitFormatter(report);
         TestHelper.builder()
-            .withFormatterUnderTest(formatter)
-            .withFeatures(features)
-            .withStepsToResult(stepsToResult)
-            .withStepsToLocation(stepsToLocation)
-            .withHooks(hooks)
-            .withHookLocations(hookLocations)
-            .withHookActions(hookActions)
-            .withTimeServiceIncrement(stepDuration)
-            .build()
-            .run();
+                .withFormatterUnderTest(formatter)
+                .withFeatures(features)
+                .withStepsToResult(stepsToResult)
+                .withStepsToLocation(stepsToLocation)
+                .withHooks(hooks)
+                .withHookLocations(hookLocations)
+                .withHookActions(hookActions)
+                .withTimeServiceIncrement(stepDuration)
+                .build()
+                .run();
 
         Scanner scanner = new Scanner(new FileInputStream(report), "UTF-8");
         String formatterOutput = scanner.useDelimiter("\\A").next();
@@ -151,18 +165,19 @@ class JUnitFormatterTest {
     void should_format_empty_scenario() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario: scenario name\n");
+                    "  Scenario: scenario name\n");
         features.add(feature);
         stepDuration = Duration.ofMillis(1L);
 
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0\">\n" +
-            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0\">\n" +
-            "        <failure message=\"The scenario has no steps\" type=\"java.lang.Exception\"/>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0\">\n" +
+                "        <failure message=\"The scenario has no steps\" type=\"java.lang.Exception\"/>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -170,18 +185,19 @@ class JUnitFormatterTest {
     void should_format_empty_scenario_strict() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario: scenario name\n");
+                    "  Scenario: scenario name\n");
         features.add(feature);
         stepDuration = Duration.ofMillis(1L);
 
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0\">\n" +
-            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0\">\n" +
-            "        <failure message=\"The scenario has no steps\" type=\"java.lang.Exception\"/>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0\">\n" +
+                "        <failure message=\"The scenario has no steps\" type=\"java.lang.Exception\"/>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -189,10 +205,10 @@ class JUnitFormatterTest {
     void should_format_skipped_scenario() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    Given first step\n" +
-                "    When second step\n" +
-                "    Then third step\n");
+                    "  Scenario: scenario name\n" +
+                    "    Given first step\n" +
+                    "    When second step\n" +
+                    "    Then third step\n");
         features.add(feature);
         Throwable exception = new TestAbortedException("message");
         stepsToResult.put("first step", result("skipped", exception));
@@ -204,18 +220,20 @@ class JUnitFormatterTest {
 
         String stackTrace = getStackTrace(exception);
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"1\" errors=\"0\" tests=\"1\" time=\"0.003\">\n" +
-            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
-            "        <skipped message=\"" + stackTrace.replace("\n\t", "&#10;&#9;").replaceAll("\r", "&#13;") + "\"><![CDATA[" +
-            "Given first step............................................................skipped\n" +
-            "When second step............................................................skipped\n" +
-            "Then third step.............................................................skipped\n" +
-            "\n" +
-            "StackTrace:\n" +
-            stackTrace +
-            "]]></skipped>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"1\" errors=\"0\" tests=\"1\" time=\"0.003\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
+                "        <skipped message=\"" + stackTrace.replace("\n\t", "&#10;&#9;").replaceAll("\r", "&#13;")
+                + "\"><![CDATA[" +
+                "Given first step............................................................skipped\n" +
+                "When second step............................................................skipped\n" +
+                "Then third step.............................................................skipped\n" +
+                "\n" +
+                "StackTrace:\n" +
+                stackTrace +
+                "]]></skipped>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -229,10 +247,10 @@ class JUnitFormatterTest {
     void should_format_pending_scenario() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    Given first step\n" +
-                "    When second step\n" +
-                "    Then third step\n");
+                    "  Scenario: scenario name\n" +
+                    "    Given first step\n" +
+                    "    When second step\n" +
+                    "    Then third step\n");
         features.add(feature);
         stepsToResult.put("first step", result("pending"));
         stepsToResult.put("second step", result("skipped"));
@@ -242,16 +260,19 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite errors=\"0\" failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.003\">\n" +
-            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
-            "        <failure message=\"The scenario has pending or undefined step(s)\" type=\"io.cucumber.core.runner.TestPendingException\">\n" +
-            "            <![CDATA[Given first step............................................................pending\n" +
-            "When second step............................................................skipped\n" +
-            "Then third step.............................................................skipped\n" +
-            "]]>\n" +
-            "        </failure>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite errors=\"0\" failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" tests=\"1\" time=\"0.003\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
+                "        <failure message=\"The scenario has pending or undefined step(s)\" type=\"io.cucumber.core.runner.TestPendingException\">\n"
+                +
+                "            <![CDATA[Given first step............................................................pending\n"
+                +
+                "When second step............................................................skipped\n" +
+                "Then third step.............................................................skipped\n" +
+                "]]>\n" +
+                "        </failure>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -259,10 +280,10 @@ class JUnitFormatterTest {
     void should_format_failed_scenario() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    Given first step\n" +
-                "    When second step\n" +
-                "    Then third step\n");
+                    "  Scenario: scenario name\n" +
+                    "    Given first step\n" +
+                    "    When second step\n" +
+                    "    Then third step\n");
         features.add(feature);
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
@@ -272,17 +293,19 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.003\">\n" +
-            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
-            "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA[" +
-            "Given first step............................................................passed\n" +
-            "When second step............................................................passed\n" +
-            "Then third step.............................................................failed\n" +
-            "\n" +
-            "StackTrace:\n" +
-            "the stack trace]]></failure>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.003\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.003\">\n" +
+                "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA["
+                +
+                "Given first step............................................................passed\n" +
+                "When second step............................................................passed\n" +
+                "Then third step.............................................................failed\n" +
+                "\n" +
+                "StackTrace:\n" +
+                "the stack trace]]></failure>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -290,10 +313,10 @@ class JUnitFormatterTest {
     void should_handle_failure_in_before_hook() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    Given first step\n" +
-                "    When second step\n" +
-                "    Then third step\n");
+                    "  Scenario: scenario name\n" +
+                    "    Given first step\n" +
+                    "    When second step\n" +
+                    "    Then third step\n");
         features.add(feature);
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
@@ -305,18 +328,20 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n" +
-            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
-            "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA[" +
-            "Given first step............................................................skipped\n" +
-            "When second step............................................................skipped\n" +
-            "Then third step.............................................................skipped\n" +
-            "\n" +
-            "StackTrace:\n" +
-            "the stack trace" +
-            "]]></failure>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
+                "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA["
+                +
+                "Given first step............................................................skipped\n" +
+                "When second step............................................................skipped\n" +
+                "Then third step.............................................................skipped\n" +
+                "\n" +
+                "StackTrace:\n" +
+                "the stack trace" +
+                "]]></failure>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -324,10 +349,10 @@ class JUnitFormatterTest {
     void should_handle_pending_in_before_hook() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    Given first step\n" +
-                "    When second step\n" +
-                "    Then third step\n");
+                    "  Scenario: scenario name\n" +
+                    "    Given first step\n" +
+                    "    When second step\n" +
+                    "    Then third step\n");
         features.add(feature);
         stepsToResult.put("first step", result("skipped"));
         stepsToResult.put("second step", result("skipped"));
@@ -339,16 +364,19 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n" +
-            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
-            "        <failure message=\"The scenario has pending or undefined step(s)\" type=\"io.cucumber.core.runner.TestPendingException\">\n" +
-            "            <![CDATA[Given first step............................................................skipped\n" +
-            "When second step............................................................skipped\n" +
-            "Then third step.............................................................skipped\n" +
-            "]]>\n" +
-            "        </failure>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
+                "        <failure message=\"The scenario has pending or undefined step(s)\" type=\"io.cucumber.core.runner.TestPendingException\">\n"
+                +
+                "            <![CDATA[Given first step............................................................skipped\n"
+                +
+                "When second step............................................................skipped\n" +
+                "Then third step.............................................................skipped\n" +
+                "]]>\n" +
+                "        </failure>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -356,11 +384,11 @@ class JUnitFormatterTest {
     void should_handle_failure_in_before_hook_with_background() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Background: background name\n" +
-                "    Given first step\n" +
-                "  Scenario: scenario name\n" +
-                "    When second step\n" +
-                "    Then third step\n");
+                    "  Background: background name\n" +
+                    "    Given first step\n" +
+                    "  Scenario: scenario name\n" +
+                    "    When second step\n" +
+                    "    Then third step\n");
         features.add(feature);
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
@@ -372,18 +400,20 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n" +
-            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
-            "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA[" +
-            "Given first step............................................................skipped\n" +
-            "When second step............................................................skipped\n" +
-            "Then third step.............................................................skipped\n" +
-            "\n" +
-            "StackTrace:\n" +
-            "the stack trace" +
-            "]]></failure>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
+                "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA["
+                +
+                "Given first step............................................................skipped\n" +
+                "When second step............................................................skipped\n" +
+                "Then third step.............................................................skipped\n" +
+                "\n" +
+                "StackTrace:\n" +
+                "the stack trace" +
+                "]]></failure>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -391,10 +421,10 @@ class JUnitFormatterTest {
     void should_handle_failure_in_after_hook() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    Given first step\n" +
-                "    When second step\n" +
-                "    Then third step\n");
+                    "  Scenario: scenario name\n" +
+                    "    Given first step\n" +
+                    "    When second step\n" +
+                    "    Then third step\n");
         features.add(feature);
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
@@ -406,18 +436,20 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n" +
-            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
-            "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA[" +
-            "Given first step............................................................passed\n" +
-            "When second step............................................................passed\n" +
-            "Then third step.............................................................passed\n" +
-            "\n" +
-            "StackTrace:\n" +
-            "the stack trace" +
-            "]]></failure>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"1\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
+                "        <failure message=\"the message\" type=\"io.cucumber.core.runner.TestHelper$1MockedTestAbortedException\"><![CDATA["
+                +
+                "Given first step............................................................passed\n" +
+                "When second step............................................................passed\n" +
+                "Then third step.............................................................passed\n" +
+                "\n" +
+                "StackTrace:\n" +
+                "the stack trace" +
+                "]]></failure>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -425,9 +457,9 @@ class JUnitFormatterTest {
     void should_accumulate_time_from_steps_and_hooks() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    * first step\n" +
-                "    * second step\n");
+                    "  Scenario: scenario name\n" +
+                    "    * first step\n" +
+                    "    * second step\n");
         features.add(feature);
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
@@ -440,14 +472,15 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n" +
-            "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
-            "        <system-out><![CDATA[" +
-            "* first step................................................................passed\n" +
-            "* second step...............................................................passed\n" +
-            "]]></system-out>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"1\" time=\"0.004\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"scenario name\" time=\"0.004\">\n" +
+                "        <system-out><![CDATA[" +
+                "* first step................................................................passed\n" +
+                "* second step...............................................................passed\n" +
+                "]]></system-out>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -455,14 +488,14 @@ class JUnitFormatterTest {
     void should_format_scenario_outlines() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario Outline: outline_name\n" +
-                "    Given first step \"<arg>\"\n" +
-                "    When second step\n" +
-                "    Then third step\n\n" +
-                "  Examples: examples\n" +
-                "    | arg |\n" +
-                "    |  a  |\n" +
-                "    |  b  |\n");
+                    "  Scenario Outline: outline_name\n" +
+                    "    Given first step \"<arg>\"\n" +
+                    "    When second step\n" +
+                    "    Then third step\n\n" +
+                    "  Examples: examples\n" +
+                    "    | arg |\n" +
+                    "    |  a  |\n" +
+                    "    |  b  |\n");
         features.add(feature);
         stepsToResult.put("first step \"a\"", result("passed"));
         stepsToResult.put("first step \"b\"", result("passed"));
@@ -473,22 +506,23 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"2\" time=\"0.006\">\n" +
-            "    <testcase classname=\"feature name\" name=\"outline_name\" time=\"0.003\">\n" +
-            "        <system-out><![CDATA[" +
-            "Given first step \"a\"........................................................passed\n" +
-            "When second step............................................................passed\n" +
-            "Then third step.............................................................passed\n" +
-            "]]></system-out>\n" +
-            "    </testcase>\n" +
-            "    <testcase classname=\"feature name\" name=\"outline_name_2\" time=\"0.003\">\n" +
-            "        <system-out><![CDATA[" +
-            "Given first step \"b\"........................................................passed\n" +
-            "When second step............................................................passed\n" +
-            "Then third step.............................................................passed\n" +
-            "]]></system-out>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"2\" time=\"0.006\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"outline_name\" time=\"0.003\">\n" +
+                "        <system-out><![CDATA[" +
+                "Given first step \"a\"........................................................passed\n" +
+                "When second step............................................................passed\n" +
+                "Then third step.............................................................passed\n" +
+                "]]></system-out>\n" +
+                "    </testcase>\n" +
+                "    <testcase classname=\"feature name\" name=\"outline_name_2\" time=\"0.003\">\n" +
+                "        <system-out><![CDATA[" +
+                "Given first step \"b\"........................................................passed\n" +
+                "When second step............................................................passed\n" +
+                "Then third step.............................................................passed\n" +
+                "]]></system-out>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -496,18 +530,18 @@ class JUnitFormatterTest {
     void should_format_scenario_outlines_with_multiple_examples() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario Outline: outline name\n" +
-                "    Given first step \"<arg>\"\n" +
-                "    When second step\n" +
-                "    Then third step\n\n" +
-                "  Examples: examples 1\n" +
-                "    | arg |\n" +
-                "    |  a  |\n" +
-                "    |  b  |\n\n" +
-                "  Examples: examples 2\n" +
-                "    | arg |\n" +
-                "    |  c  |\n" +
-                "    |  d  |\n");
+                    "  Scenario Outline: outline name\n" +
+                    "    Given first step \"<arg>\"\n" +
+                    "    When second step\n" +
+                    "    Then third step\n\n" +
+                    "  Examples: examples 1\n" +
+                    "    | arg |\n" +
+                    "    |  a  |\n" +
+                    "    |  b  |\n\n" +
+                    "  Examples: examples 2\n" +
+                    "    | arg |\n" +
+                    "    |  c  |\n" +
+                    "    |  d  |\n");
         features.add(feature);
         stepsToResult.put("first step \"a\"", result("passed"));
         stepsToResult.put("first step \"b\"", result("passed"));
@@ -520,36 +554,37 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"4\" time=\"0.012\">\n" +
-            "    <testcase classname=\"feature name\" name=\"outline name\" time=\"0.003\">\n" +
-            "        <system-out><![CDATA[" +
-            "Given first step \"a\"........................................................passed\n" +
-            "When second step............................................................passed\n" +
-            "Then third step.............................................................passed\n" +
-            "]]></system-out>\n" +
-            "    </testcase>\n" +
-            "    <testcase classname=\"feature name\" name=\"outline name 2\" time=\"0.003\">\n" +
-            "        <system-out><![CDATA[" +
-            "Given first step \"b\"........................................................passed\n" +
-            "When second step............................................................passed\n" +
-            "Then third step.............................................................passed\n" +
-            "]]></system-out>\n" +
-            "    </testcase>\n" +
-            "    <testcase classname=\"feature name\" name=\"outline name 3\" time=\"0.003\">\n" +
-            "        <system-out><![CDATA[" +
-            "Given first step \"c\"........................................................passed\n" +
-            "When second step............................................................passed\n" +
-            "Then third step.............................................................passed\n" +
-            "]]></system-out>\n" +
-            "    </testcase>\n" +
-            "    <testcase classname=\"feature name\" name=\"outline name 4\" time=\"0.003\">\n" +
-            "        <system-out><![CDATA[" +
-            "Given first step \"d\"........................................................passed\n" +
-            "When second step............................................................passed\n" +
-            "Then third step.............................................................passed\n" +
-            "]]></system-out>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"4\" time=\"0.012\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"outline name\" time=\"0.003\">\n" +
+                "        <system-out><![CDATA[" +
+                "Given first step \"a\"........................................................passed\n" +
+                "When second step............................................................passed\n" +
+                "Then third step.............................................................passed\n" +
+                "]]></system-out>\n" +
+                "    </testcase>\n" +
+                "    <testcase classname=\"feature name\" name=\"outline name 2\" time=\"0.003\">\n" +
+                "        <system-out><![CDATA[" +
+                "Given first step \"b\"........................................................passed\n" +
+                "When second step............................................................passed\n" +
+                "Then third step.............................................................passed\n" +
+                "]]></system-out>\n" +
+                "    </testcase>\n" +
+                "    <testcase classname=\"feature name\" name=\"outline name 3\" time=\"0.003\">\n" +
+                "        <system-out><![CDATA[" +
+                "Given first step \"c\"........................................................passed\n" +
+                "When second step............................................................passed\n" +
+                "Then third step.............................................................passed\n" +
+                "]]></system-out>\n" +
+                "    </testcase>\n" +
+                "    <testcase classname=\"feature name\" name=\"outline name 4\" time=\"0.003\">\n" +
+                "        <system-out><![CDATA[" +
+                "Given first step \"d\"........................................................passed\n" +
+                "When second step............................................................passed\n" +
+                "Then third step.............................................................passed\n" +
+                "]]></system-out>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 
@@ -557,14 +592,14 @@ class JUnitFormatterTest {
     void should_format_scenario_outlines_with_arguments_in_name() throws Throwable {
         Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario Outline: outline name <arg>\n" +
-                "    Given first step \"<arg>\"\n" +
-                "    When second step\n" +
-                "    Then third step\n\n" +
-                "  Examples: examples 1\n" +
-                "    | arg |\n" +
-                "    |  a  |\n" +
-                "    |  b  |\n");
+                    "  Scenario Outline: outline name <arg>\n" +
+                    "    Given first step \"<arg>\"\n" +
+                    "    When second step\n" +
+                    "    Then third step\n\n" +
+                    "  Examples: examples 1\n" +
+                    "    | arg |\n" +
+                    "    |  a  |\n" +
+                    "    |  b  |\n");
         features.add(feature);
         stepsToResult.put("first step \"a\"", result("passed"));
         stepsToResult.put("first step \"b\"", result("passed"));
@@ -575,22 +610,23 @@ class JUnitFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"2\" time=\"0.006\">\n" +
-            "    <testcase classname=\"feature name\" name=\"outline name a\" time=\"0.003\">\n" +
-            "        <system-out><![CDATA[" +
-            "Given first step \"a\"........................................................passed\n" +
-            "When second step............................................................passed\n" +
-            "Then third step.............................................................passed\n" +
-            "]]></system-out>\n" +
-            "    </testcase>\n" +
-            "    <testcase classname=\"feature name\" name=\"outline name b\" time=\"0.003\">\n" +
-            "        <system-out><![CDATA[" +
-            "Given first step \"b\"........................................................passed\n" +
-            "When second step............................................................passed\n" +
-            "Then third step.............................................................passed\n" +
-            "]]></system-out>\n" +
-            "    </testcase>\n" +
-            "</testsuite>\n";
+                "<testsuite failures=\"0\" name=\"io.cucumber.core.plugin.JUnitFormatter\" skipped=\"0\" errors=\"0\" tests=\"2\" time=\"0.006\">\n"
+                +
+                "    <testcase classname=\"feature name\" name=\"outline name a\" time=\"0.003\">\n" +
+                "        <system-out><![CDATA[" +
+                "Given first step \"a\"........................................................passed\n" +
+                "When second step............................................................passed\n" +
+                "Then third step.............................................................passed\n" +
+                "]]></system-out>\n" +
+                "    </testcase>\n" +
+                "    <testcase classname=\"feature name\" name=\"outline name b\" time=\"0.003\">\n" +
+                "        <system-out><![CDATA[" +
+                "Given first step \"b\"........................................................passed\n" +
+                "When second step............................................................passed\n" +
+                "Then third step.............................................................passed\n" +
+                "]]></system-out>\n" +
+                "    </testcase>\n" +
+                "</testsuite>\n";
         assertXmlEqual(expected, formatterOutput);
     }
 

--- a/core/src/test/java/io/cucumber/core/plugin/JsonFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/JsonFormatterTest.java
@@ -56,8 +56,8 @@ class JsonFormatterTest {
         String actual = runFeaturesWithFormatter(featurePaths);
         InputStream resourceAsStream = getClass().getResourceAsStream("JsonPrettyFormatterTest.json");
         String expected = new Scanner(resourceAsStream, "UTF-8")
-            .useDelimiter("\\A")
-            .next();
+                .useDelimiter("\\A")
+                .next();
         assertThat(actual, sameJSONAs(expected));
     }
 
@@ -79,12 +79,12 @@ class JsonFormatterTest {
         RuntimeOptionsBuilder options = new RuntimeOptionsBuilder();
         featurePaths.forEach(s -> options.addFeature(FeatureWithLines.parse(s)));
         Runtime.builder()
-            .withRuntimeOptions(options.build())
-            .withEventBus(bus)
-            .withBackendSupplier(backendSupplier)
-            .withAdditionalPlugins(new JsonFormatter(out))
-            .build()
-            .run();
+                .withRuntimeOptions(options.build())
+                .withEventBus(bus)
+                .withBackendSupplier(backendSupplier)
+                .withAdditionalPlugins(new JsonFormatter(out))
+                .build()
+                .run();
 
         return new String(out.toByteArray(), UTF_8);
     }
@@ -95,8 +95,8 @@ class JsonFormatterTest {
         String actual = runFeaturesWithFormatterInParallel(featurePaths);
         InputStream resourceAsStream = getClass().getResourceAsStream("JsonPrettyFormatterTest.json");
         String expected = new Scanner(resourceAsStream, "UTF-8")
-            .useDelimiter("\\A")
-            .next();
+                .useDelimiter("\\A")
+                .next();
 
         assertThat(actual, sameJSONAs(expected));
     }
@@ -117,12 +117,12 @@ class JsonFormatterTest {
         RuntimeOptionsBuilder options = new RuntimeOptionsBuilder();
         featurePaths.forEach(s -> options.addFeature(FeatureWithLines.parse(s)));
         Runtime.builder()
-            .withRuntimeOptions(options.build())
-            .withEventBus(bus)
-            .withBackendSupplier(backendSupplier)
-            .withAdditionalPlugins(new JsonFormatter(out))
-            .build()
-            .run();
+                .withRuntimeOptions(options.build())
+                .withEventBus(bus)
+                .withBackendSupplier(backendSupplier)
+                .withAdditionalPlugins(new JsonFormatter(out))
+                .build()
+                .run();
 
         return new String(out.toByteArray(), UTF_8);
     }
@@ -130,49 +130,49 @@ class JsonFormatterTest {
     @Test
     void should_format_scenario_with_an_undefined_step() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("undefined"));
 
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {},\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"undefined\"\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {},\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"undefined\"\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
@@ -180,16 +180,16 @@ class JsonFormatterTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         TestHelper.builder()
-            .withFormatterUnderTest(new JsonFormatter(out))
-            .withFeatures(features)
-            .withStepsToResult(stepsToResult)
-            .withStepsToLocation(stepsToLocation)
-            .withHooks(hooks)
-            .withHookLocations(hookLocations)
-            .withHookActions(hookActions)
-            .withTimeServiceIncrement(stepDuration)
-            .build()
-            .run();
+                .withFormatterUnderTest(new JsonFormatter(out))
+                .withFeatures(features)
+                .withStepsToResult(stepsToResult)
+                .withStepsToLocation(stepsToLocation)
+                .withHooks(hooks)
+                .withHookLocations(hookLocations)
+                .withHookActions(hookActions)
+                .withTimeServiceIncrement(stepDuration)
+                .build()
+                .run();
 
         return new String(out.toByteArray(), UTF_8);
     }
@@ -197,10 +197,10 @@ class JsonFormatterTest {
     @Test
     void should_format_scenario_with_a_passed_step() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
@@ -209,52 +209,52 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_format_scenario_with_a_failed_step() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("failed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
@@ -263,54 +263,54 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"failed\",\n" +
-            "              \"error_message\": \"the stack trace\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"failed\",\n" +
+                "              \"error_message\": \"the stack trace\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_format_scenario_with_a_rule() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Rule: This is all monkey business\n" +
-            "    Scenario: Monkey eats bananas\n" +
-            "      Given there are bananas\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Rule: This is all monkey business\n" +
+                "    Scenario: Monkey eats bananas\n" +
+                "      Given there are bananas\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
@@ -319,60 +319,60 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"line\": 1,\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"line\": 4,\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"description\": \"\",\n" +
-            "        \"id\": \";monkey-eats-bananas\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"result\": {\n" +
-            "              \"duration\": 1000000,\n" +
-            "              \"status\": \"passed\"\n" +
-            "            },\n" +
-            "            \"line\": 5,\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"keyword\": \"Given \"\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"description\": \"\",\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"line\": 1,\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"line\": 4,\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"description\": \"\",\n" +
+                "        \"id\": \";monkey-eats-bananas\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"result\": {\n" +
+                "              \"duration\": 1000000,\n" +
+                "              \"status\": \"passed\"\n" +
+                "            },\n" +
+                "            \"line\": 5,\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"keyword\": \"Given \"\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"description\": \"\",\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_format_scenario_with_a_rule_and_background() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Background: \n" +
-            "     Given there are bananas\n" +
-            "\n" +
-            "  Rule: This is all monkey business\n" +
-            "\n" +
-            "  Background: \n" +
-            "     Given there are bananas\n" +
-            "\n" +
-            "    Scenario: Monkey eats bananas\n" +
-            "      Given there are bananas\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Background: \n" +
+                "     Given there are bananas\n" +
+                "\n" +
+                "  Rule: This is all monkey business\n" +
+                "\n" +
+                "  Background: \n" +
+                "     Given there are bananas\n" +
+                "\n" +
+                "    Scenario: Monkey eats bananas\n" +
+                "      Given there are bananas\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
@@ -381,88 +381,88 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"line\": 1,\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"line\": 3,\n" +
-            "        \"name\": \"\",\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"background\",\n" +
-            "        \"keyword\": \"Background\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"result\": {\n" +
-            "              \"duration\": 1000000,\n" +
-            "              \"status\": \"passed\"\n" +
-            "            },\n" +
-            "            \"line\": 4,\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"keyword\": \"Given \"\n" +
-            "          },\n" +
-            "          {\n" +
-            "            \"result\": {\n" +
-            "              \"duration\": 1000000,\n" +
-            "              \"status\": \"passed\"\n" +
-            "            },\n" +
-            "            \"line\": 9,\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"keyword\": \"Given \"\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      },\n" +
-            "      {\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"line\": 11,\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"description\": \"\",\n" +
-            "        \"id\": \";monkey-eats-bananas\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"result\": {\n" +
-            "              \"duration\": 1000000,\n" +
-            "              \"status\": \"passed\"\n" +
-            "            },\n" +
-            "            \"line\": 12,\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"keyword\": \"Given \"\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"description\": \"\",\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"line\": 1,\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"line\": 3,\n" +
+                "        \"name\": \"\",\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"background\",\n" +
+                "        \"keyword\": \"Background\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"result\": {\n" +
+                "              \"duration\": 1000000,\n" +
+                "              \"status\": \"passed\"\n" +
+                "            },\n" +
+                "            \"line\": 4,\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"keyword\": \"Given \"\n" +
+                "          },\n" +
+                "          {\n" +
+                "            \"result\": {\n" +
+                "              \"duration\": 1000000,\n" +
+                "              \"status\": \"passed\"\n" +
+                "            },\n" +
+                "            \"line\": 9,\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"keyword\": \"Given \"\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"line\": 11,\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"description\": \"\",\n" +
+                "        \"id\": \";monkey-eats-bananas\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"result\": {\n" +
+                "              \"duration\": 1000000,\n" +
+                "              \"status\": \"passed\"\n" +
+                "            },\n" +
+                "            \"line\": 12,\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"keyword\": \"Given \"\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"description\": \"\",\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_format_scenario_outline_with_one_example() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Fruit party\n" +
-            "\n" +
-            "  Scenario Outline: Monkey eats fruits\n" +
-            "    Given there are <fruits>\n" +
-            "      Examples: Fruit table\n" +
-            "      | fruits  |\n" +
-            "      | bananas |\n");
+                "Feature: Fruit party\n" +
+                "\n" +
+                "  Scenario Outline: Monkey eats fruits\n" +
+                "    Given there are <fruits>\n" +
+                "      Examples: Fruit table\n" +
+                "      | fruits  |\n" +
+                "      | bananas |\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
@@ -471,58 +471,58 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"fruit-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Fruit party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"fruit-party;monkey-eats-fruits;fruit-table;2\",\n" +
-            "        \"keyword\": \"Scenario Outline\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats fruits\",\n" +
-            "        \"line\": 7,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"fruit-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Fruit party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"fruit-party;monkey-eats-fruits;fruit-table;2\",\n" +
+                "        \"keyword\": \"Scenario Outline\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats fruits\",\n" +
+                "        \"line\": 7,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_format_feature_with_background() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Background: There are bananas\n" +
-            "    Given there are bananas\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Then the monkey eats bananas\n" +
-            "\n" +
-            "  Scenario: Monkey eats more bananas\n" +
-            "    Then the monkey eats more bananas\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Background: There are bananas\n" +
+                "    Given there are bananas\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Then the monkey eats bananas\n" +
+                "\n" +
+                "  Scenario: Monkey eats more bananas\n" +
+                "    Then the monkey eats more bananas\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToResult.put("the monkey eats bananas", result("passed"));
@@ -535,118 +535,118 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"keyword\": \"Background\",\n" +
-            "        \"name\": \"There are bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"background\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      },\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 6,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Then \",\n" +
-            "            \"name\": \"the monkey eats bananas\",\n" +
-            "            \"line\": 7,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.monkey_eats_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      },\n" +
-            "      {\n" +
-            "        \"keyword\": \"Background\",\n" +
-            "        \"name\": \"There are bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"background\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      },\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-more-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.002Z\",\n" +
-            "        \"name\": \"Monkey eats more bananas\",\n" +
-            "        \"line\": 9,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Then \",\n" +
-            "            \"name\": \"the monkey eats more bananas\",\n" +
-            "            \"line\": 10,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.monkey_eats_more_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"keyword\": \"Background\",\n" +
+                "        \"name\": \"There are bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"background\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 6,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Then \",\n" +
+                "            \"name\": \"the monkey eats bananas\",\n" +
+                "            \"line\": 7,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.monkey_eats_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"keyword\": \"Background\",\n" +
+                "        \"name\": \"There are bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"background\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-more-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.002Z\",\n" +
+                "        \"name\": \"Monkey eats more bananas\",\n" +
+                "        \"line\": 9,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Then \",\n" +
+                "            \"name\": \"the monkey eats more bananas\",\n" +
+                "            \"line\": 10,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.monkey_eats_more_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_format_feature_and_scenario_with_tags() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "@Party @Banana\n" +
-            "Feature: Banana party\n" +
-            "  @Monkey\n" +
-            "  Scenario: Monkey eats more bananas\n" +
-            "    Then the monkey eats more bananas\n");
+                "@Party @Banana\n" +
+                "Feature: Banana party\n" +
+                "  @Monkey\n" +
+                "  Scenario: Monkey eats more bananas\n" +
+                "    Then the monkey eats more bananas\n");
         features.add(feature);
         stepsToResult.put("the monkey eats more bananas", result("passed"));
         stepsToLocation.put("the monkey eats more bananas", "StepDefs.monkey_eats_more_bananas()");
@@ -655,80 +655,80 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"line\": 2,\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"line\": 4,\n" +
-            "        \"name\": \"Monkey eats more bananas\",\n" +
-            "        \"description\": \"\",\n" +
-            "        \"id\": \"banana-party;monkey-eats-more-bananas\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"result\": {\n" +
-            "              \"duration\": 1000000,\n" +
-            "              \"status\": \"passed\"\n" +
-            "            },\n" +
-            "            \"line\": 5,\n" +
-            "            \"name\": \"the monkey eats more bananas\",\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.monkey_eats_more_bananas()\"\n" +
-            "            },\n" +
-            "            \"keyword\": \"Then \"\n" +
-            "          }\n" +
-            "        ],\n" +
-            "        \"tags\": [\n" +
-            "          {\n" +
-            "            \"name\": \"@Party\"\n" +
-            "          },\n" +
-            "          {\n" +
-            "            \"name\": \"@Banana\"\n" +
-            "          },\n" +
-            "          {\n" +
-            "            \"name\": \"@Monkey\"\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"description\": \"\",\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"tags\": [\n" +
-            "      {\n" +
-            "        \"name\": \"@Party\",\n" +
-            "        \"type\": \"Tag\",\n" +
-            "        \"location\": {\n" +
-            "          \"line\": 1,\n" +
-            "          \"column\": 1\n" +
-            "        }\n" +
-            "      },\n" +
-            "      {\n" +
-            "        \"name\": \"@Banana\",\n" +
-            "        \"type\": \"Tag\",\n" +
-            "        \"location\": {\n" +
-            "          \"line\": 1,\n" +
-            "          \"column\": 8\n" +
-            "        }\n" +
-            "      }\n" +
-            "    ]\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"line\": 2,\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"line\": 4,\n" +
+                "        \"name\": \"Monkey eats more bananas\",\n" +
+                "        \"description\": \"\",\n" +
+                "        \"id\": \"banana-party;monkey-eats-more-bananas\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"result\": {\n" +
+                "              \"duration\": 1000000,\n" +
+                "              \"status\": \"passed\"\n" +
+                "            },\n" +
+                "            \"line\": 5,\n" +
+                "            \"name\": \"the monkey eats more bananas\",\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.monkey_eats_more_bananas()\"\n" +
+                "            },\n" +
+                "            \"keyword\": \"Then \"\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"tags\": [\n" +
+                "          {\n" +
+                "            \"name\": \"@Party\"\n" +
+                "          },\n" +
+                "          {\n" +
+                "            \"name\": \"@Banana\"\n" +
+                "          },\n" +
+                "          {\n" +
+                "            \"name\": \"@Monkey\"\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"description\": \"\",\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"tags\": [\n" +
+                "      {\n" +
+                "        \"name\": \"@Party\",\n" +
+                "        \"type\": \"Tag\",\n" +
+                "        \"location\": {\n" +
+                "          \"line\": 1,\n" +
+                "          \"column\": 1\n" +
+                "        }\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"name\": \"@Banana\",\n" +
+                "        \"type\": \"Tag\",\n" +
+                "        \"location\": {\n" +
+                "          \"line\": 1,\n" +
+                "          \"column\": 8\n" +
+                "        }\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_format_scenario_with_hooks() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
@@ -741,75 +741,75 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"before\": [\n" +
-            "          {\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"Hooks.before_hook_1()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ],\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ],\n" +
-            "        \"after\": [\n" +
-            "          {\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"Hooks.after_hook_1()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"before\": [\n" +
+                "          {\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"Hooks.before_hook_1()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"after\": [\n" +
+                "          {\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"Hooks.after_hook_1()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_add_step_hooks_to_step() {
         Feature feature = TestFeatureParser.parse("file:path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n" +
-            "    When monkey arrives\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n" +
+                "    When monkey arrives\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToResult.put("monkey arrives", result("passed"));
@@ -826,126 +826,126 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"line\": 1,\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"line\": 3,\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"description\": \"\",\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"result\": {\n" +
-            "              \"duration\": 1000000,\n" +
-            "              \"status\": \"passed\"\n" +
-            "            },\n" +
-            "            \"before\": [\n" +
-            "              {\n" +
-            "                \"result\": {\n" +
-            "                  \"duration\": 1000000,\n" +
-            "                  \"status\": \"passed\"\n" +
-            "                },\n" +
-            "                \"match\": {\n" +
-            "                  \"location\": \"Hooks.beforestep_hooks_1()\"\n" +
-            "                }\n" +
-            "              }\n" +
-            "            ],\n" +
-            "            \"line\": 4,\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"after\": [\n" +
-            "              {\n" +
-            "                \"result\": {\n" +
-            "                  \"duration\": 1000000,\n" +
-            "                  \"status\": \"passed\"\n" +
-            "                },\n" +
-            "                \"match\": {\n" +
-            "                  \"location\": \"Hooks.afterstep_hooks_2()\"\n" +
-            "                }\n" +
-            "              },\n" +
-            "              {\n" +
-            "                \"result\": {\n" +
-            "                  \"duration\": 1000000,\n" +
-            "                  \"status\": \"passed\"\n" +
-            "                },\n" +
-            "                \"match\": {\n" +
-            "                  \"location\": \"Hooks.afterstep_hooks_1()\"\n" +
-            "                }\n" +
-            "              }\n" +
-            "            ],\n" +
-            "            \"keyword\": \"Given \"\n" +
-            "          },\n" +
-            "          {\n" +
-            "            \"result\": {\n" +
-            "              \"duration\": 1000000,\n" +
-            "              \"status\": \"passed\"\n" +
-            "            },\n" +
-            "            \"before\": [\n" +
-            "              {\n" +
-            "                \"result\": {\n" +
-            "                  \"duration\": 1000000,\n" +
-            "                  \"status\": \"passed\"\n" +
-            "                },\n" +
-            "                \"match\": {\n" +
-            "                  \"location\": \"Hooks.beforestep_hooks_1()\"\n" +
-            "                }\n" +
-            "              }\n" +
-            "            ],\n" +
-            "            \"line\": 5,\n" +
-            "            \"name\": \"monkey arrives\",\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.monkey_arrives()\"\n" +
-            "            },\n" +
-            "            \"after\": [\n" +
-            "              {\n" +
-            "                \"result\": {\n" +
-            "                  \"duration\": 1000000,\n" +
-            "                  \"status\": \"passed\"\n" +
-            "                },\n" +
-            "                \"match\": {\n" +
-            "                  \"location\": \"Hooks.afterstep_hooks_2()\"\n" +
-            "                }\n" +
-            "              },\n" +
-            "              {\n" +
-            "                \"result\": {\n" +
-            "                  \"duration\": 1000000,\n" +
-            "                  \"status\": \"passed\"\n" +
-            "                },\n" +
-            "                \"match\": {\n" +
-            "                  \"location\": \"Hooks.afterstep_hooks_1()\"\n" +
-            "                }\n" +
-            "              }\n" +
-            "            ],\n" +
-            "            \"keyword\": \"When \"\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"description\": \"\",\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"line\": 1,\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"line\": 3,\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"description\": \"\",\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"result\": {\n" +
+                "              \"duration\": 1000000,\n" +
+                "              \"status\": \"passed\"\n" +
+                "            },\n" +
+                "            \"before\": [\n" +
+                "              {\n" +
+                "                \"result\": {\n" +
+                "                  \"duration\": 1000000,\n" +
+                "                  \"status\": \"passed\"\n" +
+                "                },\n" +
+                "                \"match\": {\n" +
+                "                  \"location\": \"Hooks.beforestep_hooks_1()\"\n" +
+                "                }\n" +
+                "              }\n" +
+                "            ],\n" +
+                "            \"line\": 4,\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"after\": [\n" +
+                "              {\n" +
+                "                \"result\": {\n" +
+                "                  \"duration\": 1000000,\n" +
+                "                  \"status\": \"passed\"\n" +
+                "                },\n" +
+                "                \"match\": {\n" +
+                "                  \"location\": \"Hooks.afterstep_hooks_2()\"\n" +
+                "                }\n" +
+                "              },\n" +
+                "              {\n" +
+                "                \"result\": {\n" +
+                "                  \"duration\": 1000000,\n" +
+                "                  \"status\": \"passed\"\n" +
+                "                },\n" +
+                "                \"match\": {\n" +
+                "                  \"location\": \"Hooks.afterstep_hooks_1()\"\n" +
+                "                }\n" +
+                "              }\n" +
+                "            ],\n" +
+                "            \"keyword\": \"Given \"\n" +
+                "          },\n" +
+                "          {\n" +
+                "            \"result\": {\n" +
+                "              \"duration\": 1000000,\n" +
+                "              \"status\": \"passed\"\n" +
+                "            },\n" +
+                "            \"before\": [\n" +
+                "              {\n" +
+                "                \"result\": {\n" +
+                "                  \"duration\": 1000000,\n" +
+                "                  \"status\": \"passed\"\n" +
+                "                },\n" +
+                "                \"match\": {\n" +
+                "                  \"location\": \"Hooks.beforestep_hooks_1()\"\n" +
+                "                }\n" +
+                "              }\n" +
+                "            ],\n" +
+                "            \"line\": 5,\n" +
+                "            \"name\": \"monkey arrives\",\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.monkey_arrives()\"\n" +
+                "            },\n" +
+                "            \"after\": [\n" +
+                "              {\n" +
+                "                \"result\": {\n" +
+                "                  \"duration\": 1000000,\n" +
+                "                  \"status\": \"passed\"\n" +
+                "                },\n" +
+                "                \"match\": {\n" +
+                "                  \"location\": \"Hooks.afterstep_hooks_2()\"\n" +
+                "                }\n" +
+                "              },\n" +
+                "              {\n" +
+                "                \"result\": {\n" +
+                "                  \"duration\": 1000000,\n" +
+                "                  \"status\": \"passed\"\n" +
+                "                },\n" +
+                "                \"match\": {\n" +
+                "                  \"location\": \"Hooks.afterstep_hooks_1()\"\n" +
+                "                }\n" +
+                "              }\n" +
+                "            ],\n" +
+                "            \"keyword\": \"When \"\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"description\": \"\",\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_handle_write_from_a_hook() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
@@ -957,218 +957,218 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"before\": [\n" +
-            "          {\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"Hooks.before_hook_1()\"\n" +
-            "            },\n" +
-            "            \"output\": [\n" +
-            "              \"printed from hook\"\n" +
-            "            ],\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ],\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"before\": [\n" +
+                "          {\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"Hooks.before_hook_1()\"\n" +
+                "            },\n" +
+                "            \"output\": [\n" +
+                "              \"printed from hook\"\n" +
+                "            ],\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_handle_embed_from_a_hook() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
         hooks.add(TestHelper.hookEntry("before", result("passed")));
         hookLocations.add("Hooks.before_hook_1()");
-        hookActions.add(createAttachHookAction(new byte[]{1, 2, 3}, "mime-type;base64"));
+        hookActions.add(createAttachHookAction(new byte[] { 1, 2, 3 }, "mime-type;base64"));
         stepDuration = ofMillis(1L);
 
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"before\": [\n" +
-            "          {\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"Hooks.before_hook_1()\"\n" +
-            "            },\n" +
-            "            \"embeddings\": [\n" +
-            "              {\n" +
-            "                \"mime_type\": \"mime-type;base64\",\n" +
-            "                \"data\": \"AQID\"\n" +
-            "              }\n" +
-            "            ],\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ],\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"before\": [\n" +
+                "          {\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"Hooks.before_hook_1()\"\n" +
+                "            },\n" +
+                "            \"embeddings\": [\n" +
+                "              {\n" +
+                "                \"mime_type\": \"mime-type;base64\",\n" +
+                "                \"data\": \"AQID\"\n" +
+                "              }\n" +
+                "            ],\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_handle_embed_with_name_from_a_hook() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
         hooks.add(TestHelper.hookEntry("before", result("passed")));
         hookLocations.add("Hooks.before_hook_1()");
-        hookActions.add(createAttachHookAction(new byte[]{1, 2, 3}, "mime-type;base64", "someEmbedding"));
+        hookActions.add(createAttachHookAction(new byte[] { 1, 2, 3 }, "mime-type;base64", "someEmbedding"));
         stepDuration = ofMillis(1L);
 
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"before\": [\n" +
-            "          {\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"Hooks.before_hook_1()\"\n" +
-            "            },\n" +
-            "            \"embeddings\": [\n" +
-            "              {\n" +
-            "                \"mime_type\": \"mime-type;base64\",\n" +
-            "                \"data\": \"AQID\",\n" +
-            "                \"name\": \"someEmbedding\"\n" +
-            "              }\n" +
-            "            ],\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ],\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"before\": [\n" +
+                "          {\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"Hooks.before_hook_1()\"\n" +
+                "            },\n" +
+                "            \"embeddings\": [\n" +
+                "              {\n" +
+                "                \"mime_type\": \"mime-type;base64\",\n" +
+                "                \"data\": \"AQID\",\n" +
+                "                \"name\": \"someEmbedding\"\n" +
+                "              }\n" +
+                "            ],\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_format_scenario_with_a_step_with_a_doc_string() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n" +
-            "    \"\"\"\n" +
-            "    doc string content\n" +
-            "    \"\"\"\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n" +
+                "    \"\"\"\n" +
+                "    doc string content\n" +
+                "    \"\"\"\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
@@ -1177,59 +1177,59 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"doc_string\": {\n" +
-            "              \"value\": \"doc string content\",\n" +
-            "              \"line\": 5\n" +
-            "            },\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"doc_string\": {\n" +
+                "              \"value\": \"doc string content\",\n" +
+                "              \"line\": 5\n" +
+                "            },\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_format_scenario_with_a_step_with_a_doc_string_and_content_type() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n" +
-            "    \"\"\"doc\n" +
-            "    doc string content\n" +
-            "    \"\"\"\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n" +
+                "    \"\"\"doc\n" +
+                "    doc string content\n" +
+                "    \"\"\"\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
@@ -1238,59 +1238,59 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"doc_string\": {\n" +
-            "              \"content_type\": \"doc\",\n" +
-            "              \"value\": \"doc string content\",\n" +
-            "              \"line\": 5\n" +
-            "            },\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"doc_string\": {\n" +
+                "              \"content_type\": \"doc\",\n" +
+                "              \"value\": \"doc string content\",\n" +
+                "              \"line\": 5\n" +
+                "            },\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_format_scenario_with_a_step_with_a_data_table() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n" +
-            "      | aa | 11 |\n" +
-            "      | bb | 22 |\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n" +
+                "      | aa | 11 |\n" +
+                "      | bb | 22 |\n");
         features.add(feature);
         stepsToResult.put("there are bananas", result("passed"));
         stepsToLocation.put("there are bananas", "StepDefs.there_are_bananas()");
@@ -1299,71 +1299,71 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"rows\": [\n" +
-            "              {\n" +
-            "                \"cells\": [\n" +
-            "                  \"aa\",\n" +
-            "                  \"11\"\n" +
-            "                ]\n" +
-            "              },\n" +
-            "              {\n" +
-            "                \"cells\": [\n" +
-            "                  \"bb\",\n" +
-            "                  \"22\"\n" +
-            "                ]\n" +
-            "              }\n" +
-            "            ],\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"rows\": [\n" +
+                "              {\n" +
+                "                \"cells\": [\n" +
+                "                  \"aa\",\n" +
+                "                  \"11\"\n" +
+                "                ]\n" +
+                "              },\n" +
+                "              {\n" +
+                "                \"cells\": [\n" +
+                "                  \"bb\",\n" +
+                "                  \"22\"\n" +
+                "                ]\n" +
+                "              }\n" +
+                "            ],\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 
     @Test
     void should_handle_several_features() {
         Feature feature1 = TestFeatureParser.parse("path/test1.feature", "" +
-            "Feature: Banana party\n" +
-            "\n" +
-            "  Scenario: Monkey eats bananas\n" +
-            "    Given there are bananas\n");
+                "Feature: Banana party\n" +
+                "\n" +
+                "  Scenario: Monkey eats bananas\n" +
+                "    Given there are bananas\n");
         Feature feature2 = TestFeatureParser.parse("path/test2.feature", "" +
-            "Feature: Orange party\n" +
-            "\n" +
-            "  Scenario: Monkey eats oranges\n" +
-            "    Given there are oranges\n");
+                "Feature: Orange party\n" +
+                "\n" +
+                "  Scenario: Monkey eats oranges\n" +
+                "    Given there are oranges\n");
         features.add(feature1);
         features.add(feature2);
         stepsToResult.put("there are bananas", result("passed"));
@@ -1375,76 +1375,76 @@ class JsonFormatterTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         String expected = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"id\": \"banana-party\",\n" +
-            "    \"uri\": \"file:path/test1.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Banana party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
-            "        \"name\": \"Monkey eats bananas\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are bananas\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  },\n" +
-            "  {\n" +
-            "    \"id\": \"orange-party\",\n" +
-            "    \"uri\": \"file:path/test2.feature\",\n" +
-            "    \"keyword\": \"Feature\",\n" +
-            "    \"name\": \"Orange party\",\n" +
-            "    \"line\": 1,\n" +
-            "    \"description\": \"\",\n" +
-            "    \"elements\": [\n" +
-            "      {\n" +
-            "        \"id\": \"orange-party;monkey-eats-oranges\",\n" +
-            "        \"keyword\": \"Scenario\",\n" +
-            "        \"start_timestamp\": \"1970-01-01T00:00:00.001Z\",\n" +
-            "        \"name\": \"Monkey eats oranges\",\n" +
-            "        \"line\": 3,\n" +
-            "        \"description\": \"\",\n" +
-            "        \"type\": \"scenario\",\n" +
-            "        \"steps\": [\n" +
-            "          {\n" +
-            "            \"keyword\": \"Given \",\n" +
-            "            \"name\": \"there are oranges\",\n" +
-            "            \"line\": 4,\n" +
-            "            \"match\": {\n" +
-            "              \"location\": \"StepDefs.there_are_oranges()\"\n" +
-            "            },\n" +
-            "            \"result\": {\n" +
-            "              \"status\": \"passed\",\n" +
-            "              \"duration\": 1000000\n" +
-            "            }\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ],\n" +
-            "    \"tags\": []\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"id\": \"banana-party\",\n" +
+                "    \"uri\": \"file:path/test1.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Banana party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"banana-party;monkey-eats-bananas\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.000Z\",\n" +
+                "        \"name\": \"Monkey eats bananas\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are bananas\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_bananas()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"id\": \"orange-party\",\n" +
+                "    \"uri\": \"file:path/test2.feature\",\n" +
+                "    \"keyword\": \"Feature\",\n" +
+                "    \"name\": \"Orange party\",\n" +
+                "    \"line\": 1,\n" +
+                "    \"description\": \"\",\n" +
+                "    \"elements\": [\n" +
+                "      {\n" +
+                "        \"id\": \"orange-party;monkey-eats-oranges\",\n" +
+                "        \"keyword\": \"Scenario\",\n" +
+                "        \"start_timestamp\": \"1970-01-01T00:00:00.001Z\",\n" +
+                "        \"name\": \"Monkey eats oranges\",\n" +
+                "        \"line\": 3,\n" +
+                "        \"description\": \"\",\n" +
+                "        \"type\": \"scenario\",\n" +
+                "        \"steps\": [\n" +
+                "          {\n" +
+                "            \"keyword\": \"Given \",\n" +
+                "            \"name\": \"there are oranges\",\n" +
+                "            \"line\": 4,\n" +
+                "            \"match\": {\n" +
+                "              \"location\": \"StepDefs.there_are_oranges()\"\n" +
+                "            },\n" +
+                "            \"result\": {\n" +
+                "              \"status\": \"passed\",\n" +
+                "              \"duration\": 1000000\n" +
+                "            }\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"tags\": []\n" +
+                "  }\n" +
+                "]";
         assertThat(formatterOutput, sameJSONAs(expected));
     }
 

--- a/core/src/test/java/io/cucumber/core/plugin/JsonParallelRuntimeTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/JsonParallelRuntimeTest.java
@@ -21,30 +21,30 @@ class JsonParallelRuntimeTest {
         ByteArrayOutputStream parallel = new ByteArrayOutputStream();
 
         Runtime.builder()
-            .withRuntimeOptions(
-                new RuntimeOptionsBuilder()
-                    .setThreads(3)
-                    .addFeature(FeatureWithLines.parse("src/test/resources/io/cucumber/core/plugin/JsonPrettyFormatterTest.feature"))
-                    .build()
-            )
-            .withAdditionalPlugins(new JsonFormatter(parallel))
-            .withEventBus(new TimeServiceEventBus(new ClockStub(ZERO), UUID::randomUUID))
-            .build()
-            .run();
+                .withRuntimeOptions(
+                    new RuntimeOptionsBuilder()
+                            .setThreads(3)
+                            .addFeature(FeatureWithLines.parse(
+                                "src/test/resources/io/cucumber/core/plugin/JsonPrettyFormatterTest.feature"))
+                            .build())
+                .withAdditionalPlugins(new JsonFormatter(parallel))
+                .withEventBus(new TimeServiceEventBus(new ClockStub(ZERO), UUID::randomUUID))
+                .build()
+                .run();
 
         ByteArrayOutputStream serial = new ByteArrayOutputStream();
 
         Runtime.builder()
-            .withRuntimeOptions(
-                new RuntimeOptionsBuilder()
-                    .setThreads(1)
-                    .addFeature(FeatureWithLines.parse("src/test/resources/io/cucumber/core/plugin/JsonPrettyFormatterTest.feature"))
-                    .build()
-            )
-            .withAdditionalPlugins(new JsonFormatter(serial))
-            .withEventBus(new TimeServiceEventBus(new ClockStub(ZERO), UUID::randomUUID))
-            .build()
-            .run();
+                .withRuntimeOptions(
+                    new RuntimeOptionsBuilder()
+                            .setThreads(1)
+                            .addFeature(FeatureWithLines.parse(
+                                "src/test/resources/io/cucumber/core/plugin/JsonPrettyFormatterTest.feature"))
+                            .build())
+                .withAdditionalPlugins(new JsonFormatter(serial))
+                .withEventBus(new TimeServiceEventBus(new ClockStub(ZERO), UUID::randomUUID))
+                .build()
+                .run();
 
         assertThat(parallel.toString(), sameJSONAs(serial.toString()).allowingAnyArrayOrdering());
     }
@@ -54,32 +54,34 @@ class JsonParallelRuntimeTest {
         ByteArrayOutputStream parallel = new ByteArrayOutputStream();
 
         Runtime.builder()
-            .withRuntimeOptions(
-                new RuntimeOptionsBuilder()
-                    .setThreads(3)
-                    .addFeature(FeatureWithLines.parse("src/test/resources/io/cucumber/core/plugin/JsonPrettyFormatterTest.feature"))
-                    .addFeature(FeatureWithLines.parse("src/test/resources/io/cucumber/core/plugin/FormatterInParallel.feature"))
-                    .build()
-            )
-            .withAdditionalPlugins(new JsonFormatter(parallel))
-            .withEventBus(new TimeServiceEventBus(new ClockStub(ZERO), UUID::randomUUID))
-            .build()
-            .run();
+                .withRuntimeOptions(
+                    new RuntimeOptionsBuilder()
+                            .setThreads(3)
+                            .addFeature(FeatureWithLines.parse(
+                                "src/test/resources/io/cucumber/core/plugin/JsonPrettyFormatterTest.feature"))
+                            .addFeature(FeatureWithLines
+                                    .parse("src/test/resources/io/cucumber/core/plugin/FormatterInParallel.feature"))
+                            .build())
+                .withAdditionalPlugins(new JsonFormatter(parallel))
+                .withEventBus(new TimeServiceEventBus(new ClockStub(ZERO), UUID::randomUUID))
+                .build()
+                .run();
 
         ByteArrayOutputStream serial = new ByteArrayOutputStream();
 
         Runtime.builder()
-            .withRuntimeOptions(
-                new RuntimeOptionsBuilder()
-                    .setThreads(1)
-                    .addFeature(FeatureWithLines.parse("src/test/resources/io/cucumber/core/plugin/JsonPrettyFormatterTest.feature"))
-                    .addFeature(FeatureWithLines.parse("src/test/resources/io/cucumber/core/plugin/FormatterInParallel.feature"))
-                    .build()
-            )
-            .withAdditionalPlugins(new JsonFormatter(serial))
-            .withEventBus(new TimeServiceEventBus(new ClockStub(ZERO), UUID::randomUUID))
-            .build()
-            .run();
+                .withRuntimeOptions(
+                    new RuntimeOptionsBuilder()
+                            .setThreads(1)
+                            .addFeature(FeatureWithLines.parse(
+                                "src/test/resources/io/cucumber/core/plugin/JsonPrettyFormatterTest.feature"))
+                            .addFeature(FeatureWithLines
+                                    .parse("src/test/resources/io/cucumber/core/plugin/FormatterInParallel.feature"))
+                            .build())
+                .withAdditionalPlugins(new JsonFormatter(serial))
+                .withEventBus(new TimeServiceEventBus(new ClockStub(ZERO), UUID::randomUUID))
+                .build()
+                .run();
 
         assertThat(parallel.toString(), sameJSONAs(serial.toString()).allowingAnyArrayOrdering());
     }

--- a/core/src/test/java/io/cucumber/core/plugin/MessageFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/MessageFormatterTest.java
@@ -23,27 +23,26 @@ public class MessageFormatterTest {
         formatter.setEventPublisher(bus);
 
         bus.send(Messages.Envelope.newBuilder()
-            .setTestRunStarted(Messages.TestRunStarted.newBuilder()
-                .setTimestamp(Messages.Timestamp.newBuilder()
-                    .setSeconds(10)
-                    .build())
-                .build())
-            .build());
+                .setTestRunStarted(Messages.TestRunStarted.newBuilder()
+                        .setTimestamp(Messages.Timestamp.newBuilder()
+                                .setSeconds(10)
+                                .build())
+                        .build())
+                .build());
 
         bus.send(
             Messages.Envelope.newBuilder()
-                .setTestRunFinished(Messages.TestRunFinished.newBuilder()
-                    .setTimestamp(Messages.Timestamp.newBuilder()
-                        .setSeconds(15)
-                        .build())
-                    .build())
-                .build());
+                    .setTestRunFinished(Messages.TestRunFinished.newBuilder()
+                            .setTimestamp(Messages.Timestamp.newBuilder()
+                                    .setSeconds(15)
+                                    .build())
+                            .build())
+                    .build());
 
         String html = new String(bytes.toByteArray(), UTF_8);
         assertThat(html, containsString("" +
-            "{\"testRunStarted\":{\"timestamp\":{\"seconds\":\"10\"}}}\n" +
-            "{\"testRunFinished\":{\"timestamp\":{\"seconds\":\"15\"}}}"
-        ));
+                "{\"testRunStarted\":{\"timestamp\":{\"seconds\":\"10\"}}}\n" +
+                "{\"testRunFinished\":{\"timestamp\":{\"seconds\":\"15\"}}}"));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/plugin/PluginFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/PluginFactoryTest.java
@@ -55,8 +55,7 @@ class PluginFactoryTest {
     void fails_to_instantiates_html_plugin_with_dir_arg() {
         assertThrows(
             IllegalArgumentException.class,
-            () -> fc.create(parse("html:" + TempDir.createTempDirectory().getAbsolutePath()))
-        );
+            () -> fc.create(parse("html:" + TempDir.createTempDirectory().getAbsolutePath())));
     }
 
     @Test
@@ -65,8 +64,7 @@ class PluginFactoryTest {
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         actualThrown.printStackTrace();
         assertThat(actualThrown.getMessage(), is(equalTo(
-            "You must supply an output argument to io.cucumber.core.plugin.PluginFactoryTest$WantsFile. Like so: io.cucumber.core.plugin.PluginFactoryTest$WantsFile:DIR|FILE|URL"
-        )));
+            "You must supply an output argument to io.cucumber.core.plugin.PluginFactoryTest$WantsFile. Like so: io.cucumber.core.plugin.PluginFactoryTest$WantsFile:DIR|FILE|URL")));
     }
 
     @Test
@@ -101,14 +99,16 @@ class PluginFactoryTest {
         try {
             System.setOut(new PrintStream(mockSystemOut));
 
-            // Need to create a new plugin factory here since we need it to pick up the new value of System.out
+            // Need to create a new plugin factory here since we need it to pick
+            // up the new value of System.out
             fc = new PluginFactory();
 
             ProgressFormatter plugin = (ProgressFormatter) fc.create(parse("progress"));
             EventBus bus = new TimeServiceEventBus(new ClockStub(ZERO), UUID::randomUUID);
             plugin.setEventPublisher(bus);
             Result result = new Result(Status.PASSED, ZERO, null);
-            TestStepFinished event = new TestStepFinished(bus.getInstant(), mock(TestCase.class), mock(PickleStepTestStep.class), result);
+            TestStepFinished event = new TestStepFinished(bus.getInstant(), mock(TestCase.class),
+                mock(PickleStepTestStep.class), result);
             bus.send(event);
 
             assertThat(mockSystemOut.toString(), is(not(equalTo(""))));
@@ -126,9 +126,8 @@ class PluginFactoryTest {
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
             "Only one plugin can use STDOUT, now both io.cucumber.core.plugin.PluginFactoryTest$WantsOutputStream " +
-                "and io.cucumber.core.plugin.PluginFactoryTest$WantsOutputStream use it. " +
-                "If you use more than one plugin you must specify output path with io.cucumber.core.plugin.PluginFactoryTest$WantsOutputStream:DIR|FILE|URL"
-        )));
+                    "and io.cucumber.core.plugin.PluginFactoryTest$WantsOutputStream use it. " +
+                    "If you use more than one plugin you must specify output path with io.cucumber.core.plugin.PluginFactoryTest$WantsOutputStream:DIR|FILE|URL")));
     }
 
     @Test
@@ -145,7 +144,8 @@ class PluginFactoryTest {
 
     @Test
     void instantiates_file_or_empty_arg_plugin_with_arg() throws IOException {
-        WantsFileOrEmpty plugin = (WantsFileOrEmpty) fc.create(parse(WantsFileOrEmpty.class.getName() + ":" + File.createTempFile("blah", "txt")));
+        WantsFileOrEmpty plugin = (WantsFileOrEmpty) fc
+                .create(parse(WantsFileOrEmpty.class.getName() + ":" + File.createTempFile("blah", "txt")));
         assertThat(plugin.out, is(notNullValue()));
     }
 
@@ -158,7 +158,8 @@ class PluginFactoryTest {
     @Test
     void instantiates_custom_deprecated_appendable_arg_plugin() throws IOException {
         String tempDirPath = TempDir.createTempFile().getAbsolutePath();
-        WantsAppendable plugin = (WantsAppendable) fc.create(parse(WantsAppendable.class.getName() + ":" + tempDirPath));
+        WantsAppendable plugin = (WantsAppendable) fc
+                .create(parse(WantsAppendable.class.getName() + ":" + tempDirPath));
         plugin.writeAndClose("hello");
         String written = new BufferedReader(new FileReader(tempDirPath)).lines().collect(Collectors.joining());
         assertThat(written, is(equalTo("hello")));
@@ -182,8 +183,7 @@ class PluginFactoryTest {
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         actualThrown.printStackTrace();
         assertThat(actualThrown.getMessage(), is(equalTo(
-            "class io.cucumber.core.plugin.PluginFactoryTest$WantsTooMuch must have at least one empty constructor or a constructor that declares a single parameter of one of: [class java.lang.String, class java.io.File, class java.net.URI, class java.net.URL, class java.io.OutputStream, interface java.lang.Appendable]"
-        )));
+            "class io.cucumber.core.plugin.PluginFactoryTest$WantsTooMuch must have at least one empty constructor or a constructor that declares a single parameter of one of: [class java.lang.String, class java.io.File, class java.net.URI, class java.net.URL, class java.io.OutputStream, interface java.lang.Appendable]")));
     }
 
     @Test
@@ -192,8 +192,7 @@ class PluginFactoryTest {
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         actualThrown.printStackTrace();
         assertThat(actualThrown.getMessage(), is(equalTo(
-            "class io.cucumber.core.plugin.PluginFactoryTest$WantsFileOrURL must have exactly one constructor that declares a single parameter of one of: [class java.lang.String, class java.io.File, class java.net.URI, class java.net.URL, class java.io.OutputStream, interface java.lang.Appendable]"
-        )));
+            "class io.cucumber.core.plugin.PluginFactoryTest$WantsFileOrURL must have exactly one constructor that declares a single parameter of one of: [class java.lang.String, class java.io.File, class java.net.URI, class java.net.URL, class java.io.OutputStream, interface java.lang.Appendable]")));
     }
 
     @Test
@@ -202,8 +201,7 @@ class PluginFactoryTest {
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         actualThrown.printStackTrace();
         assertThat(actualThrown.getMessage(), is(equalTo(
-            "You must supply an output argument to io.cucumber.core.plugin.PluginFactoryTest$WantsFileOrURL. Like so: io.cucumber.core.plugin.PluginFactoryTest$WantsFileOrURL:DIR|FILE|URL"
-        )));
+            "You must supply an output argument to io.cucumber.core.plugin.PluginFactoryTest$WantsFileOrURL. Like so: io.cucumber.core.plugin.PluginFactoryTest$WantsFileOrURL:DIR|FILE|URL")));
     }
 
     public static class WantsOutputStream extends StubFormatter {

--- a/core/src/test/java/io/cucumber/core/plugin/PluginsTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/PluginsTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({MockitoExtension.class})
+@ExtendWith({ MockitoExtension.class })
 class PluginsTest {
 
     private final PluginFactory pluginFactory = new PluginFactory();

--- a/core/src/test/java/io/cucumber/core/plugin/PrettyFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/PrettyFormatterTest.java
@@ -45,22 +45,22 @@ class PrettyFormatterTest {
     @Test
     void should_align_the_indentation_of_location_strings() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n" +
-            "    When second step\n" +
-            "    Then third step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n" +
+                "    When second step\n" +
+                "    Then third step\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToLocation.put("second step", "path/step_definitions.java:7");
         stepsToLocation.put("third step", "path/step_definitions.java:11");
 
         assertThat(runFeaturesWithFormatter(true), isBytesEqualTo("" +
-            "\n" +
-            "Scenario: scenario name # path/test.feature:2\n" +
-            "  Given first step      # path/step_definitions.java:3\n" +
-            "  When second step      # path/step_definitions.java:7\n" +
-            "  Then third step       # path/step_definitions.java:11\n"));
+                "\n" +
+                "Scenario: scenario name # path/test.feature:2\n" +
+                "  Given first step      # path/step_definitions.java:3\n" +
+                "  When second step      # path/step_definitions.java:7\n" +
+                "  Then third step       # path/step_definitions.java:11\n"));
     }
 
     private ByteArrayOutputStream runFeaturesWithFormatter(boolean monochrome) {
@@ -69,15 +69,15 @@ class PrettyFormatterTest {
         formatter.setMonochrome(monochrome);
 
         TestHelper.builder()
-            .withFormatterUnderTest(formatter)
-            .withFeatures(features)
-            .withStepsToResult(stepsToResult)
-            .withStepsToLocation(stepsToLocation)
-            .withHooks(hooks)
-            .withHookLocations(hookLocations)
-            .withHookActions(hookActions)
-            .build()
-            .run();
+                .withFormatterUnderTest(formatter)
+                .withFeatures(features)
+                .withStepsToResult(stepsToResult)
+                .withStepsToLocation(stepsToLocation)
+                .withHooks(hooks)
+                .withHookLocations(hookLocations)
+                .withHookActions(hookActions)
+                .build()
+                .run();
 
         return report;
     }
@@ -85,108 +85,108 @@ class PrettyFormatterTest {
     @Test
     void should_handle_background() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Background: background name\n" +
-            "    Given first step\n" +
-            "  Scenario: s1\n" +
-            "    Then second step\n" +
-            "  Scenario: s2\n" +
-            "    Then third step\n");
+                "Feature: feature name\n" +
+                "  Background: background name\n" +
+                "    Given first step\n" +
+                "  Scenario: s1\n" +
+                "    Then second step\n" +
+                "  Scenario: s2\n" +
+                "    Then third step\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToLocation.put("second step", "path/step_definitions.java:7");
         stepsToLocation.put("third step", "path/step_definitions.java:11");
 
         assertThat(runFeaturesWithFormatter(true), bytesContainsString("" +
-            "\n" +
-            "Scenario: s1       # path/test.feature:4\n" +
-            "  Given first step # path/step_definitions.java:3\n" +
-            "  Then second step # path/step_definitions.java:7\n" +
-            "\n" +
-            "Scenario: s2       # path/test.feature:6\n" +
-            "  Given first step # path/step_definitions.java:3\n" +
-            "  Then third step  # path/step_definitions.java:11\n"));
+                "\n" +
+                "Scenario: s1       # path/test.feature:4\n" +
+                "  Given first step # path/step_definitions.java:3\n" +
+                "  Then second step # path/step_definitions.java:7\n" +
+                "\n" +
+                "Scenario: s2       # path/test.feature:6\n" +
+                "  Given first step # path/step_definitions.java:3\n" +
+                "  Then third step  # path/step_definitions.java:11\n"));
     }
 
     @Test
     void should_handle_scenario_outline() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario Outline: <name>\n" +
-            "    Given first step\n" +
-            "    Then <arg> step\n" +
-            "    Examples: examples name\n" +
-            "      |  name  |  arg   |\n" +
-            "      | name 1 | second |\n" +
-            "      | name 2 | third  |\n");
+                "Feature: feature name\n" +
+                "  Scenario Outline: <name>\n" +
+                "    Given first step\n" +
+                "    Then <arg> step\n" +
+                "    Examples: examples name\n" +
+                "      |  name  |  arg   |\n" +
+                "      | name 1 | second |\n" +
+                "      | name 2 | third  |\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToLocation.put("second step", "path/step_definitions.java:7");
         stepsToLocation.put("third step", "path/step_definitions.java:11");
 
         assertThat(runFeaturesWithFormatter(true), bytesContainsString("" +
-            "\n" +
-            "Scenario Outline: name 1 # path/test.feature:7\n" +
-            "  Given first step       # path/step_definitions.java:3\n" +
-            "  Then second step       # path/step_definitions.java:7\n" +
-            "\n" +
-            "Scenario Outline: name 2 # path/test.feature:8\n" +
-            "  Given first step       # path/step_definitions.java:3\n" +
-            "  Then third step        # path/step_definitions.java:11\n"));
+                "\n" +
+                "Scenario Outline: name 1 # path/test.feature:7\n" +
+                "  Given first step       # path/step_definitions.java:3\n" +
+                "  Then second step       # path/step_definitions.java:7\n" +
+                "\n" +
+                "Scenario Outline: name 2 # path/test.feature:8\n" +
+                "  Given first step       # path/step_definitions.java:3\n" +
+                "  Then third step        # path/step_definitions.java:11\n"));
     }
 
     @Test
     void should_print_tags() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "@feature_tag\n" +
-            "Feature: feature name\n" +
-            "  @scenario_tag\n" +
-            "  Scenario: scenario name\n" +
-            "    Then second step\n" +
-            "  @scenario_outline_tag\n" +
-            "  Scenario Outline: scenario outline name\n" +
-            "    Then <arg> step\n" +
-            "    @examples_tag\n" +
-            "    Examples: examples name\n" +
-            "      |  arg   |\n" +
-            "      | third  |\n");
+                "@feature_tag\n" +
+                "Feature: feature name\n" +
+                "  @scenario_tag\n" +
+                "  Scenario: scenario name\n" +
+                "    Then second step\n" +
+                "  @scenario_outline_tag\n" +
+                "  Scenario Outline: scenario outline name\n" +
+                "    Then <arg> step\n" +
+                "    @examples_tag\n" +
+                "    Examples: examples name\n" +
+                "      |  arg   |\n" +
+                "      | third  |\n");
         features.add(feature);
         stepsToLocation.put("second step", "path/step_definitions.java:7");
         stepsToLocation.put("third step", "path/step_definitions.java:11");
 
         assertThat(runFeaturesWithFormatter(true), isBytesEqualTo("" +
 
-            "\n" +
-            "@feature_tag @scenario_tag\n" +
-            "Scenario: scenario name # path/test.feature:4\n" +
-            "  Then second step      # path/step_definitions.java:7\n" +
-            "\n" +
-            "@feature_tag @scenario_outline_tag @examples_tag\n" +
-            "Scenario Outline: scenario outline name # path/test.feature:12\n" +
-            "  Then third step                       # path/step_definitions.java:11\n"));
+                "\n" +
+                "@feature_tag @scenario_tag\n" +
+                "Scenario: scenario name # path/test.feature:4\n" +
+                "  Then second step      # path/step_definitions.java:7\n" +
+                "\n" +
+                "@feature_tag @scenario_outline_tag @examples_tag\n" +
+                "Scenario Outline: scenario outline name # path/test.feature:12\n" +
+                "  Then third step                       # path/step_definitions.java:11\n"));
     }
 
     @Test
     void should_print_error_message_for_failed_steps() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToResult.put("first step", result("failed"));
 
         assertThat(runFeaturesWithFormatter(true), bytesContainsString("" +
-            "  Given first step      # path/step_definitions.java:3\n" +
-            "      the stack trace\n"));
+                "  Given first step      # path/step_definitions.java:3\n" +
+                "      the stack trace\n"));
     }
 
     @Test
     void should_print_error_message_for_before_hooks() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToResult.put("first step", result("passed"));
@@ -194,17 +194,17 @@ class PrettyFormatterTest {
         hookLocations.add("hook-location");
 
         assertThat(runFeaturesWithFormatter(true), bytesContainsString("" +
-            "Scenario: scenario name # path/test.feature:2\n" +
-            "      the stack trace\n" +
-            "  Given first step      # path/step_definitions.java:3\n"));
+                "Scenario: scenario name # path/test.feature:2\n" +
+                "      the stack trace\n" +
+                "  Given first step      # path/step_definitions.java:3\n"));
     }
 
     @Test
     void should_print_error_message_for_after_hooks() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToResult.put("first step", result("passed"));
@@ -212,16 +212,16 @@ class PrettyFormatterTest {
         hookLocations.add("hook-location");
 
         assertThat(runFeaturesWithFormatter(true), bytesContainsString("" +
-            "  Given first step      # path/step_definitions.java:3\n" +
-            "      the stack trace\n"));
+                "  Given first step      # path/step_definitions.java:3\n" +
+                "      the stack trace\n"));
     }
 
     @Test
     void should_print_output_from_before_hooks() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToResult.put("first step", result("passed"));
@@ -230,19 +230,19 @@ class PrettyFormatterTest {
         hookActions.add(createWriteHookAction("printed from hook"));
 
         assertThat(runFeaturesWithFormatter(true), bytesContainsString("" +
-            "Scenario: scenario name # path/test.feature:2\n" +
-            "\n" +
-            "    printed from hook\n" +
-            "\n" +
-            "  Given first step      # path/step_definitions.java:3\n"));
+                "Scenario: scenario name # path/test.feature:2\n" +
+                "\n" +
+                "    printed from hook\n" +
+                "\n" +
+                "  Given first step      # path/step_definitions.java:3\n"));
     }
 
     @Test
     void should_print_output_from_after_hooks() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToResult.put("first step", result("passed"));
@@ -251,18 +251,18 @@ class PrettyFormatterTest {
         hookActions.add(createWriteHookAction("printed from hook"));
 
         assertThat(runFeaturesWithFormatter(true), bytesContainsString("" +
-            "  Given first step      # path/step_definitions.java:3\n" +
-            "\n" +
-            "    printed from hook\n"));
+                "  Given first step      # path/step_definitions.java:3\n" +
+                "\n" +
+                "    printed from hook\n"));
     }
 
     @Test
     void should_print_output_from_afterStep_hooks() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n" +
-            "    When second step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n" +
+                "    When second step\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToLocation.put("second step", "path/step_definitions.java:4");
@@ -273,56 +273,57 @@ class PrettyFormatterTest {
         hookActions.add(createWriteHookAction("printed from afterstep hook"));
 
         assertThat(runFeaturesWithFormatter(true), bytesContainsString("" +
-            "  Given first step      # path/step_definitions.java:3\n" +
-            "\n" +
-            "    printed from afterstep hook\n" +
-            "\n" +
-            "  When second step      # path/step_definitions.java:4\n" +
-            "\n" +
-            "    printed from afterstep hook" +
-            "\n"));
+                "  Given first step      # path/step_definitions.java:3\n" +
+                "\n" +
+                "    printed from afterstep hook\n" +
+                "\n" +
+                "  When second step      # path/step_definitions.java:4\n" +
+                "\n" +
+                "    printed from afterstep hook" +
+                "\n"));
     }
 
     @Test
     void should_color_code_steps_according_to_the_result() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToResult.put("first step", result("passed"));
 
         assertThat(runFeaturesWithFormatter(false), bytesContainsString("" +
-            "  " + AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET + AnsiEscapes.GREEN + "first step" + AnsiEscapes.RESET));
+                "  " + AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET + AnsiEscapes.GREEN + "first step"
+                + AnsiEscapes.RESET));
     }
 
     @Test
     void should_color_code_locations_as_comments() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToResult.put("first step", result("passed"));
 
         assertThat(runFeaturesWithFormatter(false), bytesContainsString("" +
-            AnsiEscapes.GREY + "# path/step_definitions.java:3" + AnsiEscapes.RESET + "\n"));
+                AnsiEscapes.GREY + "# path/step_definitions.java:3" + AnsiEscapes.RESET + "\n"));
     }
 
     @Test
     void should_color_code_error_message_according_to_the_result() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "path/step_definitions.java:3");
         stepsToResult.put("first step", result("failed"));
 
         assertThat(runFeaturesWithFormatter(false), bytesContainsString("" +
-            "      " + AnsiEscapes.RED + "the stack trace" + AnsiEscapes.RESET + "\n"));
+                "      " + AnsiEscapes.RED + "the stack trace" + AnsiEscapes.RESET + "\n"));
     }
 
     @Test
@@ -336,13 +337,14 @@ class PrettyFormatterTest {
 
         PrettyFormatter prettyFormatter = new PrettyFormatter(new ByteArrayOutputStream());
         String stepText = "text 'arg1' text 'arg2'";
-        String formattedText = prettyFormatter.formatStepText("Given ", stepText, formats.get("passed"), formats.get("passed_arg"), createArguments(expression.match(stepText)));
+        String formattedText = prettyFormatter.formatStepText("Given ", stepText, formats.get("passed"),
+            formats.get("passed_arg"), createArguments(expression.match(stepText)));
 
         assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + "text " + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "'arg1'" + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + " text " + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "'arg2'" + AnsiEscapes.RESET));
+                AnsiEscapes.GREEN + "text " + AnsiEscapes.RESET +
+                AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "'arg1'" + AnsiEscapes.RESET +
+                AnsiEscapes.GREEN + " text " + AnsiEscapes.RESET +
+                AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + "'arg2'" + AnsiEscapes.RESET));
     }
 
     @Test
@@ -351,17 +353,19 @@ class PrettyFormatterTest {
 
         StepTypeRegistry registry = new StepTypeRegistry(Locale.ENGLISH);
         StepExpressionFactory stepExpressionFactory = new StepExpressionFactory(registry, bus);
-        StepDefinition stepDefinition = new StubStepDefinition("^the order is placed( and (not yet )?confirmed)?$", String.class);
+        StepDefinition stepDefinition = new StubStepDefinition("^the order is placed( and (not yet )?confirmed)?$",
+            String.class);
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
 
         PrettyFormatter prettyFormatter = new PrettyFormatter(new ByteArrayOutputStream());
         String stepText = "the order is placed and not yet confirmed";
 
-        String formattedText = prettyFormatter.formatStepText("Given ", stepText, formats.get("passed"), formats.get("passed_arg"), createArguments(expression.match(stepText)));
+        String formattedText = prettyFormatter.formatStepText("Given ", stepText, formats.get("passed"),
+            formats.get("passed_arg"), createArguments(expression.match(stepText)));
 
         assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + "the order is placed" + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + " and not yet confirmed" + AnsiEscapes.RESET));
+                AnsiEscapes.GREEN + "the order is placed" + AnsiEscapes.RESET +
+                AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + " and not yet confirmed" + AnsiEscapes.RESET));
     }
 
     @Test
@@ -370,15 +374,16 @@ class PrettyFormatterTest {
         PrettyFormatter prettyFormatter = new PrettyFormatter(new ByteArrayOutputStream());
         StepTypeRegistry registry = new StepTypeRegistry(Locale.ENGLISH);
         StepExpressionFactory stepExpressionFactory = new StepExpressionFactory(registry, bus);
-        StepDefinition stepDefinition = new StubStepDefinition("^the order is placed( and (not( yet)? )?confirmed)?$", String.class);
+        StepDefinition stepDefinition = new StubStepDefinition("^the order is placed( and (not( yet)? )?confirmed)?$",
+            String.class);
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         String stepText = "the order is placed and not yet confirmed";
-        String formattedText = prettyFormatter.formatStepText("Given ", stepText, formats.get("passed"), formats.get("passed_arg"), createArguments(expression.match(stepText)));
-
+        String formattedText = prettyFormatter.formatStepText("Given ", stepText, formats.get("passed"),
+            formats.get("passed_arg"), createArguments(expression.match(stepText)));
 
         assertThat(formattedText, equalTo(AnsiEscapes.GREEN + "Given " + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + "the order is placed" + AnsiEscapes.RESET +
-            AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + " and not yet confirmed" + AnsiEscapes.RESET));
+                AnsiEscapes.GREEN + "the order is placed" + AnsiEscapes.RESET +
+                AnsiEscapes.GREEN + AnsiEscapes.INTENSITY_BOLD + " and not yet confirmed" + AnsiEscapes.RESET));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/plugin/RerunFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/RerunFormatterTest.java
@@ -28,12 +28,11 @@ class RerunFormatterTest {
     @Test
     void should_leave_report_empty_when_exit_code_is_zero() {
         Feature feature = TestFeatureParser.parse("classpath:path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: passed scenario\n" +
-            "    Given passed step\n" +
-            "  Scenario: skipped scenario\n" +
-            "    Given skipped step\n"
-        );
+                "Feature: feature name\n" +
+                "  Scenario: passed scenario\n" +
+                "    Given passed step\n" +
+                "  Scenario: skipped scenario\n" +
+                "    Given skipped step\n");
         features.add(feature);
         stepsToResult.put("passed step", result("passed"));
         stepsToResult.put("skipped step", result("skipped"));
@@ -46,14 +45,14 @@ class RerunFormatterTest {
         final RerunFormatter formatter = new RerunFormatter(report);
 
         TestHelper.builder()
-            .withFormatterUnderTest(formatter)
-            .withFeatures(features)
-            .withStepsToResult(stepsToResult)
-            .withHooks(hooks)
-            .withHookLocations(hookLocations)
-            .withTimeServiceIncrement(ZERO)
-            .build()
-            .run();
+                .withFormatterUnderTest(formatter)
+                .withFeatures(features)
+                .withStepsToResult(stepsToResult)
+                .withHooks(hooks)
+                .withHookLocations(hookLocations)
+                .withTimeServiceIncrement(ZERO)
+                .build()
+                .run();
 
         return report;
     }
@@ -61,13 +60,13 @@ class RerunFormatterTest {
     @Test
     void should_put_data_in_report_when_exit_code_is_non_zero() {
         Feature feature = TestFeatureParser.parse("classpath:path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: failed scenario\n" +
-            "    Given failed step\n" +
-            "  Scenario: pending scenario\n" +
-            "    Given pending step\n" +
-            "  Scenario: undefined scenario\n" +
-            "    Given undefined step\n");
+                "Feature: feature name\n" +
+                "  Scenario: failed scenario\n" +
+                "    Given failed step\n" +
+                "  Scenario: pending scenario\n" +
+                "    Given pending step\n" +
+                "  Scenario: undefined scenario\n" +
+                "    Given undefined step\n");
         features.add(feature);
         stepsToResult.put("failed step", result("failed"));
         stepsToResult.put("pending step", result("pending"));
@@ -79,11 +78,11 @@ class RerunFormatterTest {
     @Test
     void should_use_scenario_location_when_scenario_step_fails() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n" +
-            "    When second step\n" +
-            "    Then third step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n" +
+                "    When second step\n" +
+                "    Then third step\n");
         features.add(feature);
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
@@ -95,12 +94,12 @@ class RerunFormatterTest {
     @Test
     void should_use_scenario_location_when_background_step_fails() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Background: the background\n" +
-            "    Given background step\n" +
-            "  Scenario: scenario name\n" +
-            "    When second step\n" +
-            "    Then third step\n");
+                "Feature: feature name\n" +
+                "  Background: the background\n" +
+                "    Given background step\n" +
+                "  Scenario: scenario name\n" +
+                "    When second step\n" +
+                "    Then third step\n");
         features.add(feature);
         stepsToResult.put("background step", result("failed"));
         stepsToResult.put("second step", result("passed"));
@@ -112,14 +111,14 @@ class RerunFormatterTest {
     @Test
     void should_use_example_row_location_when_scenario_outline_fails() {
         Feature feature = TestFeatureParser.parse("classpath:path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario Outline: scenario name\n" +
-            "    When executing <row> row\n" +
-            "    Then everything is ok\n" +
-            "    Examples:\n" +
-            "    |  row   |\n" +
-            "    | first  |\n" +
-            "    | second |");
+                "Feature: feature name\n" +
+                "  Scenario Outline: scenario name\n" +
+                "    When executing <row> row\n" +
+                "    Then everything is ok\n" +
+                "    Examples:\n" +
+                "    |  row   |\n" +
+                "    | first  |\n" +
+                "    | second |");
         features.add(feature);
         stepsToResult.put("executing first row", result("passed"));
         stepsToResult.put("executing second row", result("failed"));
@@ -131,11 +130,11 @@ class RerunFormatterTest {
     @Test
     void should_use_scenario_location_when_before_hook_fails() {
         Feature feature = TestFeatureParser.parse("classpath:path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n" +
-            "    When second step\n" +
-            "    Then third step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n" +
+                "    When second step\n" +
+                "    Then third step\n");
         features.add(feature);
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
@@ -149,11 +148,11 @@ class RerunFormatterTest {
     @Test
     void should_use_scenario_location_when_after_hook_fails() {
         Feature feature = TestFeatureParser.parse("classpath:path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n" +
-            "    When second step\n" +
-            "    Then third step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n" +
+                "    When second step\n" +
+                "    Then third step\n");
         features.add(feature);
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
@@ -167,13 +166,13 @@ class RerunFormatterTest {
     @Test
     void should_one_entry_for_feature_with_many_failing_scenarios() {
         Feature feature = TestFeatureParser.parse("classpath:path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario 1 name\n" +
-            "    When first step\n" +
-            "    Then second step\n" +
-            "  Scenario: scenario 2 name\n" +
-            "    When third step\n" +
-            "    Then forth step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario 1 name\n" +
+                "    When first step\n" +
+                "    Then second step\n" +
+                "  Scenario: scenario 2 name\n" +
+                "    When third step\n" +
+                "    Then forth step\n");
         features.add(feature);
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("failed"));
@@ -186,15 +185,15 @@ class RerunFormatterTest {
     @Test
     void should_one_entry_for_each_failing_feature() {
         Feature feature1 = TestFeatureParser.parse("classpath:path/first.feature", "" +
-            "Feature: feature 1 name\n" +
-            "  Scenario: scenario 1 name\n" +
-            "    When first step\n" +
-            "    Then second step\n");
+                "Feature: feature 1 name\n" +
+                "  Scenario: scenario 1 name\n" +
+                "    When first step\n" +
+                "    Then second step\n");
         Feature feature2 = TestFeatureParser.parse("classpath:path/second.feature", "" +
-            "Feature: feature 2 name\n" +
-            "  Scenario: scenario 2 name\n" +
-            "    When third step\n" +
-            "    Then forth step\n");
+                "Feature: feature 2 name\n" +
+                "  Scenario: scenario 2 name\n" +
+                "    When third step\n" +
+                "    Then forth step\n");
         features.add(feature1);
         features.add(feature2);
         stepsToResult.put("first step", result("passed"));
@@ -202,7 +201,8 @@ class RerunFormatterTest {
         stepsToResult.put("third step", result("failed"));
         stepsToResult.put("forth step", result("passed"));
 
-        assertThat(runFeaturesWithFormatter(), isBytesEqualTo("classpath:path/first.feature:2\nclasspath:path/second.feature:2\n"));
+        assertThat(runFeaturesWithFormatter(),
+            isBytesEqualTo("classpath:path/first.feature:2\nclasspath:path/second.feature:2\n"));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/plugin/StatsTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/StatsTest.java
@@ -29,7 +29,7 @@ class StatsTest {
 
         assertThat(baos.toString(), startsWith(String.format(
             "0 Scenarios%n" +
-                "0 Steps%n")));
+                    "0 Steps%n")));
     }
 
     private Stats createMonochromeSummaryCounter() {
@@ -51,7 +51,7 @@ class StatsTest {
 
         assertThat(baos.toString(), startsWith(String.format(
             "1 Scenarios (1 passed)%n" +
-                "3 Steps (3 passed)%n")));
+                    "3 Steps (3 passed)%n")));
     }
 
     @Test
@@ -68,8 +68,8 @@ class StatsTest {
         counter.printStats(new PrintStream(baos));
 
         assertThat(baos.toString(), containsString(String.format("" +
-            "6 Scenarios (1 failed, 1 ambiguous, 1 skipped, 1 pending, 1 undefined, 1 passed)%n" +
-            "6 Steps (1 failed, 1 ambiguous, 1 skipped, 1 pending, 1 undefined, 1 passed)%n")));
+                "6 Scenarios (1 failed, 1 ambiguous, 1 skipped, 1 pending, 1 undefined, 1 passed)%n" +
+                "6 Steps (1 failed, 1 ambiguous, 1 skipped, 1 pending, 1 undefined, 1 passed)%n")));
     }
 
     private void addOneStepScenario(Stats counter, Status status) {
@@ -91,15 +91,15 @@ class StatsTest {
         counter.printStats(new PrintStream(baos));
 
         String colorSubCounts = "" +
-            AnsiEscapes.RED + "1 failed" + AnsiEscapes.RESET + ", " +
-            AnsiEscapes.RED + "1 ambiguous" + AnsiEscapes.RESET + ", " +
-            AnsiEscapes.CYAN + "1 skipped" + AnsiEscapes.RESET + ", " +
-            AnsiEscapes.YELLOW + "1 pending" + AnsiEscapes.RESET + ", " +
-            AnsiEscapes.YELLOW + "1 undefined" + AnsiEscapes.RESET + ", " +
-            AnsiEscapes.GREEN + "1 passed" + AnsiEscapes.RESET;
+                AnsiEscapes.RED + "1 failed" + AnsiEscapes.RESET + ", " +
+                AnsiEscapes.RED + "1 ambiguous" + AnsiEscapes.RESET + ", " +
+                AnsiEscapes.CYAN + "1 skipped" + AnsiEscapes.RESET + ", " +
+                AnsiEscapes.YELLOW + "1 pending" + AnsiEscapes.RESET + ", " +
+                AnsiEscapes.YELLOW + "1 undefined" + AnsiEscapes.RESET + ", " +
+                AnsiEscapes.GREEN + "1 passed" + AnsiEscapes.RESET;
         assertThat(baos.toString(), containsString(String.format("" +
-            "6 Scenarios (" + colorSubCounts + ")%n" +
-            "6 Steps (" + colorSubCounts + ")%n")));
+                "6 Scenarios (" + colorSubCounts + ")%n" +
+                "6 Steps (" + colorSubCounts + ")%n")));
     }
 
     private Stats createColorSummaryCounter() {
@@ -184,19 +184,19 @@ class StatsTest {
         counter.printStats(new PrintStream(baos));
 
         assertThat(baos.toString(), startsWith(String.format("" +
-            "Failed scenarios:%n" +
-            "path/file.feature:3 # Scenario: scenario_name%n" +
-            "%n" +
-            "Ambiguous scenarios:%n" +
-            "path/file.feature:3 # Scenario: scenario_name%n" +
-            "%n" +
-            "Pending scenarios:%n" +
-            "path/file.feature:3 # Scenario: scenario_name%n" +
-            "%n" +
-            "Undefined scenarios:%n" +
-            "path/file.feature:3 # Scenario: scenario_name%n" +
-            "%n" +
-            "4 Scenarios")));
+                "Failed scenarios:%n" +
+                "path/file.feature:3 # Scenario: scenario_name%n" +
+                "%n" +
+                "Ambiguous scenarios:%n" +
+                "path/file.feature:3 # Scenario: scenario_name%n" +
+                "%n" +
+                "Pending scenarios:%n" +
+                "path/file.feature:3 # Scenario: scenario_name%n" +
+                "%n" +
+                "Undefined scenarios:%n" +
+                "path/file.feature:3 # Scenario: scenario_name%n" +
+                "%n" +
+                "4 Scenarios")));
     }
 
     @Test
@@ -215,19 +215,19 @@ class StatsTest {
         counter.printStats(new PrintStream(baos));
 
         assertThat(baos.toString(), startsWith(String.format("" +
-            "Failed scenarios:%n" +
-            "path/file.feature:3 # Scenario: scenario_name%n" +
-            "%n" +
-            "Ambiguous scenarios:%n" +
-            "path/file.feature:3 # Scenario: scenario_name%n" +
-            "%n" +
-            "Pending scenarios:%n" +
-            "path/file.feature:3 # Scenario: scenario_name%n" +
-            "%n" +
-            "Undefined scenarios:%n" +
-            "path/file.feature:3 # Scenario: scenario_name%n" +
-            "%n" +
-            "4 Scenarios")));
+                "Failed scenarios:%n" +
+                "path/file.feature:3 # Scenario: scenario_name%n" +
+                "%n" +
+                "Ambiguous scenarios:%n" +
+                "path/file.feature:3 # Scenario: scenario_name%n" +
+                "%n" +
+                "Pending scenarios:%n" +
+                "path/file.feature:3 # Scenario: scenario_name%n" +
+                "%n" +
+                "Undefined scenarios:%n" +
+                "path/file.feature:3 # Scenario: scenario_name%n" +
+                "%n" +
+                "4 Scenarios")));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/plugin/TeamCityPluginTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/TeamCityPluginTest.java
@@ -40,14 +40,14 @@ class TeamCityPluginTest {
     @Test
     void should_handle_scenario_outline() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario Outline: <name>\n" +
-            "    Given first step\n" +
-            "    Then <arg> step\n" +
-            "    Examples: examples name\n" +
-            "      |  name  |  arg   |\n" +
-            "      | name 1 | second |\n" +
-            "      | name 2 | third  |\n");
+                "Feature: feature name\n" +
+                "  Scenario Outline: <name>\n" +
+                "    Given first step\n" +
+                "    Then <arg> step\n" +
+                "    Examples: examples name\n" +
+                "      |  name  |  arg   |\n" +
+                "      | name 1 | second |\n" +
+                "      | name 2 | third  |\n");
         features.add(feature);
         stepsToLocation.put("first step", "com.example.StepDefinition.firstStep()");
         stepsToLocation.put("second step", "com.example.StepDefinition.secondStep()");
@@ -56,34 +56,48 @@ class TeamCityPluginTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         assertThat(formatterOutput, containsString("" +
-            "##teamcity[enteredTheMatrix timestamp = '1970-01-01T12:00:00.000+0000']\n" +
-            "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' name = 'Cucumber']\n" +
-            "##teamcity[customProgressStatus testsCategory = 'Scenarios' count = '0' timestamp = '1970-01-01T12:00:00.000+0000']\n" +
-            "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location + "path/test.feature:1' name = 'feature name']\n" +
-            "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location + "path/test.feature:2' name = '<name>']\n" +
-            "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location + "path/test.feature:5' name = 'examples name']\n" +
-            "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location + "path/test.feature:7' name = 'Example #1']\n" +
-            "##teamcity[customProgressStatus type = 'testStarted' timestamp = '1970-01-01T12:00:00.000+0000']\n" +
-            "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location + "path/test.feature:3' captureStandardOutput = 'true' name = 'first step']\n" +
-            "##teamcity[testFinished timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' name = 'first step']\n" +
-            "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location + "path/test.feature:4' captureStandardOutput = 'true' name = 'second step']\n" +
-            "##teamcity[testFinished timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' name = 'second step']\n" +
-            "##teamcity[customProgressStatus type = 'testFinished' timestamp = '1970-01-01T12:00:00.000+0000']\n" +
-            "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = 'Example #1']\n" +
-            "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location + "path/test.feature:8' name = 'Example #2']\n" +
-            "##teamcity[customProgressStatus type = 'testStarted' timestamp = '1970-01-01T12:00:00.000+0000']\n" +
-            "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location + "path/test.feature:3' captureStandardOutput = 'true' name = 'first step']\n" +
-            "##teamcity[testFinished timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' name = 'first step']\n" +
-            "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location + "path/test.feature:4' captureStandardOutput = 'true' name = 'third step']\n" +
-            "##teamcity[testFinished timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' name = 'third step']\n" +
-            "##teamcity[customProgressStatus type = 'testFinished' timestamp = '1970-01-01T12:00:00.000+0000']\n" +
-            "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = 'Example #2']\n" +
-            "##teamcity[customProgressStatus testsCategory = '' count = '0' timestamp = '1970-01-01T12:00:00.000+0000']\n" +
-            "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = 'examples name']\n" +
-            "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = '<name>']\n" +
-            "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = 'feature name']\n" +
-            "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = 'Cucumber']\n"
-        ));
+                "##teamcity[enteredTheMatrix timestamp = '1970-01-01T12:00:00.000+0000']\n" +
+                "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' name = 'Cucumber']\n" +
+                "##teamcity[customProgressStatus testsCategory = 'Scenarios' count = '0' timestamp = '1970-01-01T12:00:00.000+0000']\n"
+                +
+                "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location
+                + "path/test.feature:1' name = 'feature name']\n" +
+                "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location
+                + "path/test.feature:2' name = '<name>']\n" +
+                "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location
+                + "path/test.feature:5' name = 'examples name']\n" +
+                "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location
+                + "path/test.feature:7' name = 'Example #1']\n" +
+                "##teamcity[customProgressStatus type = 'testStarted' timestamp = '1970-01-01T12:00:00.000+0000']\n" +
+                "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location
+                + "path/test.feature:3' captureStandardOutput = 'true' name = 'first step']\n" +
+                "##teamcity[testFinished timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' name = 'first step']\n"
+                +
+                "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location
+                + "path/test.feature:4' captureStandardOutput = 'true' name = 'second step']\n" +
+                "##teamcity[testFinished timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' name = 'second step']\n"
+                +
+                "##teamcity[customProgressStatus type = 'testFinished' timestamp = '1970-01-01T12:00:00.000+0000']\n" +
+                "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = 'Example #1']\n" +
+                "##teamcity[testSuiteStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location
+                + "path/test.feature:8' name = 'Example #2']\n" +
+                "##teamcity[customProgressStatus type = 'testStarted' timestamp = '1970-01-01T12:00:00.000+0000']\n" +
+                "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location
+                + "path/test.feature:3' captureStandardOutput = 'true' name = 'first step']\n" +
+                "##teamcity[testFinished timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' name = 'first step']\n"
+                +
+                "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '" + location
+                + "path/test.feature:4' captureStandardOutput = 'true' name = 'third step']\n" +
+                "##teamcity[testFinished timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' name = 'third step']\n"
+                +
+                "##teamcity[customProgressStatus type = 'testFinished' timestamp = '1970-01-01T12:00:00.000+0000']\n" +
+                "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = 'Example #2']\n" +
+                "##teamcity[customProgressStatus testsCategory = '' count = '0' timestamp = '1970-01-01T12:00:00.000+0000']\n"
+                +
+                "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = 'examples name']\n" +
+                "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = '<name>']\n" +
+                "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = 'feature name']\n" +
+                "##teamcity[testSuiteFinished timestamp = '1970-01-01T12:00:00.000+0000' name = 'Cucumber']\n"));
     }
 
     private String runFeaturesWithFormatter() {
@@ -92,15 +106,15 @@ class TeamCityPluginTest {
         final TeamCityPlugin formatter = new TeamCityPlugin(printStream);
 
         TestHelper.builder()
-            .withFormatterUnderTest(formatter)
-            .withFeatures(features)
-            .withStepsToResult(stepsToResult)
-            .withStepsToLocation(stepsToLocation)
-            .withHooks(hooks)
-            .withHookLocations(hookLocations)
-            .withHookActions(hookActions)
-            .build()
-            .run();
+                .withFormatterUnderTest(formatter)
+                .withFeatures(features)
+                .withStepsToResult(stepsToResult)
+                .withStepsToLocation(stepsToLocation)
+                .withHooks(hooks)
+                .withHookLocations(hookLocations)
+                .withHookActions(hookActions)
+                .build()
+                .run();
 
         return new String(byteArrayOutputStream.toByteArray(), UTF_8);
     }
@@ -108,9 +122,9 @@ class TeamCityPluginTest {
     @Test
     void should_handle_nameless_attach_events() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "com.example.StepDefinition.firstStep()");
         stepsToResult.put("first step", result("passed"));
@@ -123,16 +137,15 @@ class TeamCityPluginTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         assertThat(formatterOutput, containsString("" +
-            "##teamcity[message text='Embed event: |[text/plain 9 bytes|]|n' status='NORMAL']\n"
-        ));
+                "##teamcity[message text='Embed event: |[text/plain 9 bytes|]|n' status='NORMAL']\n"));
     }
 
     @Test
     void should_handle_write_events() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "com.example.StepDefinition.firstStep()");
         stepsToResult.put("first step", result("passed"));
@@ -145,16 +158,15 @@ class TeamCityPluginTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         assertThat(formatterOutput, containsString("" +
-            "##teamcity[message text='Write event:|nA message|n' status='NORMAL']\n"
-        ));
+                "##teamcity[message text='Write event:|nA message|n' status='NORMAL']\n"));
     }
 
     @Test
     void should_handle_attach_events() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "com.example.StepDefinition.firstStep()");
         stepsToResult.put("first step", result("passed"));
@@ -167,16 +179,15 @@ class TeamCityPluginTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         assertThat(formatterOutput, containsString("" +
-            "##teamcity[message text='Embed event: message.txt |[text/plain 9 bytes|]|n' status='NORMAL']\n"
-        ));
+                "##teamcity[message text='Embed event: message.txt |[text/plain 9 bytes|]|n' status='NORMAL']\n"));
     }
 
     @Test
     void should_print_error_message_for_failed_steps() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "com.example.StepDefinition.firstStep()");
         stepsToResult.put("first step", result("failed"));
@@ -184,16 +195,15 @@ class TeamCityPluginTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         assertThat(formatterOutput, containsString("" +
-            "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step failed' details = 'the stack trace' name = 'first step']\n"
-        ));
+                "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step failed' details = 'the stack trace' name = 'first step']\n"));
     }
 
     @Test
     void should_print_error_message_for_undefined_steps() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "com.example.StepDefinition.firstStep()");
         stepsToResult.put("first step", result("undefined"));
@@ -201,16 +211,15 @@ class TeamCityPluginTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         assertThat(formatterOutput, containsString("" +
-            "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step undefined' details = 'You can implement missing steps with the snippets below:|n|n' name = 'first step']\n"
-        ));
+                "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step undefined' details = 'You can implement missing steps with the snippets below:|n|n' name = 'first step']\n"));
     }
 
     @Test
     void should_print_error_message_for_before_hooks() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Given first step\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
         features.add(feature);
         stepsToLocation.put("first step", "com.example.StepDefinition.firstStep()");
         stepsToResult.put("first step", result("passed"));
@@ -220,9 +229,9 @@ class TeamCityPluginTest {
         String formatterOutput = runFeaturesWithFormatter();
 
         assertThat(formatterOutput, containsString("" +
-            "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = 'java:test://com.example.HookDefinition/beforeHook' captureStandardOutput = 'true' name = 'Before']\n" +
-            "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step failed' details = 'the stack trace' name = 'Before']"
-        ));
+                "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = 'java:test://com.example.HookDefinition/beforeHook' captureStandardOutput = 'true' name = 'Before']\n"
+                +
+                "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step failed' details = 'the stack trace' name = 'Before']"));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/plugin/TestNGFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/TestNGFormatterTest.java
@@ -36,36 +36,39 @@ final class TestNGFormatterTest {
     @Test
     void testScenarioWithUndefinedSteps() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature\n" +
-            "  Scenario: scenario\n" +
-            "    When step\n" +
-            "    Then step\n");
+                "Feature: feature\n" +
+                "  Scenario: scenario\n" +
+                "    When step\n" +
+                "    Then step\n");
         features.add(feature);
         stepsToResult.put("step", result("undefined"));
         stepDuration = ZERO;
         String actual = runFeaturesWithFormatter();
         assertXmlEqual("" +
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testng-results failed=\"1\" passed=\"0\" skipped=\"0\" total=\"1\">\n" +
-            "    <suite duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
-            "        <test duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
-            "            <class name=\"feature\">\n" +
-            "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n" +
-            "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
-            "                        <message>\n" +
-            "                            <![CDATA[When step...................................................................undefined\n" +
-            "Then step...................................................................skipped\n" +
-            "]]>\n" +
-            "                        </message>\n" +
-            "                        <full-stacktrace>\n" +
-            "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
-            "                        </full-stacktrace>\n" +
-            "                    </exception>\n" +
-            "                </test-method>\n" +
-            "            </class>\n" +
-            "        </test>\n" +
-            "    </suite>\n" +
-            "</testng-results>\n", actual);
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+                "<testng-results failed=\"1\" passed=\"0\" skipped=\"0\" total=\"1\">\n" +
+                "    <suite duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
+                "        <test duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
+                "            <class name=\"feature\">\n" +
+                "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n"
+                +
+                "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
+                "                        <message>\n" +
+                "                            <![CDATA[When step...................................................................undefined\n"
+                +
+                "Then step...................................................................skipped\n" +
+                "]]>\n" +
+                "                        </message>\n" +
+                "                        <full-stacktrace>\n" +
+                "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
+                "                        </full-stacktrace>\n" +
+                "                    </exception>\n" +
+                "                </test-method>\n" +
+                "            </class>\n" +
+                "        </test>\n" +
+                "    </suite>\n" +
+                "</testng-results>\n",
+            actual);
     }
 
     private String runFeaturesWithFormatter() {
@@ -73,16 +76,16 @@ final class TestNGFormatterTest {
         final TestNGFormatter formatter = new TestNGFormatter(out);
 
         TestHelper.builder()
-            .withFormatterUnderTest(formatter)
-            .withFeatures(features)
-            .withStepsToResult(stepsToResult)
-            .withStepsToLocation(stepsToLocation)
-            .withHooks(hooks)
-            .withHookLocations(hookLocations)
-            .withHookActions(hookActions)
-            .withTimeServiceIncrement(stepDuration)
-            .build()
-            .run();
+                .withFormatterUnderTest(formatter)
+                .withFeatures(features)
+                .withStepsToResult(stepsToResult)
+                .withStepsToLocation(stepsToLocation)
+                .withHooks(hooks)
+                .withHookLocations(hookLocations)
+                .withHookActions(hookActions)
+                .withTimeServiceIncrement(stepDuration)
+                .build()
+                .run();
 
         return new String(out.toByteArray(), UTF_8);
     }
@@ -94,237 +97,257 @@ final class TestNGFormatterTest {
     @Test
     void testScenarioWithUndefinedStepsStrict() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature\n" +
-            "  Scenario: scenario\n" +
-            "    When step\n" +
-            "    Then step\n");
+                "Feature: feature\n" +
+                "  Scenario: scenario\n" +
+                "    When step\n" +
+                "    Then step\n");
         features.add(feature);
         stepsToResult.put("step", result("undefined"));
         stepDuration = ZERO;
         String actual = runFeaturesWithFormatter();
         assertXmlEqual("" +
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testng-results failed=\"1\" passed=\"0\" skipped=\"0\" total=\"1\">\n" +
-            "    <suite duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
-            "        <test duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
-            "            <class name=\"feature\">\n" +
-            "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n" +
-            "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
-            "                        <message>\n" +
-            "                            <![CDATA[When step...................................................................undefined\n" +
-            "Then step...................................................................skipped\n" +
-            "]]>\n" +
-            "                        </message>\n" +
-            "                        <full-stacktrace>\n" +
-            "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
-            "                        </full-stacktrace>\n" +
-            "                    </exception>\n" +
-            "                </test-method>\n" +
-            "            </class>\n" +
-            "        </test>\n" +
-            "    </suite>\n" +
-            "</testng-results>\n", actual);
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+                "<testng-results failed=\"1\" passed=\"0\" skipped=\"0\" total=\"1\">\n" +
+                "    <suite duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
+                "        <test duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
+                "            <class name=\"feature\">\n" +
+                "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n"
+                +
+                "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
+                "                        <message>\n" +
+                "                            <![CDATA[When step...................................................................undefined\n"
+                +
+                "Then step...................................................................skipped\n" +
+                "]]>\n" +
+                "                        </message>\n" +
+                "                        <full-stacktrace>\n" +
+                "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
+                "                        </full-stacktrace>\n" +
+                "                    </exception>\n" +
+                "                </test-method>\n" +
+                "            </class>\n" +
+                "        </test>\n" +
+                "    </suite>\n" +
+                "</testng-results>\n",
+            actual);
     }
 
     @Test
     void testScenarioWithPendingSteps() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature\n" +
-            "  Scenario: scenario\n" +
-            "    When step1\n" +
-            "    Then step2\n");
+                "Feature: feature\n" +
+                "  Scenario: scenario\n" +
+                "    When step1\n" +
+                "    Then step2\n");
         features.add(feature);
         stepsToResult.put("step1", result("pending"));
         stepsToResult.put("step2", result("skipped"));
         stepDuration = ZERO;
         String actual = runFeaturesWithFormatter();
         assertXmlEqual("" +
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testng-results failed=\"1\" passed=\"0\" skipped=\"0\" total=\"1\">\n" +
-            "    <suite duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
-            "        <test duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
-            "            <class name=\"feature\">\n" +
-            "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n" +
-            "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
-            "                        <message>\n" +
-            "                            <![CDATA[When step1..................................................................pending\n" +
-            "Then step2..................................................................skipped\n" +
-            "]]>\n" +
-            "                        </message>\n" +
-            "                        <full-stacktrace>\n" +
-            "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
-            "                        </full-stacktrace>\n" +
-            "                    </exception>\n" +
-            "                </test-method>\n" +
-            "            </class>\n" +
-            "        </test>\n" +
-            "    </suite>\n" +
-            "</testng-results>\n", actual);
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+                "<testng-results failed=\"1\" passed=\"0\" skipped=\"0\" total=\"1\">\n" +
+                "    <suite duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
+                "        <test duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
+                "            <class name=\"feature\">\n" +
+                "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n"
+                +
+                "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
+                "                        <message>\n" +
+                "                            <![CDATA[When step1..................................................................pending\n"
+                +
+                "Then step2..................................................................skipped\n" +
+                "]]>\n" +
+                "                        </message>\n" +
+                "                        <full-stacktrace>\n" +
+                "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
+                "                        </full-stacktrace>\n" +
+                "                    </exception>\n" +
+                "                </test-method>\n" +
+                "            </class>\n" +
+                "        </test>\n" +
+                "    </suite>\n" +
+                "</testng-results>\n",
+            actual);
     }
 
     @Test
     void testScenarioWithFailedSteps() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature\n" +
-            "  Scenario: scenario\n" +
-            "    When step1\n" +
-            "    Then step2\n");
+                "Feature: feature\n" +
+                "  Scenario: scenario\n" +
+                "    When step1\n" +
+                "    Then step2\n");
         features.add(feature);
         stepsToResult.put("step1", result("failed", new TestNGException("message", "stacktrace")));
         stepsToResult.put("step2", result("skipped"));
         stepDuration = ZERO;
         String actual = runFeaturesWithFormatter();
         assertXmlEqual("" +
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
-            "<testng-results total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\">" +
-            "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
-            "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
-            "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\">" +
-            "                    <exception class=\"io.cucumber.core.plugin.TestNGFormatterTest$TestNGException\">" +
-            "                        <message><![CDATA[When step1..................................................................failed\n" +
-            "Then step2..................................................................skipped\n" +
-            "]]></message>" +
-            "                        <full-stacktrace><![CDATA[stacktrace]]></full-stacktrace>" +
-            "                    </exception>" +
-            "                </test-method>" +
-            "            </class>" +
-            "        </test>" +
-            "    </suite>" +
-            "</testng-results>", actual);
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
+                "<testng-results total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\">" +
+                "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
+                "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
+                "            <class name=\"feature\">" +
+                "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\">"
+                +
+                "                    <exception class=\"io.cucumber.core.plugin.TestNGFormatterTest$TestNGException\">"
+                +
+                "                        <message><![CDATA[When step1..................................................................failed\n"
+                +
+                "Then step2..................................................................skipped\n" +
+                "]]></message>" +
+                "                        <full-stacktrace><![CDATA[stacktrace]]></full-stacktrace>" +
+                "                    </exception>" +
+                "                </test-method>" +
+                "            </class>" +
+                "        </test>" +
+                "    </suite>" +
+                "</testng-results>",
+            actual);
     }
 
     @Test
     void testScenarioWithPassedSteps() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature\n" +
-            "  Scenario: scenario\n" +
-            "    When step\n" +
-            "    Then step\n");
+                "Feature: feature\n" +
+                "  Scenario: scenario\n" +
+                "    When step\n" +
+                "    Then step\n");
         features.add(feature);
         stepsToResult.put("step", result("passed"));
         stepDuration = ZERO;
         String actual = runFeaturesWithFormatter();
         assertXmlEqual("" +
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
-            "<testng-results total=\"1\" passed=\"1\" failed=\"0\" skipped=\"0\">" +
-            "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
-            "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
-            "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"PASS\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\"/>" +
-            "            </class>" +
-            "        </test>" +
-            "    </suite>" +
-            "</testng-results>", actual);
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
+                "<testng-results total=\"1\" passed=\"1\" failed=\"0\" skipped=\"0\">" +
+                "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
+                "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
+                "            <class name=\"feature\">" +
+                "                <test-method name=\"scenario\" status=\"PASS\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\"/>"
+                +
+                "            </class>" +
+                "        </test>" +
+                "    </suite>" +
+                "</testng-results>",
+            actual);
     }
 
     @Test
     void testScenarioWithBackground() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature\n" +
-            "  Background:\n" +
-            "    When background\n" +
-            "    Then background\n" +
-            "  Scenario: scenario\n" +
-            "    When step\n" +
-            "    Then step\n");
+                "Feature: feature\n" +
+                "  Background:\n" +
+                "    When background\n" +
+                "    Then background\n" +
+                "  Scenario: scenario\n" +
+                "    When step\n" +
+                "    Then step\n");
         features.add(feature);
         stepsToResult.put("background", result("undefined"));
         stepsToResult.put("step", result("undefined"));
         stepDuration = ZERO;
         String actual = runFeaturesWithFormatter();
         assertXmlEqual("" +
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testng-results failed=\"1\" passed=\"0\" skipped=\"0\" total=\"1\">\n" +
-            "    <suite duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
-            "        <test duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
-            "            <class name=\"feature\">\n" +
-            "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n" +
-            "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
-            "                        <message>\n" +
-            "                            <![CDATA[When background.............................................................undefined\n" +
-            "Then background.............................................................skipped\n" +
-            "When step...................................................................skipped\n" +
-            "Then step...................................................................skipped\n" +
-            "]]>\n" +
-            "                        </message>\n" +
-            "                        <full-stacktrace>\n" +
-            "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
-            "                        </full-stacktrace>\n" +
-            "                    </exception>\n" +
-            "                </test-method>\n" +
-            "            </class>\n" +
-            "        </test>\n" +
-            "    </suite>\n" +
-            "</testng-results>\n", actual);
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+                "<testng-results failed=\"1\" passed=\"0\" skipped=\"0\" total=\"1\">\n" +
+                "    <suite duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
+                "        <test duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
+                "            <class name=\"feature\">\n" +
+                "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n"
+                +
+                "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
+                "                        <message>\n" +
+                "                            <![CDATA[When background.............................................................undefined\n"
+                +
+                "Then background.............................................................skipped\n" +
+                "When step...................................................................skipped\n" +
+                "Then step...................................................................skipped\n" +
+                "]]>\n" +
+                "                        </message>\n" +
+                "                        <full-stacktrace>\n" +
+                "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
+                "                        </full-stacktrace>\n" +
+                "                    </exception>\n" +
+                "                </test-method>\n" +
+                "            </class>\n" +
+                "        </test>\n" +
+                "    </suite>\n" +
+                "</testng-results>\n",
+            actual);
     }
 
     @Test
     void testScenarioOutlineWithExamples() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature\n" +
-            "  Scenario Outline: scenario\n" +
-            "    When step\n" +
-            "    Then step\n" +
-            "    Examples:\n" +
-            "    | arg |\n" +
-            "    |  1  |\n" +
-            "    |  2  |\n");
+                "Feature: feature\n" +
+                "  Scenario Outline: scenario\n" +
+                "    When step\n" +
+                "    Then step\n" +
+                "    Examples:\n" +
+                "    | arg |\n" +
+                "    |  1  |\n" +
+                "    |  2  |\n");
         features.add(feature);
         stepsToResult.put("step", result("undefined"));
         stepDuration = ZERO;
         String actual = runFeaturesWithFormatter();
         assertXmlEqual("" +
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
-            "<testng-results failed=\"2\" passed=\"0\" skipped=\"0\" total=\"2\">\n" +
-            "    <suite duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
-            "        <test duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
-            "            <class name=\"feature\">\n" +
-            "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n" +
-            "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
-            "                        <message>\n" +
-            "                            <![CDATA[When step...................................................................undefined\n" +
-            "Then step...................................................................skipped\n" +
-            "]]>\n" +
-            "                        </message>\n" +
-            "                        <full-stacktrace>\n" +
-            "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
-            "                        </full-stacktrace>\n" +
-            "                    </exception>\n" +
-            "                </test-method>\n" +
-            "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario_2\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n" +
-            "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
-            "                        <message>\n" +
-            "                            <![CDATA[When step...................................................................undefined\n" +
-            "Then step...................................................................skipped\n" +
-            "]]>\n" +
-            "                        </message>\n" +
-            "                        <full-stacktrace>\n" +
-            "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
-            "                        </full-stacktrace>\n" +
-            "                    </exception>\n" +
-            "                </test-method>\n" +
-            "            </class>\n" +
-            "        </test>\n" +
-            "    </suite>\n" +
-            "</testng-results>\n", actual);
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+                "<testng-results failed=\"2\" passed=\"0\" skipped=\"0\" total=\"2\">\n" +
+                "    <suite duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
+                "        <test duration-ms=\"0\" name=\"io.cucumber.core.plugin.TestNGFormatter\">\n" +
+                "            <class name=\"feature\">\n" +
+                "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n"
+                +
+                "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
+                "                        <message>\n" +
+                "                            <![CDATA[When step...................................................................undefined\n"
+                +
+                "Then step...................................................................skipped\n" +
+                "]]>\n" +
+                "                        </message>\n" +
+                "                        <full-stacktrace>\n" +
+                "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
+                "                        </full-stacktrace>\n" +
+                "                    </exception>\n" +
+                "                </test-method>\n" +
+                "                <test-method duration-ms=\"0\" finished-at=\"1970-01-01T00:00:00Z\" name=\"scenario_2\" started-at=\"1970-01-01T00:00:00Z\" status=\"FAIL\">\n"
+                +
+                "                    <exception class=\"The scenario has pending or undefined step(s)\">\n" +
+                "                        <message>\n" +
+                "                            <![CDATA[When step...................................................................undefined\n"
+                +
+                "Then step...................................................................skipped\n" +
+                "]]>\n" +
+                "                        </message>\n" +
+                "                        <full-stacktrace>\n" +
+                "                            <![CDATA[The scenario has pending or undefined step(s)]]>\n" +
+                "                        </full-stacktrace>\n" +
+                "                    </exception>\n" +
+                "                </test-method>\n" +
+                "            </class>\n" +
+                "        </test>\n" +
+                "    </suite>\n" +
+                "</testng-results>\n",
+            actual);
     }
 
     @Test
     void testDurationCalculationOfStepsAndHooks() {
         Feature feature1 = TestFeatureParser.parse("path/feature1.feature", "" +
-            "Feature: feature_1\n" +
-            "  Scenario: scenario_1\n" +
-            "    When step\n" +
-            "    Then step\n" +
-            "  Scenario: scenario_2\n" +
-            "    When step\n" +
-            "    Then step\n");
+                "Feature: feature_1\n" +
+                "  Scenario: scenario_1\n" +
+                "    When step\n" +
+                "    Then step\n" +
+                "  Scenario: scenario_2\n" +
+                "    When step\n" +
+                "    Then step\n");
         Feature feature2 = TestFeatureParser.parse("path/feature2.feature", "" +
-            "Feature: feature_2\n" +
-            "  Scenario: scenario_3\n" +
-            "    When step\n" +
-            "    Then step\n");
+                "Feature: feature_2\n" +
+                "  Scenario: scenario_3\n" +
+                "    When step\n" +
+                "    Then step\n");
         features.add(feature1);
         features.add(feature2);
         stepsToResult.put("step", result("passed"));
@@ -335,29 +358,33 @@ final class TestNGFormatterTest {
         stepDuration = ofMillis(1);
         String actual = runFeaturesWithFormatter();
         assertXmlEqual("" +
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
-            "<testng-results total=\"3\" passed=\"3\" failed=\"0\" skipped=\"0\">" +
-            "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"12\">" +
-            "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"12\">" +
-            "            <class name=\"feature_1\">" +
-            "                <test-method name=\"scenario_1\" status=\"PASS\" duration-ms=\"4\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00.004Z\"/>" +
-            "                <test-method name=\"scenario_2\" status=\"PASS\" duration-ms=\"4\" started-at=\"1970-01-01T00:00:00.004Z\" finished-at=\"1970-01-01T00:00:00.008Z\"/>" +
-            "            </class>" +
-            "            <class name=\"feature_2\">" +
-            "                <test-method name=\"scenario_3\" status=\"PASS\" duration-ms=\"4\" started-at=\"1970-01-01T00:00:00.008Z\" finished-at=\"1970-01-01T00:00:00.012Z\"/>" +
-            "            </class>" +
-            "        </test>" +
-            "    </suite>" +
-            "</testng-results>", actual);
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
+                "<testng-results total=\"3\" passed=\"3\" failed=\"0\" skipped=\"0\">" +
+                "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"12\">" +
+                "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"12\">" +
+                "            <class name=\"feature_1\">" +
+                "                <test-method name=\"scenario_1\" status=\"PASS\" duration-ms=\"4\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00.004Z\"/>"
+                +
+                "                <test-method name=\"scenario_2\" status=\"PASS\" duration-ms=\"4\" started-at=\"1970-01-01T00:00:00.004Z\" finished-at=\"1970-01-01T00:00:00.008Z\"/>"
+                +
+                "            </class>" +
+                "            <class name=\"feature_2\">" +
+                "                <test-method name=\"scenario_3\" status=\"PASS\" duration-ms=\"4\" started-at=\"1970-01-01T00:00:00.008Z\" finished-at=\"1970-01-01T00:00:00.012Z\"/>"
+                +
+                "            </class>" +
+                "        </test>" +
+                "    </suite>" +
+                "</testng-results>",
+            actual);
     }
 
     @Test
     void testScenarioWithFailedBeforeHook() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature\n" +
-            "  Scenario: scenario\n" +
-            "    When step\n" +
-            "    Then step\n");
+                "Feature: feature\n" +
+                "  Scenario: scenario\n" +
+                "    When step\n" +
+                "    Then step\n");
         features.add(feature);
         stepsToResult.put("step", result("skipped"));
         hooks.add(TestHelper.hookEntry("before", result("failed", new TestNGException("message", "stacktrace"))));
@@ -365,32 +392,36 @@ final class TestNGFormatterTest {
         stepDuration = ZERO;
         String actual = runFeaturesWithFormatter();
         assertXmlEqual("" +
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
-            "<testng-results total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\">" +
-            "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
-            "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
-            "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\">" +
-            "                    <exception class=\"io.cucumber.core.plugin.TestNGFormatterTest$TestNGException\">" +
-            "                        <message><![CDATA[When step...................................................................skipped\n" +
-            "Then step...................................................................skipped\n" +
-            "]]></message>" +
-            "                        <full-stacktrace><![CDATA[stacktrace]]></full-stacktrace>" +
-            "                    </exception>" +
-            "                </test-method>" +
-            "            </class>" +
-            "        </test>" +
-            "    </suite>" +
-            "</testng-results>", actual);
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
+                "<testng-results total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\">" +
+                "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
+                "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
+                "            <class name=\"feature\">" +
+                "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\">"
+                +
+                "                    <exception class=\"io.cucumber.core.plugin.TestNGFormatterTest$TestNGException\">"
+                +
+                "                        <message><![CDATA[When step...................................................................skipped\n"
+                +
+                "Then step...................................................................skipped\n" +
+                "]]></message>" +
+                "                        <full-stacktrace><![CDATA[stacktrace]]></full-stacktrace>" +
+                "                    </exception>" +
+                "                </test-method>" +
+                "            </class>" +
+                "        </test>" +
+                "    </suite>" +
+                "</testng-results>",
+            actual);
     }
 
     @Test
     void testScenarioWithFailedAfterHook() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature\n" +
-            "  Scenario: scenario\n" +
-            "    When step\n" +
-            "    Then step\n");
+                "Feature: feature\n" +
+                "  Scenario: scenario\n" +
+                "    When step\n" +
+                "    Then step\n");
         features.add(feature);
         stepsToResult.put("step", result("passed"));
         hooks.add(TestHelper.hookEntry("after", result("failed", new TestNGException("message", "stacktrace"))));
@@ -398,23 +429,27 @@ final class TestNGFormatterTest {
         stepDuration = ZERO;
         String actual = runFeaturesWithFormatter();
         assertXmlEqual("" +
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
-            "<testng-results total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\">" +
-            "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
-            "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
-            "            <class name=\"feature\">" +
-            "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\">" +
-            "                    <exception class=\"io.cucumber.core.plugin.TestNGFormatterTest$TestNGException\">" +
-            "                        <message><![CDATA[When step...................................................................passed\n" +
-            "Then step...................................................................passed\n" +
-            "]]></message>" +
-            "                        <full-stacktrace><![CDATA[stacktrace]]></full-stacktrace>" +
-            "                    </exception>" +
-            "                </test-method>" +
-            "            </class>" +
-            "        </test>" +
-            "    </suite>" +
-            "</testng-results>", actual);
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
+                "<testng-results total=\"1\" passed=\"0\" failed=\"1\" skipped=\"0\">" +
+                "    <suite name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
+                "        <test name=\"io.cucumber.core.plugin.TestNGFormatter\" duration-ms=\"0\">" +
+                "            <class name=\"feature\">" +
+                "                <test-method name=\"scenario\" status=\"FAIL\" duration-ms=\"0\" started-at=\"1970-01-01T00:00:00Z\" finished-at=\"1970-01-01T00:00:00Z\">"
+                +
+                "                    <exception class=\"io.cucumber.core.plugin.TestNGFormatterTest$TestNGException\">"
+                +
+                "                        <message><![CDATA[When step...................................................................passed\n"
+                +
+                "Then step...................................................................passed\n" +
+                "]]></message>" +
+                "                        <full-stacktrace><![CDATA[stacktrace]]></full-stacktrace>" +
+                "                    </exception>" +
+                "                </test-method>" +
+                "            </class>" +
+                "        </test>" +
+                "    </suite>" +
+                "</testng-results>",
+            actual);
     }
 
     private static class TestNGException extends Exception {

--- a/core/src/test/java/io/cucumber/core/plugin/TimelineFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/TimelineFormatterTest.java
@@ -34,7 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class TimelineFormatterTest {
 
-    private static final Comparator<TimelineFormatter.TestData> TEST_DATA_COMPARATOR = Comparator.comparing(o -> o.scenario);
+    private static final Comparator<TimelineFormatter.TestData> TEST_DATA_COMPARATOR = Comparator
+            .comparing(o -> o.scenario);
 
     private static final String REPORT_TEMPLATE_RESOURCE_DIR = "src/main/resources/io/cucumber/core/plugin/timeline";
     private static final String REPORT_JS = "report.js";
@@ -42,52 +43,52 @@ class TimelineFormatterTest {
 
     private final Gson gson = new GsonBuilder().registerTypeAdapter(
         Instant.class,
-        (JsonDeserializer<Instant>) (json, type, jsonDeserializationContext) ->
-            json.isJsonObject()
+        (JsonDeserializer<Instant>) (json, type, jsonDeserializationContext) -> json.isJsonObject()
                 ? Instant.ofEpochSecond(json.getAsJsonObject().get("seconds").getAsLong())
-                : Instant.ofEpochMilli(json.getAsLong())).create();
+                : Instant.ofEpochMilli(json.getAsLong()))
+            .create();
 
     private final Map<String, Result> stepsToResult = new HashMap<>();
     private final Map<String, String> stepsToLocation = new HashMap<>();
 
     private final Feature failingFeature = TestFeatureParser.parse("some/path/failing.feature", "" +
-        "Feature: Failing Feature\n" +
-        "  Background:\n" +
-        "    Given bg_1\n" +
-        "    When bg_2\n" +
-        "    Then bg_3\n" +
-        "  @TagA\n" +
-        "  Scenario: Scenario 1\n" +
-        "    Given step_01\n" +
-        "    When step_02\n" +
-        "    Then step_03\n" +
-        "  Scenario: Scenario 2\n" +
-        "    Given step_01\n" +
-        "    When step_02\n" +
-        "    Then step_03");
+            "Feature: Failing Feature\n" +
+            "  Background:\n" +
+            "    Given bg_1\n" +
+            "    When bg_2\n" +
+            "    Then bg_3\n" +
+            "  @TagA\n" +
+            "  Scenario: Scenario 1\n" +
+            "    Given step_01\n" +
+            "    When step_02\n" +
+            "    Then step_03\n" +
+            "  Scenario: Scenario 2\n" +
+            "    Given step_01\n" +
+            "    When step_02\n" +
+            "    Then step_03");
 
     private final Feature successfulFeature = TestFeatureParser.parse("some/path/successful.feature", "" +
-        "Feature: Successful Feature\n" +
-        "  Background:\n" +
-        "    Given bg_1\n" +
-        "    When bg_2\n" +
-        "    Then bg_3\n" +
-        "  @TagB @TagC\n" +
-        "  Scenario: Scenario 3\n" +
-        "    Given step_10\n" +
-        "    When step_20\n" +
-        "    Then step_30");
+            "Feature: Successful Feature\n" +
+            "  Background:\n" +
+            "    Given bg_1\n" +
+            "    When bg_2\n" +
+            "    Then bg_3\n" +
+            "  @TagB @TagC\n" +
+            "  Scenario: Scenario 3\n" +
+            "    Given step_10\n" +
+            "    When step_20\n" +
+            "    Then step_30");
 
     private final Feature pendingFeature = TestFeatureParser.parse("some/path/pending.feature", "" +
-        "Feature: Pending Feature\n" +
-        "  Background:\n" +
-        "    Given bg_1\n" +
-        "    When bg_2\n" +
-        "    Then bg_3\n" +
-        "  Scenario: Scenario 4\n" +
-        "    Given step_10\n" +
-        "    When step_20\n" +
-        "    Then step_50");
+            "Feature: Pending Feature\n" +
+            "  Background:\n" +
+            "    Given bg_1\n" +
+            "    When bg_2\n" +
+            "    Then bg_3\n" +
+            "  Scenario: Scenario 4\n" +
+            "    Given step_10\n" +
+            "    When step_20\n" +
+            "    Then step_50");
 
     private File reportDir;
     private File reportJsFile;
@@ -117,7 +118,8 @@ class TimelineFormatterTest {
 
         assertThat(REPORT_JS + ": did not exist in output dir", reportJsFile.exists(), is(equalTo(true)));
 
-        final List<String> files = Arrays.asList("index.html", "formatter.js", "jquery-3.4.1.min.js", "vis.min.css", "vis.min.js", "vis.override.css");
+        final List<String> files = Arrays.asList("index.html", "formatter.js", "jquery-3.4.1.min.js", "vis.min.css",
+            "vis.min.js", "vis.override.css");
         for (final String e : files) {
             final File actualFile = new File(reportDir, e);
             assertThat(e + ": did not exist in output dir", actualFile.exists(), is(equalTo(true)));
@@ -129,13 +131,14 @@ class TimelineFormatterTest {
 
     private void runFormatterWithPlugin() {
         TestHelper.builder()
-            .withFeatures(failingFeature, successfulFeature, pendingFeature)
-            .withRuntimeArgs(new RuntimeOptionsBuilder().addPluginName("timeline:" + reportDir.getAbsolutePath()).build())
-            .withStepsToResult(stepsToResult)
-            .withStepsToLocation(stepsToLocation)
-            .withTimeServiceIncrement(STEP_DURATION)
-            .build()
-            .run();
+                .withFeatures(failingFeature, successfulFeature, pendingFeature)
+                .withRuntimeArgs(
+                    new RuntimeOptionsBuilder().addPluginName("timeline:" + reportDir.getAbsolutePath()).build())
+                .withStepsToResult(stepsToResult)
+                .withStepsToLocation(stepsToLocation)
+                .withTimeServiceIncrement(STEP_DURATION)
+                .build()
+                .run();
     }
 
     private String readFileContents(final String outputPath) throws IOException {
@@ -148,78 +151,92 @@ class TimelineFormatterTest {
     @Test
     void shouldWriteItemsCorrectlyToReportJsWhenRunInParallel() throws Throwable {
         TestHelper.builder()
-            .withFeatures(failingFeature, successfulFeature, pendingFeature)
-            .withRuntimeArgs(new RuntimeOptionsBuilder().addPluginName("timeline:" + reportDir.getAbsolutePath()).setThreads(2).build())
-            .withStepsToResult(stepsToResult)
-            .withStepsToLocation(stepsToLocation)
-            .withTimeServiceIncrement(STEP_DURATION)
-            .build()
-            .run();
+                .withFeatures(failingFeature, successfulFeature, pendingFeature)
+                .withRuntimeArgs(new RuntimeOptionsBuilder().addPluginName("timeline:" + reportDir.getAbsolutePath())
+                        .setThreads(2).build())
+                .withStepsToResult(stepsToResult)
+                .withStepsToLocation(stepsToLocation)
+                .withTimeServiceIncrement(STEP_DURATION)
+                .build()
+                .run();
 
-        final TimelineFormatter.TestData[] expectedTests = getExpectedTestData(0L); // Have to ignore actual thread id and just check not null
+        final TimelineFormatter.TestData[] expectedTests = getExpectedTestData(0L); // Have
+                                                                                    // to
+                                                                                    // ignore
+                                                                                    // actual
+                                                                                    // thread
+                                                                                    // id
+                                                                                    // and
+                                                                                    // just
+                                                                                    // check
+                                                                                    // not
+                                                                                    // null
 
         final ActualReportOutput actualOutput = readReport();
 
-        //Cannot verify size / contents of Groups as multi threading not guaranteed in Travis CI
+        // Cannot verify size / contents of Groups as multi threading not
+        // guaranteed in Travis CI
         assertThat(actualOutput.groups, not(empty()));
         for (int i = 0; i < actualOutput.groups.size(); i++) {
             final TimelineFormatter.GroupData actual = actualOutput.groups.get(i);
 
             final int idx = i;
-            assertAll("Checking TimelineFormatter.GroupData",
-                () -> assertThat(String.format("id on group %s, was not as expected", idx), actual.id > 0, is(equalTo(true))),
-                () -> assertThat(String.format("content on group %s, was not as expected", idx), actual.content, is(notNullValue()))
-            );
+            assertAll(
+                () -> assertThat(String.format("id on group %s, was not as expected", idx), actual.id > 0,
+                    is(equalTo(true))),
+                () -> assertThat(String.format("content on group %s, was not as expected", idx), actual.content,
+                    is(notNullValue())));
         }
 
-        //Sort the tests, output order is not a problem but obviously asserting it is
+        // Sort the tests, output order is not a problem but obviously asserting
+        // it is
         actualOutput.tests.sort(TEST_DATA_COMPARATOR);
         assertTimelineTestDataIsAsExpected(expectedTests, actualOutput.tests, false, false);
     }
 
     private TimelineFormatter.TestData[] getExpectedTestData(Long groupId) {
         String expectedJson = ("[\n" +
-            "  {\n" +
-            "    \"feature\": \"Failing Feature\",\n" +
-            "    \"scenario\": \"Scenario 1\",\n" +
-            "    \"start\": 0,\n" +
-            "    \"end\": 6000,\n" +
-            "    \"group\": groupId,\n" +
-            "    \"content\": \"\",\n" +
-            "    \"tags\": \"@taga,\",\n" +
-            "    \"className\": \"failed\"\n" +
-            "  },\n" +
-            "  {\n" +
-            "    \"feature\": \"Failing Feature\",\n" +
-            "    \"scenario\": \"Scenario 2\",\n" +
-            "    \"start\": 6000,\n" +
-            "    \"end\": 12000,\n" +
-            "    \"group\": groupId,\n" +
-            "    \"content\": \"\",\n" +
-            "    \"tags\": \"\",\n" +
-            "    \"className\": \"failed\"\n" +
-            "  },\n" +
-            "  {\n" +
-            "    \"feature\": \"Successful Feature\",\n" +
-            "    \"scenario\": \"Scenario 3\",\n" +
-            "    \"start\": 18000,\n" +
-            "    \"end\": 24000,\n" +
-            "    \"group\": groupId,\n" +
-            "    \"content\": \"\",\n" +
-            "    \"tags\": \"@tagb,@tagc,\",\n" +
-            "    \"className\": \"passed\"\n" +
-            "  },\n" +
-            "  {\n" +
-            "    \"scenario\": \"Scenario 4\",\n" +
-            "    \"feature\": \"Pending Feature\",\n" +
-            "    \"start\": 12000,\n" +
-            "    \"end\": 18000,\n" +
-            "    \"group\": groupId,\n" +
-            "    \"content\": \"\",\n" +
-            "    \"tags\": \"\",\n" +
-            "    \"className\": \"undefined\"\n" +
-            "  }\n" +
-            "]").replaceAll("groupId", groupId.toString());
+                "  {\n" +
+                "    \"feature\": \"Failing Feature\",\n" +
+                "    \"scenario\": \"Scenario 1\",\n" +
+                "    \"start\": 0,\n" +
+                "    \"end\": 6000,\n" +
+                "    \"group\": groupId,\n" +
+                "    \"content\": \"\",\n" +
+                "    \"tags\": \"@taga,\",\n" +
+                "    \"className\": \"failed\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"feature\": \"Failing Feature\",\n" +
+                "    \"scenario\": \"Scenario 2\",\n" +
+                "    \"start\": 6000,\n" +
+                "    \"end\": 12000,\n" +
+                "    \"group\": groupId,\n" +
+                "    \"content\": \"\",\n" +
+                "    \"tags\": \"\",\n" +
+                "    \"className\": \"failed\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"feature\": \"Successful Feature\",\n" +
+                "    \"scenario\": \"Scenario 3\",\n" +
+                "    \"start\": 18000,\n" +
+                "    \"end\": 24000,\n" +
+                "    \"group\": groupId,\n" +
+                "    \"content\": \"\",\n" +
+                "    \"tags\": \"@tagb,@tagc,\",\n" +
+                "    \"className\": \"passed\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"scenario\": \"Scenario 4\",\n" +
+                "    \"feature\": \"Pending Feature\",\n" +
+                "    \"start\": 12000,\n" +
+                "    \"end\": 18000,\n" +
+                "    \"group\": groupId,\n" +
+                "    \"content\": \"\",\n" +
+                "    \"tags\": \"\",\n" +
+                "    \"className\": \"undefined\"\n" +
+                "  }\n" +
+                "]").replaceAll("groupId", groupId.toString());
 
         return gson.fromJson(expectedJson, TimelineFormatter.TestData[].class);
     }
@@ -242,47 +259,58 @@ class TimelineFormatterTest {
         itemLines.append("]");
         groupLines.append("]");
 
-        final TimelineFormatter.TestData[] tests = gson.fromJson(itemLines.toString(), TimelineFormatter.TestData[].class);
-        final TimelineFormatter.GroupData[] groups = gson.fromJson(groupLines.toString(), TimelineFormatter.GroupData[].class);
+        final TimelineFormatter.TestData[] tests = gson.fromJson(itemLines.toString(),
+            TimelineFormatter.TestData[].class);
+        final TimelineFormatter.GroupData[] groups = gson.fromJson(groupLines.toString(),
+            TimelineFormatter.GroupData[].class);
         return new ActualReportOutput(tests, groups);
     }
 
-    private void assertTimelineTestDataIsAsExpected(final TimelineFormatter.TestData[] expectedTests,
-                                                    final List<TimelineFormatter.TestData> actualOutput,
-                                                    final boolean checkActualThreadData,
-                                                    final boolean checkActualTimeStamps) {
+    private void assertTimelineTestDataIsAsExpected(
+            final TimelineFormatter.TestData[] expectedTests,
+            final List<TimelineFormatter.TestData> actualOutput,
+            final boolean checkActualThreadData,
+            final boolean checkActualTimeStamps
+    ) {
         assertThat("Number of tests was not as expected", actualOutput.size(), is(equalTo(expectedTests.length)));
         for (int i = 0; i < expectedTests.length; i++) {
             final TimelineFormatter.TestData expected = expectedTests[i];
             final TimelineFormatter.TestData actual = actualOutput.get(i);
             final int idx = i;
 
-            assertAll("Checking TimelineFormatter.TestData",
-                () -> assertThat(String.format("feature on item %s, was not as expected", idx), actual.feature, is(equalTo(expected.feature))),
-                () -> assertThat(String.format("className on item %s, was not as expected", idx), actual.className, is(equalTo(expected.className))),
-                () -> assertThat(String.format("content on item %s, was not as expected", idx), actual.content, is(equalTo(expected.content))),
-                () -> assertThat(String.format("tags on item %s, was not as expected", idx), actual.tags, is(equalTo(expected.tags))),
+            assertAll(
+                () -> assertThat(String.format("feature on item %s, was not as expected", idx), actual.feature,
+                    is(equalTo(expected.feature))),
+                () -> assertThat(String.format("className on item %s, was not as expected", idx), actual.className,
+                    is(equalTo(expected.className))),
+                () -> assertThat(String.format("content on item %s, was not as expected", idx), actual.content,
+                    is(equalTo(expected.content))),
+                () -> assertThat(String.format("tags on item %s, was not as expected", idx), actual.tags,
+                    is(equalTo(expected.tags))),
                 () -> {
                     if (checkActualTimeStamps) {
-                        assertAll("Checking ActualTimeStamps",
-                            () -> assertThat(String.format("startTime on item %s, was not as expected", idx), actual.startTime, is(equalTo(expected.startTime))),
-                            () -> assertThat(String.format("endTime on item %s, was not as expected", idx), actual.endTime, is(equalTo(expected.endTime)))
-                        );
+                        assertAll(
+                            () -> assertThat(String.format("startTime on item %s, was not as expected", idx),
+                                actual.startTime, is(equalTo(expected.startTime))),
+                            () -> assertThat(String.format("endTime on item %s, was not as expected", idx),
+                                actual.endTime, is(equalTo(expected.endTime))));
                     } else {
-                        assertAll("Checking TimeStamps",
-                            () -> assertThat(String.format("startTime on item %s, was not as expected", idx), actual.startTime, is(notNullValue())),
-                            () -> assertThat(String.format("endTime on item %s, was not as expected", idx), actual.endTime, is(notNullValue()))
-                        );
+                        assertAll(
+                            () -> assertThat(String.format("startTime on item %s, was not as expected", idx),
+                                actual.startTime, is(notNullValue())),
+                            () -> assertThat(String.format("endTime on item %s, was not as expected", idx),
+                                actual.endTime, is(notNullValue())));
                     }
                 },
                 () -> {
                     if (checkActualThreadData) {
-                        assertThat(String.format("threadId on item %s, was not as expected", idx), actual.threadId, is(equalTo(expected.threadId)));
+                        assertThat(String.format("threadId on item %s, was not as expected", idx), actual.threadId,
+                            is(equalTo(expected.threadId)));
                     } else {
-                        assertThat(String.format("threadId on item %s, was not as expected", idx), actual.threadId, is(notNullValue()));
+                        assertThat(String.format("threadId on item %s, was not as expected", idx), actual.threadId,
+                            is(notNullValue()));
                     }
-                }
-            );
+                });
         }
     }
 
@@ -299,38 +327,41 @@ class TimelineFormatterTest {
 
         final TimelineFormatter.GroupData[] expectedGroups = gson.fromJson(
             ("[\n" +
-                "  {\n" +
-                "    \"id\": groupId,\n" +
-                "    \"content\": \"groupName\"\n" +
-                "  }\n" +
-                "]")
-                .replaceAll("groupId", groupId.toString())
-                .replaceAll("groupName", groupName)
-            , TimelineFormatter.GroupData[].class);
+                    "  {\n" +
+                    "    \"id\": groupId,\n" +
+                    "    \"content\": \"groupName\"\n" +
+                    "  }\n" +
+                    "]")
+                            .replaceAll("groupId", groupId.toString())
+                            .replaceAll("groupName", groupName),
+            TimelineFormatter.GroupData[].class);
 
         final ActualReportOutput actualOutput = readReport();
 
-        //Sort the tests, output order is not a problem but obviously asserting it is
+        // Sort the tests, output order is not a problem but obviously asserting
+        // it is
         actualOutput.tests.sort(TEST_DATA_COMPARATOR);
 
-        assertAll("Checking Timeline",
+        assertAll(
             () -> assertTimelineTestDataIsAsExpected(expectedTests, actualOutput.tests, true, true),
-            () -> assertTimelineGroupDataIsAsExpected(expectedGroups, actualOutput.groups)
-        );
+            () -> assertTimelineGroupDataIsAsExpected(expectedGroups, actualOutput.groups));
     }
 
-    private void assertTimelineGroupDataIsAsExpected(final TimelineFormatter.GroupData[] expectedGroups,
-                                                     final List<TimelineFormatter.GroupData> actualOutput) {
+    private void assertTimelineGroupDataIsAsExpected(
+            final TimelineFormatter.GroupData[] expectedGroups,
+            final List<TimelineFormatter.GroupData> actualOutput
+    ) {
         assertThat("Number of groups was not as expected", actualOutput.size(), is(equalTo(expectedGroups.length)));
         for (int i = 0; i < expectedGroups.length; i++) {
             final TimelineFormatter.GroupData expected = expectedGroups[i];
             final TimelineFormatter.GroupData actual = actualOutput.get(i);
 
             final int idx = i;
-            assertAll("Checking TimelineFormatter.GroupData",
-                () -> assertThat(String.format("id on group %s, was not as expected", idx), actual.id, is(equalTo(expected.id))),
-                () -> assertThat(String.format("content on group %s, was not as expected", idx), actual.content, is(equalTo(expected.content)))
-            );
+            assertAll(
+                () -> assertThat(String.format("id on group %s, was not as expected", idx), actual.id,
+                    is(equalTo(expected.id))),
+                () -> assertThat(String.format("content on group %s, was not as expected", idx), actual.content,
+                    is(equalTo(expected.content))));
         }
     }
 

--- a/core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
@@ -34,11 +34,13 @@ class UnusedStepsSummaryPrinterTest {
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/belly.feature:3", "a few cukes")));
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/tummy.feature:5", "some more cukes")));
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/gut.feature:7", "even more cukes")));
-        bus.send(new TestStepFinished(bus.getInstant(), mock(TestCase.class), mockTestStep("my/belly.feature:3"), new Result(Status.UNUSED, Duration.ZERO, null)));
+        bus.send(new TestStepFinished(bus.getInstant(), mock(TestCase.class), mockTestStep("my/belly.feature:3"),
+            new Result(Status.UNUSED, Duration.ZERO, null)));
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/belly.feature:3", "a few cukes")));
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/tummy.feature:5", "some more cukes")));
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/gut.feature:7", "even more cukes")));
-        bus.send(new TestStepFinished(bus.getInstant(), mock(TestCase.class), mockTestStep("my/gut.feature:7"), new Result(Status.UNUSED, Duration.ZERO, null)));
+        bus.send(new TestStepFinished(bus.getInstant(), mock(TestCase.class), mockTestStep("my/gut.feature:7"),
+            new Result(Status.UNUSED, Duration.ZERO, null)));
         bus.send(new TestRunFinished(bus.getInstant()));
 
         // Verify produced output

--- a/core/src/test/java/io/cucumber/core/plugin/UrlOutputStreamTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/UrlOutputStreamTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-@ExtendWith({VertxExtension.class})
+@ExtendWith({ VertxExtension.class })
 public class UrlOutputStreamTest {
 
     private int port;
@@ -44,20 +44,22 @@ public class UrlOutputStreamTest {
     @Test
     void throws_exception_for_500_status(Vertx vertx, VertxTestContext testContext) throws InterruptedException {
         String requestBody = "hello";
-        TestServer testServer = new TestServer(port, testContext, requestBody, HttpMethod.PUT, null, null, 500, "Oh noes");
+        TestServer testServer = new TestServer(port, testContext, requestBody, HttpMethod.PUT, null, null, 500,
+            "Oh noes");
         CurlOption option = CurlOption.parse(format("http://localhost:%d", port));
 
         verifyRequest(option, testServer, vertx, testContext, requestBody);
         assertThat(testContext.awaitCompletion(5, TimeUnit.SECONDS), is(true));
         assertThat(exception.getMessage(), equalTo("HTTP request failed:\n" +
-            "> PUT http://localhost:" + port + "\n" +
-            "< HTTP/1.1 500 Internal Server Error\n" +
-            "< transfer-encoding: chunked\n" +
-            "Oh noes"
-        ));
+                "> PUT http://localhost:" + port + "\n" +
+                "< HTTP/1.1 500 Internal Server Error\n" +
+                "< transfer-encoding: chunked\n" +
+                "Oh noes"));
     }
 
-    private void verifyRequest(CurlOption url, TestServer testServer, Vertx vertx, VertxTestContext testContext, String requestBody) {
+    private void verifyRequest(
+            CurlOption url, TestServer testServer, Vertx vertx, VertxTestContext testContext, String requestBody
+    ) {
         vertx.deployVerticle(testServer, testContext.succeeding(id -> {
             try {
                 OutputStream out = new UrlOutputStream(url);
@@ -84,18 +86,19 @@ public class UrlOutputStreamTest {
     }
 
     @Test
-    void throws_exception_for_307_temporary_redirect_without_location(Vertx vertx, VertxTestContext testContext) throws InterruptedException {
+    void throws_exception_for_307_temporary_redirect_without_location(Vertx vertx, VertxTestContext testContext)
+            throws InterruptedException {
         String requestBody = "hello";
-        TestServer testServer = new TestServer(port, testContext, requestBody, HttpMethod.POST, null, "application/x-www-form-urlencoded", 200, "");
+        TestServer testServer = new TestServer(port, testContext, requestBody, HttpMethod.POST, null,
+            "application/x-www-form-urlencoded", 200, "");
         CurlOption url = CurlOption.parse(format("http://localhost:%d/redirect-no-location -X POST", port));
         verifyRequest(url, testServer, vertx, testContext, requestBody);
 
         assertThat(testContext.awaitCompletion(5, TimeUnit.SECONDS), is(true));
         assertThat(exception.getMessage(), equalTo("HTTP request failed:\n" +
-            "> POST http://localhost:" + port + "/redirect-no-location\n" +
-            "< HTTP/1.1 307 Temporary Redirect\n" +
-            "< content-length: 0\n"
-        ));
+                "> POST http://localhost:" + port + "/redirect-no-location\n" +
+                "< HTTP/1.1 307 Temporary Redirect\n" +
+                "< content-length: 0\n"));
     }
 
     @Test
@@ -109,13 +112,15 @@ public class UrlOutputStreamTest {
     private String makeOneKilobyteStringWithEmoji() {
         String base = "abcå\uD83D\uDE02";
         int baseLength = base.length();
-        return IntStream.range(0, 1024).mapToObj(i -> base.substring(i % baseLength, i % baseLength + 1)).collect(Collectors.joining());
+        return IntStream.range(0, 1024).mapToObj(i -> base.substring(i % baseLength, i % baseLength + 1))
+                .collect(Collectors.joining());
     }
 
     @Test
     void overrides_request_method(Vertx vertx, VertxTestContext testContext) {
         String requestBody = "hello";
-        TestServer testServer = new TestServer(port, testContext, requestBody, HttpMethod.POST, null, "application/x-www-form-urlencoded", 200, "");
+        TestServer testServer = new TestServer(port, testContext, requestBody, HttpMethod.POST, null,
+            "application/x-www-form-urlencoded", 200, "");
         CurlOption url = CurlOption.parse(format("http://localhost:%d -X POST", port));
         verifyRequest(url, testServer, vertx, testContext, requestBody);
     }
@@ -123,8 +128,10 @@ public class UrlOutputStreamTest {
     @Test
     void sets_request_headers(Vertx vertx, VertxTestContext testContext) {
         String requestBody = "hello";
-        TestServer testServer = new TestServer(port, testContext, requestBody, HttpMethod.PUT, "foo=bar", "application/x-ndjson", 200, "");
-        CurlOption url = CurlOption.parse(format("http://localhost:%d?foo=bar -H 'Content-Type: application/x-ndjson'", port));
+        TestServer testServer = new TestServer(port, testContext, requestBody, HttpMethod.PUT, "foo=bar",
+            "application/x-ndjson", 200, "");
+        CurlOption url = CurlOption
+                .parse(format("http://localhost:%d?foo=bar -H 'Content-Type: application/x-ndjson'", port));
         verifyRequest(url, testServer, vertx, testContext, requestBody);
     }
 
@@ -140,13 +147,14 @@ public class UrlOutputStreamTest {
         private final String responseBody;
 
         public TestServer(
-            int port,
-            VertxTestContext testContext,
-            String expectedBody,
-            HttpMethod expectedMethod,
-            String expectedQuery,
-            String expectedContentType,
-            int statusCode, String responseBody) {
+                int port,
+                VertxTestContext testContext,
+                String expectedBody,
+                HttpMethod expectedMethod,
+                String expectedQuery,
+                String expectedContentType,
+                int statusCode, String responseBody
+        ) {
             this.port = port;
             this.testContext = testContext;
             this.expectedBody = expectedBody;
@@ -189,9 +197,9 @@ public class UrlOutputStreamTest {
                 });
             });
             vertx
-                .createHttpServer()
-                .requestHandler(router)
-                .listen(port, e -> startPromise.complete());
+                    .createHttpServer()
+                    .requestHandler(router)
+                    .listen(port, e -> startPromise.complete());
         }
 
     }

--- a/core/src/test/java/io/cucumber/core/plugin/UsageFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/UsageFormatterTest.java
@@ -36,7 +36,8 @@ class UsageFormatterTest {
         TestStep testStep = mockTestStep();
         Result result = new Result(Status.PASSED, Duration.ofNanos(12345L), null);
 
-        usageFormatter.handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, result));
+        usageFormatter
+                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, result));
 
         Map<String, List<UsageFormatter.StepContainer>> usageMap = usageFormatter.usageMap;
         assertThat(usageMap.size(), is(equalTo(1)));
@@ -61,10 +62,12 @@ class UsageFormatterTest {
         TestStep testStep = mockTestStep();
 
         Result passed = new Result(Status.PASSED, Duration.ofSeconds(12345L), null);
-        usageFormatter.handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, passed));
+        usageFormatter
+                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, passed));
 
         Result failed = new Result(Status.FAILED, Duration.ZERO, null);
-        usageFormatter.handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, failed));
+        usageFormatter
+                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, failed));
 
         Map<String, List<UsageFormatter.StepContainer>> usageMap = usageFormatter.usageMap;
         assertThat(usageMap.size(), is(equalTo(1)));
@@ -82,7 +85,8 @@ class UsageFormatterTest {
         TestStep testStep = mockTestStep();
         Result result = new Result(Status.PASSED, Duration.ZERO, null);
 
-        usageFormatter.handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, result));
+        usageFormatter
+                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, result));
 
         Map<String, List<UsageFormatter.StepContainer>> usageMap = usageFormatter.usageMap;
         assertThat(usageMap.size(), is(equalTo(1)));
@@ -101,7 +105,8 @@ class UsageFormatterTest {
         PickleStepTestStep testStep = mockTestStep();
         Result result = new Result(Status.PASSED, Duration.ZERO, null);
 
-        usageFormatter.handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, result));
+        usageFormatter
+                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, result));
 
         Map<String, List<UsageFormatter.StepContainer>> usageMap = usageFormatter.usageMap;
         assertThat(usageMap.size(), is(equalTo(1)));
@@ -117,33 +122,34 @@ class UsageFormatterTest {
         OutputStream out = new ByteArrayOutputStream();
         UsageFormatter usageFormatter = new UsageFormatter(out);
         UsageFormatter.StepContainer stepContainer = new UsageFormatter.StepContainer("a step");
-        UsageFormatter.StepDuration stepDuration = new UsageFormatter.StepDuration(Duration.ofNanos(12345678L), "location.feature");
+        UsageFormatter.StepDuration stepDuration = new UsageFormatter.StepDuration(Duration.ofNanos(12345678L),
+            "location.feature");
         stepContainer.getDurations().addAll(singletonList(stepDuration));
         usageFormatter.usageMap.put("a (.*)", singletonList(stepContainer));
 
         usageFormatter.finishReport();
 
         String json = "" +
-            "[\n" +
-            "  {\n" +
-            "    \"source\": \"a (.*)\",\n" +
-            "    \"steps\": [\n" +
-            "      {\n" +
-            "        \"name\": \"a step\",\n" +
-            "        \"aggregatedDurations\": {\n" +
-            "          \"median\": 0.012345678,\n" +
-            "          \"average\": 0.012345678\n" +
-            "        },\n" +
-            "        \"durations\": [\n" +
-            "          {\n" +
-            "            \"duration\": 0.012345678,\n" +
-            "            \"location\": \"location.feature\"\n" +
-            "          }\n" +
-            "        ]\n" +
-            "      }\n" +
-            "    ]\n" +
-            "  }\n" +
-            "]";
+                "[\n" +
+                "  {\n" +
+                "    \"source\": \"a (.*)\",\n" +
+                "    \"steps\": [\n" +
+                "      {\n" +
+                "        \"name\": \"a step\",\n" +
+                "        \"aggregatedDurations\": {\n" +
+                "          \"median\": 0.012345678,\n" +
+                "          \"average\": 0.012345678\n" +
+                "        },\n" +
+                "        \"durations\": [\n" +
+                "          {\n" +
+                "            \"duration\": 0.012345678,\n" +
+                "            \"location\": \"location.feature\"\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "]";
 
         assertThat(out.toString(), sameJSONAs(json));
     }
@@ -154,7 +160,8 @@ class UsageFormatterTest {
         UsageFormatter usageFormatter = new UsageFormatter(out);
 
         UsageFormatter.StepContainer stepContainer = new UsageFormatter.StepContainer("a step");
-        UsageFormatter.StepDuration stepDuration = new UsageFormatter.StepDuration(Duration.ofNanos(12345678L), "location.feature");
+        UsageFormatter.StepDuration stepDuration = new UsageFormatter.StepDuration(Duration.ofNanos(12345678L),
+            "location.feature");
         stepContainer.getDurations().addAll(singletonList(stepDuration));
 
         usageFormatter.usageMap.put("a (.*)", singletonList(stepContainer));
@@ -162,8 +169,7 @@ class UsageFormatterTest {
         usageFormatter.finishReport();
 
         assertThat(out.toString(), containsString("0.012345678"));
-        String json =
-            "[\n" +
+        String json = "[\n" +
                 "  {\n" +
                 "    \"source\": \"a (.*)\",\n" +
                 "    \"steps\": [\n" +
@@ -191,7 +197,8 @@ class UsageFormatterTest {
     void calculateAverageFromList() {
         OutputStream out = new ByteArrayOutputStream();
         UsageFormatter usageFormatter = new UsageFormatter(out);
-        Duration result = usageFormatter.calculateAverage(asList(Duration.ofSeconds(1L), Duration.ofSeconds(2L), Duration.ofSeconds(3L)));
+        Duration result = usageFormatter
+                .calculateAverage(asList(Duration.ofSeconds(1L), Duration.ofSeconds(2L), Duration.ofSeconds(3L)));
         assertThat(result, is(equalTo(Duration.ofSeconds(2L))));
     }
 
@@ -199,7 +206,8 @@ class UsageFormatterTest {
     void calculateAverageOf() {
         OutputStream out = new ByteArrayOutputStream();
         UsageFormatter usageFormatter = new UsageFormatter(out);
-        Duration result = usageFormatter.calculateAverage(asList(Duration.ofSeconds(1L), Duration.ofSeconds(1L), Duration.ofSeconds(2L)));
+        Duration result = usageFormatter
+                .calculateAverage(asList(Duration.ofSeconds(1L), Duration.ofSeconds(1L), Duration.ofSeconds(2L)));
         assertThat(result, is(equalTo(Duration.ofNanos(1333333333))));
     }
 
@@ -215,7 +223,8 @@ class UsageFormatterTest {
     void calculateMedianOfOddNumberOfEntries() {
         OutputStream out = new ByteArrayOutputStream();
         UsageFormatter usageFormatter = new UsageFormatter(out);
-        Duration result = usageFormatter.calculateMedian(asList(Duration.ofSeconds(1L), Duration.ofSeconds(2L), Duration.ofSeconds(3L)));
+        Duration result = usageFormatter
+                .calculateMedian(asList(Duration.ofSeconds(1L), Duration.ofSeconds(2L), Duration.ofSeconds(3L)));
         assertThat(result, is(equalTo(Duration.ofSeconds(2L))));
     }
 
@@ -223,7 +232,8 @@ class UsageFormatterTest {
     void calculateMedianOfEvenNumberOfEntries() {
         OutputStream out = new ByteArrayOutputStream();
         UsageFormatter usageFormatter = new UsageFormatter(out);
-        Duration result = usageFormatter.calculateMedian(asList(Duration.ofSeconds(1L), Duration.ofSeconds(3L), Duration.ofSeconds(10L), Duration.ofSeconds(5L)));
+        Duration result = usageFormatter.calculateMedian(
+            asList(Duration.ofSeconds(1L), Duration.ofSeconds(3L), Duration.ofSeconds(10L), Duration.ofSeconds(5L)));
         assertThat(result, is(equalTo(Duration.ofSeconds(4))));
     }
 

--- a/core/src/test/java/io/cucumber/core/resource/ClasspathScannerTest.java
+++ b/core/src/test/java/io/cucumber/core/resource/ClasspathScannerTest.java
@@ -15,41 +15,37 @@ import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 class ClasspathScannerTest {
 
     private final ClasspathScanner scanner = new ClasspathScanner(
-        ClasspathScannerTest.class::getClassLoader
-    );
+        ClasspathScannerTest.class::getClassLoader);
 
     @Test
     void scanForSubClassesInPackage() {
-        List<Class<? extends ExampleInterface>> classes = scanner.
-            scanForSubClassesInPackage("io.cucumber", ExampleInterface.class);
+        List<Class<? extends ExampleInterface>> classes = scanner.scanForSubClassesInPackage("io.cucumber",
+            ExampleInterface.class);
 
         assertThat(classes, contains(ExampleClass.class));
     }
 
     @Test
     void scanForSubClassesInNonExistingPackage() {
-        List<Class<? extends ExampleInterface>> classes = scanner.
-            scanForSubClassesInPackage("io.cucumber.core.resource.does.not.exist", ExampleInterface.class);
+        List<Class<? extends ExampleInterface>> classes = scanner
+                .scanForSubClassesInPackage("io.cucumber.core.resource.does.not.exist", ExampleInterface.class);
         assertThat(classes, empty());
     }
 
     @Test
     void scanForClassesInPackage() {
-        List<Class<?>> classes = scanner.
-            scanForClassesInPackage("io.cucumber.core.resource.test");
+        List<Class<?>> classes = scanner.scanForClassesInPackage("io.cucumber.core.resource.test");
 
         assertThat(classes, containsInAnyOrder(
             ExampleClass.class,
             ExampleInterface.class,
-            OtherClass.class
-        ));
+            OtherClass.class));
 
     }
 
     @Test
     void scanForClassesInNonExistingPackage() {
-        List<Class<?>> classes = scanner.
-            scanForClassesInPackage("io.cucumber.core.resource.does.not.exist");
+        List<Class<?>> classes = scanner.scanForClassesInPackage("io.cucumber.core.resource.does.not.exist");
         assertThat(classes, empty());
     }
 

--- a/core/src/test/java/io/cucumber/core/resource/JarUriFileSystemServiceTest.java
+++ b/core/src/test/java/io/cucumber/core/resource/JarUriFileSystemServiceTest.java
@@ -25,9 +25,9 @@ class JarUriFileSystemServiceTest {
     void canOpenMultipleConcurrently() throws IOException, URISyntaxException {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         URI first = getUrisForPackage(classLoader, "io.cucumber").stream()
-            .filter(JarUriFileSystemService::supports)
-            .findFirst()
-            .orElseThrow(IllegalStateException::new);
+                .filter(JarUriFileSystemService::supports)
+                .findFirst()
+                .orElseThrow(IllegalStateException::new);
 
         CloseablePath path1 = JarUriFileSystemService.open(first);
         FileSystem fileSystem1 = path1.getPath().getFileSystem();
@@ -45,6 +45,5 @@ class JarUriFileSystemServiceTest {
         assertFalse(fileSystem1.isOpen());
         assertFalse(fileSystem2.isOpen());
     }
-
 
 }

--- a/core/src/test/java/io/cucumber/core/resource/ResourceScannerTest.java
+++ b/core/src/test/java/io/cucumber/core/resource/ResourceScannerTest.java
@@ -19,8 +19,7 @@ class ResourceScannerTest {
     private final ResourceScanner<URI> resourceScanner = new ResourceScanner<>(
         ResourceScannerTest.class::getClassLoader,
         path -> path.getFileName().toString().endsWith("resource.txt"),
-        resource -> of(resource.getUri())
-    );
+        resource -> of(resource.getUri()));
 
     @Test
     void scanForResourcesInClasspathRoot() {
@@ -29,8 +28,7 @@ class ResourceScannerTest {
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:resource.txt"),
             URI.create("classpath:other-resource.txt"),
-            URI.create("classpath:spaces%20in%20name%20resource.txt")
-        ));
+            URI.create("classpath:spaces%20in%20name%20resource.txt")));
     }
 
     @Test
@@ -39,8 +37,7 @@ class ResourceScannerTest {
         List<URI> resources = resourceScanner.scanForResourcesInClasspathRoot(classpathRoot, aPackage -> true);
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:jar-resource.txt"),
-            URI.create("classpath:com/example/package-jar-resource.txt")
-        ));
+            URI.create("classpath:com/example/package-jar-resource.txt")));
     }
 
     @Test
@@ -50,8 +47,7 @@ class ResourceScannerTest {
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:io/cucumber/core/resource/test/resource.txt"),
             URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt"),
-            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")
-        ));
+            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")));
     }
 
     @Test
@@ -61,8 +57,7 @@ class ResourceScannerTest {
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:io/cucumber/core/resource/test/resource.txt"),
             URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt"),
-            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")
-        ));
+            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")));
     }
 
     @Test
@@ -72,8 +67,7 @@ class ResourceScannerTest {
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:io/cucumber/core/resource/test/resource.txt"),
             URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt"),
-            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")
-        ));
+            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")));
     }
 
     @Test
@@ -87,7 +81,8 @@ class ResourceScannerTest {
     void scanForClasspathResourceWithSpaces() {
         String resourceName = "io/cucumber/core/resource/test/spaces in name resource.txt";
         List<URI> resources = resourceScanner.scanForClasspathResource(resourceName, aPackage -> true);
-        assertThat(resources, contains(URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")));
+        assertThat(resources,
+            contains(URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")));
     }
 
     @Test
@@ -97,8 +92,7 @@ class ResourceScannerTest {
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:io/cucumber/core/resource/test/resource.txt"),
             URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt"),
-            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")
-        ));
+            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")));
     }
 
     @Test
@@ -115,8 +109,7 @@ class ResourceScannerTest {
         assertThat(resources, containsInAnyOrder(
             new File("src/test/resources/io/cucumber/core/resource/test/resource.txt").toURI(),
             new File("src/test/resources/io/cucumber/core/resource/test/other-resource.txt").toURI(),
-            new File("src/test/resources/io/cucumber/core/resource/test/spaces in name resource.txt").toURI()
-        ));
+            new File("src/test/resources/io/cucumber/core/resource/test/spaces in name resource.txt").toURI()));
     }
 
     @Test
@@ -129,36 +122,37 @@ class ResourceScannerTest {
     @Test
     void scanForResourcesJarUri() {
         URI jarFileUri = new File("src/test/resources/io/cucumber/core/resource/test/jar-resource.jar").toURI();
-        URI resourceUri = URI.create("jar:file://" + jarFileUri.getSchemeSpecificPart() + "!/com/example/package-jar-resource.txt");
+        URI resourceUri = URI
+                .create("jar:file://" + jarFileUri.getSchemeSpecificPart() + "!/com/example/package-jar-resource.txt");
         List<URI> resources = resourceScanner.scanForResourcesUri(resourceUri);
         assertThat(resources, contains(resourceUri));
     }
 
-
     @Test
     void scanForResourcesNestedJarUri() {
         URI jarFileUri = new File("src/test/resources/io/cucumber/core/resource/test/spring-resource.jar").toURI();
-        URI resourceUri = URI.create("jar:file://" + jarFileUri.getSchemeSpecificPart() + "!/BOOT-INF/lib/jar-resource.jar!/com/example/package-jar-resource.txt");
+        URI resourceUri = URI.create("jar:file://" + jarFileUri.getSchemeSpecificPart()
+                + "!/BOOT-INF/lib/jar-resource.jar!/com/example/package-jar-resource.txt");
 
         CucumberException exception = assertThrows(
             CucumberException.class,
-            () -> resourceScanner.scanForResourcesUri(resourceUri)
-        );
-        assertThat(exception.getMessage(), containsString("Cucumber currently doesn't support classpath scanning in nested jars."));
+            () -> resourceScanner.scanForResourcesUri(resourceUri));
+        assertThat(exception.getMessage(),
+            containsString("Cucumber currently doesn't support classpath scanning in nested jars."));
 
     }
 
     @Test
     void scanForResourcesNestedJarUriUnPackaged() {
         URI jarFileUri = new File("src/test/resources/io/cucumber/core/resource/test/spring-resource.jar").toURI();
-        URI resourceUri = URI.create("jar:file://" + jarFileUri.getSchemeSpecificPart() + "!/BOOT-INF/classes!/com/example/");
+        URI resourceUri = URI
+                .create("jar:file://" + jarFileUri.getSchemeSpecificPart() + "!/BOOT-INF/classes!/com/example/");
 
         List<URI> resources = resourceScanner.scanForResourcesUri(resourceUri);
         assertThat(resources, containsInAnyOrder(
-            URI.create("jar:file://" + jarFileUri.getSchemeSpecificPart() + "!/BOOT-INF/classes/com/example/resource.txt")
-        ));
+            URI.create(
+                "jar:file://" + jarFileUri.getSchemeSpecificPart() + "!/BOOT-INF/classes/com/example/resource.txt")));
     }
-
 
     @Test
     void scanForResourcesDirectoryUri() {
@@ -167,8 +161,7 @@ class ResourceScannerTest {
         assertThat(resources, containsInAnyOrder(
             new File("src/test/resources/io/cucumber/core/resource/test/resource.txt").toURI(),
             new File("src/test/resources/io/cucumber/core/resource/test/other-resource.txt").toURI(),
-            new File("src/test/resources/io/cucumber/core/resource/test/spaces in name resource.txt").toURI()
-        ));
+            new File("src/test/resources/io/cucumber/core/resource/test/spaces in name resource.txt").toURI()));
     }
 
     @Test
@@ -185,8 +178,7 @@ class ResourceScannerTest {
         assertThat(resources, containsInAnyOrder(
             URI.create("classpath:io/cucumber/core/resource/test/resource.txt"),
             URI.create("classpath:io/cucumber/core/resource/test/other-resource.txt"),
-            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")
-        ));
+            URI.create("classpath:io/cucumber/core/resource/test/spaces%20in%20name%20resource.txt")));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionMatchTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionMatchTest.java
@@ -18,30 +18,30 @@ import static org.mockito.Mockito.mock;
 class AmbiguousStepDefinitionMatchTest {
 
     private final Feature feature = TestFeatureParser.parse("file:test.feature", "" +
-        "Feature: Test feature\n" +
-        "  Scenario: Test scenario\n" +
-        "     Given I have 4 cukes in my belly\n"
-    );
+            "Feature: Test feature\n" +
+            "  Scenario: Test scenario\n" +
+            "     Given I have 4 cukes in my belly\n");
     private final Step step = feature.getPickles().get(0).getSteps().get(0);
     private final AmbiguousStepDefinitionsException e = new AmbiguousStepDefinitionsException(step, emptyList());
-    private final AmbiguousPickleStepDefinitionsMatch match = new AmbiguousPickleStepDefinitionsMatch(URI.create("file:path/to.feature"), step, e);
+    private final AmbiguousPickleStepDefinitionsMatch match = new AmbiguousPickleStepDefinitionsMatch(
+        URI.create("file:path/to.feature"), step, e);
 
     @Test
     void throws_ambiguous_step_definitions_exception_when_run() {
         Executable testMethod = () -> match.runStep(mock(TestCaseState.class));
-        AmbiguousStepDefinitionsException actualThrown = assertThrows(AmbiguousStepDefinitionsException.class, testMethod);
+        AmbiguousStepDefinitionsException actualThrown = assertThrows(AmbiguousStepDefinitionsException.class,
+            testMethod);
         assertThat(actualThrown.getMessage(), is(equalTo(
-            "\"I have 4 cukes in my belly\" matches more than one step definition:\n"
-        )));
+            "\"I have 4 cukes in my belly\" matches more than one step definition:\n")));
     }
 
     @Test
     void throws_ambiguous_step_definitions_exception_when_dry_run() {
         Executable testMethod = () -> match.dryRunStep(mock(TestCaseState.class));
-        AmbiguousStepDefinitionsException actualThrown = assertThrows(AmbiguousStepDefinitionsException.class, testMethod);
+        AmbiguousStepDefinitionsException actualThrown = assertThrows(AmbiguousStepDefinitionsException.class,
+            testMethod);
         assertThat(actualThrown.getMessage(), is(equalTo(
-            "\"I have 4 cukes in my belly\" matches more than one step definition:\n"
-        )));
+            "\"I have 4 cukes in my belly\" matches more than one step definition:\n")));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionsExceptionTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionsExceptionTest.java
@@ -21,10 +21,9 @@ class AmbiguousStepDefinitionsExceptionTest {
     @Test
     void can_report_ambiguous_step_definitions() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my belly\n");
 
         Step mockPickleStep = feature.getPickles().get(0).getSteps().get(0);
 
@@ -36,19 +35,19 @@ class AmbiguousStepDefinitionsExceptionTest {
         when(mockPickleStepDefinitionMatchTwo.getPattern()).thenReturn("PickleStepDefinitionMatchTwo_Pattern");
         when(mockPickleStepDefinitionMatchTwo.getLocation()).thenReturn("PickleStepDefinitionMatchTwo_Location");
 
-        List<PickleStepDefinitionMatch> matches = asList(mockPickleStepDefinitionMatchOne, mockPickleStepDefinitionMatchTwo);
+        List<PickleStepDefinitionMatch> matches = asList(mockPickleStepDefinitionMatchOne,
+            mockPickleStepDefinitionMatchTwo);
 
-        AmbiguousStepDefinitionsException expectedThrown = new AmbiguousStepDefinitionsException(mockPickleStep, matches);
+        AmbiguousStepDefinitionsException expectedThrown = new AmbiguousStepDefinitionsException(mockPickleStep,
+            matches);
         assertAll(
             () -> assertThat(expectedThrown.getMessage(), is(equalTo(
                 "" +
-                    "\"I have 4 cukes in my belly\" matches more than one step definition:\n" +
-                    "  \"PickleStepDefinitionMatchOne_Pattern\" in PickleStepDefinitionMatchOne_Location\n" +
-                    "  \"PickleStepDefinitionMatchTwo_Pattern\" in PickleStepDefinitionMatchTwo_Location"
-            ))),
+                        "\"I have 4 cukes in my belly\" matches more than one step definition:\n" +
+                        "  \"PickleStepDefinitionMatchOne_Pattern\" in PickleStepDefinitionMatchOne_Location\n" +
+                        "  \"PickleStepDefinitionMatchTwo_Pattern\" in PickleStepDefinitionMatchTwo_Location"))),
             () -> assertThat(expectedThrown.getCause(), is(nullValue())),
-            () -> assertThat(expectedThrown.getMatches(), is(equalTo(matches)))
-        );
+            () -> assertThat(expectedThrown.getMatches(), is(equalTo(matches))));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -62,8 +62,7 @@ class CachingGlueTest {
 
         DuplicateStepDefinitionException exception = assertThrows(
             DuplicateStepDefinitionException.class,
-            () -> glue.prepareGlue(stepTypeRegistry)
-        );
+            () -> glue.prepareGlue(stepTypeRegistry));
         assertThat(exception.getMessage(), equalTo("Duplicate step definitions in foo.bf:10 and bar.bf:90"));
     }
 
@@ -74,13 +73,11 @@ class CachingGlueTest {
 
         DuplicateDefaultParameterTransformers exception = assertThrows(
             DuplicateDefaultParameterTransformers.class,
-            () -> glue.prepareGlue(stepTypeRegistry)
-        );
+            () -> glue.prepareGlue(stepTypeRegistry));
         assertThat(exception.getMessage(), equalTo("" +
-            "There may not be more then one default parameter transformer. Found:\n" +
-            " - mocked default parameter transformer\n" +
-            " - mocked default parameter transformer\n"
-        ));
+                "There may not be more then one default parameter transformer. Found:\n" +
+                " - mocked default parameter transformer\n" +
+                " - mocked default parameter transformer\n"));
     }
 
     @Test
@@ -90,13 +87,11 @@ class CachingGlueTest {
 
         DuplicateDefaultDataTableEntryTransformers exception = assertThrows(
             DuplicateDefaultDataTableEntryTransformers.class,
-            () -> glue.prepareGlue(stepTypeRegistry)
-        );
+            () -> glue.prepareGlue(stepTypeRegistry));
         assertThat(exception.getMessage(), equalTo("" +
-            "There may not be more then one default data table entry. Found:\n" +
-            " - mocked default data table entry transformer\n" +
-            " - mocked default data table entry transformer\n"
-        ));
+                "There may not be more then one default data table entry. Found:\n" +
+                " - mocked default data table entry transformer\n" +
+                " - mocked default data table entry transformer\n"));
     }
 
     @Test
@@ -106,19 +101,18 @@ class CachingGlueTest {
 
         DuplicateDefaultDataTableCellTransformers exception = assertThrows(
             DuplicateDefaultDataTableCellTransformers.class,
-            () -> glue.prepareGlue(stepTypeRegistry)
-        );
+            () -> glue.prepareGlue(stepTypeRegistry));
         assertThat(exception.getMessage(), equalTo("" +
-            "There may not be more then one default table cell transformers. Found:\n" +
-            " - mocked default data table cell transformer\n" +
-            " - mocked default data table cell transformer\n"
-        ));
+                "There may not be more then one default table cell transformers. Found:\n" +
+                " - mocked default data table cell transformer\n" +
+                " - mocked default data table cell transformer\n"));
     }
 
     @Test
     void removes_glue_that_is_scenario_scoped() {
         // This test is a bit fragile - it is testing state, not behaviour.
-        // But it was too much hassle creating a better test without refactoring RuntimeGlue
+        // But it was too much hassle creating a better test without refactoring
+        // RuntimeGlue
         // and probably some of its immediate collaborators... Aslak.
 
         glue.addStepDefinition(new MockedScenarioScopedStepDefinition("pattern"));
@@ -135,7 +129,7 @@ class CachingGlueTest {
 
         glue.prepareGlue(stepTypeRegistry);
 
-        assertAll("Checking Glue",
+        assertAll(
             () -> assertThat(glue.getStepDefinitions().size(), is(equalTo(1))),
             () -> assertThat(glue.getBeforeHooks().size(), is(equalTo(1))),
             () -> assertThat(glue.getAfterHooks().size(), is(equalTo(1))),
@@ -146,12 +140,11 @@ class CachingGlueTest {
             () -> assertThat(glue.getDefaultParameterTransformers().size(), is(equalTo(1))),
             () -> assertThat(glue.getDefaultDataTableCellTransformers().size(), is(equalTo(1))),
             () -> assertThat(glue.getDefaultDataTableEntryTransformers().size(), is(equalTo(1))),
-            () -> assertThat(glue.getDocStringTypeDefinitions().size(), is(equalTo(1)))
-        );
+            () -> assertThat(glue.getDocStringTypeDefinitions().size(), is(equalTo(1))));
 
         glue.removeScenarioScopedGlue();
 
-        assertAll("Checking Glue",
+        assertAll(
             () -> assertThat(glue.getStepDefinitions().size(), is(equalTo(0))),
             () -> assertThat(glue.getBeforeHooks().size(), is(equalTo(0))),
             () -> assertThat(glue.getAfterHooks().size(), is(equalTo(0))),
@@ -162,8 +155,7 @@ class CachingGlueTest {
             () -> assertThat(glue.getDefaultParameterTransformers().size(), is(equalTo(0))),
             () -> assertThat(glue.getDefaultDataTableCellTransformers().size(), is(equalTo(0))),
             () -> assertThat(glue.getDefaultDataTableEntryTransformers().size(), is(equalTo(0))),
-            () -> assertThat(glue.getDocStringTypeDefinitions().size(), is(equalTo(0)))
-        );
+            () -> assertThat(glue.getDocStringTypeDefinitions().size(), is(equalTo(0))));
     }
 
     @Test
@@ -178,10 +170,9 @@ class CachingGlueTest {
 
     private static Step getPickleStep(String text) {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given " + text + "\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given " + text + "\n");
 
         return feature.getPickles().get(0).getSteps().get(0);
     }
@@ -202,8 +193,7 @@ class CachingGlueTest {
         PickleStepDefinitionMatch pickleStepDefinitionMatch = glue.stepDefinitionMatch(uri, pickleStep1);
         assertThat(pickleStepDefinitionMatch.getStepDefinition(), is(equalTo(stepDefinition1)));
 
-
-        //check cache
+        // check cache
         assertThat(glue.getStepPatternByStepText().get(stepText), is(equalTo(stepDefinition1.getPattern())));
         CoreStepDefinition coreStepDefinition = glue.getStepDefinitionsByPattern().get(stepDefinition1.getPattern());
         assertThat(coreStepDefinition.getStepDefinition(), is(equalTo(stepDefinition1)));
@@ -228,29 +218,28 @@ class CachingGlueTest {
         PickleStepDefinitionMatch match1 = glue.stepDefinitionMatch(uri, pickleStep1);
         assertThat(match1.getStepDefinition(), is(equalTo(stepDefinition1)));
 
-        //check cache
+        // check cache
         assertThat(glue.getStepPatternByStepText().get(stepText), is(equalTo(stepDefinition1.getPattern())));
         CoreStepDefinition coreStepDefinition = glue.getStepDefinitionsByPattern().get(stepDefinition1.getPattern());
         assertThat(coreStepDefinition.getStepDefinition(), is(equalTo(stepDefinition1)));
 
-        //check arguments
+        // check arguments
         assertThat(((DataTable) match1.getArguments().get(0).getValue()).cell(0, 0), is(equalTo("cell 1")));
 
-        //check second match
+        // check second match
         Step pickleStep2 = getPickleStepWithSingleCellTable(stepText, "cell 2");
         PickleStepDefinitionMatch match2 = glue.stepDefinitionMatch(uri, pickleStep2);
 
-        //check arguments
+        // check arguments
         assertThat(((DataTable) match2.getArguments().get(0).getValue()).cell(0, 0), is(equalTo("cell 2")));
     }
 
     private static Step getPickleStepWithSingleCellTable(String stepText, String cell) {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given " + stepText + "\n" +
-            "       | " + cell + " |\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given " + stepText + "\n" +
+                "       | " + cell + " |\n");
 
         return feature.getPickles().get(0).getSteps().get(0);
     }
@@ -271,30 +260,29 @@ class CachingGlueTest {
         PickleStepDefinitionMatch match1 = glue.stepDefinitionMatch(uri, pickleStep1);
         assertThat(match1.getStepDefinition(), is(equalTo(stepDefinition1)));
 
-        //check cache
+        // check cache
         assertThat(glue.getStepPatternByStepText().get(stepText), is(equalTo(stepDefinition1.getPattern())));
         CoreStepDefinition coreStepDefinition = glue.getStepDefinitionsByPattern().get(stepDefinition1.getPattern());
         assertThat(coreStepDefinition.getStepDefinition(), is(equalTo(stepDefinition1)));
 
-        //check arguments
+        // check arguments
         assertThat(match1.getArguments().get(0).getValue(), is(equalTo("doc string 1")));
 
-        //check second match
+        // check second match
         Step pickleStep2 = getPickleStepWithDocString(stepText, "doc string 2");
         PickleStepDefinitionMatch match2 = glue.stepDefinitionMatch(uri, pickleStep2);
-        //check arguments
+        // check arguments
         assertThat(match2.getArguments().get(0).getValue(), is(equalTo("doc string 2")));
     }
 
     private static Step getPickleStepWithDocString(String stepText, String doc) {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given " + stepText + "\n" +
-            "       \"\"\"\n" +
-            "       " + doc + "\n" +
-            "       \"\"\"\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given " + stepText + "\n" +
+                "       \"\"\"\n" +
+                "       " + doc + "\n" +
+                "       \"\"\"\n");
 
         return feature.getPickles().get(0).getSteps().get(0);
     }
@@ -305,11 +293,9 @@ class CachingGlueTest {
         String stepText = "pattern1";
         Step pickleStep1 = getPickleStep(stepText);
 
-
         StepDefinition stepDefinition1 = new MockedScenarioScopedStepDefinition("^pattern1");
         glue.addStepDefinition(stepDefinition1);
         glue.prepareGlue(stepTypeRegistry);
-
 
         PickleStepDefinitionMatch pickleStepDefinitionMatch = glue.stepDefinitionMatch(uri, pickleStep1);
         assertThat(pickleStepDefinitionMatch.getStepDefinition(), is(equalTo(stepDefinition1)));
@@ -330,11 +316,9 @@ class CachingGlueTest {
         String stepText = "pattern1";
         Step pickleStep1 = getPickleStep(stepText);
 
-
         StepDefinition stepDefinition1 = new MockedScenarioScopedStepDefinition("^pattern1");
         glue.addStepDefinition(stepDefinition1);
         glue.prepareGlue(stepTypeRegistry);
-
 
         PickleStepDefinitionMatch pickleStepDefinitionMatch = glue.stepDefinitionMatch(uri, pickleStep1);
         assertThat(pickleStepDefinitionMatch.getStepDefinition(), is(equalTo(stepDefinition1)));
@@ -360,7 +344,7 @@ class CachingGlueTest {
         URI uri = URI.create("file:path/to.feature");
 
         checkAmbiguousCalled(uri);
-        //try again to verify if we don't cache when there is ambiguous step
+        // try again to verify if we don't cache when there is ambiguous step
         checkAmbiguousCalled(uri);
     }
 
@@ -386,9 +370,9 @@ class CachingGlueTest {
         glue.addBeforeHook(hookDefinition3);
 
         List<HookDefinition> hooks = glue.getBeforeHooks()
-            .stream()
-            .map(CoreHookDefinition::getDelegate)
-            .collect(Collectors.toList());
+                .stream()
+                .map(CoreHookDefinition::getDelegate)
+                .collect(Collectors.toList());
 
         assertThat(hooks, contains(hookDefinition1, hookDefinition2, hookDefinition3));
     }
@@ -403,9 +387,9 @@ class CachingGlueTest {
         glue.addAfterHook(hookDefinition3);
 
         List<HookDefinition> hooks = glue.getAfterHooks()
-            .stream()
-            .map(CoreHookDefinition::getDelegate)
-            .collect(Collectors.toList());
+                .stream()
+                .map(CoreHookDefinition::getDelegate)
+                .collect(Collectors.toList());
 
         assertThat(hooks, contains(hookDefinition3, hookDefinition2, hookDefinition1));
     }
@@ -420,15 +404,14 @@ class CachingGlueTest {
         glue.addBeforeHook(hookDefinition3);
 
         List<HookDefinition> hooks = glue.getBeforeHooks()
-            .stream()
-            .map(CoreHookDefinition::getDelegate)
-            .collect(Collectors.toList());
+                .stream()
+                .map(CoreHookDefinition::getDelegate)
+                .collect(Collectors.toList());
 
         assertThat(hooks, contains(hookDefinition2, hookDefinition1, hookDefinition3));
     }
 
     private static class MockedScenarioScopedStepDefinition extends StubStepDefinition implements ScenarioScoped {
-
 
         MockedScenarioScopedStepDefinition(String pattern, Type... types) {
             super(pattern, types);
@@ -477,7 +460,6 @@ class CachingGlueTest {
         }
 
     }
-
 
     private static class MockedHookDefinition implements HookDefinition {
 
@@ -531,7 +513,6 @@ class CachingGlueTest {
             this.order = order;
         }
 
-
         @Override
         public boolean isDefinedAt(StackTraceElement stackTraceElement) {
             return false;
@@ -567,7 +548,8 @@ class CachingGlueTest {
 
     }
 
-    private static class MockedDefaultParameterTransformer implements DefaultParameterTransformerDefinition, ScenarioScoped {
+    private static class MockedDefaultParameterTransformer
+            implements DefaultParameterTransformerDefinition, ScenarioScoped {
 
         @Override
         public ParameterByTypeTransformer parameterByTypeTransformer() {
@@ -586,7 +568,8 @@ class CachingGlueTest {
 
     }
 
-    private static class MockedDefaultDataTableCellTransformer implements DefaultDataTableCellTransformerDefinition, ScenarioScoped {
+    private static class MockedDefaultDataTableCellTransformer
+            implements DefaultDataTableCellTransformerDefinition, ScenarioScoped {
 
         @Override
         public TableCellByTypeTransformer tableCellByTypeTransformer() {
@@ -605,7 +588,8 @@ class CachingGlueTest {
 
     }
 
-    private static class MockedDefaultDataTableEntryTransformer implements DefaultDataTableEntryTransformerDefinition, ScenarioScoped {
+    private static class MockedDefaultDataTableEntryTransformer
+            implements DefaultDataTableEntryTransformerDefinition, ScenarioScoped {
 
         @Override
         public boolean headersToProperties() {

--- a/core/src/test/java/io/cucumber/core/runner/CamelCaseConverterTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/CamelCaseConverterTest.java
@@ -1,6 +1,5 @@
 package io.cucumber.core.runner;
 
-
 import io.cucumber.core.exception.CucumberException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,29 +19,29 @@ class CamelCaseConverterTest {
     private final CamelCaseStringConverter camelCaseConverter = new CamelCaseStringConverter();
 
     @ParameterizedTest
-    @ValueSource(strings = {
-        "testString", "TestString", "Test String",
-        "test String", "Test string"
-    })
+    @ValueSource(
+            strings = {
+                    "testString", "TestString", "Test String",
+                    "test String", "Test string"
+            })
     void convert_to_camel_case(String header) {
         assertThat(
             camelCaseConverter.toCamelCase(singletonMap(header, "value")),
-            equalTo(singletonMap("testString", "value"))
-        );
+            equalTo(singletonMap("testString", "value")));
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-        "threeWordsString", "ThreeWordsString", "three Words String",
-        "Three Words String", "Three words String", "Three Words string",
-        "Three words string", "three Words string", "three words String",
-        "threeWords string", "three WordsString", "three wordsString",
-    })
+    @ValueSource(
+            strings = {
+                    "threeWordsString", "ThreeWordsString", "three Words String",
+                    "Three Words String", "Three words String", "Three Words string",
+                    "Three words string", "three Words string", "three words String",
+                    "threeWords string", "three WordsString", "three wordsString",
+            })
     void convert_three_words_to_camel_case(String header) {
         assertThat(
             camelCaseConverter.toCamelCase(singletonMap(header, "value")),
-            equalTo(singletonMap("threeWordsString", "value"))
-        );
+            equalTo(singletonMap("threeWordsString", "value")));
     }
 
     @Test
@@ -53,12 +52,10 @@ class CamelCaseConverterTest {
 
         CucumberException exception = assertThrows(
             CucumberException.class,
-            () -> camelCaseConverter.toCamelCase(table)
-        );
+            () -> camelCaseConverter.toCamelCase(table));
         assertThat(exception.getMessage(), is("" +
-            "Failed to convert header 'Title Case Header' to property name. " +
-            "'TitleCaseHeader' also converted to 'titleCaseHeader'"
-        ));
+                "Failed to convert header 'Title Case Header' to property name. " +
+                "'TitleCaseHeader' also converted to 'titleCaseHeader'"));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/runner/CoreStepDefinitionTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/CoreStepDefinitionTest.java
@@ -41,13 +41,12 @@ class CoreStepDefinitionTest {
     @Test
     void should_apply_identity_transform_to_doc_string_when_target_type_is_object() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have some step\n" +
-            "       \"\"\"\n" +
-            "       content\n" +
-            "       \"\"\"\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have some step\n" +
+                "       \"\"\"\n" +
+                "       content\n" +
+                "       \"\"\"\n");
         StepDefinition stepDefinition = new StubStepDefinition("I have some step", Object.class);
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
@@ -56,15 +55,13 @@ class CoreStepDefinitionTest {
         assertThat(arguments.get(0).getValue(), is(equalTo(DocString.create("content"))));
     }
 
-
     @Test
     void should_apply_identity_transform_to_data_table_when_target_type_is_object() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have some step\n" +
-            "      | content |\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have some step\n" +
+                "      | content |\n");
         StepDefinition stepDefinition = new StubStepDefinition("I have some step", Object.class);
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
@@ -75,11 +72,10 @@ class CoreStepDefinitionTest {
     @Test
     void should_convert_empty_pickle_table_cells_to_null_values() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have some step\n" +
-            "       |  |\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have some step\n" +
+                "       |  |\n");
         StepDefinition stepDefinition = new StubStepDefinition("I have some step", Object.class);
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
@@ -91,25 +87,24 @@ class CoreStepDefinitionTest {
     void transforms_to_map_of_double_to_double() throws Throwable {
         Method m = Steps.class.getMethod("mapOfDoubleToDouble", Map.class);
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given some text\n" +
-            "      | 100.5 | 99.5 | \n" +
-            "      | 0.5   | -0.5 | \n" +
-            "      | 1000  | 999  | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given some text\n" +
+                "      | 100.5 | 99.5 | \n" +
+                "      | 0.5   | -0.5 | \n" +
+                "      | 1000  | 999  | \n");
         Map<Double, Double> stepDefs = runStepDef(m, false, feature);
 
-        assertAll("Checking StepDefs",
+        assertAll(
             () -> assertThat(stepDefs, hasEntry(1000.0, 999.0)),
             () -> assertThat(stepDefs, hasEntry(0.5, -0.5)),
-            () -> assertThat(stepDefs, hasEntry(100.5, 99.5))
-        );
+            () -> assertThat(stepDefs, hasEntry(100.5, 99.5)));
     }
 
     @SuppressWarnings("unchecked")
     private <T> T runStepDef(Method method, boolean transposed, Feature feature) {
-        StubStepDefinition stepDefinition = new StubStepDefinition("some text", transposed, method.getGenericParameterTypes());
+        StubStepDefinition stepDefinition = new StubStepDefinition("some text", transposed,
+            method.getGenericParameterTypes());
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
         Step stepWithTable = feature.getPickles().get(0).getSteps().get(0);
@@ -128,13 +123,12 @@ class CoreStepDefinitionTest {
     void transforms_transposed_to_map_of_double_to_double() throws Throwable {
         Method m = Steps.class.getMethod("transposedMapOfDoubleToListOfDouble", Map.class);
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given some text\n" +
-            "      | 100.5 | 99.5 | \n" +
-            "      | 0.5   | -0.5 | \n" +
-            "      | 1000  | 999  | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given some text\n" +
+                "      | 100.5 | 99.5 | \n" +
+                "      | 0.5   | -0.5 | \n" +
+                "      | 1000  | 999  | \n");
         Map<Double, List<Double>> stepDefs = runStepDef(m, true, feature);
         assertThat(stepDefs, hasEntry(100.5, asList(0.5, 1000.0)));
     }
@@ -143,13 +137,12 @@ class CoreStepDefinitionTest {
     void transforms_to_list_of_single_values() throws Throwable {
         Method m = Steps.class.getMethod("listOfListOfDoubles", List.class);
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given some text\n" +
-            "      | 100.5 | 99.5 | \n" +
-            "      | 0.5   | -0.5 | \n" +
-            "      | 1000  | 999  | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given some text\n" +
+                "      | 100.5 | 99.5 | \n" +
+                "      | 0.5   | -0.5 | \n" +
+                "      | 1000  | 999  | \n");
         List<List<Double>> stepDefs = runStepDef(m, false, feature);
         assertThat(stepDefs.toString(), is(equalTo("[[100.5, 99.5], [0.5, -0.5], [1000.0, 999.0]]")));
     }
@@ -158,12 +151,11 @@ class CoreStepDefinitionTest {
     void transforms_to_list_of_single_values_transposed() throws Throwable {
         Method m = Steps.class.getMethod("listOfListOfDoubles", List.class);
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given some text\n" +
-            "      | 100.5 | 0.5   | 1000| \n" +
-            "      | 99.5   | -0.5 | 999 | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given some text\n" +
+                "      | 100.5 | 0.5   | 1000| \n" +
+                "      | 99.5   | -0.5 | 999 | \n");
         List<List<Double>> stepDefs = runStepDef(m, true, feature);
         assertThat(stepDefs.toString(), is(equalTo("[[100.5, 99.5], [0.5, -0.5], [1000.0, 999.0]]")));
     }
@@ -172,39 +164,35 @@ class CoreStepDefinitionTest {
     void passes_plain_data_table() throws Throwable {
         Method m = Steps.class.getMethod("plainDataTable", DataTable.class);
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given some text\n" +
-            "      | Birth Date | \n" +
-            "      | 1957-05-10 | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given some text\n" +
+                "      | Birth Date | \n" +
+                "      | 1957-05-10 | \n");
         DataTable stepDefs = runStepDef(m, false, feature);
 
-        assertAll("Checking stepDefs",
+        assertAll(
             () -> assertThat(stepDefs.cell(0, 0), is(equalTo("Birth Date"))),
-            () -> assertThat(stepDefs.cell(1, 0), is(equalTo("1957-05-10")))
-        );
+            () -> assertThat(stepDefs.cell(1, 0), is(equalTo("1957-05-10"))));
     }
 
     @Test
     void passes_transposed_data_table() throws Throwable {
         Method m = Steps.class.getMethod("plainDataTable", DataTable.class);
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given some text\n" +
-            "      | Birth Date | \n" +
-            "      | 1957-05-10 | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given some text\n" +
+                "      | Birth Date | \n" +
+                "      | 1957-05-10 | \n");
         DataTable stepDefs = runStepDef(m, true, feature);
 
-        assertAll("Checking stepDefs",
+        assertAll(
             () -> assertThat(stepDefs.cell(0, 0), is(equalTo("Birth Date"))),
-            () -> assertThat(stepDefs.cell(0, 1), is(equalTo("1957-05-10")))
-        );
+            () -> assertThat(stepDefs.cell(0, 1), is(equalTo("1957-05-10"))));
     }
 
-    @SuppressWarnings({"WeakerAccess", "unused"})
+    @SuppressWarnings({ "WeakerAccess", "unused" })
     public static class Steps {
 
         public void listOfListOfDoubles(List<List<Double>> listOfListOfDoubles) {

--- a/core/src/test/java/io/cucumber/core/runner/DuplicateStepDefinitionExceptionTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/DuplicateStepDefinitionExceptionTest.java
@@ -20,12 +20,12 @@ class DuplicateStepDefinitionExceptionTest {
         final StepDefinition mockStepDefinitionB = mock(StepDefinition.class);
         when(mockStepDefinitionB.getLocation()).thenReturn("StepDefinitionB_Location");
 
-        DuplicateStepDefinitionException expectedThrown = new DuplicateStepDefinitionException(mockStepDefinitionA, mockStepDefinitionB);
+        DuplicateStepDefinitionException expectedThrown = new DuplicateStepDefinitionException(mockStepDefinitionA,
+            mockStepDefinitionB);
         assertAll(
-            () -> assertThat(expectedThrown.getMessage(), is(equalTo("Duplicate step definitions in StepDefinitionA_Location and StepDefinitionB_Location"))),
-            () -> assertThat(expectedThrown.getCause(), is(nullValue()))
-        );
+            () -> assertThat(expectedThrown.getMessage(),
+                is(equalTo("Duplicate step definitions in StepDefinitionA_Location and StepDefinitionB_Location"))),
+            () -> assertThat(expectedThrown.getCause(), is(nullValue())));
     }
 
 }
-

--- a/core/src/test/java/io/cucumber/core/runner/HookOrderTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/HookOrderTest.java
@@ -30,10 +30,9 @@ class HookOrderTest {
 
     private final StubStepDefinition stepDefinition = new StubStepDefinition("I have 4 cukes in my belly");
     private final Feature feature = TestFeatureParser.parse("" +
-        "Feature: Test feature\n" +
-        "  Scenario: Test scenario\n" +
-        "     Given I have 4 cukes in my belly\n"
-    );
+            "Feature: Test feature\n" +
+            "  Scenario: Test scenario\n" +
+            "     Given I have 4 cukes in my belly\n");
     private final Pickle pickle = feature.getPickles().get(0);
 
     @Test
@@ -160,7 +159,6 @@ class HookOrderTest {
     void hooks_order_across_many_backends() {
         final List<HookDefinition> backend1Hooks = mockHooks(3, Integer.MAX_VALUE, 1);
         final List<HookDefinition> backend2Hooks = mockHooks(2, Integer.MAX_VALUE, 4);
-
 
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override

--- a/core/src/test/java/io/cucumber/core/runner/HookTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/HookTest.java
@@ -31,15 +31,14 @@ class HookTest {
     private final EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
     private final RuntimeOptions runtimeOptions = RuntimeOptions.defaultOptions();
     private final Feature feature = TestFeatureParser.parse("" +
-        "Feature: Test feature\n" +
-        "  Scenario: Test scenario\n" +
-        "     Given I have 4 cukes in my belly\n"
-    );
+            "Feature: Test feature\n" +
+            "  Scenario: Test scenario\n" +
+            "     Given I have 4 cukes in my belly\n");
     private final Pickle pickle = feature.getPickles().get(0);
 
-
     /**
-     * Test for <a href="https://github.com/cucumber/cucumber-jvm/issues/23">#23</a>.
+     * Test for
+     * <a href="https://github.com/cucumber/cucumber-jvm/issues/23">#23</a>.
      */
     @Test
     void after_hooks_execute_before_objects_are_disposed() {
@@ -57,7 +56,8 @@ class HookTest {
             return null;
         }).when(backend).loadGlue(any(Glue.class), ArgumentMatchers.anyList());
 
-        Runner runner = new Runner(bus, Collections.singleton(backend), objectFactory, typeRegistryConfigurer, runtimeOptions);
+        Runner runner = new Runner(bus, Collections.singleton(backend), objectFactory, typeRegistryConfigurer,
+            runtimeOptions);
 
         runner.runPickle(pickle);
 

--- a/core/src/test/java/io/cucumber/core/runner/HookTestStepTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/HookTestStepTest.java
@@ -30,10 +30,9 @@ import static org.mockito.Mockito.never;
 class HookTestStepTest {
 
     private final Feature feature = TestFeatureParser.parse("" +
-        "Feature: Test feature\n" +
-        "  Scenario: Test scenario\n" +
-        "     Given I have 4 cukes in my belly\n"
-    );
+            "Feature: Test feature\n" +
+            "  Scenario: Test scenario\n" +
+            "     Given I have 4 cukes in my belly\n");
     private final CoreHookDefinition hookDefintion = mock(CoreHookDefinition.class);
     private final HookDefinitionMatch definitionMatch = new HookDefinitionMatch(hookDefintion);
     private final TestCase testCase = new TestCase(
@@ -42,8 +41,7 @@ class HookTestStepTest {
         Collections.emptyList(),
         Collections.emptyList(),
         feature.getPickles().get(0),
-        false
-    );
+        false);
     private final EventBus bus = mock(EventBus.class);
     private final UUID testExecutionId = UUID.randomUUID();
     private final TestCaseState state = new TestCaseState(bus, testExecutionId, testCase);

--- a/core/src/test/java/io/cucumber/core/runner/PickleStepTestStepTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/PickleStepTestStepTest.java
@@ -53,28 +53,29 @@ import static org.mockito.Mockito.when;
 class PickleStepTestStepTest {
 
     private final Feature feature = TestFeatureParser.parse("" +
-        "Feature: Test feature\n" +
-        "  Scenario: Test scenario\n" +
-        "     Given I have 4 cukes in my belly\n"
-    );
+            "Feature: Test feature\n" +
+            "  Scenario: Test scenario\n" +
+            "     Given I have 4 cukes in my belly\n");
     private final Pickle pickle = feature.getPickles().get(0);
-    private final TestCase testCase = new TestCase(UUID.randomUUID(), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), pickle, false);
+    private final TestCase testCase = new TestCase(UUID.randomUUID(), Collections.emptyList(), Collections.emptyList(),
+        Collections.emptyList(), pickle, false);
     private final EventBus bus = mock(EventBus.class);
     private final UUID testExecutionId = UUID.randomUUID();
     private final TestCaseState state = new TestCaseState(bus, testExecutionId, testCase);
     private final PickleStepDefinitionMatch definitionMatch = mock(PickleStepDefinitionMatch.class);
     private final CoreHookDefinition afterHookDefinition = mock(CoreHookDefinition.class);
-    private final HookTestStep afterHook = new HookTestStep(UUID.randomUUID(), AFTER_STEP, new HookDefinitionMatch(afterHookDefinition));
+    private final HookTestStep afterHook = new HookTestStep(UUID.randomUUID(), AFTER_STEP,
+        new HookDefinitionMatch(afterHookDefinition));
     private final CoreHookDefinition beforeHookDefinition = mock(CoreHookDefinition.class);
-    private final HookTestStep beforeHook = new HookTestStep(UUID.randomUUID(), BEFORE_STEP, new HookDefinitionMatch(beforeHookDefinition));
+    private final HookTestStep beforeHook = new HookTestStep(UUID.randomUUID(), BEFORE_STEP,
+        new HookDefinitionMatch(beforeHookDefinition));
     private final PickleStepTestStep step = new PickleStepTestStep(
         UUID.randomUUID(),
         URI.create("file:path/to.feature"),
         pickle.getSteps().get(0),
         singletonList(beforeHook),
         singletonList(afterHook),
-        definitionMatch
-    );
+        definitionMatch);
 
     @BeforeEach
     void init() {
@@ -245,17 +246,15 @@ class PickleStepTestStepTest {
     @Test
     void step_execution_time_is_measured() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my belly\n");
 
         TestStep step = new PickleStepTestStep(
             UUID.randomUUID(),
             URI.create("file:path/to.feature"),
             feature.getPickles().get(0).getSteps().get(0),
-            definitionMatch
-        );
+            definitionMatch);
         when(bus.getInstant()).thenReturn(ofEpochMilli(234L), ofEpochMilli(1234L));
         step.run(testCase, bus, state, false);
 
@@ -266,11 +265,10 @@ class PickleStepTestStepTest {
         TestStepStarted started = (TestStepStarted) allValues.get(0);
         TestStepFinished finished = (TestStepFinished) allValues.get(2);
 
-        assertAll("Checking TestStep",
+        assertAll(
             () -> assertThat(started.getInstant(), is(equalTo(ofEpochMilli(234L)))),
             () -> assertThat(finished.getInstant(), is(equalTo(ofEpochMilli(1234L)))),
-            () -> assertThat(finished.getResult().getDuration(), is(equalTo(ofMillis(1000L))))
-        );
+            () -> assertThat(finished.getResult().getDuration(), is(equalTo(ofMillis(1000L)))));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/runner/RunnerTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/RunnerTest.java
@@ -60,9 +60,8 @@ class RunnerTest {
             return null;
         }).when(backend).loadGlue(any(Glue.class), ArgumentMatchers.anyList());
 
-
         new Runner(bus, singletonList(backend), objectFactory, typeRegistryConfigurer, runtimeOptions)
-            .runPickle(createPicklesWithSteps());
+                .runPickle(createPicklesWithSteps());
 
         InOrder inOrder = inOrder(beforeHook, afterHook, backend);
         inOrder.verify(backend).buildWorld();
@@ -81,10 +80,9 @@ class RunnerTest {
 
     private Pickle createPicklesWithSteps() {
         Feature feature = TestFeatureParser.parse("file:path/to.feature", "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given some step\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given some step\n");
         return feature.getPickles().get(0);
     }
 
@@ -120,10 +118,9 @@ class RunnerTest {
     private Pickle createPickleMatchingStepDefinitions(StubStepDefinition stepDefinition) {
         String pattern = stepDefinition.getPattern();
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given " + pattern + "\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given " + pattern + "\n");
         return feature.getPickles().get(0);
     }
 
@@ -289,9 +286,8 @@ class RunnerTest {
 
     private Pickle createEmptyPickle() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n");
         return feature.getPickles().get(0);
     }
 

--- a/core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
@@ -55,14 +55,12 @@ class StepDefinitionMatchTest {
         }
     };
 
-
     @Test
     void executes_a_step() throws Throwable {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my belly\n");
         Step step = feature.getPickles().get(0).getSteps().get(0);
 
         StepDefinition stepDefinition = new StubStepDefinition("I have {int} cukes in my belly", Integer.class);
@@ -76,10 +74,9 @@ class StepDefinitionMatchTest {
     @Test
     void throws_arity_mismatch_exception_when_there_are_fewer_parameters_than_arguments() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my belly\n");
         Step step = feature.getPickles().get(0).getSteps().get(0);
 
         StepDefinition stepDefinition = new StubStepDefinition("I have {int} cukes in my belly");
@@ -91,84 +88,85 @@ class StepDefinitionMatchTest {
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "Step [I have {int} cukes in my belly] is defined with 0 parameters at '{stubbed location with details}'.\n" +
-                "However, the gherkin step has 1 arguments:\n" +
-                " * 4\n" +
-                "Step text: I have 4 cukes in my belly"
-        )));
+            "Step [I have {int} cukes in my belly] is defined with 0 parameters at '{stubbed location with details}'.\n"
+                    +
+                    "However, the gherkin step has 1 arguments:\n" +
+                    " * 4\n" +
+                    "Step text: I have 4 cukes in my belly")));
     }
 
     @Test
     void throws_arity_mismatch_exception_when_there_are_fewer_parameters_than_arguments_with_data_table() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my belly\n" +
-            "       | A | B | \n" +
-            "       | C | D | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my belly\n" +
+                "       | A | B | \n" +
+                "       | C | D | \n");
         Step step = feature.getPickles().get(0).getSteps().get(0);
 
         StepDefinition stepDefinition = new StubStepDefinition("I have {int} cukes in my belly");
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
-        PickleStepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
+        PickleStepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null,
+            step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "Step [I have {int} cukes in my belly] is defined with 0 parameters at '{stubbed location with details}'.\n" +
-                "However, the gherkin step has 2 arguments:\n" +
-                " * 4\n" +
-                " * Table:\n" +
-                "      | A | B |\n" +
-                "      | C | D |\n" +
-                "\n" +
-                "Step text: I have 4 cukes in my belly"
-        )));
+            "Step [I have {int} cukes in my belly] is defined with 0 parameters at '{stubbed location with details}'.\n"
+                    +
+                    "However, the gherkin step has 2 arguments:\n" +
+                    " * 4\n" +
+                    " * Table:\n" +
+                    "      | A | B |\n" +
+                    "      | C | D |\n" +
+                    "\n" +
+                    "Step text: I have 4 cukes in my belly")));
     }
 
     @Test
     void throws_arity_mismatch_exception_when_there_are_more_parameters_than_arguments() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my belly\n" +
-            "       | A | B | \n" +
-            "       | C | D | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my belly\n" +
+                "       | A | B | \n" +
+                "       | C | D | \n");
         Step step = feature.getPickles().get(0).getSteps().get(0);
 
-        StepDefinition stepDefinition = new StubStepDefinition("I have {int} cukes in my belly", Integer.TYPE, Short.TYPE, List.class);
+        StepDefinition stepDefinition = new StubStepDefinition("I have {int} cukes in my belly", Integer.TYPE,
+            Short.TYPE, List.class);
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
-        PickleStepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
+        PickleStepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null,
+            step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "Step [I have {int} cukes in my belly] is defined with 3 parameters at '{stubbed location with details}'.\n" +
-                "However, the gherkin step has 2 arguments:\n" +
-                " * 4\n" +
-                " * Table:\n" +
-                "      | A | B |\n" +
-                "      | C | D |\n" +
-                "\n" +
-                "Step text: I have 4 cukes in my belly"
-        )));
+            "Step [I have {int} cukes in my belly] is defined with 3 parameters at '{stubbed location with details}'.\n"
+                    +
+                    "However, the gherkin step has 2 arguments:\n" +
+                    " * 4\n" +
+                    " * Table:\n" +
+                    "      | A | B |\n" +
+                    "      | C | D |\n" +
+                    "\n" +
+                    "Step text: I have 4 cukes in my belly")));
     }
 
     @Test
     void throws_arity_mismatch_exception_when_there_are_more_parameters_and_no_arguments() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have cukes in my belly\n");
         Step step = feature.getPickles().get(0).getSteps().get(0);
-        StepDefinition stepDefinition = new StubStepDefinition("I have cukes in my belly", Integer.TYPE, Short.TYPE, List.class);
+        StepDefinition stepDefinition = new StubStepDefinition("I have cukes in my belly", Integer.TYPE, Short.TYPE,
+            List.class);
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
@@ -178,25 +176,22 @@ class StepDefinitionMatchTest {
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
             "Step [I have cukes in my belly] is defined with 3 parameters at '{stubbed location with details}'.\n" +
-                "However, the gherkin step has 0 arguments.\n" +
-                "Step text: I have cukes in my belly"
-        )));
+                    "However, the gherkin step has 0 arguments.\n" +
+                    "Step text: I have cukes in my belly")));
     }
 
     @Test
     void throws_register_type_in_configuration_exception_when_there_is_no_data_table_type_defined() {
         Feature feature = TestFeatureParser.parse("file:test.feature", "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have a data table\n" +
-            "       | A | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have a data table\n" +
+                "       | A | \n");
         Step step = feature.getPickles().get(0).getSteps().get(0);
 
         StepDefinition stepDefinition = new StubStepDefinition(
             "I have a data table",
-            UndefinedDataTableType.class
-        );
+            UndefinedDataTableType.class);
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
@@ -204,15 +199,14 @@ class StepDefinitionMatchTest {
             arguments,
             stepDefinition,
             URI.create("file:path/to.feature"),
-            step
-        );
+            step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "Could not convert arguments for step [I have a data table] defined at '{stubbed location with details}'.\n" +
-                "It appears you did not register a data table type."
-        )));
+            "Could not convert arguments for step [I have a data table] defined at '{stubbed location with details}'.\n"
+                    +
+                    "It appears you did not register a data table type.")));
     }
 
     @Test
@@ -225,10 +219,9 @@ class StepDefinitionMatchTest {
         ));
 
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have some cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have some cukes in my belly\n");
         Step step = feature.getPickles().get(0).getSteps().get(0);
         StepDefinition stepDefinition = new StubStepDefinition("I have {itemQuantity} in my belly", ItemQuantity.class);
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
@@ -239,8 +232,7 @@ class StepDefinitionMatchTest {
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "Could not convert arguments for step [I have {itemQuantity} in my belly] defined at '{stubbed location with details}'."
-        )));
+            "Could not convert arguments for step [I have {itemQuantity} in my belly] defined at '{stubbed location with details}'.")));
     }
 
     @Test
@@ -252,15 +244,14 @@ class StepDefinitionMatchTest {
             "(few|some|lots of) (cukes|gherkins)",
             ItemQuantity.class,
             (String[] s) -> {
-                throw new CucumberInvocationTargetException(stubbedLocation, new InvocationTargetException(userException));
-            }
-        ));
+                throw new CucumberInvocationTargetException(stubbedLocation,
+                    new InvocationTargetException(userException));
+            }));
 
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have some cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have some cukes in my belly\n");
         Step step = feature.getPickles().get(0).getSteps().get(0);
         StepDefinition stepDefinition = new StubStepDefinition("I have {itemQuantity} in my belly", ItemQuantity.class);
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
@@ -276,13 +267,12 @@ class StepDefinitionMatchTest {
     @Test
     void throws_could_not_convert_exception_for_singleton_table_dimension_mismatch() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have some cukes in my belly\n" +
-            "       | 3 | \n" +
-            "       | 14 | \n" +
-            "       | 15 | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have some cukes in my belly\n" +
+                "       | 3 | \n" +
+                "       | 14 | \n" +
+                "       | 15 | \n");
 
         stepTypeRegistry.defineDataTableType(new DataTableType(ItemQuantity.class, ItemQuantity::new));
 
@@ -296,28 +286,26 @@ class StepDefinitionMatchTest {
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat(actualThrown.getMessage(), is(equalTo(
-            "Could not convert arguments for step [I have some cukes in my belly] defined at '{stubbed location with details}'."
-        )));
+            "Could not convert arguments for step [I have some cukes in my belly] defined at '{stubbed location with details}'.")));
     }
 
     @Test
     void rethrows_target_invocation_exceptions_from_data_table() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have some cukes in my belly\n" +
-            "       | 3 | \n" +
-            "       | 14 | \n" +
-            "       | 15 | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have some cukes in my belly\n" +
+                "       | 3 | \n" +
+                "       | 14 | \n" +
+                "       | 15 | \n");
         RuntimeException userException = new RuntimeException();
 
         stepTypeRegistry.defineDataTableType(new DataTableType(
             ItemQuantity.class,
             (String cell) -> {
-                throw new CucumberInvocationTargetException(stubbedLocation, new InvocationTargetException(userException));
-            }
-        ));
+                throw new CucumberInvocationTargetException(stubbedLocation,
+                    new InvocationTargetException(userException));
+            }));
 
         Step step = feature.getPickles().get(0).getSteps().get(0);
         StepDefinition stepDefinition = new StubStepDefinition("I have some cukes in my belly", ItemQuantity.class);
@@ -334,13 +322,12 @@ class StepDefinitionMatchTest {
     @Test
     void throws_could_not_convert_exception_for_docstring() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have some cukes in my belly\n" +
-            "       \"\"\"doc\n" +
-            "        converting this should throw an exception\n" +
-            "       \"\"\"\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have some cukes in my belly\n" +
+                "       \"\"\"doc\n" +
+                "        converting this should throw an exception\n" +
+                "       \"\"\"\n");
 
         stepTypeRegistry.defineDocStringType(new DocStringType(ItemQuantity.class, "doc", content -> {
             throw new IllegalArgumentException(content);
@@ -356,8 +343,7 @@ class StepDefinitionMatchTest {
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat(actualThrown.getMessage(), is(equalTo(
-            "Could not convert arguments for step [I have some cukes in my belly] defined at '{stubbed location with details}'."
-        )));
+            "Could not convert arguments for step [I have some cukes in my belly] defined at '{stubbed location with details}'.")));
     }
 
     @Test
@@ -365,13 +351,12 @@ class StepDefinitionMatchTest {
         RuntimeException userException = new RuntimeException();
 
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have some cukes in my belly\n" +
-            "       \"\"\"doc\n" +
-            "        converting this should throw an exception\n" +
-            "       \"\"\"\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have some cukes in my belly\n" +
+                "       \"\"\"doc\n" +
+                "        converting this should throw an exception\n" +
+                "       \"\"\"\n");
 
         stepTypeRegistry.defineDocStringType(new DocStringType(ItemQuantity.class, "doc", content -> {
             throw new CucumberInvocationTargetException(stubbedLocation, new InvocationTargetException(userException));
@@ -392,17 +377,15 @@ class StepDefinitionMatchTest {
     @Test
     void throws_could_not_invoke_argument_conversion_when_argument_could_not_be_got() {
         Feature feature = TestFeatureParser.parse("file:test.feature", "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have a data table\n" +
-            "       | A | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have a data table\n" +
+                "       | A | \n");
         Step step = feature.getPickles().get(0).getSteps().get(0);
 
         StepDefinition stepDefinition = new StubStepDefinition(
             "I have a data table",
-            UndefinedDataTableType.class
-        );
+            UndefinedDataTableType.class);
         List<Argument> arguments = Collections.singletonList(() -> {
             throw new CucumberBackendException("This exception is expected", new IllegalAccessException());
         });
@@ -410,87 +393,76 @@ class StepDefinitionMatchTest {
             arguments,
             stepDefinition,
             URI.create("file:path/to.feature"),
-            step
-        );
+            step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "Could not convert arguments for step [I have a data table] defined at '{stubbed location with details}'.\n" +
-                "It appears there was a problem with a hook or transformer definition."
-        )));
+            "Could not convert arguments for step [I have a data table] defined at '{stubbed location with details}'.\n"
+                    +
+                    "It appears there was a problem with a hook or transformer definition.")));
     }
 
     @Test
     void throws_could_not_invoke_step_when_execution_failed_due_to_bad_methods() {
         Feature feature = TestFeatureParser.parse("file:test.feature", "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have a data table\n" +
-            "       | A | \n" +
-            "       | B | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have a data table\n" +
+                "       | A | \n" +
+                "       | B | \n");
         Step step = feature.getPickles().get(0).getSteps().get(0);
 
         StepDefinition stepDefinition = new StubStepDefinition(
             "I have a data table",
             new CucumberBackendException("This exception is expected!", new IllegalAccessException()),
             String.class,
-            String.class
-        );
+            String.class);
 
         List<Argument> arguments = asList(
             () -> "mocked table cell",
-            () -> "mocked table cell"
-        );
+            () -> "mocked table cell");
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(
             arguments,
             stepDefinition,
             URI.create("file:path/to.feature"),
-            step
-        );
+            step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
             "Could not invoke step [I have a data table] defined at '{stubbed location with details}'.\n" +
-                "It appears there was a problem with the step definition.\n" +
-                "The converted arguments types were (java.lang.String, java.lang.String)"
-        )));
+                    "It appears there was a problem with the step definition.\n" +
+                    "The converted arguments types were (java.lang.String, java.lang.String)")));
     }
 
     @Test
     void throws_could_not_invoke_step_when_execution_failed_with_null_arguments() {
         Feature feature = TestFeatureParser.parse("file:test.feature", "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have an null value\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have an null value\n");
         Step step = feature.getPickles().get(0).getSteps().get(0);
 
         StepDefinition stepDefinition = new StubStepDefinition(
             "I have an {word} value",
             new CucumberBackendException("This exception is expected!", new IllegalAccessException()),
-            String.class
-        );
+            String.class);
 
         List<Argument> arguments = asList(
-            () -> null
-        );
+            () -> null);
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(
             arguments,
             stepDefinition,
             URI.create("file:path/to.feature"),
-            step
-        );
+            step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
             "Could not invoke step [I have an {word} value] defined at '{stubbed location with details}'.\n" +
-                "It appears there was a problem with the step definition.\n" +
-                "The converted arguments types were (null)"
-        )));
+                    "It appears there was a problem with the step definition.\n" +
+                    "The converted arguments types were (null)")));
     }
 
     private static final class ItemQuantity {

--- a/core/src/test/java/io/cucumber/core/runner/TestBackendSupplier.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestBackendSupplier.java
@@ -25,7 +25,6 @@ public abstract class TestBackendSupplier implements Backend, BackendSupplier {
         return new TestSnippet();
     }
 
-
     @Override
     public Collection<? extends Backend> get() {
         return Collections.singleton(this);

--- a/core/src/test/java/io/cucumber/core/runner/TestCaseStateResultTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestCaseStateResultTest.java
@@ -36,10 +36,9 @@ import static org.mockito.Mockito.when;
 class TestCaseStateResultTest {
 
     private final Feature feature = TestFeatureParser.parse("file:path/file.feature", "" +
-        "Feature: Test feature\n" +
-        "  Scenario: Test scenario\n" +
-        "     Given I have 4 cukes in my belly\n"
-    );
+            "Feature: Test feature\n" +
+            "  Scenario: Test scenario\n" +
+            "     Given I have 4 cukes in my belly\n");
     private final EventBus bus = mock(EventBus.class);
     private final TestCaseState s = new TestCaseState(
         bus,
@@ -50,9 +49,7 @@ class TestCaseStateResultTest {
             Collections.emptyList(),
             Collections.emptyList(),
             feature.getPickles().get(0),
-            false
-        )
-    );
+            false));
 
     @BeforeEach
     void setup() {
@@ -79,10 +76,9 @@ class TestCaseStateResultTest {
         s.add(new Result(Status.UNDEFINED, ZERO, null));
         s.add(new Result(Status.SKIPPED, ZERO, null));
 
-        assertAll("Checking Scenario",
+        assertAll(
             () -> assertThat(s.getStatus(), is(equalTo(FAILED))),
-            () -> assertTrue(s.isFailed())
-        );
+            () -> assertTrue(s.isFailed()));
     }
 
     @Test
@@ -90,10 +86,9 @@ class TestCaseStateResultTest {
         s.add(new Result(Status.PASSED, ZERO, null));
         s.add(new Result(Status.SKIPPED, ZERO, null));
 
-        assertAll("Checking Scenario",
+        assertAll(
             () -> assertThat(s.getStatus(), is(equalTo(SKIPPED))),
-            () -> assertFalse(s.isFailed())
-        );
+            () -> assertFalse(s.isFailed()));
     }
 
     @Test
@@ -103,10 +98,9 @@ class TestCaseStateResultTest {
         s.add(new Result(Status.PENDING, ZERO, null));
         s.add(new Result(Status.SKIPPED, ZERO, null));
 
-        assertAll("Checking Scenario",
+        assertAll(
             () -> assertThat(s.getStatus(), is(equalTo(UNDEFINED))),
-            () -> assertFalse(s.isFailed())
-        );
+            () -> assertFalse(s.isFailed()));
     }
 
     @Test
@@ -115,16 +109,15 @@ class TestCaseStateResultTest {
         s.add(new Result(Status.UNDEFINED, ZERO, null));
         s.add(new Result(Status.SKIPPED, ZERO, null));
 
-        assertAll("Checking Scenario",
+        assertAll(
             () -> assertThat(s.getStatus(), is(equalTo(UNDEFINED))),
-            () -> assertFalse(s.isFailed())
-        );
+            () -> assertFalse(s.isFailed()));
     }
 
     @SuppressWarnings("deprecation")
     @Test
     void embeds_data() {
-        byte[] data = new byte[]{1, 2, 3};
+        byte[] data = new byte[] { 1, 2, 3 };
         s.attach(data, "bytes/foo", null);
         verify(bus).send(argThat(new EmbedEventMatcher(data, "bytes/foo")));
     }
@@ -170,7 +163,7 @@ class TestCaseStateResultTest {
         @Override
         public boolean matches(EmbedEvent argument) {
             return (argument != null &&
-                Arrays.equals(argument.getData(), data) && argument.getMediaType().equals(mediaType));
+                    Arrays.equals(argument.getData(), data) && argument.getMediaType().equals(mediaType));
         }
 
     }

--- a/core/src/test/java/io/cucumber/core/runner/TestCaseStateTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestCaseStateTest.java
@@ -18,10 +18,9 @@ class TestCaseStateTest {
     @Test
     void provides_the_uri_of_the_feature_file() {
         Feature feature = TestFeatureParser.parse("file:path/file.feature", "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my belly\n");
         TestCaseState state = createTestCaseState(feature);
         assertThat(state.getUri(), is(new File("path/file.feature").toURI()));
     }
@@ -35,17 +34,15 @@ class TestCaseStateTest {
                 Collections.emptyList(),
                 Collections.emptyList(),
                 feature.getPickles().get(0),
-                false
-            ));
+                false));
     }
 
     @Test
     void provides_the_scenario_line() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my belly\n");
 
         TestCaseState state = createTestCaseState(feature);
         assertThat(state.getLine(), is(2));
@@ -54,13 +51,12 @@ class TestCaseStateTest {
     @Test
     void provides_both_the_example_row_line_and_scenario_outline_line_for_scenarios_from_scenario_outlines() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario Outline: Test scenario\n" +
-            "     Given I have 4 <thing> in my belly\n" +
-            "     Examples:\n" +
-            "       | thing | \n" +
-            "       | cuke  | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario Outline: Test scenario\n" +
+                "     Given I have 4 <thing> in my belly\n" +
+                "     Examples:\n" +
+                "       | thing | \n" +
+                "       | cuke  | \n");
 
         TestCaseState state = createTestCaseState(feature);
         assertThat(state.getLine(), is(6));
@@ -69,10 +65,9 @@ class TestCaseStateTest {
     @Test
     void provides_the_uri_and_scenario_line_as_unique_id() {
         Feature feature = TestFeatureParser.parse("file:path/file.feature", "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my belly\n");
 
         TestCaseState state = createTestCaseState(feature);
 
@@ -82,13 +77,12 @@ class TestCaseStateTest {
     @Test
     void provides_the_uri_and_example_row_line_as_unique_id_for_scenarios_from_scenario_outlines() {
         Feature feature = TestFeatureParser.parse("file:path/file.feature", "" +
-            "Feature: Test feature\n" +
-            "  Scenario Outline: Test scenario\n" +
-            "     Given I have 4 <thing> in my belly\n" +
-            "     Examples:\n" +
-            "       | thing | \n" +
-            "       | cuke  | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario Outline: Test scenario\n" +
+                "     Given I have 4 <thing> in my belly\n" +
+                "     Examples:\n" +
+                "       | thing | \n" +
+                "       | cuke  | \n");
         TestCaseState state = createTestCaseState(feature);
 
         assertThat(state.getId(), is(new File("path/file.feature:6").toURI().toString()));

--- a/core/src/test/java/io/cucumber/core/runner/TestCaseTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestCaseTest.java
@@ -29,11 +29,10 @@ import static org.mockito.Mockito.when;
 class TestCaseTest {
 
     private final Feature feature = TestFeatureParser.parse("" +
-        "Feature: Test feature\n" +
-        "  Scenario: Test scenario\n" +
-        "     Given I have 4 cukes in my belly\n" +
-        "     And I have 4 cucumber on my plate\n"
-    );
+            "Feature: Test feature\n" +
+            "  Scenario: Test scenario\n" +
+            "     Given I have 4 cukes in my belly\n" +
+            "     And I have 4 cucumber on my plate\n");
 
     private final EventBus bus = mock(EventBus.class);
 
@@ -45,10 +44,11 @@ class TestCaseTest {
         UUID.randomUUID(),
         URI.create("file:path/to.feature"),
         feature.getPickles().get(0).getSteps().get(0),
-        singletonList(new HookTestStep(UUID.randomUUID(), BEFORE_STEP, new HookDefinitionMatch(beforeStep1HookDefinition1))),
-        singletonList(new HookTestStep(UUID.randomUUID(), AFTER_STEP, new HookDefinitionMatch(afterStep1HookDefinition1))),
-        definitionMatch1
-    );
+        singletonList(
+            new HookTestStep(UUID.randomUUID(), BEFORE_STEP, new HookDefinitionMatch(beforeStep1HookDefinition1))),
+        singletonList(
+            new HookTestStep(UUID.randomUUID(), AFTER_STEP, new HookDefinitionMatch(afterStep1HookDefinition1))),
+        definitionMatch1);
 
     private final PickleStepDefinitionMatch definitionMatch2 = mock(PickleStepDefinitionMatch.class);
     private final CoreHookDefinition beforeStep1HookDefinition2 = mock(CoreHookDefinition.class);
@@ -57,10 +57,11 @@ class TestCaseTest {
         UUID.randomUUID(),
         URI.create("file:path/to.feature"),
         feature.getPickles().get(0).getSteps().get(1),
-        singletonList(new HookTestStep(UUID.randomUUID(), BEFORE_STEP, new HookDefinitionMatch(beforeStep1HookDefinition2))),
-        singletonList(new HookTestStep(UUID.randomUUID(), AFTER_STEP, new HookDefinitionMatch(afterStep1HookDefinition2))),
-        definitionMatch2
-    );
+        singletonList(
+            new HookTestStep(UUID.randomUUID(), BEFORE_STEP, new HookDefinitionMatch(beforeStep1HookDefinition2))),
+        singletonList(
+            new HookTestStep(UUID.randomUUID(), AFTER_STEP, new HookDefinitionMatch(afterStep1HookDefinition2))),
+        definitionMatch2);
 
     @BeforeEach
     void init() {
@@ -81,15 +82,15 @@ class TestCaseTest {
     }
 
     private TestCase createTestCase(PickleStepTestStep... steps) {
-        return new TestCase(UUID.randomUUID(), asList(steps), Collections.emptyList(), Collections.emptyList(), pickle(), false);
+        return new TestCase(UUID.randomUUID(), asList(steps), Collections.emptyList(), Collections.emptyList(),
+            pickle(), false);
     }
 
     private Pickle pickle() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my belly\n");
         return feature.getPickles().get(0);
     }
 

--- a/core/src/test/java/io/cucumber/core/runner/TestHelper.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestHelper.java
@@ -182,21 +182,20 @@ public class TestHelper {
             stepsToLocation,
             hooks,
             hookLocations,
-            hookActions
-        );
+            hookActions);
 
         final EventBus bus = createEventBus();
 
         final FeatureSupplier featureSupplier = features.isEmpty()
-            ? null // assume feature paths passed in as args instead
-            : new TestFeatureSupplier(features);
+                ? null // assume feature paths passed in as args instead
+                : new TestFeatureSupplier(features);
 
         Runtime.Builder runtimeBuilder = Runtime.builder()
-            .withRuntimeOptions(runtimeArgs)
-            .withClassLoader(classLoader)
-            .withBackendSupplier(backendSupplier)
-            .withFeatureSupplier(featureSupplier)
-            .withEventBus(bus);
+                .withRuntimeOptions(runtimeArgs)
+                .withClassLoader(classLoader)
+                .withBackendSupplier(backendSupplier)
+                .withFeatureSupplier(featureSupplier)
+                .withEventBus(bus);
 
         if (formatterUnderTest instanceof ConcurrentEventListener) {
             ((ConcurrentEventListener) formatterUnderTest).setEventPublisher(bus);
@@ -244,11 +243,13 @@ public class TestHelper {
                 Collections.emptyMap(),
                 Collections.emptyList(),
                 Collections.emptyList(),
-                Collections.emptyList()
-            );
+                Collections.emptyList());
         }
 
-        TestHelperBackendSupplier(List<Feature> features, Map<String, Result> stepsToResult, Map<String, String> stepsToLocation, List<SimpleEntry<String, Result>> hooks, List<String> hookLocations, List<Answer<Object>> hookActions) {
+        TestHelperBackendSupplier(
+                List<Feature> features, Map<String, Result> stepsToResult, Map<String, String> stepsToLocation,
+                List<SimpleEntry<String, Result>> hooks, List<String> hookLocations, List<Answer<Object>> hookActions
+        ) {
             this.features = features;
             this.stepsToResult = stepsToResult;
             this.stepsToLocation = stepsToLocation;
@@ -263,9 +264,11 @@ public class TestHelper {
             mockHooks(glue, hooks, hookLocations, hookActions);
         }
 
-        private static void mockSteps(Glue glue, List<Feature> features,
-                                      Map<String, Result> stepsToResult,
-                                      final Map<String, String> stepsToLocation) {
+        private static void mockSteps(
+                Glue glue, List<Feature> features,
+                Map<String, Result> stepsToResult,
+                final Map<String, String> stepsToLocation
+        ) {
             List<Step> steps = new ArrayList<>();
             for (Feature feature : features) {
                 for (Pickle pickle : feature.getPickles()) {
@@ -304,9 +307,11 @@ public class TestHelper {
                         if (stepResult.getStatus().is(PENDING)) {
                             throw new TestPendingException();
                         } else if (stepResult.getStatus().is(FAILED)) {
-                            throw new CucumberInvocationTargetException(located, new InvocationTargetException(stepResult.getError()));
+                            throw new CucumberInvocationTargetException(located,
+                                new InvocationTargetException(stepResult.getError()));
                         } else if (stepResult.getStatus().is(SKIPPED) && (stepResult.getError() != null)) {
-                            throw new CucumberInvocationTargetException(located, new InvocationTargetException(stepResult.getError()));
+                            throw new CucumberInvocationTargetException(located,
+                                new InvocationTargetException(stepResult.getError()));
                         } else if (!stepResult.getStatus().is(PASSED) && !stepResult.getStatus().is(SKIPPED)) {
                             fail("Cannot mock step to the result: " + stepResult.getStatus());
                         }
@@ -322,9 +327,11 @@ public class TestHelper {
             }
         }
 
-        private static void mockHooks(Glue glue, final List<SimpleEntry<String, Result>> hooks,
-                                      final List<String> hookLocations,
-                                      final List<Answer<Object>> hookActions) {
+        private static void mockHooks(
+                Glue glue, final List<SimpleEntry<String, Result>> hooks,
+                final List<String> hookLocations,
+                final List<Answer<Object>> hookActions
+        ) {
             List<HookDefinition> beforeHooks = new ArrayList<>();
             List<HookDefinition> afterHooks = new ArrayList<>();
             List<HookDefinition> beforeStepHooks = new ArrayList<>();
@@ -332,7 +339,8 @@ public class TestHelper {
             for (int i = 0; i < hooks.size(); ++i) {
                 String hookLocation = hookLocations.size() > i ? hookLocations.get(i) : null;
                 Answer<Object> hookAction = hookActions.size() > i ? hookActions.get(i) : null;
-                mockHook(hooks.get(i), hookLocation, hookAction, beforeHooks, afterHooks, beforeStepHooks, afterStepHooks);
+                mockHook(hooks.get(i), hookLocation, hookAction, beforeHooks, afterHooks, beforeStepHooks,
+                    afterStepHooks);
             }
             for (HookDefinition hook : beforeHooks) {
                 glue.addBeforeHook(hook);
@@ -351,7 +359,7 @@ public class TestHelper {
         private static boolean containsStep(List<Step> steps, Step step) {
             for (Step definedSteps : steps) {
                 if (definedSteps.getText().equals(step.getText())
-                    && (definedSteps.getArgument() == null) == (step.getArgument() == null)) {
+                        && (definedSteps.getArgument() == null) == (step.getArgument() == null)) {
                     return true;
                 }
             }
@@ -369,20 +377,22 @@ public class TestHelper {
             if (argument == null) {
                 return types;
             } else if (argument instanceof DocStringArgument) {
-                types = new Type[]{String.class};
+                types = new Type[] { String.class };
             } else if (argument instanceof DataTableArgument) {
-                types = new Type[]{DataTable.class};
+                types = new Type[] { DataTable.class };
             }
             return types;
         }
 
-        private static void mockHook(final SimpleEntry<String, Result> hookEntry,
-                                     final String hookLocation,
-                                     final Answer<Object> action,
-                                     final List<HookDefinition> beforeHooks,
-                                     final List<HookDefinition> afterHooks,
-                                     final List<HookDefinition> beforeStepHooks,
-                                     final List<HookDefinition> afterStepHooks) {
+        private static void mockHook(
+                final SimpleEntry<String, Result> hookEntry,
+                final String hookLocation,
+                final Answer<Object> action,
+                final List<HookDefinition> beforeHooks,
+                final List<HookDefinition> afterHooks,
+                final List<HookDefinition> beforeStepHooks,
+                final List<HookDefinition> afterStepHooks
+        ) {
             HookDefinition hook = mock(HookDefinition.class);
             if (hookLocation == null) {
                 throw new RuntimeException("hookLocation cannot be null");
@@ -407,11 +417,13 @@ public class TestHelper {
             };
             if (hookEntry.getValue().getStatus().is(FAILED)) {
                 Throwable error = hookEntry.getValue().getError();
-                CucumberInvocationTargetException exception = new CucumberInvocationTargetException(located, new InvocationTargetException(error));
+                CucumberInvocationTargetException exception = new CucumberInvocationTargetException(located,
+                    new InvocationTargetException(error));
                 doThrow(exception).when(hook).execute(any());
             } else if (hookEntry.getValue().getStatus().is(PENDING)) {
                 TestPendingException testPendingException = new TestPendingException();
-                CucumberInvocationTargetException exception = new CucumberInvocationTargetException(located, new InvocationTargetException(testPendingException));
+                CucumberInvocationTargetException exception = new CucumberInvocationTargetException(located,
+                    new InvocationTargetException(testPendingException));
                 doThrow(exception).when(hook).execute(any());
             }
             if ("before".equals(hookEntry.getKey())) {
@@ -471,11 +483,12 @@ public class TestHelper {
         }
 
         /**
-         * Set what the time increment should be when using {@link TimeServiceType#FIXED_INCREMENT}
-         * or {@link TimeServiceType#FIXED_INCREMENT_ON_STEP_START}
+         * Set what the time increment should be when using
+         * {@link TimeServiceType#FIXED_INCREMENT} or
+         * {@link TimeServiceType#FIXED_INCREMENT_ON_STEP_START}
          *
-         * @param timeServiceIncrement increment to be used
-         * @return this instance
+         * @param  timeServiceIncrement increment to be used
+         * @return                      this instance
          */
         public Builder withTimeServiceIncrement(Duration timeServiceIncrement) {
             this.instance.timeServiceIncrement = timeServiceIncrement;
@@ -486,13 +499,15 @@ public class TestHelper {
          * Specifies what type of TimeService to be used by the {@link EventBus}
          * {@link TimeServiceType#REAL_TIME} > {@link Clock#systemUTC()}
          * {@link TimeServiceType#FIXED_INCREMENT} > {@link ClockStub}
-         * {@link TimeServiceType#FIXED_INCREMENT_ON_STEP_START} > {@link StepDurationTimeService}
+         * {@link TimeServiceType#FIXED_INCREMENT_ON_STEP_START} >
+         * {@link StepDurationTimeService}
          * <p>
          * Defaults to {@link TimeServiceType#FIXED_INCREMENT_ON_STEP_START}
          * <p>
-         * Note: when running tests with multiple threads & not using {@link TimeServiceType#REAL_TIME}
-         * it can inadvertently affect the order of {@link Event}s
-         * published to any {@link ConcurrentEventListener}s used during the test run
+         * Note: when running tests with multiple threads & not using
+         * {@link TimeServiceType#REAL_TIME} it can inadvertently affect the
+         * order of {@link Event}s published to any
+         * {@link ConcurrentEventListener}s used during the test run
          *
          * @return this instance
          */
@@ -504,8 +519,8 @@ public class TestHelper {
         /**
          * Specify a plugin under test, Formatter or ConcurrentFormatter
          *
-         * @param formatter the plugin under test
-         * @return this instance
+         * @param  formatter the plugin under test
+         * @return           this instance
          */
         public Builder withFormatterUnderTest(Object formatter) {
             this.instance.formatterUnderTest = formatter;

--- a/core/src/test/java/io/cucumber/core/runner/UndefinedStepDefinitionMatchTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/UndefinedStepDefinitionMatchTest.java
@@ -17,20 +17,19 @@ import static org.mockito.Mockito.mock;
 class UndefinedStepDefinitionMatchTest {
 
     private final Feature feature = TestFeatureParser.parse("" +
-        "Feature: Test feature\n" +
-        "  Scenario: Test scenario\n" +
-        "     Given I have 4 cukes in my belly\n"
-    );
+            "Feature: Test feature\n" +
+            "  Scenario: Test scenario\n" +
+            "     Given I have 4 cukes in my belly\n");
 
     private final UndefinedPickleStepDefinitionMatch match = new UndefinedPickleStepDefinitionMatch(
         URI.create("file:path/to.feature"),
-        feature.getPickles().get(0).getSteps().get(0)
-    );
+        feature.getPickles().get(0).getSteps().get(0));
 
     @Test
     void throws_undefined_step_definitions_exception_when_run() {
         Executable testMethod = () -> match.runStep(mock(TestCaseState.class));
-        UndefinedStepDefinitionException expectedThrown = assertThrows(UndefinedStepDefinitionException.class, testMethod);
+        UndefinedStepDefinitionException expectedThrown = assertThrows(UndefinedStepDefinitionException.class,
+            testMethod);
         assertThat(expectedThrown.getMessage(), is(equalTo("No step definitions found")));
     }
 

--- a/core/src/test/java/io/cucumber/core/runtime/BackendServiceLoaderTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/BackendServiceLoaderTest.java
@@ -33,8 +33,7 @@ class BackendServiceLoaderTest {
         Executable testMethod = () -> backendSupplier.get(emptyList()).iterator().next();
         CucumberException actualThrown = assertThrows(CucumberException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "No backends were found. Please make sure you have a backend module on your CLASSPATH."
-        )));
+            "No backends were found. Please make sure you have a backend module on your CLASSPATH.")));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/runtime/CucumberExecutionContextTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/CucumberExecutionContextTest.java
@@ -31,32 +31,31 @@ class CucumberExecutionContextTest {
     private final Options options = new RuntimeOptionsBuilder().build();
     private final ExitStatus exitStatus = new ExitStatus(options);
     private final RuntimeException failure = new IllegalStateException("failure runner");
-    private final CucumberExecutionContext context = new CucumberExecutionContext(bus, exitStatus, mock(RunnerSupplier.class));
+    private final CucumberExecutionContext context = new CucumberExecutionContext(bus, exitStatus,
+        mock(RunnerSupplier.class));
 
     @Test
     public void collects_and_rethrows_failures_in_runner() {
-        IllegalStateException thrown = assertThrows(IllegalStateException.class, () ->
-            context.runTestCase(runner -> {
-                throw failure;
-            }));
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> context.runTestCase(runner -> {
+            throw failure;
+        }));
         assertThat(thrown, is(failure));
         assertThat(context.getException().getCause(), is(failure));
     }
 
     @Test
     public void rethrows_but_does_not_collect_failures_in_test_case() {
-        IllegalStateException thrown = assertThrows(IllegalStateException.class, () ->
-            context.runTestCase(runner -> {
-                try (TestCaseResultObserver r = new TestCaseResultObserver(bus)) {
-                    bus.send(new TestCaseFinished(bus.getInstant(), mock(TestCase.class), new Result(Status.FAILED, Duration.ZERO, failure)));
-                    r.assertTestCasePassed(
-                        Exception::new,
-                        Function.identity(),
-                        (suggestions) -> new Exception(),
-                        Function.identity()
-                    );
-                }
-            }));
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> context.runTestCase(runner -> {
+            try (TestCaseResultObserver r = new TestCaseResultObserver(bus)) {
+                bus.send(new TestCaseFinished(bus.getInstant(), mock(TestCase.class),
+                    new Result(Status.FAILED, Duration.ZERO, failure)));
+                r.assertTestCasePassed(
+                    Exception::new,
+                    Function.identity(),
+                    (suggestions) -> new Exception(),
+                    Function.identity());
+            }
+        }));
         assertThat(thrown, is(failure));
         assertThat(context.getException(), nullValue());
     }
@@ -70,10 +69,9 @@ class CucumberExecutionContextTest {
         bus.registerHandlerFor(TestRunFinished.class, testRunFinished::add);
 
         context.startTestRun();
-        assertThrows(IllegalStateException.class, () ->
-            context.runTestCase(runner -> {
-                throw failure;
-            }));
+        assertThrows(IllegalStateException.class, () -> context.runTestCase(runner -> {
+            throw failure;
+        }));
         context.finishTestRun();
 
         assertThat(testRunStarted.get(0), notNullValue());

--- a/core/src/test/java/io/cucumber/core/runtime/FeatureBuilderTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/FeatureBuilderTest.java
@@ -68,8 +68,7 @@ class FeatureBuilderTest {
         assertAll(
             () -> assertThat(features.size(), equalTo(2)),
             () -> assertThat(features.get(0).getUri(), equalTo(featurePath1)),
-            () -> assertThat(features.get(1).getUri(), equalTo(featurePath2))
-        );
+            () -> assertThat(features.get(1).getUri(), equalTo(featurePath2)));
     }
 
     @Test
@@ -91,8 +90,7 @@ class FeatureBuilderTest {
         assertAll(
             () -> assertThat(features.get(0).getUri(), equalTo(featurePath3)),
             () -> assertThat(features.get(1).getUri(), equalTo(featurePath2)),
-            () -> assertThat(features.get(2).getUri(), equalTo(featurePath1))
-        );
+            () -> assertThat(features.get(2).getUri(), equalTo(featurePath1)));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/runtime/FeaturePathFeatureSupplierTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/FeaturePathFeatureSupplierTest.java
@@ -43,9 +43,10 @@ class FeaturePathFeatureSupplierTest {
         FeaturePathFeatureSupplier supplier = new FeaturePathFeatureSupplier(classLoader, featureOptions, parser);
         supplier.get();
         assertAll(
-            () -> assertThat(logRecordListener.getLogRecords().get(1).getMessage(), containsString("No features found at file:")),
-            () -> assertThat(logRecordListener.getLogRecords().get(1).getMessage(), containsString("src/test/resources/io/cucumber/core/options"))
-        );
+            () -> assertThat(logRecordListener.getLogRecords().get(1).getMessage(),
+                containsString("No features found at file:")),
+            () -> assertThat(logRecordListener.getLogRecords().get(1).getMessage(),
+                containsString("src/test/resources/io/cucumber/core/options")));
     }
 
     @Test
@@ -54,7 +55,8 @@ class FeaturePathFeatureSupplierTest {
 
         FeaturePathFeatureSupplier supplier = new FeaturePathFeatureSupplier(classLoader, featureOptions, parser);
         supplier.get();
-        assertThat(logRecordListener.getLogRecords().get(1).getMessage(), containsString("Got no path to feature directory or feature file"));
+        assertThat(logRecordListener.getLogRecords().get(1).getMessage(),
+            containsString("Got no path to feature directory or feature file"));
     }
 
     @Test
@@ -63,8 +65,7 @@ class FeaturePathFeatureSupplierTest {
         FeaturePathFeatureSupplier supplier = new FeaturePathFeatureSupplier(classLoader, featureOptions, parser);
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            supplier::get
-        );
+            supplier::get);
         assertThat(exception.getMessage(), containsString("path must exist"));
     }
 
@@ -74,8 +75,7 @@ class FeaturePathFeatureSupplierTest {
         FeaturePathFeatureSupplier supplier = new FeaturePathFeatureSupplier(classLoader, featureOptions, parser);
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            supplier::get
-        );
+            supplier::get);
         assertThat(exception.getMessage(), containsString("Feature not found"));
     }
 

--- a/core/src/test/java/io/cucumber/core/runtime/JavaObjectFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/JavaObjectFactoryTest.java
@@ -28,11 +28,10 @@ class JavaObjectFactoryTest {
         StepDefinition o2 = factory.getInstance(StepDefinition.class);
         factory.stop();
 
-        assertAll("Checking SteDef",
+        assertAll(
             () -> assertThat(o1, is(notNullValue())),
             () -> assertThat(o1, is(not(equalTo(o2)))),
-            () -> assertThat(o2, is(not(equalTo(o1))))
-        );
+            () -> assertThat(o2, is(not(equalTo(o1)))));
     }
 
     public static class StepDefinition {

--- a/core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
@@ -74,12 +74,11 @@ class RuntimeTest {
 
     private Runtime createStrictRuntime() {
         return Runtime.builder()
-            .withRuntimeOptions(
-                new RuntimeOptionsBuilder()
-                    .build()
-            )
-            .withEventBus(bus)
-            .build();
+                .withRuntimeOptions(
+                    new RuntimeOptionsBuilder()
+                            .build())
+                .withEventBus(bus)
+                .build();
     }
 
     private TestCaseFinished testCaseFinishedWithStatus(Status resultStatus) {
@@ -111,8 +110,8 @@ class RuntimeTest {
 
     private Runtime createNonStrictRuntime() {
         return Runtime.builder()
-            .withEventBus(bus)
-            .build();
+                .withEventBus(bus)
+                .build();
     }
 
     @Test
@@ -134,9 +133,9 @@ class RuntimeTest {
     @Test
     void should_pass_if_no_features_are_found() {
         Runtime runtime = Runtime.builder()
-            .withRuntimeOptions(new RuntimeOptionsBuilder()
-                .build())
-            .build();
+                .withRuntimeOptions(new RuntimeOptionsBuilder()
+                        .build())
+                .build();
 
         runtime.run();
 
@@ -147,10 +146,10 @@ class RuntimeTest {
     void should_make_scenario_name_available_to_hooks() {
         final Feature feature = TestFeatureParser.parse("path/test.feature",
             "Feature: feature name\n" +
-                "  Scenario: scenario name\n" +
-                "    Given first step\n" +
-                "    When second step\n" +
-                "    Then third step\n");
+                    "  Scenario: scenario name\n" +
+                    "    Given first step\n" +
+                    "    When second step\n" +
+                    "    Then third step\n");
         final HookDefinition beforeHook = mock(HookDefinition.class);
         when(beforeHook.getLocation()).thenReturn("");
         when(beforeHook.getTagExpression()).thenReturn("");
@@ -160,10 +159,10 @@ class RuntimeTest {
         FeatureSupplier featureSupplier = new TestFeatureSupplier(feature);
 
         Runtime runtime = Runtime.builder()
-            .withBackendSupplier(testBackendSupplier)
-            .withFeatureSupplier(featureSupplier)
-            .withEventBus(bus)
-            .build();
+                .withBackendSupplier(testBackendSupplier)
+                .withFeatureSupplier(featureSupplier)
+                .withEventBus(bus)
+                .build();
         runtime.run();
 
         ArgumentCaptor<TestCaseState> capturedScenario = ArgumentCaptor.forClass(TestCaseState.class);
@@ -212,14 +211,14 @@ class RuntimeTest {
     @Test
     void should_call_formatter_for_two_scenarios_with_background() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Background: background\n" +
-            "    Given first step\n" +
-            "  Scenario: scenario_1 name\n" +
-            "    When second step\n" +
-            "    Then third step\n" +
-            "  Scenario: scenario_2 name\n" +
-            "    Then second step\n");
+                "Feature: feature name\n" +
+                "  Background: background\n" +
+                "    Given first step\n" +
+                "  Scenario: scenario_1 name\n" +
+                "    When second step\n" +
+                "    Then third step\n" +
+                "  Scenario: scenario_2 name\n" +
+                "    Then second step\n");
         Map<String, Result> stepsToResult = new HashMap<>();
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
@@ -229,33 +228,33 @@ class RuntimeTest {
 
         assertThat(formatterOutput,
             is(equalTo("" +
-                "TestCase started\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "TestCase finished\n" +
-                "TestCase started\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "TestCase finished\n" +
-                "TestRun finished\n")));
+                    "TestCase started\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "TestCase finished\n" +
+                    "TestCase started\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "TestCase finished\n" +
+                    "TestRun finished\n")));
     }
 
     private String runFeatureWithFormatterSpy(Feature feature, Map<String, Result> stepsToResult) {
         FormatterSpy formatterSpy = new FormatterSpy();
 
         TestHelper.builder()
-            .withFeatures(feature)
-            .withStepsToResult(stepsToResult)
-            .withFormatterUnderTest(formatterSpy)
-            .withTimeServiceType(TestHelper.TimeServiceType.REAL_TIME)
-            .build()
-            .run();
+                .withFeatures(feature)
+                .withStepsToResult(stepsToResult)
+                .withFormatterUnderTest(formatterSpy)
+                .withTimeServiceType(TestHelper.TimeServiceType.REAL_TIME)
+                .build()
+                .run();
 
         return formatterSpy.toString();
     }
@@ -263,19 +262,19 @@ class RuntimeTest {
     @Test
     void should_call_formatter_for_scenario_outline_with_two_examples_table_and_background() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Background: background\n" +
-            "    Given first step\n" +
-            "  Scenario Outline: scenario outline name\n" +
-            "    When <x> step\n" +
-            "    Then <y> step\n" +
-            "    Examples: examples 1 name\n" +
-            "      |   x    |   y   |\n" +
-            "      | second | third |\n" +
-            "      | second | third |\n" +
-            "    Examples: examples 2 name\n" +
-            "      |   x    |   y   |\n" +
-            "      | second | third |\n");
+                "Feature: feature name\n" +
+                "  Background: background\n" +
+                "    Given first step\n" +
+                "  Scenario Outline: scenario outline name\n" +
+                "    When <x> step\n" +
+                "    Then <y> step\n" +
+                "    Examples: examples 1 name\n" +
+                "      |   x    |   y   |\n" +
+                "      | second | third |\n" +
+                "      | second | third |\n" +
+                "    Examples: examples 2 name\n" +
+                "      |   x    |   y   |\n" +
+                "      | second | third |\n");
         Map<String, Result> stepsToResult = new HashMap<>();
         stepsToResult.put("first step", result("passed"));
         stepsToResult.put("second step", result("passed"));
@@ -285,154 +284,155 @@ class RuntimeTest {
 
         assertThat(formatterOutput,
             is(equalTo("" +
-                "TestCase started\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "TestCase finished\n" +
-                "TestCase started\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "TestCase finished\n" +
-                "TestCase started\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "TestCase finished\n" +
-                "TestRun finished\n")));
+                    "TestCase started\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "TestCase finished\n" +
+                    "TestCase started\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "TestCase finished\n" +
+                    "TestCase started\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "TestCase finished\n" +
+                    "TestRun finished\n")));
     }
 
     @Test
     void should_call_formatter_with_correct_sequence_of_events_when_running_in_parallel() {
         Feature feature1 = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name 1\n" +
-            "  Scenario: scenario_1 name\n" +
-            "    Given first step\n" +
-            "  Scenario: scenario_2 name\n" +
-            "    Given first step\n");
+                "Feature: feature name 1\n" +
+                "  Scenario: scenario_1 name\n" +
+                "    Given first step\n" +
+                "  Scenario: scenario_2 name\n" +
+                "    Given first step\n");
 
         Feature feature2 = TestFeatureParser.parse("path/test2.feature", "" +
-            "Feature: feature name 2\n" +
-            "  Scenario: scenario_2 name\n" +
-            "    Given first step\n");
+                "Feature: feature name 2\n" +
+                "  Scenario: scenario_2 name\n" +
+                "    Given first step\n");
 
         Feature feature3 = TestFeatureParser.parse("path/test3.feature", "" +
-            "Feature: feature name 3\n" +
-            "  Scenario: scenario_3 name\n" +
-            "    Given first step\n");
+                "Feature: feature name 3\n" +
+                "  Scenario: scenario_3 name\n" +
+                "    Given first step\n");
 
         FormatterSpy formatterSpy = new FormatterSpy();
         final List<Feature> features = Arrays.asList(feature1, feature2, feature3);
 
         Runtime.builder()
-            .withFeatureSupplier(new TestFeatureSupplier(features))
-            .withEventBus(bus)
-            .withRuntimeOptions(new RuntimeOptionsBuilder().setThreads(features.size()).build())
-            .withAdditionalPlugins(formatterSpy)
-            .withBackendSupplier(new TestHelper.TestHelperBackendSupplier(features))
-            .build()
-            .run();
+                .withFeatureSupplier(new TestFeatureSupplier(features))
+                .withEventBus(bus)
+                .withRuntimeOptions(new RuntimeOptionsBuilder().setThreads(features.size()).build())
+                .withAdditionalPlugins(formatterSpy)
+                .withBackendSupplier(new TestHelper.TestHelperBackendSupplier(features))
+                .build()
+                .run();
 
         String formatterOutput = formatterSpy.toString();
 
         assertThat(formatterOutput,
             is(equalTo("" +
-                "TestCase started\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "TestCase finished\n" +
-                "TestCase started\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "TestCase finished\n" +
-                "TestCase started\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "TestCase finished\n" +
-                "TestCase started\n" +
-                "  TestStep started\n" +
-                "  TestStep finished\n" +
-                "TestCase finished\n" +
-                "TestRun finished\n")));
+                    "TestCase started\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "TestCase finished\n" +
+                    "TestCase started\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "TestCase finished\n" +
+                    "TestCase started\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "TestCase finished\n" +
+                    "TestCase started\n" +
+                    "  TestStep started\n" +
+                    "  TestStep finished\n" +
+                    "TestCase finished\n" +
+                    "TestRun finished\n")));
     }
 
     @Test
     void should_fail_on_event_listener_exception_when_running_in_parallel() {
         Feature feature1 = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name 1\n" +
-            "  Scenario: scenario_1 name\n" +
-            "    Given first step\n" +
-            "  Scenario: scenario_2 name\n" +
-            "    Given first step\n");
+                "Feature: feature name 1\n" +
+                "  Scenario: scenario_1 name\n" +
+                "    Given first step\n" +
+                "  Scenario: scenario_2 name\n" +
+                "    Given first step\n");
 
         Feature feature2 = TestFeatureParser.parse("path/test2.feature", "" +
-            "Feature: feature name 2\n" +
-            "  Scenario: scenario_2 name\n" +
-            "    Given first step\n");
+                "Feature: feature name 2\n" +
+                "  Scenario: scenario_2 name\n" +
+                "    Given first step\n");
 
-        ConcurrentEventListener brokenEventListener = publisher -> publisher.registerHandlerFor(TestStepFinished.class, (TestStepFinished event) -> {
-            throw new RuntimeException("This exception is expected");
-        });
+        ConcurrentEventListener brokenEventListener = publisher -> publisher.registerHandlerFor(TestStepFinished.class,
+            (TestStepFinished event) -> {
+                throw new RuntimeException("This exception is expected");
+            });
 
         Executable testMethod = () -> TestHelper.builder()
-            .withFeatures(Arrays.asList(feature1, feature2))
-            .withFormatterUnderTest(brokenEventListener)
-            .withTimeServiceType(TestHelper.TimeServiceType.REAL_TIME)
-            .withRuntimeArgs(new RuntimeOptionsBuilder().setThreads(2).build())
-            .build()
-            .run();
+                .withFeatures(Arrays.asList(feature1, feature2))
+                .withFormatterUnderTest(brokenEventListener)
+                .withTimeServiceType(TestHelper.TimeServiceType.REAL_TIME)
+                .withRuntimeArgs(new RuntimeOptionsBuilder().setThreads(2).build())
+                .build()
+                .run();
         CompositeCucumberException actualThrown = assertThrows(CompositeCucumberException.class, testMethod);
         assertThat(actualThrown.getMessage(), is(equalTo(
             "There were 3 exceptions:\n" +
-                "  java.lang.RuntimeException(This exception is expected)\n" +
-                "  java.lang.RuntimeException(This exception is expected)\n" +
-                "  java.lang.RuntimeException(This exception is expected)"
-        )));
+                    "  java.lang.RuntimeException(This exception is expected)\n" +
+                    "  java.lang.RuntimeException(This exception is expected)\n" +
+                    "  java.lang.RuntimeException(This exception is expected)")));
     }
 
     @Test
     void should_interrupt_waiting_plugins() throws InterruptedException {
         final Feature feature1 = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: feature name 1\n" +
-            "  Scenario: scenario_1 name\n" +
-            "    Given first step\n" +
-            "  Scenario: scenario_2 name\n" +
-            "    Given first step\n");
+                "Feature: feature name 1\n" +
+                "  Scenario: scenario_1 name\n" +
+                "    Given first step\n" +
+                "  Scenario: scenario_2 name\n" +
+                "    Given first step\n");
 
         final Feature feature2 = TestFeatureParser.parse("path/test2.feature", "" +
-            "Feature: feature name 2\n" +
-            "  Scenario: scenario_2 name\n" +
-            "    Given first step\n");
+                "Feature: feature name 2\n" +
+                "  Scenario: scenario_2 name\n" +
+                "    Given first step\n");
 
         final CountDownLatch threadBlocked = new CountDownLatch(1);
         final CountDownLatch interruptHit = new CountDownLatch(1);
 
-        final ConcurrentEventListener brokenEventListener = publisher -> publisher.registerHandlerFor(TestStepFinished.class, (TestStepFinished event) -> {
-            try {
-                threadBlocked.countDown();
-                HOURS.sleep(1);
-            } catch (InterruptedException ignored) {
-                interruptHit.countDown();
-            }
-        });
+        final ConcurrentEventListener brokenEventListener = publisher -> publisher
+                .registerHandlerFor(TestStepFinished.class, (TestStepFinished event) -> {
+                    try {
+                        threadBlocked.countDown();
+                        HOURS.sleep(1);
+                    } catch (InterruptedException ignored) {
+                        interruptHit.countDown();
+                    }
+                });
 
         Thread thread = new Thread(() -> TestHelper.builder()
-            .withFeatures(Arrays.asList(feature1, feature2))
-            .withFormatterUnderTest(brokenEventListener)
-            .withTimeServiceType(TestHelper.TimeServiceType.REAL_TIME)
-            .withRuntimeArgs(new RuntimeOptionsBuilder().setThreads(2).build())
-            .build()
-            .run());
+                .withFeatures(Arrays.asList(feature1, feature2))
+                .withFormatterUnderTest(brokenEventListener)
+                .withTimeServiceType(TestHelper.TimeServiceType.REAL_TIME)
+                .withRuntimeArgs(new RuntimeOptionsBuilder().setThreads(2).build())
+                .build()
+                .run());
 
         thread.start();
         threadBlocked.await(1, SECONDS);
@@ -444,21 +444,21 @@ class RuntimeTest {
     @Test
     void generates_events_for_glue_and_scenario_scoped_glue() {
         final Feature feature = TestFeatureParser.parse("test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: Run a scenario once\n" +
-            "    Given global scoped\n" +
-            "    And scenario scoped\n" +
-            "  Scenario: Then do it again\n" +
-            "    Given global scoped\n" +
-            "    And scenario scoped\n" +
-            "");
+                "Feature: feature name\n" +
+                "  Scenario: Run a scenario once\n" +
+                "    Given global scoped\n" +
+                "    And scenario scoped\n" +
+                "  Scenario: Then do it again\n" +
+                "    Given global scoped\n" +
+                "    And scenario scoped\n" +
+                "");
 
         final List<StepDefinition> stepDefinedEvents = new ArrayList<>();
 
-        Plugin eventListener = (EventListener) publisher -> publisher.registerHandlerFor(StepDefinedEvent.class, (StepDefinedEvent event) -> {
-            stepDefinedEvents.add(event.getStepDefinition());
-        });
-
+        Plugin eventListener = (EventListener) publisher -> publisher.registerHandlerFor(StepDefinedEvent.class,
+            (StepDefinedEvent event) -> {
+                stepDefinedEvents.add(event.getStepDefinition());
+            });
 
         final MockedStepDefinition mockedStepDefinition = new MockedStepDefinition();
         final MockedScenarioScopedStepDefinition mockedScenarioScopedStepDefinition = new MockedScenarioScopedStepDefinition();
@@ -481,12 +481,12 @@ class RuntimeTest {
 
         FeatureSupplier featureSupplier = () -> singletonList(feature);
         Runtime.builder()
-            .withBackendSupplier(backendSupplier)
-            .withAdditionalPlugins(eventListener)
-            .withEventBus(new TimeServiceEventBus(new StepDurationTimeService(ZERO), UUID::randomUUID))
-            .withFeatureSupplier(featureSupplier)
-            .build()
-            .run();
+                .withBackendSupplier(backendSupplier)
+                .withAdditionalPlugins(eventListener)
+                .withEventBus(new TimeServiceEventBus(new StepDurationTimeService(ZERO), UUID::randomUUID))
+                .withFeatureSupplier(featureSupplier)
+                .build()
+                .run();
 
         assertThat(stepDefinedEvents.get(0).getPattern(), is(mockedStepDefinition.getPattern()));
         assertThat(stepDefinedEvents.get(1).getPattern(), is(mockedScenarioScopedStepDefinition.getPattern()));
@@ -499,12 +499,12 @@ class RuntimeTest {
     @Test
     void emits_a_meta_message() {
         List<Messages.Envelope> messages = new ArrayList<>();
-        ConcurrentEventListener messageListener =
-            publisher -> publisher.registerHandlerFor(Messages.Envelope.class, messages::add);
+        ConcurrentEventListener messageListener = publisher -> publisher.registerHandlerFor(Messages.Envelope.class,
+            messages::add);
         Runtime.builder()
-            .withAdditionalPlugins(messageListener)
-            .build()
-            .run();
+                .withAdditionalPlugins(messageListener)
+                .build()
+                .run();
 
         Messages.Meta meta = messages.get(0).getMeta();
         assertThat(meta.getProtocolVersion(), matchesPattern("\\d+\\.\\d+\\.\\d+"));
@@ -543,7 +543,8 @@ class RuntimeTest {
 
     }
 
-    private static final class MockedScenarioScopedStepDefinition implements ScenarioScoped, io.cucumber.core.backend.StepDefinition {
+    private static final class MockedScenarioScopedStepDefinition
+            implements ScenarioScoped, io.cucumber.core.backend.StepDefinition {
 
         @Override
         public void execute(Object[] args) {

--- a/core/src/test/java/io/cucumber/core/runtime/SingletonRunnerSupplierTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/SingletonRunnerSupplierTest.java
@@ -26,8 +26,10 @@ class SingletonRunnerSupplierTest {
         ObjectFactorySupplier objectFactory = new SingletonObjectFactorySupplier(objectFactoryServiceLoader);
         BackendServiceLoader backendSupplier = new BackendServiceLoader(getClass()::getClassLoader, objectFactory);
         EventBus eventBus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
-        TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(classLoader, runtimeOptions);
-        runnerSupplier = new SingletonRunnerSupplier(runtimeOptions, eventBus, backendSupplier, objectFactory, typeRegistryConfigurerSupplier);
+        TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(
+            classLoader, runtimeOptions);
+        runnerSupplier = new SingletonRunnerSupplier(runtimeOptions, eventBus, backendSupplier, objectFactory,
+            typeRegistryConfigurerSupplier);
     }
 
     @Test

--- a/core/src/test/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplierTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplierTest.java
@@ -35,10 +35,11 @@ class ThreadLocalRunnerSupplierTest {
         ObjectFactorySupplier objectFactory = new SingletonObjectFactorySupplier(objectFactoryServiceLoader);
         BackendServiceLoader backendSupplier = new BackendServiceLoader(classLoader, objectFactory);
         eventBus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
-        TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(classLoader, runtimeOptions);
-        runnerSupplier = new ThreadLocalRunnerSupplier(runtimeOptions, eventBus, backendSupplier, objectFactory, typeRegistryConfigurerSupplier);
+        TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(
+            classLoader, runtimeOptions);
+        runnerSupplier = new ThreadLocalRunnerSupplier(runtimeOptions, eventBus, backendSupplier, objectFactory,
+            typeRegistryConfigurerSupplier);
     }
-
 
     @Test
     void should_create_a_runner() {
@@ -58,10 +59,9 @@ class ThreadLocalRunnerSupplierTest {
         thread0.join();
         thread1.join();
 
-        assertAll("Checking Runner",
+        assertAll(
             () -> assertThat(runners[0], is(not(equalTo(runners[1])))),
-            () -> assertThat(runners[1], is(not(equalTo(runners[0]))))
-        );
+            () -> assertThat(runners[1], is(not(equalTo(runners[0])))));
     }
 
     @Test
@@ -71,22 +71,20 @@ class ThreadLocalRunnerSupplierTest {
 
     @Test
     void runner_should_wrap_event_bus_bus() {
-        //This avoids problems with JUnit which listens to individual runners
+        // This avoids problems with JUnit which listens to individual runners
         EventBus runnerBus = runnerSupplier.get().getBus();
 
-        assertAll("Checking EventBus",
+        assertAll(
             () -> assertThat(eventBus, is(not(equalTo(runnerBus)))),
-            () -> assertThat(runnerBus, is(not(equalTo(eventBus))))
-        );
+            () -> assertThat(runnerBus, is(not(equalTo(eventBus)))));
     }
 
     @Test
     void should_limit_runner_bus_scope_to_events_generated_by_runner() {
-        //This avoids problems with JUnit which listens to individual runners
+        // This avoids problems with JUnit which listens to individual runners
         runnerSupplier.get().getBus().registerHandlerFor(
             TestCaseStarted.class,
-            event -> fail("Should not receive event")
-        );
+            event -> fail("Should not receive event"));
         eventBus.send(new TestCaseStarted(EPOCH, mock(TestCase.class)));
     }
 

--- a/core/src/test/java/io/cucumber/core/runtime/TooManyInstancesExceptionTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/TooManyInstancesExceptionTest.java
@@ -19,9 +19,9 @@ class TooManyInstancesExceptionTest {
         Collection<String> instances = Arrays.asList("one", "two");
         TooManyInstancesException expectedThrown = new TooManyInstancesException(instances);
         assertAll(
-            () -> assertThat(expectedThrown.getMessage(), is(equalTo("Expected only one instance, but found too many: [one, two]"))),
-            () -> assertThat(expectedThrown.getCause(), is(nullValue()))
-        );
+            () -> assertThat(expectedThrown.getMessage(),
+                is(equalTo("Expected only one instance, but found too many: [one, two]"))),
+            () -> assertThat(expectedThrown.getCause(), is(nullValue())));
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/snippets/FunctionNameGeneratorTest.java
+++ b/core/src/test/java/io/cucumber/core/snippets/FunctionNameGeneratorTest.java
@@ -30,10 +30,9 @@ class FunctionNameGeneratorTest {
     }
 
     private void assertFunctionNames(String expectedUnderscore, String expectedCamelCase, String sentence) {
-        assertAll("Checking FunctionNameGenerator",
+        assertAll(
             () -> assertThat(underscore.generateFunctionName(sentence), is(equalTo(expectedUnderscore))),
-            () -> assertThat(camelCase.generateFunctionName(sentence), is(equalTo(expectedCamelCase)))
-        );
+            () -> assertThat(camelCase.generateFunctionName(sentence), is(equalTo(expectedCamelCase))));
     }
 
     @Test

--- a/core/src/test/java/io/cucumber/core/stepexpression/StepExpressionFactoryTest.java
+++ b/core/src/test/java/io/cucumber/core/stepexpression/StepExpressionFactoryTest.java
@@ -43,7 +43,8 @@ class StepExpressionFactoryTest {
     private final StepTypeRegistry registry = new StepTypeRegistry(Locale.ENGLISH);
     private final StepExpressionFactory stepExpressionFactory = new StepExpressionFactory(registry, bus);
     private final List<List<String>> table = asList(asList("name", "amount", "unit"), asList("chocolate", "2", "tbsp"));
-    private final List<List<String>> tableTransposed = asList(asList("name", "chocolate"), asList("amount", "2"), asList("unit", "tbsp"));
+    private final List<List<String>> tableTransposed = asList(asList("name", "chocolate"), asList("amount", "2"),
+        asList("unit", "tbsp"));
 
     @Test
     void creates_a_step_expression() {
@@ -63,11 +64,10 @@ class StepExpressionFactoryTest {
 
         CucumberException exception = assertThrows(
             CucumberException.class,
-            () -> stepExpressionFactory.createExpression(stepDefinition)
-        );
+            () -> stepExpressionFactory.createExpression(stepDefinition));
         assertThat(exception.getMessage(), is("" +
-            "Could not create a cucumber expression for 'Given a {unknownParameterType}'.\n" +
-            "It appears you did not register a parameter type."
+                "Could not create a cucumber expression for 'Given a {unknownParameterType}'.\n" +
+                "It appears you did not register a parameter type."
 
         ));
         assertThat(events, iterableWithSize(1));
@@ -94,7 +94,6 @@ class StepExpressionFactoryTest {
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         List<Argument> match = expression.match("Given some stuff:", tableTransposed);
 
-
         Ingredient ingredient = (Ingredient) match.get(0).getValue();
         assertThat(ingredient.name, is(equalTo("chocolate")));
     }
@@ -107,7 +106,7 @@ class StepExpressionFactoryTest {
     }
 
     private TableEntryTransformer<Ingredient> listBeanMapper(final StepTypeRegistry registry) {
-        //Just pretend this is a bean mapper.
+        // Just pretend this is a bean mapper.
         return tableRow -> {
             Ingredient bean = new Ingredient();
             bean.amount = Integer.valueOf(tableRow.get("amount"));
@@ -175,8 +174,7 @@ class StepExpressionFactoryTest {
         registry.defineDocStringType(new DocStringType(
             JsonNode.class,
             contentType,
-            (String s) -> objectMapper.convertValue(docString, JsonNode.class)
-        ));
+            (String s) -> objectMapper.convertValue(docString, JsonNode.class)));
 
         StepDefinition stepDefinition = new StubStepDefinition("Given some stuff:", JsonNode.class);
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
@@ -189,7 +187,8 @@ class StepExpressionFactoryTest {
     @Test
     void empty_table_cells_are_presented_as_null_to_transformer() {
         registry.setDefaultDataTableEntryTransformer(
-            (map, valueType, tableCellByTypeTransformer) -> objectMapper.convertValue(map, objectMapper.constructType(valueType)));
+            (map, valueType, tableCellByTypeTransformer) -> objectMapper.convertValue(map,
+                objectMapper.constructType(valueType)));
 
         StepDefinition stepDefinition = new StubStepDefinition("Given some stuff:", getTypeFromStepDefinition());
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);

--- a/core/src/test/java/io/cucumber/core/stepexpression/StepTypeRegistryTest.java
+++ b/core/src/test/java/io/cucumber/core/stepexpression/StepTypeRegistryTest.java
@@ -29,8 +29,7 @@ class StepTypeRegistryTest {
             "example",
             ".*",
             Object.class,
-            (String s) -> null
-        );
+            (String s) -> null);
         registry.defineParameterType(expected);
         Expression expresion = expressionFactory.createExpression("{example}");
         assertThat(expresion.getRegexp().pattern(), is("^(.*)$"));

--- a/deltaspike/src/main/java/io/cucumber/deltaspike/DeltaSpikeObjectFactory.java
+++ b/deltaspike/src/main/java/io/cucumber/deltaspike/DeltaSpikeObjectFactory.java
@@ -8,6 +8,7 @@ import org.apiguardian.api.API;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
+
 import java.util.Set;
 
 @API(status = API.Status.STABLE)

--- a/docstring/src/main/java/io/cucumber/docstring/ConversionRequired.java
+++ b/docstring/src/main/java/io/cucumber/docstring/ConversionRequired.java
@@ -13,8 +13,7 @@ final class ConversionRequired implements DocStringConverter {
         throw new CucumberDocStringException(format("" +
                 "Can't convert DocString to %s. " +
                 "You have to write the conversion for it in this method",
-            type
-        ));
+            type));
     }
 
 }

--- a/docstring/src/main/java/io/cucumber/docstring/DocString.java
+++ b/docstring/src/main/java/io/cucumber/docstring/DocString.java
@@ -20,9 +20,9 @@ import static java.util.stream.Collectors.joining;
  * """
  * </pre>
  * <p>
- * A doc string is either empty or contains some content.
- * The content type is an optional description of the
- * content using a <a href=https://tools.ietf.org/html/rfc2616#section-3.7>media-type</a>.
+ * A doc string is either empty or contains some content. The content type is an
+ * optional description of the content using a <a
+ * href=https://tools.ietf.org/html/rfc2616#section-3.7>media-type</a>.
  * <p>
  * A DocString is immutable and thread safe.
  */
@@ -70,21 +70,22 @@ public final class DocString {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         DocString docString = (DocString) o;
         return content.equals(docString.content) &&
-            Objects.equals(contentType, docString.contentType);
+                Objects.equals(contentType, docString.contentType);
     }
 
     @Override
     public String toString() {
         return stream(content.split("\n"))
-            .collect(joining(
-                "\n      ",
-                "      \"\"\"" + contentType + "\n      ",
-                "\n      \"\"\""
-            ));
+                .collect(joining(
+                    "\n      ",
+                    "      \"\"\"" + contentType + "\n      ",
+                    "\n      \"\"\""));
     }
 
     public interface DocStringConverter {

--- a/docstring/src/main/java/io/cucumber/docstring/DocStringType.java
+++ b/docstring/src/main/java/io/cucumber/docstring/DocStringType.java
@@ -1,6 +1,5 @@
 package io.cucumber.docstring;
 
-
 import org.apiguardian.api.API;
 
 import java.lang.reflect.Type;
@@ -23,7 +22,11 @@ public final class DocStringType {
      * Creates a doc string type that can convert a doc string to an object.
      *
      * @param type        the type of the object
-     * @param contentType the <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">media type</a> or <a href="https://github.github.com/gfm/#info-string">GFM info string</a>
+     * @param contentType the <a href=
+     *                    "https://www.iana.org/assignments/media-types/media-types.xhtml">media
+     *                    type</a> or <a href=
+     *                    "https://github.github.com/gfm/#info-string">GFM info
+     *                    string</a>
      * @param transformer a function that creates an instance of
      *                    <code>type</code> from the doc string
      * @param <T>         see <code>type</code>

--- a/docstring/src/main/java/io/cucumber/docstring/DocStringTypeRegistry.java
+++ b/docstring/src/main/java/io/cucumber/docstring/DocStringTypeRegistry.java
@@ -32,7 +32,9 @@ public final class DocStringTypeRegistry {
         docStringTypesByType.put(docStringType.getType(), docStringType);
     }
 
-    private static CucumberDocStringException createDuplicateTypeException(DocStringType existing, DocStringType docStringType) {
+    private static CucumberDocStringException createDuplicateTypeException(
+            DocStringType existing, DocStringType docStringType
+    ) {
         String contentType = existing.getContentType();
         return new CucumberDocStringException(format("" +
                 "There is already docstring type registered for '%s' and %s.\n" +
@@ -40,8 +42,7 @@ public final class DocStringTypeRegistry {
             emptyToAnonymous(contentType),
             existing.getType().getTypeName(),
             emptyToAnonymous(docStringType.getContentType()),
-            docStringType.getType().getTypeName()
-        ));
+            docStringType.getType().getTypeName()));
     }
 
     private static String emptyToAnonymous(String contentType) {

--- a/docstring/src/main/java/io/cucumber/docstring/DocStringTypeRegistryDocStringConverter.java
+++ b/docstring/src/main/java/io/cucumber/docstring/DocStringTypeRegistryDocStringConverter.java
@@ -36,15 +36,13 @@ public final class DocStringTypeRegistryDocStringConverter implements DocStringC
         if (docString.getContentType() == null) {
             throw new CucumberDocStringException(format(
                 "It appears you did not register docstring type for %s",
-                targetType.getTypeName()
-            ));
+                targetType.getTypeName()));
         }
 
         throw new CucumberDocStringException(format(
             "It appears you did not register docstring type for '%s' or %s",
             docString.getContentType(),
-            targetType.getTypeName()
-        ));
+            targetType.getTypeName()));
     }
 
 }

--- a/docstring/src/test/java/io/cucumber/docstring/DocStringTest.java
+++ b/docstring/src/test/java/io/cucumber/docstring/DocStringTest.java
@@ -14,47 +14,40 @@ class DocStringTest {
         DocString docString = DocString.create("hello world");
         CucumberDocStringException exception = assertThrows(
             CucumberDocStringException.class,
-            () -> docString.convert(Object.class)
-        );
+            () -> docString.convert(Object.class));
         assertThat(exception.getMessage(), is("" +
-            "Can't convert DocString to class java.lang.Object. You have to write the conversion for it in this method"
-        ));
+                "Can't convert DocString to class java.lang.Object. You have to write the conversion for it in this method"));
     }
 
     @Test
     void pretty_prints_doc_string_objects() {
         DocString docString = DocString.create(
             "{\n" +
-                "  \"hello\":\"world\"\n" +
-                "}",
-            "application/json"
-        );
-
+                    "  \"hello\":\"world\"\n" +
+                    "}",
+            "application/json");
 
         assertThat(docString.toString(), is("" +
-            "      \"\"\"application/json\n" +
-            "      {\n" +
-            "        \"hello\":\"world\"\n" +
-            "      }\n" +
-            "      \"\"\""
-        ));
+                "      \"\"\"application/json\n" +
+                "      {\n" +
+                "        \"hello\":\"world\"\n" +
+                "      }\n" +
+                "      \"\"\""));
     }
 
     @Test
     void doc_string_equals_doc_string() {
         DocString docString = DocString.create(
             "{\n" +
-                "  \"hello\":\"world\"\n" +
-                "}",
-            "application/json"
-        );
+                    "  \"hello\":\"world\"\n" +
+                    "}",
+            "application/json");
 
         DocString other = DocString.create(
             "{\n" +
-                "  \"hello\":\"world\"\n" +
-                "}",
-            "application/json"
-        );
+                    "  \"hello\":\"world\"\n" +
+                    "}",
+            "application/json");
 
         assertThat(docString, CoreMatchers.equalTo(other));
         assertThat(docString.hashCode(), CoreMatchers.equalTo(other.hashCode()));
@@ -64,15 +57,12 @@ class DocStringTest {
     void pretty_prints_empty_doc_string_objects() {
         DocString docString = DocString.create(
             "",
-            "application/json"
-        );
-
+            "application/json");
 
         assertThat(docString.toString(), is("" +
-            "      \"\"\"application/json\n" +
-            "      \n" +
-            "      \"\"\""
-        ));
+                "      \"\"\"application/json\n" +
+                "      \n" +
+                "      \"\"\""));
     }
 
 }

--- a/docstring/src/test/java/io/cucumber/docstring/DocStringTypeRegistryDocStringConverterTest.java
+++ b/docstring/src/test/java/io/cucumber/docstring/DocStringTypeRegistryDocStringConverterTest.java
@@ -12,21 +12,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class DocStringTypeRegistryDocStringConverterTest {
 
     private final DocStringTypeRegistry registry = new DocStringTypeRegistry();
-    private final DocStringTypeRegistryDocStringConverter converter =
-        new DocStringTypeRegistryDocStringConverter(registry);
+    private final DocStringTypeRegistryDocStringConverter converter = new DocStringTypeRegistryDocStringConverter(
+        registry);
 
     @Test
     void uses_doc_string_type_when_available() {
         registry.defineDocStringType(new DocStringType(
             JsonNode.class,
             "json",
-            (String s) -> new ObjectMapper().readTree(s)
-        ));
+            (String s) -> new ObjectMapper().readTree(s)));
 
         DocString docString = DocString.create(
             "{\"hello\":\"world\"}",
-            "json"
-        );
+            "json");
 
         JsonNode converted = converter.convert(docString, Object.class);
         assertThat(converted.get("hello").textValue(), is("world"));
@@ -37,12 +35,10 @@ class DocStringTypeRegistryDocStringConverterTest {
         registry.defineDocStringType(new DocStringType(
             JsonNode.class,
             "json",
-            (String s) -> new ObjectMapper().readTree(s)
-        ));
+            (String s) -> new ObjectMapper().readTree(s)));
 
         DocString docString = DocString.create(
-            "{\"hello\":\"world\"}"
-        );
+            "{\"hello\":\"world\"}");
 
         JsonNode converted = converter.convert(docString, JsonNode.class);
         assertThat(converted.get("hello").textValue(), is("world"));
@@ -51,8 +47,7 @@ class DocStringTypeRegistryDocStringConverterTest {
     @Test
     void target_type_to_string_is_predefined() {
         DocString docString = DocString.create(
-            "hello world"
-        );
+            "hello world");
         String converted = converter.convert(docString, String.class);
         assertThat(converted, is("hello world"));
     }
@@ -60,8 +55,7 @@ class DocStringTypeRegistryDocStringConverterTest {
     @Test
     void converts_doc_string_to_doc_string() {
         DocString docString = DocString.create(
-            "{\"hello\":\"world\"}"
-        );
+            "{\"hello\":\"world\"}");
 
         DocString converted = converter.convert(docString, DocString.class);
         assertThat(converted, is(docString));
@@ -71,33 +65,27 @@ class DocStringTypeRegistryDocStringConverterTest {
     void throws_when_no_converter_available() {
         DocString docString = DocString.create(
             "{\"hello\":\"world\"}",
-            "application/json"
-        );
+            "application/json");
 
         CucumberDocStringException exception = assertThrows(
             CucumberDocStringException.class,
-            () -> converter.convert(docString, JsonNode.class)
-        );
+            () -> converter.convert(docString, JsonNode.class));
 
         assertThat(exception.getMessage(), is("" +
-            "It appears you did not register docstring type for 'application/json' or com.fasterxml.jackson.databind.JsonNode"
-        ));
+                "It appears you did not register docstring type for 'application/json' or com.fasterxml.jackson.databind.JsonNode"));
     }
 
     @Test
     void throws_when_no_converter_available_for_type() {
         DocString docString = DocString.create(
-            "{\"hello\":\"world\"}"
-        );
+            "{\"hello\":\"world\"}");
 
         CucumberDocStringException exception = assertThrows(
             CucumberDocStringException.class,
-            () -> converter.convert(docString, JsonNode.class)
-        );
+            () -> converter.convert(docString, JsonNode.class));
 
         assertThat(exception.getMessage(), is("" +
-            "It appears you did not register docstring type for com.fasterxml.jackson.databind.JsonNode"
-        ));
+                "It appears you did not register docstring type for com.fasterxml.jackson.databind.JsonNode"));
     }
 
     @Test
@@ -107,25 +95,21 @@ class DocStringTypeRegistryDocStringConverterTest {
             "json",
             (String s) -> {
                 throw new RuntimeException();
-            }
-        ));
+            }));
 
         DocString docString = DocString.create(
             "{\"hello\":\"world\"}",
-            "json"
-        );
+            "json");
 
         CucumberDocStringException exception = assertThrows(
             CucumberDocStringException.class,
-            () -> converter.convert(docString, JsonNode.class)
-        );
+            () -> converter.convert(docString, JsonNode.class));
 
         assertThat(exception.getMessage(), is(equalToCompressingWhiteSpace("" +
-            "'json' could not transform\n" +
-            "      \"\"\"json\n" +
-            "      {\"hello\":\"world\"}\n" +
-            "      \"\"\""
-        )));
+                "'json' could not transform\n" +
+                "      \"\"\"json\n" +
+                "      {\"hello\":\"world\"}\n" +
+                "      \"\"\"")));
     }
 
 }

--- a/docstring/src/test/java/io/cucumber/docstring/DocStringTypeRegistryTest.java
+++ b/docstring/src/test/java/io/cucumber/docstring/DocStringTypeRegistryTest.java
@@ -17,17 +17,13 @@ class DocStringTypeRegistryTest {
         DocStringType docStringType = new DocStringType(
             String.class,
             "",
-            (String s) -> s
-        );
+            (String s) -> s);
 
         CucumberDocStringException actualThrown = assertThrows(
-            CucumberDocStringException.class, () ->
-                registry.defineDocStringType(docStringType)
-        );
+            CucumberDocStringException.class, () -> registry.defineDocStringType(docStringType));
         assertThat(actualThrown.getMessage(), is(equalTo(
             "There is already docstring type registered for '[anonymous]' and java.lang.String.\n" +
-                "You are trying to add '[anonymous]' and java.lang.String"
-        )));
+                    "You are trying to add '[anonymous]' and java.lang.String")));
     }
 
     @Test
@@ -35,23 +31,19 @@ class DocStringTypeRegistryTest {
         registry.defineDocStringType(new DocStringType(
             JsonNode.class,
             "json",
-            (String s) -> null
-        ));
+            (String s) -> null));
 
         DocStringType duplicate = new DocStringType(
             JsonNode.class,
             "application/json",
-            (String s) -> null
-        );
+            (String s) -> null);
 
         CucumberDocStringException exception = assertThrows(
             CucumberDocStringException.class,
-            () -> registry.defineDocStringType(duplicate)
-        );
+            () -> registry.defineDocStringType(duplicate));
         assertThat(exception.getMessage(), is("" +
-            "There is already docstring type registered for 'json' and com.fasterxml.jackson.databind.JsonNode.\n" +
-            "You are trying to add 'application/json' and com.fasterxml.jackson.databind.JsonNode"
-        ));
+                "There is already docstring type registered for 'json' and com.fasterxml.jackson.databind.JsonNode.\n" +
+                "You are trying to add 'application/json' and com.fasterxml.jackson.databind.JsonNode"));
     }
 
 }

--- a/examples/java-calculator-junit5/src/test/java/io/cucumber/examples/junit5/calculator/RpnCalculatorStepDefinitions.java
+++ b/examples/java-calculator-junit5/src/test/java/io/cucumber/examples/junit5/calculator/RpnCalculatorStepDefinitions.java
@@ -11,7 +11,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
 public class RpnCalculatorStepDefinitions {
 
     private RpnCalculator calc;

--- a/examples/java-calculator-junit5/src/test/java/io/cucumber/examples/junit5/calculator/ShoppingStepDefinitions.java
+++ b/examples/java-calculator-junit5/src/test/java/io/cucumber/examples/junit5/calculator/ShoppingStepDefinitions.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
 public class ShoppingStepDefinitions {
 
     private final RpnCalculator calc = new RpnCalculator();

--- a/examples/java-calculator-testng/src/test/java/io/cucumber/examples/testng/RpnCalculatorSteps.java
+++ b/examples/java-calculator-testng/src/test/java/io/cucumber/examples/testng/RpnCalculatorSteps.java
@@ -63,8 +63,7 @@ public class RpnCalculatorSteps {
         return new Entry(
             Integer.valueOf(entry.get("first")),
             Integer.valueOf(entry.get("second")),
-            entry.get("operation")
-        );
+            entry.get("operation"));
     }
 
     static final class Entry {

--- a/examples/java-calculator-testng/src/test/java/io/cucumber/examples/testng/RunCucumberTest.java
+++ b/examples/java-calculator-testng/src/test/java/io/cucumber/examples/testng/RunCucumberTest.java
@@ -4,7 +4,7 @@ import io.cucumber.testng.AbstractTestNGCucumberTests;
 import io.cucumber.testng.CucumberOptions;
 import org.testng.annotations.DataProvider;
 
-@CucumberOptions(plugin = {"html:target/results.html", "message:target/results.ndjson"})
+@CucumberOptions(plugin = { "html:target/results.html", "message:target/results.ndjson" })
 public class RunCucumberTest extends AbstractTestNGCucumberTests {
 
     @DataProvider(parallel = true)

--- a/examples/java-calculator-testng/src/test/java/io/cucumber/examples/testng/ShoppingStepDefinitions.java
+++ b/examples/java-calculator-testng/src/test/java/io/cucumber/examples/testng/ShoppingStepDefinitions.java
@@ -37,8 +37,7 @@ public class ShoppingStepDefinitions {
     public Grocery grocery(Map<String, String> entry) {
         return new Grocery(
             entry.get("name"),
-            Price.fromString(entry.get("price"))
-        );
+            Price.fromString(entry.get("price")));
     }
 
     static class Grocery {

--- a/examples/java-calculator/src/test/java/io/cucumber/examples/java/RunCucumberTest.java
+++ b/examples/java-calculator/src/test/java/io/cucumber/examples/java/RunCucumberTest.java
@@ -5,7 +5,7 @@ import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"html:target/results.html", "message:target/results.ndjson"})
+@CucumberOptions(plugin = { "html:target/results.html", "message:target/results.ndjson" })
 public class RunCucumberTest {
 
 }

--- a/examples/java-calculator/src/test/java/io/cucumber/examples/java/ShoppingSteps.java
+++ b/examples/java-calculator/src/test/java/io/cucumber/examples/java/ShoppingSteps.java
@@ -119,8 +119,10 @@ public class ShoppingSteps {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             Grocery grocery = (Grocery) o;
             return Objects.equals(name, grocery.name);
         }

--- a/examples/java8-calculator/src/test/java/io/cucumber/examples/java8/RpnCalculatorSteps.java
+++ b/examples/java8-calculator/src/test/java/io/cucumber/examples/java8/RpnCalculatorSteps.java
@@ -48,8 +48,7 @@ public class RpnCalculatorSteps implements En {
         DataTableType((Map<String, String> row) -> new RpnCalculatorSteps.Entry(
             Integer.valueOf(row.get("first")),
             Integer.valueOf(row.get("second")),
-            row.get("operation")
-        ));
+            row.get("operation")));
 
     }
 

--- a/examples/java8-calculator/src/test/java/io/cucumber/examples/java8/ShoppingSteps.java
+++ b/examples/java8-calculator/src/test/java/io/cucumber/examples/java8/ShoppingSteps.java
@@ -60,8 +60,7 @@ public class ShoppingSteps implements En {
 
         DataTableType((Map<String, String> row) -> new ShoppingSteps.Grocery(
             row.get("name"),
-            ShoppingSteps.Price.fromString(row.get("price"))
-        ));
+            ShoppingSteps.Price.fromString(row.get("price"))));
 
         ParameterType("amount", "\\d+\\.\\d+\\s[a-zA-Z]+", (String value) -> {
             String[] arr = value.split("\\s");
@@ -70,8 +69,8 @@ public class ShoppingSteps implements En {
 
         DocStringType("shopping_list", (String docstring) -> {
             return Stream.of(docstring.split("\\s"))
-                .map(Grocery::new)
-                .toArray(Grocery[]::new);
+                    .map(Grocery::new)
+                    .toArray(Grocery[]::new);
         });
     }
 
@@ -91,8 +90,10 @@ public class ShoppingSteps implements En {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             Grocery grocery = (Grocery) o;
             return Objects.equals(name, grocery.name);
         }

--- a/examples/spring-txn/src/main/java/io/cucumber/examples/spring/txn/Message.java
+++ b/examples/spring-txn/src/main/java/io/cucumber/examples/spring/txn/Message.java
@@ -9,6 +9,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+
 import java.io.Serializable;
 import java.util.StringJoiner;
 
@@ -57,9 +58,9 @@ public class Message implements Serializable {
     @Override
     public String toString() {
         return new StringJoiner(", ", Message.class.getSimpleName() + "[", "]")
-            .add("id=" + id)
-            .add("content='" + content + "'")
-            .toString();
+                .add("id=" + id)
+                .add("content='" + content + "'")
+                .toString();
     }
 
 }

--- a/examples/spring-txn/src/main/java/io/cucumber/examples/spring/txn/User.java
+++ b/examples/spring-txn/src/main/java/io/cucumber/examples/spring/txn/User.java
@@ -10,6 +10,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.StringJoiner;
@@ -62,9 +63,9 @@ public class User implements Serializable {
     @Override
     public String toString() {
         return new StringJoiner(", ", User.class.getSimpleName() + "[", "]")
-            .add("id=" + id)
-            .add("username='" + username + "'")
-            .toString();
+                .add("id=" + id)
+                .add("username='" + username + "'")
+                .toString();
     }
 
 }

--- a/examples/spring-txn/src/test/java/io/cucumber/examples/spring/txn/MessageStepDefinitions.java
+++ b/examples/spring-txn/src/test/java/io/cucumber/examples/spring/txn/MessageStepDefinitions.java
@@ -43,14 +43,14 @@ public class MessageStepDefinitions {
     @Then("the results content should be:")
     public void the_result_should_be(List<String> contents) {
         User user = userStepDefinitions.getCurrentUser();
-        assertAll("The expected contents created by the user", () -> {
+        assertAll(() -> {
             assertThat(results)
-                .extracting(Message::getContent)
-                .isEqualTo(contents);
+                    .extracting(Message::getContent)
+                    .isEqualTo(contents);
             assertThat(results)
-                .extracting(Message::getAuthor)
-                .extracting(User::getId)
-                .allMatch(user.getId()::equals);
+                    .extracting(Message::getAuthor)
+                    .extracting(User::getId)
+                    .allMatch(user.getId()::equals);
         });
     }
 

--- a/examples/spring-txn/src/test/java/io/cucumber/examples/spring/txn/SeeMessagesStepDefinitions.java
+++ b/examples/spring-txn/src/test/java/io/cucumber/examples/spring/txn/SeeMessagesStepDefinitions.java
@@ -25,8 +25,8 @@ public class SeeMessagesStepDefinitions {
     public void i_visit_the_page_for_the_user() throws Exception {
         User user = userStepDefinitions.getCurrentUser();
         resultActions = mockMvc
-            .perform(get("/users/" + user.getId()))
-            .andExpect(status().isOk());
+                .perform(get("/users/" + user.getId()))
+                .andExpect(status().isOk());
     }
 
     @Then("I should see {string}")

--- a/examples/spring-txn/src/test/java/io/cucumber/examples/spring/txn/SpringTransactionHooks.java
+++ b/examples/spring-txn/src/test/java/io/cucumber/examples/spring/txn/SpringTransactionHooks.java
@@ -25,9 +25,9 @@ import org.springframework.transaction.support.DefaultTransactionDefinition;
  * specified bean name, from the runtime <code>BeanFactory</code>.
  * </p>
  * <p>
- * NOTE: This class is NOT threadsafe!  It relies on the fact that
- * cucumber-jvm will instantiate an instance of any applicable hookdef class
- * per scenario run.
+ * NOTE: This class is NOT threadsafe! It relies on the fact that cucumber-jvm
+ * will instantiate an instance of any applicable hookdef class per scenario
+ * run.
  * </p>
  */
 public class SpringTransactionHooks implements BeanFactoryAware {
@@ -43,7 +43,7 @@ public class SpringTransactionHooks implements BeanFactoryAware {
     @Before(value = "@txn", order = 100)
     public void startTransaction() {
         transactionStatus = obtainPlatformTransactionManager()
-            .getTransaction(new DefaultTransactionDefinition());
+                .getTransaction(new DefaultTransactionDefinition());
     }
 
     public PlatformTransactionManager obtainPlatformTransactionManager() {
@@ -53,7 +53,7 @@ public class SpringTransactionHooks implements BeanFactoryAware {
     @After(value = "@txn", order = 100)
     public void rollBackTransaction() {
         obtainPlatformTransactionManager()
-            .rollback(transactionStatus);
+                .rollback(transactionStatus);
     }
 
 }

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/CucumberQuery.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/CucumberQuery.java
@@ -26,15 +26,13 @@ final class CucumberQuery {
             if (featureChild.hasBackground()) {
                 this.updateBackground(
                     featureChild.getBackground(),
-                    gherkinDocument.getUri()
-                );
+                    gherkinDocument.getUri());
             }
 
             if (featureChild.hasScenario()) {
                 this.updateScenario(
                     featureChild.getScenario(),
-                    gherkinDocument.getUri()
-                );
+                    gherkinDocument.getUri());
             }
 
             if (featureChild.hasRule()) {
@@ -42,15 +40,13 @@ final class CucumberQuery {
                     if (ruleChild.hasBackground()) {
                         this.updateBackground(
                             ruleChild.getBackground(),
-                            gherkinDocument.getUri()
-                        );
+                            gherkinDocument.getUri());
                     }
 
                     if (ruleChild.hasScenario()) {
                         this.updateScenario(
                             ruleChild.getScenario(),
-                            gherkinDocument.getUri()
-                        );
+                            gherkinDocument.getUri());
                     }
                 }
             }

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesExamples.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesExamples.java
@@ -20,8 +20,8 @@ final class GherkinMessagesExamples implements Node.Examples {
         this.location = GherkinMessagesLocation.from(examples.getLocation());
         AtomicInteger row = new AtomicInteger(1);
         this.children = examples.getTableBodyList().stream()
-            .map(tableRow -> new GherkinMessagesExample(tableRow, row.getAndIncrement()))
-            .collect(Collectors.toList());
+                .map(tableRow -> new GherkinMessagesExample(tableRow, row.getAndIncrement()))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesFeature.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesFeature.java
@@ -24,26 +24,31 @@ final class GherkinMessagesFeature implements Feature {
     private final String gherkinSource;
     private final List<Node> children;
 
-    GherkinMessagesFeature(GherkinDocument gherkinDocument, URI uri, String gherkinSource, List<Pickle> pickles, List<Messages.Envelope> envelopes) {
+    GherkinMessagesFeature(
+            GherkinDocument gherkinDocument,
+            URI uri,
+            String gherkinSource,
+            List<Pickle> pickles,
+            List<Messages.Envelope> envelopes) {
         this.gherkinDocument = gherkinDocument;
         this.uri = uri;
         this.gherkinSource = gherkinSource;
         this.pickles = pickles;
         this.envelopes = envelopes;
         this.children = gherkinDocument.getFeature().getChildrenList().stream()
-            .filter(featureChild -> featureChild.hasRule() || featureChild.hasScenario())
-            .map(featureChild -> {
-                if (featureChild.hasRule()) {
-                    return new GherkinMessagesRule(featureChild.getRule());
-                }
-                GherkinDocument.Feature.Scenario scenario = featureChild.getScenario();
-                if (scenario.getExamplesCount() > 0) {
-                    return new GherkinMessagesScenarioOutline(scenario);
-                } else {
-                    return new GherkinMessagesScenario(scenario);
-                }
-            })
-            .collect(Collectors.toList());
+                .filter(featureChild -> featureChild.hasRule() || featureChild.hasScenario())
+                .map(featureChild -> {
+                    if (featureChild.hasRule()) {
+                        return new GherkinMessagesRule(featureChild.getRule());
+                    }
+                    GherkinDocument.Feature.Scenario scenario = featureChild.getScenario();
+                    if (scenario.getExamplesCount() > 0) {
+                        return new GherkinMessagesScenarioOutline(scenario);
+                    } else {
+                        return new GherkinMessagesScenario(scenario);
+                    }
+                })
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -71,9 +76,9 @@ final class GherkinMessagesFeature implements Feature {
     public Pickle getPickleAt(Node node) {
         Location location = node.getLocation();
         return pickles.stream()
-            .filter(pickle -> pickle.getLocation().equals(location))
-            .findFirst()
-            .orElseThrow(() -> new NoSuchElementException("No pickle in " + uri + " at " + location));
+                .filter(pickle -> pickle.getLocation().equals(location))
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException("No pickle in " + uri + " at " + location));
     }
 
     @Override
@@ -103,8 +108,10 @@ final class GherkinMessagesFeature implements Feature {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         GherkinMessagesFeature that = (GherkinMessagesFeature) o;
         return uri.equals(that.uri);
     }

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesFeature.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesFeature.java
@@ -29,7 +29,8 @@ final class GherkinMessagesFeature implements Feature {
             URI uri,
             String gherkinSource,
             List<Pickle> pickles,
-            List<Messages.Envelope> envelopes) {
+            List<Messages.Envelope> envelopes
+    ) {
         this.gherkinDocument = gherkinDocument;
         this.uri = uri;
         this.gherkinSource = gherkinSource;

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesFeatureParser.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesFeatureParser.java
@@ -26,31 +26,30 @@ public final class GherkinMessagesFeatureParser implements FeatureParser {
     @Override
     public Optional<Feature> parse(URI path, String source, Supplier<UUID> idGenerator) {
         List<Envelope> sources = singletonList(
-            makeSourceEnvelope(source, path.toString())
-        );
+            makeSourceEnvelope(source, path.toString()));
 
         List<Envelope> envelopes = Gherkin.fromSources(
             sources,
             true,
             true,
             true,
-            () -> idGenerator.get().toString()
-        ).collect(toList());
+            () -> idGenerator.get().toString()).collect(toList());
 
         GherkinDocument gherkinDocument = envelopes.stream()
-            .filter(Envelope::hasGherkinDocument)
-            .map(Envelope::getGherkinDocument)
-            .findFirst()
-            .orElse(null);
+                .filter(Envelope::hasGherkinDocument)
+                .map(Envelope::getGherkinDocument)
+                .findFirst()
+                .orElse(null);
 
         if (gherkinDocument == null || !gherkinDocument.hasFeature()) {
             List<String> errors = envelopes.stream()
-                .filter(Envelope::hasParseError)
-                .map(Envelope::getParseError)
-                .map(Messages.ParseError::getMessage)
-                .collect(toList());
+                    .filter(Envelope::hasParseError)
+                    .map(Envelope::getParseError)
+                    .map(Messages.ParseError::getMessage)
+                    .collect(toList());
             if (!errors.isEmpty()) {
-                throw new FeatureParserException("Failed to parse resource at: " + path.toString() + "\n" + String.join("\n", errors));
+                throw new FeatureParserException(
+                    "Failed to parse resource at: " + path.toString() + "\n" + String.join("\n", errors));
             }
             return Optional.empty();
         }
@@ -62,25 +61,24 @@ public final class GherkinMessagesFeatureParser implements FeatureParser {
         GherkinDialect dialect = dialectProvider.getDialect(language, null);
 
         List<Messages.Pickle> pickleMessages = envelopes.stream()
-            .filter(Envelope::hasPickle)
-            .map(Envelope::getPickle)
-            .collect(toList());
+                .filter(Envelope::hasPickle)
+                .map(Envelope::getPickle)
+                .collect(toList());
 
         if (pickleMessages.isEmpty()) {
             return Optional.empty();
         }
 
         List<Pickle> pickles = pickleMessages.stream()
-            .map(pickle -> new GherkinMessagesPickle(pickle, path, dialect, cucumberQuery))
-            .collect(toList());
+                .map(pickle -> new GherkinMessagesPickle(pickle, path, dialect, cucumberQuery))
+                .collect(toList());
 
         GherkinMessagesFeature feature = new GherkinMessagesFeature(
             gherkinDocument,
             path,
             source,
             pickles,
-            envelopes
-        );
+            envelopes);
         return Optional.of(feature);
     }
 

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesPickle.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesPickle.java
@@ -35,7 +35,8 @@ final class GherkinMessagesPickle implements Pickle {
     private static List<Step> createCucumberSteps(
             Messages.Pickle pickle,
             GherkinDialect dialect,
-            CucumberQuery cucumberQuery) {
+            CucumberQuery cucumberQuery
+    ) {
         List<Step> list = new ArrayList<>();
         String previousGivenWhenThen = dialect.getGivenKeywords()
                 .stream()

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesPickle.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesPickle.java
@@ -32,13 +32,16 @@ final class GherkinMessagesPickle implements Pickle {
         this.steps = createCucumberSteps(pickle, dialect, this.cucumberQuery);
     }
 
-    private static List<Step> createCucumberSteps(Messages.Pickle pickle, GherkinDialect dialect, CucumberQuery cucumberQuery) {
+    private static List<Step> createCucumberSteps(
+            Messages.Pickle pickle,
+            GherkinDialect dialect,
+            CucumberQuery cucumberQuery) {
         List<Step> list = new ArrayList<>();
         String previousGivenWhenThen = dialect.getGivenKeywords()
-            .stream()
-            .filter(s -> !StepType.isAstrix(s))
-            .findFirst()
-            .orElseThrow(() -> new IllegalStateException("No Given keyword for dialect: " + dialect.getName()));
+                .stream()
+                .filter(s -> !StepType.isAstrix(s))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No Given keyword for dialect: " + dialect.getName()));
 
         for (PickleStep pickleStep : pickle.getStepsList()) {
             String gherkinStepId = pickleStep.getAstNodeIds(0);
@@ -69,7 +72,6 @@ final class GherkinMessagesPickle implements Pickle {
     public String getName() {
         return pickle.getName();
     }
-
 
     @Override
     public Location getLocation() {

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesRule.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesRule.java
@@ -18,16 +18,16 @@ final class GherkinMessagesRule implements Node.Rule {
     GherkinMessagesRule(Messages.GherkinDocument.Feature.FeatureChild.Rule rule) {
         this.rule = rule;
         this.children = rule.getChildrenList().stream()
-            .filter(RuleChild::hasScenario)
-            .map(ruleChild -> {
-                Messages.GherkinDocument.Feature.Scenario scenario = ruleChild.getScenario();
-                if (scenario.getExamplesCount() > 0) {
-                    return new GherkinMessagesScenarioOutline(scenario);
-                } else {
-                    return new GherkinMessagesScenario(scenario);
-                }
-            })
-            .collect(Collectors.toList());
+                .filter(RuleChild::hasScenario)
+                .map(ruleChild -> {
+                    Messages.GherkinDocument.Feature.Scenario scenario = ruleChild.getScenario();
+                    if (scenario.getExamplesCount() > 0) {
+                        return new GherkinMessagesScenarioOutline(scenario);
+                    } else {
+                        return new GherkinMessagesScenario(scenario);
+                    }
+                })
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesScenarioOutline.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesScenarioOutline.java
@@ -17,10 +17,9 @@ final class GherkinMessagesScenarioOutline implements Node.ScenarioOutline {
     GherkinMessagesScenarioOutline(Messages.GherkinDocument.Feature.Scenario scenario) {
         this.scenario = scenario;
         this.children = scenario.getExamplesList().stream()
-            .map(GherkinMessagesExamples::new)
-            .collect(Collectors.toList());
+                .map(GherkinMessagesExamples::new)
+                .collect(Collectors.toList());
     }
-
 
     @Override
     public Collection<Examples> elements() {

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesStep.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesStep.java
@@ -20,8 +20,13 @@ final class GherkinMessagesStep implements Step {
     private final String previousGwtKeyWord;
     private final Messages.Location location;
 
-    GherkinMessagesStep(PickleStep pickleStep, GherkinDialect dialect, String previousGwtKeyWord,
-            Messages.Location location, String keyword) {
+    GherkinMessagesStep(
+            PickleStep pickleStep,
+            GherkinDialect dialect,
+            String previousGwtKeyWord,
+            Messages.Location location,
+            String keyword
+    ) {
         this.pickleStep = pickleStep;
         this.argument = extractArgument(pickleStep, location);
         this.keyWord = keyword;

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesStep.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesStep.java
@@ -20,7 +20,8 @@ final class GherkinMessagesStep implements Step {
     private final String previousGwtKeyWord;
     private final Messages.Location location;
 
-    GherkinMessagesStep(PickleStep pickleStep, GherkinDialect dialect, String previousGwtKeyWord, Messages.Location location, String keyword) {
+    GherkinMessagesStep(PickleStep pickleStep, GherkinDialect dialect, String previousGwtKeyWord,
+            Messages.Location location, String keyword) {
         this.pickleStep = pickleStep;
         this.argument = extractArgument(pickleStep, location);
         this.keyWord = keyword;
@@ -33,7 +34,7 @@ final class GherkinMessagesStep implements Step {
         PickleStepArgument argument = pickleStep.getArgument();
         if (argument.hasDocString()) {
             PickleDocString docString = argument.getDocString();
-            //TODO: Fix this work around
+            // TODO: Fix this work around
             return new GherkinMessagesDocStringArgument(docString, location.getLine() + 1);
         }
         if (argument.hasDataTable()) {

--- a/gherkin-messages/src/test/java/io/cucumber/core/gherkin/messages/FeatureParserTest.java
+++ b/gherkin-messages/src/test/java/io/cucumber/core/gherkin/messages/FeatureParserTest.java
@@ -31,7 +31,8 @@ class FeatureParserTest {
     @Test
     void feature_file_without_pickles_is_parsed_but_produces_no_feature() throws IOException {
         URI uri = URI.create("classpath:com/example.feature");
-        String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/no-pickles.feature")));
+        String source = new String(
+            readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/no-pickles.feature")));
         Optional<Feature> feature = parser.parse(uri, source, UUID::randomUUID);
         assertFalse(feature.isPresent());
     }
@@ -39,7 +40,8 @@ class FeatureParserTest {
     @Test
     void empty_feature_file_is_parsed_but_produces_no_feature() throws IOException {
         URI uri = URI.create("classpath:com/example.feature");
-        String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/empty.feature")));
+        String source = new String(
+            readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/empty.feature")));
         Optional<Feature> feature = parser.parse(uri, source, UUID::randomUUID);
         assertFalse(feature.isPresent());
     }
@@ -47,7 +49,8 @@ class FeatureParserTest {
     @Test
     void unnamed_elements_return_empty_strings_as_name() throws IOException {
         URI uri = URI.create("classpath:com/example.feature");
-        String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/unnamed.feature")));
+        String source = new String(
+            readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/unnamed.feature")));
         Feature feature = parser.parse(uri, source, UUID::randomUUID).get();
         assertEquals(Optional.empty(), feature.getName());
         Node.Rule rule = (Node.Rule) feature.elements().iterator().next();
@@ -73,7 +76,8 @@ class FeatureParserTest {
     @Test
     void empty_table_is_parsed() throws IOException {
         URI uri = URI.create("classpath:com/example.feature");
-        String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/empty-table.feature")));
+        String source = new String(
+            readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/empty-table.feature")));
         Feature feature = parser.parse(uri, source, UUID::randomUUID).get();
         Pickle pickle = feature.getPickles().get(0);
         Step step = pickle.getSteps().get(0);
@@ -84,7 +88,8 @@ class FeatureParserTest {
     @Test
     void empty_doc_string_media_type_is_null() throws IOException {
         URI uri = URI.create("classpath:com/example.feature");
-        String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/doc-string.feature")));
+        String source = new String(
+            readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/doc-string.feature")));
         Feature feature = parser.parse(uri, source, UUID::randomUUID).get();
         Pickle pickle = feature.getPickles().get(0);
         List<Step> steps = pickle.getSteps();
@@ -98,7 +103,8 @@ class FeatureParserTest {
     @Test
     void backgrounds_can_occur_twice() throws IOException {
         URI uri = URI.create("classpath:com/example.feature");
-        String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/background.feature")));
+        String source = new String(
+            readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/background.feature")));
         Feature feature = parser.parse(uri, source, UUID::randomUUID).get();
         Pickle pickle = feature.getPickles().get(0);
         List<Step> steps = pickle.getSteps();
@@ -108,8 +114,10 @@ class FeatureParserTest {
     @Test
     void lexer_error_throws_exception() throws IOException {
         URI uri = URI.create("classpath:com/example.feature");
-        String source = new String(readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/lexer-error.feature")));
-        FeatureParserException exception = assertThrows(FeatureParserException.class, () -> parser.parse(uri, source, UUID::randomUUID));
+        String source = new String(
+            readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/lexer-error.feature")));
+        FeatureParserException exception = assertThrows(FeatureParserException.class,
+            () -> parser.parse(uri, source, UUID::randomUUID));
         assertEquals("" +
                 "Failed to parse resource at: classpath:com/example.feature\n" +
                 "(1:1): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Feature  FA'\n" +
@@ -117,8 +125,7 @@ class FeatureParserTest {
                 "(4:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Given GA'\n" +
                 "(5:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'When GA'\n" +
                 "(6:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Then TA'",
-            exception.getMessage()
-        );
+            exception.getMessage());
     }
 
 }

--- a/gherkin/src/main/java/io/cucumber/core/gherkin/Pickle.java
+++ b/gherkin/src/main/java/io/cucumber/core/gherkin/Pickle.java
@@ -14,19 +14,19 @@ public interface Pickle {
     String getName();
 
     /**
-     * Returns the location in feature file of the Scenario this pickle was created
-     * from. If this pickle was created from a Scenario Outline this location is the
-     * location in the Example section used to fill in the place holders.
+     * Returns the location in feature file of the Scenario this pickle was
+     * created from. If this pickle was created from a Scenario Outline this
+     * location is the location in the Example section used to fill in the place
+     * holders.
      *
      * @return location in the feature file
      */
     Location getLocation();
 
-
     /**
-     * Returns the location in feature file of the Scenario this pickle was created
-     * from. If this pickle was created from a Scenario Outline this location is
-     * that of the Scenario
+     * Returns the location in feature file of the Scenario this pickle was
+     * created from. If this pickle was created from a Scenario Outline this
+     * location is that of the Scenario
      *
      * @return location in the feature file
      */

--- a/guice/src/main/java/io/cucumber/guice/CucumberScopes.java
+++ b/guice/src/main/java/io/cucumber/guice/CucumberScopes.java
@@ -7,9 +7,8 @@ import org.apiguardian.api.API;
  * Creates an instance of {@link ScenarioScope} for use when declaring bindings
  * in implementations of {@link Module}.
  * <p>
- * Note that when binding objects to the scenario scope it is recommended to bind
- * them to the {@link ScenarioScoped} annotation instead. E.g:
- *
+ * Note that when binding objects to the scenario scope it is recommended to
+ * bind them to the {@link ScenarioScoped} annotation instead. E.g:
  * <code>bind(ScenarioScopedObject.class).in(ScenarioScoped.class);</code>
  */
 @API(status = API.Status.STABLE)

--- a/guice/src/main/java/io/cucumber/guice/GuiceFactory.java
+++ b/guice/src/main/java/io/cucumber/guice/GuiceFactory.java
@@ -6,7 +6,8 @@ import io.cucumber.core.options.CucumberProperties;
 import org.apiguardian.api.API;
 
 /**
- * Guice implementation of the <code>io.cucumber.core.backend.ObjectFactory</code>.
+ * Guice implementation of the
+ * <code>io.cucumber.core.backend.ObjectFactory</code>.
  */
 @API(status = API.Status.STABLE)
 public final class GuiceFactory implements ObjectFactory {
@@ -18,10 +19,11 @@ public final class GuiceFactory implements ObjectFactory {
     }
 
     /**
-     * Package private constructor that is called by the public constructor at runtime and is also called directly by
-     * tests.
+     * Package private constructor that is called by the public constructor at
+     * runtime and is also called directly by tests.
      *
-     * @param injector an injector configured with a binding for <code>ScenarioScope</code>.
+     * @param injector an injector configured with a binding for
+     *                 <code>ScenarioScope</code>.
      */
     GuiceFactory(Injector injector) {
         this.injector = injector;

--- a/guice/src/main/java/io/cucumber/guice/InjectorSource.java
+++ b/guice/src/main/java/io/cucumber/guice/InjectorSource.java
@@ -4,9 +4,10 @@ import com.google.inject.Injector;
 import org.apiguardian.api.API;
 
 /**
- * An implementation of this interface is used to obtain an <code>com.google.inject.Injector</code> that is used to
- * provide instances of all the classes that are used to run the Cucumber tests. The injector should be configured with
- * a binding for <code>ScenarioScope</code>.
+ * An implementation of this interface is used to obtain an
+ * <code>com.google.inject.Injector</code> that is used to provide instances of
+ * all the classes that are used to run the Cucumber tests. The injector should
+ * be configured with a binding for <code>ScenarioScope</code>.
  */
 @API(status = API.Status.STABLE)
 public interface InjectorSource {

--- a/guice/src/main/java/io/cucumber/guice/InjectorSourceFactory.java
+++ b/guice/src/main/java/io/cucumber/guice/InjectorSourceFactory.java
@@ -31,7 +31,9 @@ final class InjectorSourceFactory {
 
     private InjectorSource instantiateUserSpecifiedInjectorSource(String injectorSourceClassName) {
         try {
-            return (InjectorSource) Class.forName(injectorSourceClassName, true, Thread.currentThread().getContextClassLoader()).newInstance();
+            return (InjectorSource) Class
+                    .forName(injectorSourceClassName, true, Thread.currentThread().getContextClassLoader())
+                    .newInstance();
         } catch (Exception e) {
             String message = format("Instantiation of ''{0}'' failed. Check the caused by exception and ensure your" +
                     "InjectorSource implementation is accessible and has a public zero args constructor.",

--- a/guice/src/main/java/io/cucumber/guice/ScenarioScope.java
+++ b/guice/src/main/java/io/cucumber/guice/ScenarioScope.java
@@ -4,8 +4,8 @@ import com.google.inject.Scope;
 import org.apiguardian.api.API;
 
 /**
- * A custom Guice scope that enables classes to be bound in a scope that will last for the lifetime of one Cucumber
- * scenario.
+ * A custom Guice scope that enables classes to be bound in a scope that will
+ * last for the lifetime of one Cucumber scenario.
  */
 @API(status = API.Status.STABLE)
 public interface ScenarioScope extends Scope {

--- a/guice/src/main/java/io/cucumber/guice/ScenarioScoped.java
+++ b/guice/src/main/java/io/cucumber/guice/ScenarioScoped.java
@@ -14,7 +14,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * A custom Guice scope annotation that is usually bound to an instance of
  * <code>ScenarioScope</code>.
  */
-@Target({TYPE, METHOD})
+@Target({ TYPE, METHOD })
 @Retention(RUNTIME)
 @ScopeAnnotation
 @API(status = API.Status.STABLE)

--- a/guice/src/main/java/io/cucumber/guice/SequentialScenarioScope.java
+++ b/guice/src/main/java/io/cucumber/guice/SequentialScenarioScope.java
@@ -20,12 +20,12 @@ class SequentialScenarioScope implements ScenarioScope {
      * {@link Object#toString} in the returned provider and include the backing
      * provider's {@code toString()} output.
      *
-     * @param key      binding key
-     * @param unscoped locates an instance when one doesn't already exist in this
-     *                 scope.
-     * @return a new provider which only delegates to the given unscoped provider
-     * when an instance of the requested object doesn't already exist in this
-     * scope
+     * @param  key      binding key
+     * @param  unscoped locates an instance when one doesn't already exist in
+     *                  this scope.
+     * @return          a new provider which only delegates to the given
+     *                  unscoped provider when an instance of the requested
+     *                  object doesn't already exist in this scope
      */
     @Override
     public <T> Provider<T> scope(final Key<T> key, final Provider<T> unscoped) {

--- a/guice/src/main/java/io/cucumber/guice/package-info.java
+++ b/guice/src/main/java/io/cucumber/guice/package-info.java
@@ -1,73 +1,91 @@
 /**
  * Cucumber Guice configuration Api
  * <p>
- * An implentation of this interface is used to obtain an <code>com.google.inject.Injector</code> that is used to
- * provide instances of all the classes that are used to run the Cucumber tests. The injector should be configured with
- * a binding for <code>ScenarioScope</code>.
+ * An implementation of this interface is used to obtain an
+ * <code>com.google.inject.Injector</code> that is used to provide instances of
+ * all the classes that are used to run the Cucumber tests. The injector should
+ * be configured with a binding for <code>ScenarioScope</code>.
  * <p>
- * This module allows you to use Google Guice dependency injection in your Cucumber tests. Guice comes as standard with
- * singleton scope and 'no scope'. This module adds Cucumber scenario scope to the scopes available for use in your
- * test code. The rest of this documentation assumes you have at least a basic understanding of Guice. Please refer to
- * the Guice wiki if necessary, see <a href="https://github.com/google/guice/wiki/Motivation"
- * target="_parent">
+ * This module allows you to use Google Guice dependency injection in your
+ * Cucumber tests. Guice comes as standard with singleton scope and 'no scope'.
+ * This module adds Cucumber scenario scope to the scopes available for use in
+ * your test code. The rest of this documentation assumes you have at least a
+ * basic understanding of Guice. Please refer to the Guice wiki if necessary,
+ * see
+ * <a href="https://github.com/google/guice/wiki/Motivation" target="_parent">
  * https://github.com/google/guice/wiki/Motivation</a>
  * </p>
  * <h3>About scopes, injectors and migration from earlier versions</h3>
  * <p>
- * It's important to realise the differences in how this module functions when compared with earlier versions. The
- * changes are as follows.
+ * It's important to realise the differences in how this module functions when
+ * compared with earlier versions. The changes are as follows.
  * </p>
  * <h4>Version 1.1.7 and earlier</h4>
  * <p>
- * A Guice injector is created at the start of each test scenario and is destroyed at the end of each test scenario.
- * There is no scenario scope, just singleton and 'no scope'.
+ * A Guice injector is created at the start of each test scenario and is
+ * destroyed at the end of each test scenario. There is no scenario scope, just
+ * singleton and 'no scope'.
  * </p>
  * <h4>Version 1.1.8 onwards</h4>
  * <p>
- * A Guice injector is created once before any tests are run and is destroyed after the last test has run. Before each
- * test scenario a new scenario scope is created. At the end of the test scenario the scenario scope is destroyed.
+ * A Guice injector is created once before any tests are run and is destroyed
+ * after the last test has run. Before each test scenario a new scenario scope
+ * is created. At the end of the test scenario the scenario scope is destroyed.
  * Singleton scope exists throughout all test scenarios.
  * </p>
  * <h4>Migrating to version 1.1.8 or later</h4>
  * <p>
- * Users wishing to migrate should replace <code>@Singleton</code> annotations with <code>@ScenarioScope</code>
- * annotations. Guice modules should also have their singleton bindings updated. All bindings in
- * <code>Scopes.SINGLETON</code> should be replaced with bindings in <code>CucumberScopes.SCENARIO</code>.
+ * Users wishing to migrate should replace <code>@Singleton</code> annotations
+ * with <code>@ScenarioScope</code> annotations. Guice modules should also have
+ * their singleton bindings updated. All bindings in
+ * <code>Scopes.SINGLETON</code> should be replaced with bindings in
+ * <code>CucumberScopes.SCENARIO</code>.
  * </p>
  * <h3>Using the module</h3>
  * <p>
- * By including the <code>cucumber-guice</code> jar on your <code>CLASSPATH</code> your Step Definitions will be
- * instantiated by Guice. There are two main modes of using the module: with scope annotations and with module
- * bindings. The two modes can also be mixed. When mixing modes it is important to realise that binding a class in a
- * scope in a module takes precedence if the same class is also bound using a scope annotation.
+ * By including the <code>cucumber-guice</code> jar on your
+ * <code>CLASSPATH</code> your Step Definitions will be instantiated by Guice.
+ * There are two main modes of using the module: with scope annotations and with
+ * module bindings. The two modes can also be mixed. When mixing modes it is
+ * important to realise that binding a class in a scope in a module takes
+ * precedence if the same class is also bound using a scope annotation.
  * </p>
  * <h3>Scoping your step definitions</h3>
  * <p>
- * Usually you will want to bind your step definition classes in either scenario scope or in singleton scope. It is not
- * recommended to leave your step definition classes with no scope as it means that Cucumber will instantiate a new
- * instance of the class for each step within a scenario that uses that step definition.
+ * Usually you will want to bind your step definition classes in either scenario
+ * scope or in singleton scope. It is not recommended to leave your step
+ * definition classes with no scope as it means that Cucumber will instantiate a
+ * new instance of the class for each step within a scenario that uses that step
+ * definition.
  * </p>
  * <h3>Scenario scope</h3>
  * <p>
- * Cucumber will create exactly one instance of a class bound in scenario scope for each scenario in which it is used.
- * You should use scenario scope when you want to store state during a scenario but do not want the state to interfere
+ * Cucumber will create exactly one instance of a class bound in scenario scope
+ * for each scenario in which it is used. You should use scenario scope when you
+ * want to store state during a scenario but do not want the state to interfere
  * with subsequent scenarios.
  * </p>
  * <h3>Singleton scope</h3>
  * <p>
- * Cucumber will create just one instance of a class bound in singleton scope that will last for the lifetime of all
- * test scenarios in the test run. You should use singleton scope if your classes are stateless. You can also use
- * singleton scope when your classes contain state but with caution. You should be absolutely sure that a state change
- * in one scenario could not possibly influence the success or failure of a subsequent scenario. As an example of when
- * you might use a singleton, imagine you have an http client that is expensive to create. By holding a reference to
- * the client in a class bound in singleton scope you can reuse the client in multiple scenarios.
+ * Cucumber will create just one instance of a class bound in singleton scope
+ * that will last for the lifetime of all test scenarios in the test run. You
+ * should use singleton scope if your classes are stateless. You can also use
+ * singleton scope when your classes contain state but with caution. You should
+ * be absolutely sure that a state change in one scenario could not possibly
+ * influence the success or failure of a subsequent scenario. As an example of
+ * when you might use a singleton, imagine you have an http client that is
+ * expensive to create. By holding a reference to the client in a class bound in
+ * singleton scope you can reuse the client in multiple scenarios.
  * </p>
  * <h3>Using scope annotations</h3>
  * <p>
- * This is the easy route if you're new to Guice. To bind a class in scenario scope add the
- * <code>io.cucumber.guice.ScenarioScoped</code> annotation to the class definition. The class should have
- * a no-args constructor or one constructor that is annotated with <code>javax.inject.Inject</code>. For example:
+ * This is the easy route if you're new to Guice. To bind a class in scenario
+ * scope add the <code>io.cucumber.guice.ScenarioScoped</code> annotation to the
+ * class definition. The class should have a no-args constructor or one
+ * constructor that is annotated with <code>javax.inject.Inject</code>. For
+ * example:
  * </p>
+ * 
  * <pre>
  * import cucumber.runtime.java.guice.ScenarioScoped;
  * import javax.inject.Inject;
@@ -86,10 +104,13 @@
  * }
  * </pre>
  * <p>
- * To bind a class in singleton scope add the <code>javax.inject.Singleton</code> annotation to the class definition.
- * One strategy for using stateless step definitions is to use providers to share stateful scenario scoped instances
- * between stateless singleton step definition instances. For example:
+ * To bind a class in singleton scope add the
+ * <code>javax.inject.Singleton</code> annotation to the class definition. One
+ * strategy for using stateless step definitions is to use providers to share
+ * stateful scenario scoped instances between stateless singleton step
+ * definition instances. For example:
  * </p>
+ * 
  * <pre>
  * import javax.inject.Inject;
  * import javax.inject.Singleton;
@@ -113,20 +134,24 @@
  * }
  * </pre>
  * <p>
- * There is an alternative explanation of using
- * <a href="https://github.com/google/guice/wiki/InjectingProviders#providers-for-mixing-scopes" target="_parent">
- * providers for mixing scopes</a> on the Guice wiki.
+ * There is an alternative explanation of using <a href=
+ * "https://github.com/google/guice/wiki/InjectingProviders#providers-for-mixing-scopes"
+ * target="_parent"> providers for mixing scopes</a> on the Guice wiki.
  * </p>
  * <h3>Using module bindings</h3>
  * <p>
- * As an alternative to using annotations you may prefer to declare Guice bindings in a class that implements
- * <code>com.google.inject.Module</code>. To do this you should create a class that implements
- * <code>io.cucumber.guice.api.InjectorSource</code>. This gives you complete control over how you obtain a
- * Guice injector and it's Guice modules. The injector must provide a binding for
- * <code>io.cucumber.guice.ScenarioScope</code>. It should also provide a binding for the
- * <code>io.cucumber.guice.ScenarioScoped</code> annotation if your classes are using the annotation. The
- * easiest way to do this it to use <code>CucumberModules.createScenarioModule()</code>. For example:
+ * As an alternative to using annotations you may prefer to declare Guice
+ * bindings in a class that implements <code>com.google.inject.Module</code>. To
+ * do this you should create a class that implements
+ * <code>io.cucumber.guice.api.InjectorSource</code>. This gives you complete
+ * control over how you obtain a Guice injector and it's Guice modules. The
+ * injector must provide a binding for
+ * <code>io.cucumber.guice.ScenarioScope</code>. It should also provide a
+ * binding for the <code>io.cucumber.guice.ScenarioScoped</code> annotation if
+ * your classes are using the annotation. The easiest way to do this it to use
+ * <code>CucumberModules.createScenarioModule()</code>. For example:
  * </p>
+ * 
  * <pre>
  * import com.google.inject.Guice;
  * import com.google.inject.Injector;
@@ -143,12 +168,16 @@
  * }
  * </pre>
  * <p>
- * Cucumber needs to know where to find the <code>io.cucumber.guice.api.InjectorSource</code> that it will use.
- * You should create a properties file called {@value io.cucumber.core.options.Constants#CUCUMBER_PROPERTIES_FILE_NAME}
- * and place it in the root of the classpath. The file should contain a single property key called
- * <code>guice.injector-source</code> with a value equal to the fully qualified name of the
+ * Cucumber needs to know where to find the
+ * <code>io.cucumber.guice.api.InjectorSource</code> that it will use. You
+ * should create a properties file called
+ * {@value io.cucumber.core.options.Constants#CUCUMBER_PROPERTIES_FILE_NAME} and
+ * place it in the root of the classpath. The file should contain a single
+ * property key called <code>guice.injector-source</code> with a value equal to
+ * the fully qualified name of the
  * <code>io.cucumber.guice.api.InjectorSource</code>. For example:
  * </p>
+ * 
  * <pre>
  * guice.injector-source=com.company.YourInjectorSource
  * </pre>

--- a/guice/src/test/java/io/cucumber/guice/GuiceFactoryTest.java
+++ b/guice/src/test/java/io/cucumber/guice/GuiceFactoryTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import javax.inject.Singleton;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -44,7 +45,8 @@ class GuiceFactoryTest {
 
     @AfterEach
     void tearDown() {
-        // If factory is left in start state it can cause cascading failures due to scope being left open
+        // If factory is left in start state it can cause cascading failures due
+        // to scope being left open
         try {
             factory.stop();
         } catch (Exception ignored) {
@@ -71,10 +73,9 @@ class GuiceFactoryTest {
         ConfigurationException actualThrown = assertThrows(ConfigurationException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalToCompressingWhiteSpace(
             "Guice configuration errors:\n\n" +
-                "1) No implementation for io.cucumber.guice.ScenarioScope was bound.\n" +
-                "  while locating io.cucumber.guice.ScenarioScope\n\n" +
-                "1 error"
-        )));
+                    "1) No implementation for io.cucumber.guice.ScenarioScope was bound.\n" +
+                    "  while locating io.cucumber.guice.ScenarioScope\n\n" +
+                    "1 error")));
     }
 
     @Test
@@ -137,7 +138,8 @@ class GuiceFactoryTest {
     @Test
     void shouldGiveNewInstanceOfAnnotatedScenarioScopedClassForEachScenario() {
         factory = new GuiceFactory(injector(CucumberModules.createScenarioModule()));
-        instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory, AnnotatedScenarioScopedClass.class);
+        instancesFromDifferentScenarios = getInstancesFromDifferentScenarios(factory,
+            AnnotatedScenarioScopedClass.class);
         assertThat(instancesFromDifferentScenarios, ElementsAreAllUniqueMatcher.elementsAreAllUnique());
     }
 

--- a/guice/src/test/java/io/cucumber/guice/InjectorSourceFactoryTest.java
+++ b/guice/src/test/java/io/cucumber/guice/InjectorSourceFactoryTest.java
@@ -46,11 +46,13 @@ class InjectorSourceFactoryTest {
         InjectorSourceFactory injectorSourceFactory = createInjectorSourceFactory(properties);
 
         Executable testMethod = injectorSourceFactory::create;
-        InjectorSourceInstantiationFailed actualThrown = assertThrows(InjectorSourceInstantiationFailed.class, testMethod);
-        assertAll("Checking Exception including cause",
-            () -> assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo("Instantiation of 'some.bogus.Class' failed. Check the caused by exception and ensure yourInjectorSource implementation is accessible and has a public zero args constructor."))),
-            () -> assertThat("Unexpected exception cause class", actualThrown.getCause(), isA(ClassNotFoundException.class))
-        );
+        InjectorSourceInstantiationFailed actualThrown = assertThrows(InjectorSourceInstantiationFailed.class,
+            testMethod);
+        assertAll(
+            () -> assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+                "Instantiation of 'some.bogus.Class' failed. Check the caused by exception and ensure yourInjectorSource implementation is accessible and has a public zero args constructor."))),
+            () -> assertThat("Unexpected exception cause class", actualThrown.getCause(),
+                isA(ClassNotFoundException.class)));
     }
 
     @Test
@@ -60,11 +62,13 @@ class InjectorSourceFactoryTest {
         InjectorSourceFactory injectorSourceFactory = createInjectorSourceFactory(properties);
 
         Executable testMethod = injectorSourceFactory::create;
-        InjectorSourceInstantiationFailed actualThrown = assertThrows(InjectorSourceInstantiationFailed.class, testMethod);
-        assertAll("Checking Exception including cause",
-            () -> assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo("Instantiation of 'java.lang.String' failed. Check the caused by exception and ensure yourInjectorSource implementation is accessible and has a public zero args constructor."))),
-            () -> assertThat("Unexpected exception cause class", actualThrown.getCause(), isA(ClassCastException.class))
-        );
+        InjectorSourceInstantiationFailed actualThrown = assertThrows(InjectorSourceInstantiationFailed.class,
+            testMethod);
+        assertAll(
+            () -> assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+                "Instantiation of 'java.lang.String' failed. Check the caused by exception and ensure yourInjectorSource implementation is accessible and has a public zero args constructor."))),
+            () -> assertThat("Unexpected exception cause class", actualThrown.getCause(),
+                isA(ClassCastException.class)));
     }
 
     @Test
@@ -74,11 +78,13 @@ class InjectorSourceFactoryTest {
         InjectorSourceFactory injectorSourceFactory = createInjectorSourceFactory(properties);
 
         Executable testMethod = injectorSourceFactory::create;
-        InjectorSourceInstantiationFailed actualThrown = assertThrows(InjectorSourceInstantiationFailed.class, testMethod);
-        assertAll("Checking Exception including cause",
-            () -> assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo("Instantiation of 'io.cucumber.guice.InjectorSourceFactoryTest$PrivateConstructor' failed. Check the caused by exception and ensure yourInjectorSource implementation is accessible and has a public zero args constructor."))),
-            () -> assertThat("Unexpected exception cause class", actualThrown.getCause(), isA(IllegalAccessException.class))
-        );
+        InjectorSourceInstantiationFailed actualThrown = assertThrows(InjectorSourceInstantiationFailed.class,
+            testMethod);
+        assertAll(
+            () -> assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+                "Instantiation of 'io.cucumber.guice.InjectorSourceFactoryTest$PrivateConstructor' failed. Check the caused by exception and ensure yourInjectorSource implementation is accessible and has a public zero args constructor."))),
+            () -> assertThat("Unexpected exception cause class", actualThrown.getCause(),
+                isA(IllegalAccessException.class)));
     }
 
     @Test
@@ -88,26 +94,34 @@ class InjectorSourceFactoryTest {
         InjectorSourceFactory injectorSourceFactory = createInjectorSourceFactory(properties);
 
         Executable testMethod = injectorSourceFactory::create;
-        InjectorSourceInstantiationFailed actualThrown = assertThrows(InjectorSourceInstantiationFailed.class, testMethod);
-        assertAll("Checking Exception including cause",
-            () -> assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo("Instantiation of 'io.cucumber.guice.InjectorSourceFactoryTest$NoDefaultConstructor' failed. Check the caused by exception and ensure yourInjectorSource implementation is accessible and has a public zero args constructor."))),
-            () -> assertThat("Unexpected exception cause class", actualThrown.getCause(), isA(InstantiationException.class))
-        );
+        InjectorSourceInstantiationFailed actualThrown = assertThrows(InjectorSourceInstantiationFailed.class,
+            testMethod);
+        assertAll(
+            () -> assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
+                "Instantiation of 'io.cucumber.guice.InjectorSourceFactoryTest$NoDefaultConstructor' failed. Check the caused by exception and ensure yourInjectorSource implementation is accessible and has a public zero args constructor."))),
+            () -> assertThat("Unexpected exception cause class", actualThrown.getCause(),
+                isA(InstantiationException.class)));
     }
 
     /**
-     * <p>Simulates enterprise applications which often use a hierarchy of classloaders.
-     *
-     * <p>MyChildClassLoader is the only classloader with knowledge of c.r.j.guice.impl.LivesInChildClassLoader
-     *
-     * <p>The bytecode of LivesInChildClassLoader is intentionally renamed to 'LivesInChildClassLoader.class.bin.txt' to prevent
-     * this test's ClassLoader from resolving it.
-     *
-     * <p>If InjectorSourceFactory calls Class#forName without an explicit ClassLoader argument, which is the behavior of
-     * 1.2.4 and earlier, Class#forName will default to the test's ClassLoader which has no knowledge
-     * of class LivesInChildClassLoader and the test will fail.
-     *
-     * <p>See <a href="https://github.com/cucumber/cucumber-jvm/issues/1036">https://github.com/cucumber/cucumber-jvm/issues/1036</a>
+     * <p>
+     * Simulates enterprise applications which often use a hierarchy of
+     * classloaders.
+     * <p>
+     * MyChildClassLoader is the only classloader with knowledge of
+     * c.r.j.guice.impl.LivesInChildClassLoader
+     * <p>
+     * The bytecode of LivesInChildClassLoader is intentionally renamed to
+     * 'LivesInChildClassLoader.class.bin.txt' to prevent this test's
+     * ClassLoader from resolving it.
+     * <p>
+     * If InjectorSourceFactory calls Class#forName without an explicit
+     * ClassLoader argument, which is the behavior of 1.2.4 and earlier,
+     * Class#forName will default to the test's ClassLoader which has no
+     * knowledge of class LivesInChildClassLoader and the test will fail.
+     * <p>
+     * 
+     * @see https://github.com/cucumber/cucumber-jvm/issues/1036
      */
     @Test
     void instantiateClassInChildClassLoader() {
@@ -115,7 +129,8 @@ class InjectorSourceFactoryTest {
         Thread.currentThread().setContextClassLoader(childClassLoader);
 
         Map<String, String> properties = new HashMap<>();
-        properties.put(InjectorSourceFactory.GUICE_INJECTOR_SOURCE_KEY, "io.cucumber.guice.impl.LivesInChildClassLoader");
+        properties.put(InjectorSourceFactory.GUICE_INJECTOR_SOURCE_KEY,
+            "io.cucumber.guice.impl.LivesInChildClassLoader");
         InjectorSourceFactory injectorSourceFactory = createInjectorSourceFactory(properties);
 
         assertThat(injectorSourceFactory.create(), is(instanceOf(InjectorSource.class)));
@@ -163,7 +178,8 @@ class InjectorSourceFactoryTest {
         @Override
         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
             if (name.equals("io.cucumber.guice.impl.LivesInChildClassLoader")) {
-                String filename = getClass().getClassLoader().getResource("io/cucumber/guice/impl/LivesInChildClassLoader.class.bin").getFile();
+                String filename = getClass().getClassLoader()
+                        .getResource("io/cucumber/guice/impl/LivesInChildClassLoader.class.bin").getFile();
                 File file = new File(filename);
                 try {
                     FileInputStream in = new FileInputStream(file);

--- a/guice/src/test/java/io/cucumber/guice/collection/CollectionUtil.java
+++ b/guice/src/test/java/io/cucumber/guice/collection/CollectionUtil.java
@@ -10,9 +10,9 @@ public class CollectionUtil {
     /**
      * Removes all elements in the supplied list except the first element.
      *
-     * @param list the list to be modified
-     * @throws java.lang.NullPointerException     if the list is null
-     * @throws java.lang.IllegalArgumentException if the list is empty
+     * @param  list                     the list to be modified
+     * @throws NullPointerException     if the list is null
+     * @throws IllegalArgumentException if the list is empty
      */
     public static <E> void removeAllExceptFirstElement(List<E> list) {
         if (list == null) {

--- a/guice/src/test/java/io/cucumber/guice/collection/CollectionUtilTest.java
+++ b/guice/src/test/java/io/cucumber/guice/collection/CollectionUtilTest.java
@@ -44,10 +44,9 @@ class CollectionUtilTest {
     }
 
     private void assertThatListContainsOneElement(String element) {
-        assertAll("Checking list",
+        assertAll(
             () -> assertThat(list.size(), equalTo(1)),
-            () -> assertThat(list.get(0), equalTo(element))
-        );
+            () -> assertThat(list.get(0), equalTo(element)));
     }
 
     @Test

--- a/guice/src/test/java/io/cucumber/guice/integration/RunCucumberTest.java
+++ b/guice/src/test/java/io/cucumber/guice/integration/RunCucumberTest.java
@@ -4,9 +4,10 @@ import io.cucumber.junit.Cucumber;
 import org.junit.runner.RunWith;
 
 /**
- * The Cucumber integration tests use a mixture of annotation and module binding to demostrate both techniques.
- * The step definition classes are all bound in scenario scope using the @ScenarioScoped annotation.
- * The test object classes are bound using cucumber.runtime.java.guice.loadguicemodule.YourModuleClass.
+ * The Cucumber integration tests use a mixture of annotation and module binding
+ * to demonstrate both techniques. The step definition classes are all bound in
+ * scenario scope using the @ScenarioScoped annotation. The test object classes
+ * are bound using {@link YourModule}.
  */
 @RunWith(Cucumber.class)
 public class RunCucumberTest {

--- a/guice/src/test/java/io/cucumber/guice/integration/ScenarioScopedSteps.java
+++ b/guice/src/test/java/io/cucumber/guice/integration/ScenarioScopedSteps.java
@@ -7,6 +7,7 @@ import io.cucumber.java.en.When;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/guice/src/test/java/io/cucumber/guice/integration/SingletonScopedSteps.java
+++ b/guice/src/test/java/io/cucumber/guice/integration/SingletonScopedSteps.java
@@ -7,6 +7,7 @@ import io.cucumber.java.en.When;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/guice/src/test/java/io/cucumber/guice/integration/UnScopedSteps.java
+++ b/guice/src/test/java/io/cucumber/guice/integration/UnScopedSteps.java
@@ -6,6 +6,7 @@ import io.cucumber.java.en.When;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/guice/src/test/java/io/cucumber/guice/matcher/AbstractMatcherTest.java
+++ b/guice/src/test/java/io/cucumber/guice/matcher/AbstractMatcherTest.java
@@ -12,7 +12,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 abstract class AbstractMatcherTest {
 
     static <T> void assertMatches(Matcher<T> matcher, T arg) {
-        assertTrue(matcher.matches(arg), "Expected match, but mismatched because: '" + mismatchDescription(matcher, arg) + "'");
+        assertTrue(matcher.matches(arg),
+            "Expected match, but mismatched because: '" + mismatchDescription(matcher, arg) + "'");
     }
 
     private static <T> String mismatchDescription(Matcher<? super T> matcher, T arg) {

--- a/guice/src/test/java/io/cucumber/guice/matcher/ElementsAreAllEqualMatcher.java
+++ b/guice/src/test/java/io/cucumber/guice/matcher/ElementsAreAllEqualMatcher.java
@@ -7,18 +7,22 @@ import java.util.Collection;
 
 public class ElementsAreAllEqualMatcher<E> extends ElementsAreAllMatcher<E> {
 
-    static final String DESCRIPTION =
-        "a collection of two or more non-null elements that are determined to be the same according to " +
-            "the java.lang.Object.equals() contract";
+    static final String DESCRIPTION = "a collection of two or more non-null elements that are determined to be the " +
+            "same according to the java.lang.Object.equals() contract";
     private static final int EXPECTED_NUMBER_OF_UNIQUE_ELEMENTS = 1;
 
     /**
-     * Creates a matcher for {@link java.util.Collection}s that matches when there are two or more non-null elements and
-     * every element is the same. Two elements are considered the same if element1.equals(element2) returns true. When
-     * collections contain more than two elements, every permutation of two elements must return true.
+     * Creates a matcher for {@link java.util.Collection}s that matches when
+     * there are two or more non-null elements and every element is the same.
+     * Two elements are considered the same if element1.equals(element2) returns
+     * true. When collections contain more than two elements, every permutation
+     * of two elements must return true.
      * <p/>
      * For example:
-     * <pre>assertThat(Arrays.asList("foo", "foo", "foo"), elementsAreAllEqual())</pre>
+     * 
+     * <pre>
+     * assertThat(Arrays.asList("foo", "foo", "foo"), elementsAreAllEqual())
+     * </pre>
      */
     public static <E> Matcher<Collection<? extends E>> elementsAreAllEqual() {
         return new ElementsAreAllEqualMatcher<>();
@@ -27,12 +31,12 @@ public class ElementsAreAllEqualMatcher<E> extends ElementsAreAllMatcher<E> {
     @Override
     protected boolean matchesSafely(Collection<? extends E> item, Description mismatchDescription) {
         return containsMoreThanOneElement(item, mismatchDescription) && noElementIsNull(item, mismatchDescription) &&
-            allElementsAreEqual(item, mismatchDescription);
+                allElementsAreEqual(item, mismatchDescription);
     }
 
     private boolean allElementsAreEqual(Collection<? extends E> item, Description mismatchDescription) {
         return actualNumberOfUniqueElements(item) == EXPECTED_NUMBER_OF_UNIQUE_ELEMENTS ||
-            fail("collection contained elements that are not equal", item, mismatchDescription);
+                fail("collection contained elements that are not equal", item, mismatchDescription);
     }
 
     @Override

--- a/guice/src/test/java/io/cucumber/guice/matcher/ElementsAreAllEqualMatcherTest.java
+++ b/guice/src/test/java/io/cucumber/guice/matcher/ElementsAreAllEqualMatcherTest.java
@@ -23,30 +23,27 @@ class ElementsAreAllEqualMatcherTest {
     void testDoesNotMatchNullCollection() {
         Collection<?> arg = null;
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("was null", matcher, arg)
-        );
+            () -> assertMismatchDescription("was null", matcher, arg));
     }
 
     @Test
     void testDoesNotMatchCollectionWithLessThanTwoElements() {
         Collection<String> arg = Collections.singletonList("foo");
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("collection did not contain more than one element <[foo]>", matcher, arg)
-        );
+            () -> assertMismatchDescription("collection did not contain more than one element <[foo]>", matcher, arg));
     }
 
     @Test
     void testDoesNotMatchCollectionWithNullElements() {
         Collection<Object> arg = Arrays.asList(null, null);
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("collection contained null element <[null, null]>", matcher, arg)
-        );
+            () -> assertMismatchDescription("collection contained null element <[null, null]>", matcher, arg));
     }
 
     @Test
@@ -58,10 +55,10 @@ class ElementsAreAllEqualMatcherTest {
     void testDoesNotMatchCollectionWithTwoElementsThatAreNotEqual() {
         Collection<String> arg = Arrays.asList("foo", "bar");
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("collection contained elements that are not equal <[foo, bar]>", matcher, arg)
-        );
+            () -> assertMismatchDescription("collection contained elements that are not equal <[foo, bar]>", matcher,
+                arg));
     }
 
     @Test
@@ -73,20 +70,20 @@ class ElementsAreAllEqualMatcherTest {
     void testDoesNotMatchCollectionWithSomeElementsThatAreNotEqual() {
         Collection<String> arg = Arrays.asList("foo", "foo", "bar");
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("collection contained elements that are not equal <[foo, foo, bar]>", matcher, arg)
-        );
+            () -> assertMismatchDescription("collection contained elements that are not equal <[foo, foo, bar]>",
+                matcher, arg));
     }
 
     @Test
     void testDoesNotMatchCollectionWithThreeElementsThatAreNotEqual() {
         Collection<String> arg = Arrays.asList("foo", "bar", "baz");
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("collection contained elements that are not equal <[foo, bar, baz]>", matcher, arg)
-        );
+            () -> assertMismatchDescription("collection contained elements that are not equal <[foo, bar, baz]>",
+                matcher, arg));
     }
 
     @Test

--- a/guice/src/test/java/io/cucumber/guice/matcher/ElementsAreAllUniqueMatcher.java
+++ b/guice/src/test/java/io/cucumber/guice/matcher/ElementsAreAllUniqueMatcher.java
@@ -7,17 +7,21 @@ import java.util.Collection;
 
 public class ElementsAreAllUniqueMatcher<E> extends ElementsAreAllMatcher<E> {
 
-    static final String DESCRIPTION =
-        "a collection of two or more non-null elements that are determined to be unique according to " +
-            "the java.lang.Object.equals() contract";
+    static final String DESCRIPTION = "a collection of two or more non-null elements that are determined to be unique" +
+            " according to the java.lang.Object.equals() contract";
 
     /**
-     * Creates a matcher for {@link java.util.Collection}s that matches when there are two or more non-null elements and
-     * every element is unique. Two elements are considered unique if element1.equals(element2) returns false. When
-     * collections contain more than two elements, every permutation of two elements must return false.
+     * Creates a matcher for {@link java.util.Collection}s that matches when
+     * there are two or more non-null elements and every element is unique. Two
+     * elements are considered unique if element1.equals(element2) returns
+     * false. When collections contain more than two elements, every permutation
+     * of two elements must return false.
      * <p/>
      * For example:
-     * <pre>assertThat(Arrays.asList("foo", "bar", "baz"), elementsAreAllUnique())</pre>
+     * 
+     * <pre>
+     * assertThat(Arrays.asList("foo", "bar", "baz"), elementsAreAllUnique())
+     * </pre>
      */
     public static <E> Matcher<Collection<? extends E>> elementsAreAllUnique() {
         return new ElementsAreAllUniqueMatcher<>();
@@ -26,12 +30,12 @@ public class ElementsAreAllUniqueMatcher<E> extends ElementsAreAllMatcher<E> {
     @Override
     protected boolean matchesSafely(Collection<? extends E> item, Description mismatchDescription) {
         return containsMoreThanOneElement(item, mismatchDescription) && noElementIsNull(item, mismatchDescription) &&
-            allElementsAreUnique(item, mismatchDescription);
+                allElementsAreUnique(item, mismatchDescription);
     }
 
     private boolean allElementsAreUnique(Collection<? extends E> item, Description mismatchDescription) {
         return actualNumberOfUniqueElements(item) == expectedNumberOfUniqueElements(item)
-            || fail("collection contained elements that are not unique", item, mismatchDescription);
+                || fail("collection contained elements that are not unique", item, mismatchDescription);
     }
 
     private int expectedNumberOfUniqueElements(Collection<? extends E> item) {

--- a/guice/src/test/java/io/cucumber/guice/matcher/ElementsAreAllUniqueMatcherTest.java
+++ b/guice/src/test/java/io/cucumber/guice/matcher/ElementsAreAllUniqueMatcherTest.java
@@ -23,30 +23,27 @@ class ElementsAreAllUniqueMatcherTest {
     void testDoesNotMatchNullCollection() {
         Collection<?> arg = null;
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("was null", matcher, arg)
-        );
+            () -> assertMismatchDescription("was null", matcher, arg));
     }
 
     @Test
     void testDoesNotMatchCollectionWithLessThanTwoElements() {
         Collection<String> arg = Collections.singletonList("foo");
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("collection did not contain more than one element <[foo]>", matcher, arg)
-        );
+            () -> assertMismatchDescription("collection did not contain more than one element <[foo]>", matcher, arg));
     }
 
     @Test
     void testDoesNotMatchCollectionWithNullElement() {
         Collection<String> arg = Arrays.asList("foo", null);
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("collection contained null element <[foo, null]>", matcher, arg)
-        );
+            () -> assertMismatchDescription("collection contained null element <[foo, null]>", matcher, arg));
     }
 
     @Test
@@ -58,10 +55,10 @@ class ElementsAreAllUniqueMatcherTest {
     void testDoesNotMatchCollectionWithTwoElementsThatAreNotUnique() {
         Collection<String> arg = Arrays.asList("foo", "foo");
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("collection contained elements that are not unique <[foo, foo]>", matcher, arg)
-        );
+            () -> assertMismatchDescription("collection contained elements that are not unique <[foo, foo]>", matcher,
+                arg));
     }
 
     @Test
@@ -73,20 +70,20 @@ class ElementsAreAllUniqueMatcherTest {
     void testDoesNotMatchCollectionWithElementsThatAreNotUnique() {
         Collection<String> arg = Arrays.asList("foo", "bar", "foo");
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("collection contained elements that are not unique <[foo, bar, foo]>", matcher, arg)
-        );
+            () -> assertMismatchDescription("collection contained elements that are not unique <[foo, bar, foo]>",
+                matcher, arg));
     }
 
     @Test
     void testDoesNotMatchCollectionWithThreeElementsThatAreNotUnique() {
         Collection<String> arg = Arrays.asList("foo", "foo", "foo");
 
-        assertAll("Checking Matcher",
+        assertAll(
             () -> assertDoesNotMatch(matcher, arg),
-            () -> assertMismatchDescription("collection contained elements that are not unique <[foo, foo, foo]>", matcher, arg)
-        );
+            () -> assertMismatchDescription("collection contained elements that are not unique <[foo, foo, foo]>",
+                matcher, arg));
     }
 
     @Test

--- a/java/src/main/java/io/cucumber/java/AbstractDatatableElementTransformerDefinition.java
+++ b/java/src/main/java/io/cucumber/java/AbstractDatatableElementTransformerDefinition.java
@@ -23,16 +23,16 @@ class AbstractDatatableElementTransformerDefinition extends AbstractGlueDefiniti
 
     DataTable replaceEmptyPatternsWithEmptyString(DataTable table) {
         List<List<String>> rawWithEmptyStrings = table.cells().stream()
-            .map(this::replaceEmptyPatternsWithEmptyString)
-            .collect(toList());
+                .map(this::replaceEmptyPatternsWithEmptyString)
+                .collect(toList());
 
         return create(rawWithEmptyStrings, table.getTableConverter());
     }
 
     List<String> replaceEmptyPatternsWithEmptyString(List<String> row) {
         return row.stream()
-            .map(this::replaceEmptyPatternsWithEmptyString)
-            .collect(toList());
+                .map(this::replaceEmptyPatternsWithEmptyString)
+                .collect(toList());
     }
 
     String replaceEmptyPatternsWithEmptyString(String t) {

--- a/java/src/main/java/io/cucumber/java/AbstractGlueDefinition.java
+++ b/java/src/main/java/io/cucumber/java/AbstractGlueDefinition.java
@@ -21,7 +21,8 @@ abstract class AbstractGlueDefinition implements Located {
 
     @Override
     public boolean isDefinedAt(StackTraceElement e) {
-        return e.getClassName().equals(method.getDeclaringClass().getName()) && e.getMethodName().equals(method.getName());
+        return e.getClassName().equals(method.getDeclaringClass().getName())
+                && e.getMethodName().equals(method.getName());
     }
 
     @Override

--- a/java/src/main/java/io/cucumber/java/AbstractJavaSnippet.java
+++ b/java/src/main/java/io/cucumber/java/AbstractJavaSnippet.java
@@ -13,20 +13,21 @@ abstract class AbstractJavaSnippet implements Snippet {
     @Override
     public final String tableHint() {
         return "" +
-            "    // For automatic transformation, change DataTable to one of\n" +
-            "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
-            "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
-            "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
-            "    //\n" +
-            "    // For other transformations you can register a DataTableType.\n"; //TODO: Add doc URL
+                "    // For automatic transformation, change DataTable to one of\n" +
+                "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
+                "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
+                "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
+                "    //\n" +
+                //TODO: Add doc URL
+                "    // For other transformations you can register a DataTableType.\n";
     }
 
     @Override
     public final String arguments(Map<String, Type> arguments) {
         return arguments.entrySet()
-            .stream()
-            .map(argType -> getArgType(argType.getValue()) + " " + argType.getKey())
-            .collect(joining(", "));
+                .stream()
+                .map(argType -> getArgType(argType.getValue()) + " " + argType.getKey())
+                .collect(joining(", "));
     }
 
     private String getArgType(Type argType) {

--- a/java/src/main/java/io/cucumber/java/AbstractJavaSnippet.java
+++ b/java/src/main/java/io/cucumber/java/AbstractJavaSnippet.java
@@ -18,7 +18,7 @@ abstract class AbstractJavaSnippet implements Snippet {
                 "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
                 "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
                 "    //\n" +
-                //TODO: Add doc URL
+                // TODO: Add doc URL
                 "    // For other transformations you can register a DataTableType.\n";
     }
 

--- a/java/src/main/java/io/cucumber/java/After.java
+++ b/java/src/main/java/io/cucumber/java/After.java
@@ -16,16 +16,16 @@ import java.lang.annotation.Target;
 public @interface After {
 
     /**
-     * Tag expression. If the expression applies to the current
-     * scenario this hook will be executed.
+     * Tag expression. If the expression applies to the current scenario this
+     * hook will be executed.
      *
      * @return a tag expression
      */
     String value() default "";
 
     /**
-     * @return the order in which this hook should run. Higher numbers are run first.
-     * The default order is 10000.
+     * @return the order in which this hook should run. Higher numbers are run
+     *         first. The default order is 10000.
      */
     int order() default 10000;
 

--- a/java/src/main/java/io/cucumber/java/AfterStep.java
+++ b/java/src/main/java/io/cucumber/java/AfterStep.java
@@ -16,16 +16,16 @@ import java.lang.annotation.Target;
 public @interface AfterStep {
 
     /**
-     * Tag expression. If the expression applies to the current
-     * scenario this hook will be executed.
+     * Tag expression. If the expression applies to the current scenario this
+     * hook will be executed.
      *
      * @return a tag expression
      */
     String value() default "";
 
     /**
-     * @return the order in which this hook should run. Higher numbers are run first.
-     * The default order is 10000.
+     * @return the order in which this hook should run. Higher numbers are run
+     *         first. The default order is 10000.
      */
     int order() default 10000;
 

--- a/java/src/main/java/io/cucumber/java/Before.java
+++ b/java/src/main/java/io/cucumber/java/Before.java
@@ -16,16 +16,16 @@ import java.lang.annotation.Target;
 public @interface Before {
 
     /**
-     * Tag expression. If the expression applies to the current
-     * scenario this hook will be executed.
+     * Tag expression. If the expression applies to the current scenario this
+     * hook will be executed.
      *
      * @return a tag expression
      */
     String value() default "";
 
     /**
-     * @return the order in which this hook should run. Lower numbers are run first.
-     * The default order is 10000.
+     * @return the order in which this hook should run. Lower numbers are run
+     *         first. The default order is 10000.
      */
     int order() default 10000;
 

--- a/java/src/main/java/io/cucumber/java/BeforeStep.java
+++ b/java/src/main/java/io/cucumber/java/BeforeStep.java
@@ -16,16 +16,16 @@ import java.lang.annotation.Target;
 public @interface BeforeStep {
 
     /**
-     * Tag expression. If the expression applies to the current
-     * scenario this hook will be executed.
+     * Tag expression. If the expression applies to the current scenario this
+     * hook will be executed.
      *
      * @return a tag expression
      */
     String value() default "";
 
     /**
-     * @return the order in which this hook should run. Lower numbers are run first.
-     * The default order is 10000.
+     * @return the order in which this hook should run. Lower numbers are run
+     *         first. The default order is 10000.
      */
     int order() default 10000;
 

--- a/java/src/main/java/io/cucumber/java/DataTableType.java
+++ b/java/src/main/java/io/cucumber/java/DataTableType.java
@@ -10,15 +10,20 @@ import java.lang.annotation.Target;
 /**
  * Register a data table type.
  * <p>
- * The signature of the method is used to determine which data table type is registered:
- *
+ * The signature of the method is used to determine which data table type is
+ * registered:
  * <ul>
- * <li>{@code String -> Author} will register a {@link io.cucumber.datatable.TableCellTransformer}</li>
- * <li>{@code Map<String, String> -> Author} will register a {@link io.cucumber.datatable.TableEntryTransformer}</li>
- * <li>{@code List<String> -> Author} will register a {@link io.cucumber.datatable.TableRowTransformer}</li>
- * <li>{@code DataTable -> Author} will register a {@link io.cucumber.datatable.TableTransformer}</li>
+ * <li>{@code String -> Author} will register a
+ * {@link io.cucumber.datatable.TableCellTransformer}</li>
+ * <li>{@code Map<String, String> -> Author} will register a
+ * {@link io.cucumber.datatable.TableEntryTransformer}</li>
+ * <li>{@code List<String> -> Author} will register a
+ * {@link io.cucumber.datatable.TableRowTransformer}</li>
+ * <li>{@code DataTable -> Author} will register a
+ * {@link io.cucumber.datatable.TableTransformer}</li>
  * </ul>
- * NOTE: {@code Author} is an example of the class you want to convert the table to.
+ * NOTE: {@code Author} is an example of the class you want to convert the table
+ * to.
  *
  * @see io.cucumber.datatable.DataTableType
  */
@@ -30,9 +35,9 @@ public @interface DataTableType {
     /**
      * Replace these strings in the Datatable with empty strings.
      * <p>
-     * A data table can only represent absent and non-empty strings. By replacing
-     * a known value (for example [empty]) a data table can also represent
-     * empty strings.
+     * A data table can only represent absent and non-empty strings. By
+     * replacing a known value (for example [empty]) a data table can also
+     * represent empty strings.
      * <p>
      * It is not recommended to use multiple replacements in the same table.
      *

--- a/java/src/main/java/io/cucumber/java/DefaultDataTableCellTransformer.java
+++ b/java/src/main/java/io/cucumber/java/DefaultDataTableCellTransformer.java
@@ -27,9 +27,9 @@ public @interface DefaultDataTableCellTransformer {
     /**
      * Replace these strings in the Datatable with empty strings.
      * <p>
-     * A data table can only represent absent and non-empty strings. By replacing
-     * a known value (for example [empty]) a data table can also represent
-     * empty strings.
+     * A data table can only represent absent and non-empty strings. By
+     * replacing a known value (for example [empty]) a data table can also
+     * represent empty strings.
      * <p>
      * It is not recommended to use multiple replacements in the same table.
      *

--- a/java/src/main/java/io/cucumber/java/DefaultDataTableEntryTransformer.java
+++ b/java/src/main/java/io/cucumber/java/DefaultDataTableEntryTransformer.java
@@ -38,9 +38,9 @@ public @interface DefaultDataTableEntryTransformer {
     /**
      * Replace these strings in the Datatable with empty strings.
      * <p>
-     * A data table can only represent absent and non-empty strings. By replacing
-     * a known value (for example [empty]) a data table can also represent
-     * empty strings.
+     * A data table can only represent absent and non-empty strings. By
+     * replacing a known value (for example [empty]) a data table can also
+     * represent empty strings.
      * <p>
      * It is not recommended to use multiple replacements in the same table.
      *

--- a/java/src/main/java/io/cucumber/java/DefaultParameterTransformer.java
+++ b/java/src/main/java/io/cucumber/java/DefaultParameterTransformer.java
@@ -7,7 +7,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 /**
  * Register default parameter type transformer.
  * <p>

--- a/java/src/main/java/io/cucumber/java/DocStringType.java
+++ b/java/src/main/java/io/cucumber/java/DocStringType.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
  * <p>
  * The method must have this signature:
  * <ul>
- * <li>{@code String -> Author} </li>
+ * <li>{@code String -> Author}</li>
  * </ul>
  * NOTE: {@code Author} is an example of the type of the parameter type.
  *

--- a/java/src/main/java/io/cucumber/java/GlueAdaptor.java
+++ b/java/src/main/java/io/cucumber/java/GlueAdaptor.java
@@ -44,21 +44,25 @@ final class GlueAdaptor {
             boolean useForSnippets = parameterType.useForSnippets();
             boolean preferForRegexMatch = parameterType.preferForRegexMatch();
             boolean useRegexpMatchAsStrongTypeHint = parameterType.useRegexpMatchAsStrongTypeHint();
-            glue.addParameterType(new JavaParameterTypeDefinition(name, pattern, method, useForSnippets, preferForRegexMatch, useRegexpMatchAsStrongTypeHint, lookup));
+            glue.addParameterType(new JavaParameterTypeDefinition(name, pattern, method, useForSnippets,
+                preferForRegexMatch, useRegexpMatchAsStrongTypeHint, lookup));
         } else if (annotationType.equals(DataTableType.class)) {
             DataTableType dataTableType = (DataTableType) annotation;
-            glue.addDataTableType(new JavaDataTableTypeDefinition(method, lookup, dataTableType.replaceWithEmptyString()));
+            glue.addDataTableType(
+                new JavaDataTableTypeDefinition(method, lookup, dataTableType.replaceWithEmptyString()));
         } else if (annotationType.equals(DefaultParameterTransformer.class)) {
             glue.addDefaultParameterTransformer(new JavaDefaultParameterTransformerDefinition(method, lookup));
         } else if (annotationType.equals(DefaultDataTableEntryTransformer.class)) {
             DefaultDataTableEntryTransformer transformer = (DefaultDataTableEntryTransformer) annotation;
             boolean headersToProperties = transformer.headersToProperties();
             String[] replaceWithEmptyString = transformer.replaceWithEmptyString();
-            glue.addDefaultDataTableEntryTransformer(new JavaDefaultDataTableEntryTransformerDefinition(method, lookup, headersToProperties, replaceWithEmptyString));
+            glue.addDefaultDataTableEntryTransformer(new JavaDefaultDataTableEntryTransformerDefinition(method, lookup,
+                headersToProperties, replaceWithEmptyString));
         } else if (annotationType.equals(DefaultDataTableCellTransformer.class)) {
             DefaultDataTableCellTransformer cellTransformer = (DefaultDataTableCellTransformer) annotation;
             String[] emptyPatterns = cellTransformer.replaceWithEmptyString();
-            glue.addDefaultDataTableCellTransformer(new JavaDefaultDataTableCellTransformerDefinition(method, lookup, emptyPatterns));
+            glue.addDefaultDataTableCellTransformer(
+                new JavaDefaultDataTableCellTransformerDefinition(method, lookup, emptyPatterns));
         } else if (annotationType.equals(DocStringType.class)) {
             DocStringType docStringType = (DocStringType) annotation;
             String contentType = docStringType.contentType();

--- a/java/src/main/java/io/cucumber/java/InvalidMethodException.java
+++ b/java/src/main/java/io/cucumber/java/InvalidMethodException.java
@@ -13,7 +13,7 @@ final class InvalidMethodException extends CucumberBackendException {
     static InvalidMethodException createInvalidMethodException(Method method, Class<?> glueCodeClass) {
         return new InvalidMethodException(
             "You're not allowed to extend classes that define Step Definitions or hooks. "
-                + glueCodeClass + " extends " + method.getDeclaringClass());
+                    + glueCodeClass + " extends " + method.getDeclaringClass());
     }
 
 }

--- a/java/src/main/java/io/cucumber/java/InvalidMethodSignatureException.java
+++ b/java/src/main/java/io/cucumber/java/InvalidMethodSignatureException.java
@@ -1,6 +1,5 @@
 package io.cucumber.java;
 
-
 import io.cucumber.core.backend.CucumberBackendException;
 
 import java.lang.reflect.Method;
@@ -35,7 +34,6 @@ final class InvalidMethodSignatureException extends CucumberBackendException {
             return this;
         }
 
-
         InvalidMethodSignatureExceptionBuilder addSignature(String signature) {
             signatures.add(signature);
             return this;
@@ -48,11 +46,10 @@ final class InvalidMethodSignatureException extends CucumberBackendException {
 
         public InvalidMethodSignatureException build() {
             return new InvalidMethodSignatureException("" +
-                describeAnnotations() + " must have one of these signatures:\n" +
-                " * " + describeAvailableSignature() + "\n" +
-                "at " + describeLocation() + "\n" +
-                describeNote() + "\n"
-            );
+                    describeAnnotations() + " must have one of these signatures:\n" +
+                    " * " + describeAvailableSignature() + "\n" +
+                    "at " + describeLocation() + "\n" +
+                    describeNote() + "\n");
         }
 
         private String describeAnnotations() {

--- a/java/src/main/java/io/cucumber/java/Invoker.java
+++ b/java/src/main/java/io/cucumber/java/Invoker.java
@@ -28,18 +28,21 @@ final class Invoker {
         Class<?> targetClass = target.getClass();
         Class<?> declaringClass = method.getDeclaringClass();
 
-        // Immediately return the provided method if the class loaders are the same.
+        // Immediately return the provided method if the class loaders are the
+        // same.
         if (targetClass.getClassLoader().equals(declaringClass.getClassLoader())) {
             return method;
         }
 
         try {
-            // Check if the method is publicly accessible. Note that methods from interfaces are always public.
+            // Check if the method is publicly accessible. Note that methods
+            // from interfaces are always public.
             if (Modifier.isPublic(method.getModifiers())) {
                 return targetClass.getMethod(method.getName(), method.getParameterTypes());
             }
 
-            // Loop through all the super classes until the declared method is found.
+            // Loop through all the super classes until the declared method is
+            // found.
             Class<?> currentClass = targetClass;
             while (currentClass != Object.class) {
                 try {

--- a/java/src/main/java/io/cucumber/java/JavaBackend.java
+++ b/java/src/main/java/io/cucumber/java/JavaBackend.java
@@ -33,14 +33,14 @@ final class JavaBackend implements Backend {
         GlueAdaptor glueAdaptor = new GlueAdaptor(lookup, glue);
 
         gluePaths.stream()
-            .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
-            .map(ClasspathSupport::packageName)
-            .map(classFinder::scanForClassesInPackage)
-            .flatMap(Collection::stream)
-            .forEach(aGlueClass -> scan(aGlueClass, (method, annotation) -> {
-                container.addClass(method.getDeclaringClass());
-                glueAdaptor.addDefinition(method, annotation);
-            }));
+                .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
+                .map(ClasspathSupport::packageName)
+                .map(classFinder::scanForClassesInPackage)
+                .flatMap(Collection::stream)
+                .forEach(aGlueClass -> scan(aGlueClass, (method, annotation) -> {
+                    container.addClass(method.getDeclaringClass());
+                    glueAdaptor.addDefinition(method, annotation);
+                }));
     }
 
     @Override

--- a/java/src/main/java/io/cucumber/java/JavaDataTableTypeDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaDataTableTypeDefinition.java
@@ -13,7 +13,8 @@ import java.util.Map;
 
 import static io.cucumber.java.InvalidMethodSignatureException.builder;
 
-class JavaDataTableTypeDefinition extends AbstractDatatableElementTransformerDefinition implements DataTableTypeDefinition {
+class JavaDataTableTypeDefinition extends AbstractDatatableElementTransformerDefinition
+        implements DataTableTypeDefinition {
 
     private final DataTableType dataTableType;
 
@@ -30,36 +31,28 @@ class JavaDataTableTypeDefinition extends AbstractDatatableElementTransformerDef
             return new DataTableType(
                 returnType,
                 (DataTable table) -> invokeMethod(
-                    replaceEmptyPatternsWithEmptyString(table)
-                )
-            );
+                    replaceEmptyPatternsWithEmptyString(table)));
         }
 
         if (List.class.equals(parameterType)) {
             return new DataTableType(
                 returnType,
                 (List<String> row) -> invokeMethod(
-                    replaceEmptyPatternsWithEmptyString(row)
-                )
-            );
+                    replaceEmptyPatternsWithEmptyString(row)));
         }
 
         if (Map.class.equals(parameterType)) {
             return new DataTableType(
                 returnType,
                 (Map<String, String> entry) -> invokeMethod(
-                    replaceEmptyPatternsWithEmptyString(entry)
-                )
-            );
+                    replaceEmptyPatternsWithEmptyString(entry)));
         }
 
         if (String.class.equals(parameterType)) {
             return new DataTableType(
                 returnType,
                 (String cell) -> invokeMethod(
-                    replaceEmptyPatternsWithEmptyString(cell)
-                )
-            );
+                    replaceEmptyPatternsWithEmptyString(cell)));
         }
 
         throw createInvalidSignatureException(method);
@@ -98,13 +91,13 @@ class JavaDataTableTypeDefinition extends AbstractDatatableElementTransformerDef
 
     private static InvalidMethodSignatureException createInvalidSignatureException(Method method) {
         return builder(method)
-            .addAnnotation(io.cucumber.java.DataTableType.class)
-            .addSignature("public Author author(DataTable table)")
-            .addSignature("public Author author(List<String> row)")
-            .addSignature("public Author author(Map<String, String> entry)")
-            .addSignature("public Author author(String cell)")
-            .addNote("Note: Author is an example of the class you want to convert the table to.")
-            .build();
+                .addAnnotation(io.cucumber.java.DataTableType.class)
+                .addSignature("public Author author(DataTable table)")
+                .addSignature("public Author author(List<String> row)")
+                .addSignature("public Author author(Map<String, String> entry)")
+                .addSignature("public Author author(String cell)")
+                .addNote("Note: Author is an example of the class you want to convert the table to.")
+                .build();
     }
 
     @Override

--- a/java/src/main/java/io/cucumber/java/JavaDefaultDataTableCellTransformerDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaDefaultDataTableCellTransformerDefinition.java
@@ -9,14 +9,15 @@ import java.lang.reflect.Type;
 
 import static io.cucumber.java.InvalidMethodSignatureException.builder;
 
-class JavaDefaultDataTableCellTransformerDefinition extends AbstractDatatableElementTransformerDefinition implements DefaultDataTableCellTransformerDefinition {
+class JavaDefaultDataTableCellTransformerDefinition extends AbstractDatatableElementTransformerDefinition
+        implements DefaultDataTableCellTransformerDefinition {
 
     private final TableCellByTypeTransformer transformer;
 
     JavaDefaultDataTableCellTransformerDefinition(Method method, Lookup lookup, String[] emptyPatterns) {
         super(requireValidMethod(method), lookup, emptyPatterns);
-        this.transformer = (cellValue, toValueType) ->
-            invokeMethod(replaceEmptyPatternsWithEmptyString(cellValue), toValueType);
+        this.transformer = (cellValue, toValueType) -> invokeMethod(replaceEmptyPatternsWithEmptyString(cellValue),
+            toValueType);
     }
 
     private static Method requireValidMethod(Method method) {
@@ -43,10 +44,10 @@ class JavaDefaultDataTableCellTransformerDefinition extends AbstractDatatableEle
 
     private static InvalidMethodSignatureException createInvalidSignatureException(Method method) {
         return builder(method)
-            .addAnnotation(DefaultDataTableCellTransformer.class)
-            .addSignature("public Object defaultDataTableCell(String fromValue, Type toValueType)")
-            .addSignature("public Object defaultDataTableCell(Object fromValue, Type toValueType)")
-            .build();
+                .addAnnotation(DefaultDataTableCellTransformer.class)
+                .addSignature("public Object defaultDataTableCell(String fromValue, Type toValueType)")
+                .addSignature("public Object defaultDataTableCell(Object fromValue, Type toValueType)")
+                .build();
     }
 
     @Override

--- a/java/src/main/java/io/cucumber/java/JavaDefaultDataTableEntryTransformerDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaDefaultDataTableEntryTransformerDefinition.java
@@ -12,7 +12,8 @@ import java.util.Map;
 
 import static io.cucumber.java.InvalidMethodSignatureException.builder;
 
-class JavaDefaultDataTableEntryTransformerDefinition extends AbstractDatatableElementTransformerDefinition implements DefaultDataTableEntryTransformerDefinition {
+class JavaDefaultDataTableEntryTransformerDefinition extends AbstractDatatableElementTransformerDefinition
+        implements DefaultDataTableEntryTransformerDefinition {
 
     private final TableEntryByTypeTransformer transformer;
     private final boolean headersToProperties;
@@ -21,11 +22,13 @@ class JavaDefaultDataTableEntryTransformerDefinition extends AbstractDatatableEl
         this(method, lookup, false, new String[0]);
     }
 
-    JavaDefaultDataTableEntryTransformerDefinition(Method method, Lookup lookup, boolean headersToProperties, String[] emptyPatterns) {
+    JavaDefaultDataTableEntryTransformerDefinition(
+            Method method, Lookup lookup, boolean headersToProperties, String[] emptyPatterns
+    ) {
         super(requireValidMethod(method), lookup, emptyPatterns);
         this.headersToProperties = headersToProperties;
-        this.transformer = (entryValue, toValueType, cellTransformer) ->
-            execute(replaceEmptyPatternsWithEmptyString(entryValue), toValueType, cellTransformer);
+        this.transformer = (entryValue, toValueType, cellTransformer) -> execute(
+            replaceEmptyPatternsWithEmptyString(entryValue), toValueType, cellTransformer);
     }
 
     private static Method requireValidMethod(Method method) {
@@ -65,7 +68,8 @@ class JavaDefaultDataTableEntryTransformerDefinition extends AbstractDatatableEl
         }
 
         if (parameterTypes.length == 3) {
-            if (!(Object.class.equals(parameterTypes[2]) || TableCellByTypeTransformer.class.equals(parameterTypes[2]))) {
+            if (!(Object.class.equals(parameterTypes[2])
+                    || TableCellByTypeTransformer.class.equals(parameterTypes[2]))) {
                 throw createInvalidSignatureException(method);
             }
         }
@@ -73,22 +77,24 @@ class JavaDefaultDataTableEntryTransformerDefinition extends AbstractDatatableEl
         return method;
     }
 
-    private Object execute(Map<String, String> fromValue, Type toValueType, TableCellByTypeTransformer cellTransformer) {
+    private Object execute(
+            Map<String, String> fromValue, Type toValueType, TableCellByTypeTransformer cellTransformer
+    ) {
         Object[] args;
         if (method.getParameterTypes().length == 3) {
-            args = new Object[]{fromValue, toValueType, cellTransformer};
+            args = new Object[] { fromValue, toValueType, cellTransformer };
         } else {
-            args = new Object[]{fromValue, toValueType};
+            args = new Object[] { fromValue, toValueType };
         }
         return invokeMethod(args);
     }
 
     private static InvalidMethodSignatureException createInvalidSignatureException(Method method) {
         return builder(method)
-            .addAnnotation(DefaultDataTableEntryTransformer.class)
-            .addSignature("public Object defaultDataTableEntry(Map<String, String> fromValue, Type toValueType)")
-            .addSignature("public Object defaultDataTableEntry(Object fromValue, Type toValueType)")
-            .build();
+                .addAnnotation(DefaultDataTableEntryTransformer.class)
+                .addSignature("public Object defaultDataTableEntry(Map<String, String> fromValue, Type toValueType)")
+                .addSignature("public Object defaultDataTableEntry(Object fromValue, Type toValueType)")
+                .build();
     }
 
     @Override

--- a/java/src/main/java/io/cucumber/java/JavaDefaultParameterTransformerDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaDefaultParameterTransformerDefinition.java
@@ -9,7 +9,8 @@ import java.lang.reflect.Type;
 
 import static io.cucumber.java.InvalidMethodSignatureException.builder;
 
-class JavaDefaultParameterTransformerDefinition extends AbstractGlueDefinition implements DefaultParameterTransformerDefinition {
+class JavaDefaultParameterTransformerDefinition extends AbstractGlueDefinition
+        implements DefaultParameterTransformerDefinition {
 
     private final Lookup lookup;
     private final ParameterByTypeTransformer transformer;
@@ -48,10 +49,10 @@ class JavaDefaultParameterTransformerDefinition extends AbstractGlueDefinition i
 
     private static InvalidMethodSignatureException createInvalidSignatureException(Method method) {
         return builder(method)
-            .addAnnotation(DefaultParameterTransformer.class)
-            .addSignature("public Object defaultDataTableEntry(String fromValue, Type toValueType)")
-            .addSignature("public Object defaultDataTableEntry(Object fromValue, Type toValueType)")
-            .build();
+                .addAnnotation(DefaultParameterTransformer.class)
+                .addSignature("public Object defaultDataTableEntry(String fromValue, Type toValueType)")
+                .addSignature("public Object defaultDataTableEntry(Object fromValue, Type toValueType)")
+                .build();
     }
 
     @Override

--- a/java/src/main/java/io/cucumber/java/JavaDocStringTypeDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaDocStringTypeDefinition.java
@@ -18,8 +18,7 @@ class JavaDocStringTypeDefinition extends AbstractGlueDefinition implements DocS
         this.docStringType = new DocStringType(
             this.method.getReturnType(),
             contentType.isEmpty() ? method.getName() : contentType,
-            this::invokeMethod
-        );
+            this::invokeMethod);
     }
 
     private static Method requireValidMethod(Method method) {
@@ -44,10 +43,10 @@ class JavaDocStringTypeDefinition extends AbstractGlueDefinition implements DocS
 
     private static InvalidMethodSignatureException createInvalidSignatureException(Method method) {
         return builder(method)
-            .addAnnotation(io.cucumber.java.DocStringType.class)
-            .addSignature("public JsonNode json(String content)")
-            .addNote("Note: JsonNode is an example of the class you want to convert content to")
-            .build();
+                .addAnnotation(io.cucumber.java.DocStringType.class)
+                .addSignature("public JsonNode json(String content)")
+                .addNote("Note: JsonNode is an example of the class you want to convert content to")
+                .build();
     }
 
     @Override

--- a/java/src/main/java/io/cucumber/java/JavaHookDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaHookDefinition.java
@@ -38,20 +38,20 @@ final class JavaHookDefinition extends AbstractGlueDefinition implements HookDef
 
     private static InvalidMethodSignatureException createInvalidSignatureException(Method method) {
         return builder(method)
-            .addAnnotation(Before.class)
-            .addAnnotation(After.class)
-            .addAnnotation(BeforeStep.class)
-            .addAnnotation(AfterStep.class)
-            .addSignature("public void before_or_after(io.cucumber.java.Scenario scenario)")
-            .addSignature("public void before_or_after()")
-            .build();
+                .addAnnotation(Before.class)
+                .addAnnotation(After.class)
+                .addAnnotation(BeforeStep.class)
+                .addAnnotation(AfterStep.class)
+                .addSignature("public void before_or_after(io.cucumber.java.Scenario scenario)")
+                .addSignature("public void before_or_after()")
+                .build();
     }
 
     @Override
     public void execute(TestCaseState state) {
         Object[] args;
         if (method.getParameterTypes().length == 1) {
-            args = new Object[]{new io.cucumber.java.Scenario(state)};
+            args = new Object[] { new io.cucumber.java.Scenario(state) };
         } else {
             args = new Object[0];
         }

--- a/java/src/main/java/io/cucumber/java/JavaParameterTypeDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaParameterTypeDefinition.java
@@ -14,7 +14,10 @@ class JavaParameterTypeDefinition extends AbstractGlueDefinition implements Para
 
     private final ParameterType<Object> parameterType;
 
-    JavaParameterTypeDefinition(String name, String pattern, Method method, boolean useForSnippets, boolean preferForRegexpMatch, boolean useRegexpMatchAsStrongTypeHint, Lookup lookup) {
+    JavaParameterTypeDefinition(
+            String name, String pattern, Method method, boolean useForSnippets, boolean preferForRegexpMatch,
+            boolean useRegexpMatchAsStrongTypeHint, Lookup lookup
+    ) {
         super(requireValidMethod(method), lookup);
         this.parameterType = new ParameterType<>(
             name.isEmpty() ? method.getName() : name,
@@ -23,8 +26,7 @@ class JavaParameterTypeDefinition extends AbstractGlueDefinition implements Para
             this::execute,
             useForSnippets,
             preferForRegexpMatch,
-            useRegexpMatchAsStrongTypeHint
-        );
+            useRegexpMatchAsStrongTypeHint);
     }
 
     private static Method requireValidMethod(Method method) {
@@ -58,7 +60,7 @@ class JavaParameterTypeDefinition extends AbstractGlueDefinition implements Para
         Object[] args;
 
         if (String[].class.equals(method.getParameterTypes()[0])) {
-            args = new Object[][]{captureGroups};
+            args = new Object[][] { captureGroups };
         } else {
             args = captureGroups;
         }
@@ -68,12 +70,12 @@ class JavaParameterTypeDefinition extends AbstractGlueDefinition implements Para
 
     private static InvalidMethodSignatureException createInvalidSignatureException(Method method) {
         return builder(method)
-            .addAnnotation(io.cucumber.java.ParameterType.class)
-            .addSignature("public Author parameterName(String all)")
-            .addSignature("public Author parameterName(String captureGroup1, String captureGroup2, ...ect )")
-            .addSignature("public Author parameterName(String... captureGroups)")
-            .addNote("Note: Author is an example of the class you want to convert captureGroups to")
-            .build();
+                .addAnnotation(io.cucumber.java.ParameterType.class)
+                .addSignature("public Author parameterName(String all)")
+                .addSignature("public Author parameterName(String captureGroup1, String captureGroup2, ...ect )")
+                .addSignature("public Author parameterName(String... captureGroups)")
+                .addNote("Note: Author is an example of the class you want to convert captureGroups to")
+                .build();
     }
 
     @Override

--- a/java/src/main/java/io/cucumber/java/JavaSnippet.java
+++ b/java/src/main/java/io/cucumber/java/JavaSnippet.java
@@ -7,11 +7,11 @@ final class JavaSnippet extends AbstractJavaSnippet {
     @Override
     public MessageFormat template() {
         return new MessageFormat("" +
-            "@{0}(\"{1}\")\n" +
-            "public void {2}({3}) '{'\n" +
-            "    // {4}\n" +
-            "{5}    throw new " + PendingException.class.getName() + "();\n" +
-            "'}'");
+                "@{0}(\"{1}\")\n" +
+                "public void {2}({3}) '{'\n" +
+                "    // {4}\n" +
+                "{5}    throw new " + PendingException.class.getName() + "();\n" +
+                "'}'");
     }
 
 }

--- a/java/src/main/java/io/cucumber/java/JavaStepDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaStepDefinition.java
@@ -14,9 +14,11 @@ final class JavaStepDefinition extends AbstractGlueDefinition implements StepDef
     private final String expression;
     private final List<ParameterInfo> parameterInfos;
 
-    JavaStepDefinition(Method method,
-                       String expression,
-                       Lookup lookup) {
+    JavaStepDefinition(
+            Method method,
+            String expression,
+            Lookup lookup
+    ) {
         super(method, lookup);
         this.parameterInfos = JavaParameterInfo.fromMethod(method);
         this.expression = requireNonNull(expression, "cucumber-expression may not be null");

--- a/java/src/main/java/io/cucumber/java/MethodFormat.java
+++ b/java/src/main/java/io/cucumber/java/MethodFormat.java
@@ -13,11 +13,13 @@ import java.util.regex.Pattern;
 final class MethodFormat {
 
     static final MethodFormat FULL = new MethodFormat("%qc.%m(%qa)");
-    private static final Pattern METHOD_PATTERN = Pattern.compile("((?:static\\s|public\\s)+)([^\\s]*)\\s\\.?(.*)\\.([^\\(]*)\\(([^\\)]*)\\)(?: throws )?(.*)");
+    private static final Pattern METHOD_PATTERN = Pattern
+            .compile("((?:static\\s|public\\s)+)([^\\s]*)\\s\\.?(.*)\\.([^\\(]*)\\(([^\\)]*)\\)(?: throws )?(.*)");
     private final MessageFormat format;
 
     /**
-     * @param format the format string to use. There are several pattern tokens that can be used:
+     * @param format the format string to use. There are several pattern tokens
+     *               that can be used:
      *               <ul>
      *               <li><strong>%M</strong>: Modifiers</li>
      *               <li><strong>%qr</strong>: Qualified return type</li>
@@ -34,9 +36,9 @@ final class MethodFormat {
      */
     private MethodFormat(String format) {
         String pattern = format
-            .replaceAll("%qc", "{0}")
-            .replaceAll("%m", "{1}")
-            .replaceAll("%qa", "{2}");
+                .replaceAll("%qc", "{0}")
+                .replaceAll("%m", "{1}")
+                .replaceAll("%qa", "{2}");
         this.format = new MessageFormat(pattern);
     }
 
@@ -48,10 +50,10 @@ final class MethodFormat {
             String m = matcher.group(4);
             String qa = matcher.group(5);
 
-            return format.format(new Object[]{
-                qc,
-                m,
-                qa,
+            return format.format(new Object[] {
+                    qc,
+                    m,
+                    qa,
             });
         } else {
             throw new CucumberBackendException("Cucumber bug: Couldn't format " + signature);

--- a/java/src/main/java/io/cucumber/java/MethodScanner.java
+++ b/java/src/main/java/io/cucumber/java/MethodScanner.java
@@ -28,18 +28,21 @@ final class MethodScanner {
 
     private static boolean isInstantiable(Class<?> clazz) {
         boolean isNonStaticInnerClass = !Modifier.isStatic(clazz.getModifiers()) && clazz.getEnclosingClass() != null;
-        return Modifier.isPublic(clazz.getModifiers()) && !Modifier.isAbstract(clazz.getModifiers()) && !isNonStaticInnerClass;
+        return Modifier.isPublic(clazz.getModifiers()) && !Modifier.isAbstract(clazz.getModifiers())
+                && !isNonStaticInnerClass;
     }
 
     private static void scan(BiConsumer<Method, Annotation> consumer, Class<?> aClass, Method method) {
-        //prevent unnecessary checking of Object methods
+        // prevent unnecessary checking of Object methods
         if (Object.class.equals(method.getDeclaringClass())) {
             return;
         }
         scan(consumer, aClass, method, method.getAnnotations());
     }
 
-    private static void scan(BiConsumer<Method, Annotation> consumer, Class<?> aClass, Method method, Annotation[] methodAnnotations) {
+    private static void scan(
+            BiConsumer<Method, Annotation> consumer, Class<?> aClass, Method method, Annotation[] methodAnnotations
+    ) {
         for (Annotation annotation : methodAnnotations) {
             if (isHookAnnotation(annotation) || isStepDefinitionAnnotation(annotation)) {
                 validateMethod(aClass, method);
@@ -59,23 +62,21 @@ final class MethodScanner {
     private static boolean isHookAnnotation(Annotation annotation) {
         Class<? extends Annotation> annotationClass = annotation.annotationType();
         return annotationClass.equals(Before.class)
-            || annotationClass.equals(After.class)
-            || annotationClass.equals(BeforeStep.class)
-            || annotationClass.equals(AfterStep.class)
-            || annotationClass.equals(ParameterType.class)
-            || annotationClass.equals(DataTableType.class)
-            || annotationClass.equals(DefaultParameterTransformer.class)
-            || annotationClass.equals(DefaultDataTableEntryTransformer.class)
-            || annotationClass.equals(DefaultDataTableCellTransformer.class)
-            || annotationClass.equals(DocStringType.class)
-            ;
+                || annotationClass.equals(After.class)
+                || annotationClass.equals(BeforeStep.class)
+                || annotationClass.equals(AfterStep.class)
+                || annotationClass.equals(ParameterType.class)
+                || annotationClass.equals(DataTableType.class)
+                || annotationClass.equals(DefaultParameterTransformer.class)
+                || annotationClass.equals(DefaultDataTableEntryTransformer.class)
+                || annotationClass.equals(DefaultDataTableCellTransformer.class)
+                || annotationClass.equals(DocStringType.class);
     }
 
     private static boolean isStepDefinitionAnnotation(Annotation annotation) {
         Class<? extends Annotation> annotationClass = annotation.annotationType();
         return annotationClass.getAnnotation(StepDefinitionAnnotation.class) != null;
     }
-
 
     private static boolean isRepeatedStepDefinitionAnnotation(Annotation annotation) {
         Class<? extends Annotation> annotationClass = annotation.annotationType();

--- a/java/src/main/java/io/cucumber/java/ParameterType.java
+++ b/java/src/main/java/io/cucumber/java/ParameterType.java
@@ -11,21 +11,23 @@ import java.lang.annotation.Target;
 /**
  * Register parameter type.
  * <p>
- * The name of the method is used as the name of the {@link io.cucumber.cucumberexpressions.ParameterType}.
+ * The name of the method is used as the name of the
+ * {@link io.cucumber.cucumberexpressions.ParameterType}.
  * <p>
- * The method must have one of these signatures. The number of {@code String} parameters must match the
- * number of capture groups in the regular expression.
- *
+ * The method must have one of these signatures. The number of {@code String}
+ * parameters must match the number of capture groups in the regular expression.
  * <ul>
- * <li>{@code String -> Author} </li>
- * <li>{@code String, String -> Author} </li>
- * <li>{@code String, String, ect -> Author} </li>
- * <li>{@code String... -> Author} </li>
+ * <li>{@code String -> Author}</li>
+ * <li>{@code String, String -> Author}</li>
+ * <li>{@code String, String, ect -> Author}</li>
+ * <li>{@code String... -> Author}</li>
  * </ul>
- * NOTE: {@code Author} is an example of the type of the parameter type. {@link io.cucumber.cucumberexpressions.ParameterType#getType()}
+ * NOTE: {@code Author} is an example of the type of the parameter type.
+ * {@link io.cucumber.cucumberexpressions.ParameterType#getType()}
  *
  * @see io.cucumber.cucumberexpressions.ParameterType
- * @see <a href=https://cucumber.io/docs/cucumber/cucumber-expressions>Cucumber Expressions</a>
+ * @see <a href=https://cucumber.io/docs/cucumber/cucumber-expressions>Cucumber
+ *      Expressions</a>
  */
 
 @Retention(RetentionPolicy.RUNTIME)
@@ -36,55 +38,58 @@ public @interface ParameterType {
     /**
      * Regular expression.
      * <p>
-     * Describes which patterns match this parameter type. If the expression includes capture groups their captured
-     * strings will be provided as individual arguments.
+     * Describes which patterns match this parameter type. If the expression
+     * includes capture groups their captured strings will be provided as
+     * individual arguments.
      *
      * @return a regular expression.
-     * @see io.cucumber.cucumberexpressions.ParameterType#getRegexps()
+     * @see    io.cucumber.cucumberexpressions.ParameterType#getRegexps()
      */
     String value();
 
     /**
      * Name of the parameter type.
      * <p>
-     * This is used as the type name in typed expressions. When not provided this will default to the name of
-     * the annotated method.
+     * This is used as the type name in typed expressions. When not provided
+     * this will default to the name of the annotated method.
      *
      * @return human readable type name
-     * @see io.cucumber.cucumberexpressions.ParameterType#getName()
+     * @see    io.cucumber.cucumberexpressions.ParameterType#getName()
      */
     String name() default "";
 
     /**
-     * Indicates whether or not this is a preferential parameter type when matching text
-     * against a RegularExpression. In case there are multiple parameter types
-     * with a regexp identical to the capture group's regexp, a preferential parameter type will
-     * win. If there are more than 1 preferential ones, an error will be thrown.
+     * Indicates whether or not this is a preferential parameter type when
+     * matching text against a RegularExpression. In case there are multiple
+     * parameter types with a regexp identical to the capture group's regexp, a
+     * preferential parameter type will win. If there are more than 1
+     * preferential ones, an error will be thrown.
      *
      * @return true if this is a preferential type
-     * @see io.cucumber.cucumberexpressions.ParameterType#preferForRegexpMatch()
+     * @see    io.cucumber.cucumberexpressions.ParameterType#preferForRegexpMatch()
      */
     boolean preferForRegexMatch() default false;
 
     /**
-     * Indicates whether or not this is a parameter type that should be used for generating
-     * {@link GeneratedExpression}s from text. Typically, parameter types with greedy regexps
-     * should return false.
+     * Indicates whether or not this is a parameter type that should be used for
+     * generating {@link GeneratedExpression}s from text. Typically, parameter
+     * types with greedy regexps should return false.
      *
      * @return true is this parameter type is used for expression generation
-     * @see io.cucumber.cucumberexpressions.ParameterType#useForSnippets()
+     * @see    io.cucumber.cucumberexpressions.ParameterType#useForSnippets()
      */
     boolean useForSnippets() default false;
 
     /**
-     * Indicates whether or not this parameter provides a strong type hint when considering a
-     * regular expression match. If so, the type hint provided by the method arguments will be
-     * ignored. If not, when both type hints are in agreement, this parameter type's transformer
-     * will be used. Otherwise parameter transformation for a regular expression match will be
-     * handled by {@link DefaultParameterTransformer}.
+     * Indicates whether or not this parameter provides a strong type hint when
+     * considering a regular expression match. If so, the type hint provided by
+     * the method arguments will be ignored. If not, when both type hints are in
+     * agreement, this parameter type's transformer will be used. Otherwise
+     * parameter transformation for a regular expression match will be handled
+     * by {@link DefaultParameterTransformer}.
      *
-     * @return true if this parameter type provides a type hint when considering a regular
-     * expression match
+     * @return true if this parameter type provides a type hint when considering
+     *         a regular expression match
      */
     boolean useRegexpMatchAsStrongTypeHint() default false;
 

--- a/java/src/main/java/io/cucumber/java/Scenario.java
+++ b/java/src/main/java/io/cucumber/java/Scenario.java
@@ -7,12 +7,14 @@ import java.net.URI;
 import java.util.Collection;
 
 /**
- * Before or After Hooks that declare a parameter of this type will receive an instance of this class.
- * It allows writing text and embedding media into reports, as well as inspecting results (in an After block).
+ * Before or After Hooks that declare a parameter of this type will receive an
+ * instance of this class. It allows writing text and embedding media into
+ * reports, as well as inspecting results (in an After block).
  * <p>
- * Note: This class is not intended to be used to create reports. To create custom reports use
- * the {@code io.cucumber.plugin.Plugin} class. The plugin system provides a much richer access to Cucumbers then
- * hooks after could provide. For an example see {@code io.cucumber.core.plugin.PrettyFormatter}.
+ * Note: This class is not intended to be used to create reports. To create
+ * custom reports use the {@code io.cucumber.plugin.Plugin} class. The plugin
+ * system provides a much richer access to Cucumbers then hooks after could
+ * provide. For an example see {@code io.cucumber.core.plugin.PrettyFormatter}.
  */
 @API(status = API.Status.STABLE)
 public final class Scenario {
@@ -51,6 +53,7 @@ public final class Scenario {
 
     /**
      * Attach data to the report(s).
+     * 
      * <pre>
      * {@code
      * // Attach a screenshot. See your UI automation tool's docs for
@@ -63,7 +66,9 @@ public final class Scenario {
      * {@code mediaType} must be provided. For example: {@code text/plain},
      * {@code image/png}, {@code text/html;charset=utf-8}.
      * <p>
-     * Media types are defined in <a href= https://tools.ietf.org/html/rfc7231#section-3.1.1.1>RFC 7231 Section 3.1.1.1</a>.
+     * Media types are defined in <a href=
+     * https://tools.ietf.org/html/rfc7231#section-3.1.1.1>RFC 7231 Section
+     * 3.1.1.1</a>.
      *
      * @param data      what to attach, for example an image.
      * @param mediaType what is the data?
@@ -79,7 +84,7 @@ public final class Scenario {
      * @param data      what to attach, for example html.
      * @param mediaType what is the data?
      * @param name      attachment name
-     * @see #attach(byte[], String, String)
+     * @see             #attach(byte[], String, String)
      */
     public void attach(String data, String mediaType, String name) {
         delegate.attach(data, mediaType, name);
@@ -89,7 +94,7 @@ public final class Scenario {
      * Outputs some text into the report.
      *
      * @param text what to put in the report.
-     * @see #attach(byte[], String, String)
+     * @see        #attach(byte[], String, String)
      */
     public void log(String text) {
         delegate.log(text);
@@ -117,9 +122,9 @@ public final class Scenario {
     }
 
     /**
-     * @return the line in the feature file of the Scenario. If this is a Scenario
-     * from Scenario Outlines this will return the line of the example row in
-     * the Scenario Outline.
+     * @return the line in the feature file of the Scenario. If this is a
+     *         Scenario from Scenario Outlines this will return the line of the
+     *         example row in the Scenario Outline.
      */
     public Integer getLine() {
         return delegate.getLine();

--- a/java/src/main/java/io/cucumber/java/Transpose.java
+++ b/java/src/main/java/io/cucumber/java/Transpose.java
@@ -9,10 +9,11 @@ import java.lang.annotation.Target;
 
 /**
  * <p>
- * This annotation can be specified on step definition method parameters to give Cucumber a hint
- * to transpose a DataTable.
+ * This annotation can be specified on step definition method parameters to give
+ * Cucumber a hint to transpose a DataTable.
  * <p>
  * For example, if you have the following Gherkin step with a table
+ * 
  * <pre>
  * Given the user is
  *    | firstname	| Roberto	|
@@ -24,7 +25,7 @@ import java.lang.annotation.Target;
  *
  * <pre>
  * {@code
- * @DataTableType
+ * &#64;DataTableType
  * public User convert(Map<String, String> entry){
  *    return new User(
  *        entry.get("firstname"),
@@ -34,7 +35,10 @@ import java.lang.annotation.Target;
  * }
  * }
  * </pre>
- * Then the following Java Step Definition would convert that into an User object:
+ * 
+ * Then the following Java Step Definition would convert that into an User
+ * object:
+ * 
  * <pre>
  * &#064;Given("^the user is$")
  * public void the_user_is(&#064;Transpose User user) {
@@ -43,7 +47,7 @@ import java.lang.annotation.Target;
  * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.PARAMETER})
+@Target({ ElementType.PARAMETER })
 @API(status = API.Status.STABLE)
 public @interface Transpose {
 

--- a/java/src/test/java/io/cucumber/java/GlueAdaptorTest.java
+++ b/java/src/test/java/io/cucumber/java/GlueAdaptorTest.java
@@ -109,13 +109,17 @@ public class GlueAdaptorTest {
         }
 
         @Override
-        public void addDefaultDataTableEntryTransformer(DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer) {
+        public void addDefaultDataTableEntryTransformer(
+                DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer
+        ) {
             GlueAdaptorTest.this.defaultDataTableEntryTransformer = defaultDataTableEntryTransformer;
 
         }
 
         @Override
-        public void addDefaultDataTableCellTransformer(DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer) {
+        public void addDefaultDataTableCellTransformer(
+                DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer
+        ) {
             GlueAdaptorTest.this.defaultDataTableCellTransformer = defaultDataTableCellTransformer;
 
         }
@@ -146,8 +150,7 @@ public class GlueAdaptorTest {
             () -> assertThat(beforeStepHook, notNullValue()),
             () -> assertThat(afterHook, notNullValue()),
             () -> assertThat(beforeHook, notNullValue()),
-            () -> assertThat(docStringTypeDefinition, notNullValue())
-        );
+            () -> assertThat(docStringTypeDefinition, notNullValue()));
     }
 
     @Given(value = "a step")
@@ -176,7 +179,12 @@ public class GlueAdaptorTest {
         return "data_table_type";
     }
 
-    @ParameterType(value = "pattern", name = "name", preferForRegexMatch = true, useForSnippets = true, useRegexpMatchAsStrongTypeHint = false)
+    @ParameterType(
+            value = "pattern",
+            name = "name",
+            preferForRegexMatch = true,
+            useForSnippets = true,
+            useRegexpMatchAsStrongTypeHint = false)
     public String parameter_type(String fromValue) {
         return "parameter_type";
     }

--- a/java/src/test/java/io/cucumber/java/JavaBackendTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaBackendTest.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({MockitoExtension.class})
+@ExtendWith({ MockitoExtension.class })
 class JavaBackendTest {
 
     @Captor
@@ -55,9 +55,11 @@ class JavaBackendTest {
 
     @Test
     void detects_subclassed_glue_and_throws_exception() {
-        Executable testMethod = () -> backend.loadGlue(glue, asList(URI.create("classpath:io/cucumber/java/steps"), URI.create("classpath:io/cucumber/java/incorrectlysubclassedsteps")));
+        Executable testMethod = () -> backend.loadGlue(glue, asList(URI.create("classpath:io/cucumber/java/steps"),
+            URI.create("classpath:io/cucumber/java/incorrectlysubclassedsteps")));
         InvalidMethodException expectedThrown = assertThrows(InvalidMethodException.class, testMethod);
-        assertThat(expectedThrown.getMessage(), is(equalTo("You're not allowed to extend classes that define Step Definitions or hooks. class io.cucumber.java.incorrectlysubclassedsteps.SubclassesSteps extends class io.cucumber.java.steps.Steps")));
+        assertThat(expectedThrown.getMessage(), is(equalTo(
+            "You're not allowed to extend classes that define Step Definitions or hooks. class io.cucumber.java.incorrectlysubclassedsteps.SubclassesSteps extends class io.cucumber.java.steps.Steps")));
     }
 
     @Test
@@ -66,9 +68,9 @@ class JavaBackendTest {
         verify(glue, times(2)).addStepDefinition(stepDefinition.capture());
 
         List<String> patterns = stepDefinition.getAllValues()
-            .stream()
-            .map(StepDefinition::getPattern)
-            .collect(toList());
+                .stream()
+                .map(StepDefinition::getPattern)
+                .collect(toList());
         assertThat(patterns, equalTo(asList("test", "test again")));
 
     }

--- a/java/src/test/java/io/cucumber/java/JavaDataTableTypeDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDataTableTypeDefinitionTest.java
@@ -34,13 +34,11 @@ class JavaDataTableTypeDefinitionTest {
 
     private final DataTable dataTable = DataTable.create(asList(
         asList("a", "b"),
-        asList("c", "d")
-    ));
+        asList("c", "d")));
 
     private final DataTable emptyTable = DataTable.create(asList(
         asList("a", "[empty]"),
-        asList("[empty]", "d")
-    ));
+        asList("[empty]", "d")));
 
     public static String static_convert_data_table_to_string(DataTable table) {
         return "static_convert_data_table_to_string=" + table.cells();
@@ -48,16 +46,21 @@ class JavaDataTableTypeDefinitionTest {
 
     @Test
     void can_define_data_table_converter() throws NoSuchMethodException {
-        Method method = JavaDataTableTypeDefinitionTest.class.getMethod("convert_data_table_to_string", DataTable.class);
+        Method method = JavaDataTableTypeDefinitionTest.class.getMethod("convert_data_table_to_string",
+            DataTable.class);
         JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookup, new String[0]);
-        assertThat(definition.dataTableType().transform(dataTable.asLists()), is("convert_data_table_to_string=[[a, b], [c, d]]"));
+        assertThat(definition.dataTableType().transform(dataTable.asLists()),
+            is("convert_data_table_to_string=[[a, b], [c, d]]"));
     }
 
     @Test
     void can_define_data_table_converter_with_empty_pattern() throws NoSuchMethodException {
-        Method method = JavaDataTableTypeDefinitionTest.class.getMethod("convert_data_table_to_string", DataTable.class);
-        JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookup, new String[]{"[empty]"});
-        assertThat(definition.dataTableType().transform(emptyTable.asLists()), is("convert_data_table_to_string=[[a, ], [, d]]"));
+        Method method = JavaDataTableTypeDefinitionTest.class.getMethod("convert_data_table_to_string",
+            DataTable.class);
+        JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookup,
+            new String[] { "[empty]" });
+        assertThat(definition.dataTableType().transform(emptyTable.asLists()),
+            is("convert_data_table_to_string=[[a, ], [, d]]"));
     }
 
     public String convert_data_table_to_string(DataTable table) {
@@ -75,7 +78,8 @@ class JavaDataTableTypeDefinitionTest {
     @Test
     void can_define_table_row_transformer_with_empty_pattern() throws NoSuchMethodException {
         Method method = JavaDataTableTypeDefinitionTest.class.getMethod("convert_table_row_to_string", List.class);
-        JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookup, new String[]{"[empty]"});
+        JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookup,
+            new String[] { "[empty]" });
         assertThat(definition.dataTableType().transform(emptyTable.asLists()),
             is(asList("convert_table_row_to_string=[a, ]", "convert_table_row_to_string=[, d]")));
     }
@@ -95,7 +99,8 @@ class JavaDataTableTypeDefinitionTest {
     @Test
     void can_define_table_entry_transformer_with_empty_pattern() throws NoSuchMethodException {
         Method method = JavaDataTableTypeDefinitionTest.class.getMethod("converts_table_entry_to_string", Map.class);
-        JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookup, new String[]{"[empty]"});
+        JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookup,
+            new String[] { "[empty]" });
         assertThat(definition.dataTableType().transform(emptyTable.asLists()),
             is(singletonList("converts_table_entry_to_string={a=, =d}")));
     }
@@ -110,8 +115,7 @@ class JavaDataTableTypeDefinitionTest {
         JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookup, new String[0]);
         assertThat(definition.dataTableType().transform(dataTable.asLists()), is(asList(
             asList("converts_table_cell_to_string=a", "converts_table_cell_to_string=b"),
-            asList("converts_table_cell_to_string=c", "converts_table_cell_to_string=d"))
-        ));
+            asList("converts_table_cell_to_string=c", "converts_table_cell_to_string=d"))));
     }
 
     @Test
@@ -120,8 +124,7 @@ class JavaDataTableTypeDefinitionTest {
         JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookup, new String[0]);
         assertThat(definition.dataTableType().transform(emptyTable.asLists()), is(asList(
             asList("converts_table_cell_to_string=a", "converts_table_cell_to_string=[empty]"),
-            asList("converts_table_cell_to_string=[empty]", "converts_table_cell_to_string=d"))
-        ));
+            asList("converts_table_cell_to_string=[empty]", "converts_table_cell_to_string=d"))));
     }
 
     public String converts_table_cell_to_string(String cell) {
@@ -130,9 +133,11 @@ class JavaDataTableTypeDefinitionTest {
 
     @Test
     void target_type_must_class_type() throws NoSuchMethodException {
-        Method method = JavaDataTableTypeDefinitionTest.class.getMethod("converts_datatable_to_optional_string", DataTable.class);
+        Method method = JavaDataTableTypeDefinitionTest.class.getMethod("converts_datatable_to_optional_string",
+            DataTable.class);
         JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookup, new String[0]);
-        assertThat(definition.dataTableType().transform(dataTable.asLists()), is(Optional.of("converts_datatable_to_optional_string")));
+        assertThat(definition.dataTableType().transform(dataTable.asLists()),
+            is(Optional.of("converts_datatable_to_optional_string")));
 
     }
 
@@ -143,7 +148,8 @@ class JavaDataTableTypeDefinitionTest {
     @Test
     void target_type_must_not_be_void() throws NoSuchMethodException {
         Method method = JavaDataTableTypeDefinitionTest.class.getMethod("converts_data_table_to_void", DataTable.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDataTableTypeDefinition(method, lookup, new String[0]));
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDataTableTypeDefinition(method, lookup, new String[0]));
     }
 
     public void converts_data_table_to_void(DataTable table) {
@@ -152,9 +158,12 @@ class JavaDataTableTypeDefinitionTest {
     @Test
     void must_have_exactly_one_argument() throws NoSuchMethodException {
         Method noArgs = JavaDataTableTypeDefinitionTest.class.getMethod("converts_nothing_to_string");
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDataTableTypeDefinition(noArgs, lookup, new String[0]));
-        Method twoArgs = JavaDataTableTypeDefinitionTest.class.getMethod("converts_two_strings_to_string", String.class, String.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDataTableTypeDefinition(twoArgs, lookup, new String[0]));
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDataTableTypeDefinition(noArgs, lookup, new String[0]));
+        Method twoArgs = JavaDataTableTypeDefinitionTest.class.getMethod("converts_two_strings_to_string", String.class,
+            String.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDataTableTypeDefinition(twoArgs, lookup, new String[0]));
     }
 
     public String converts_nothing_to_string() {
@@ -168,7 +177,8 @@ class JavaDataTableTypeDefinitionTest {
     @Test
     void argument_must_match_existing_transformer() throws NoSuchMethodException {
         Method method = JavaDataTableTypeDefinitionTest.class.getMethod("converts_object_to_string", Object.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDataTableTypeDefinition(method, lookup, new String[0]));
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDataTableTypeDefinition(method, lookup, new String[0]));
     }
 
     public String converts_object_to_string(Object string) {
@@ -178,7 +188,8 @@ class JavaDataTableTypeDefinitionTest {
     @Test
     void table_entry_transformer_must_have_map_of_strings() throws NoSuchMethodException {
         Method method = JavaDataTableTypeDefinitionTest.class.getMethod("converts_map_of_objects_to_string", Map.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDataTableTypeDefinition(method, lookup, new String[0]));
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDataTableTypeDefinition(method, lookup, new String[0]));
     }
 
     public String converts_map_of_objects_to_string(Map<Object, Object> entry) {
@@ -187,10 +198,12 @@ class JavaDataTableTypeDefinitionTest {
 
     @Test
     void static_methods_are_invoked_without_a_body() throws NoSuchMethodException {
-        Method method = JavaDataTableTypeDefinitionTest.class.getMethod("static_convert_data_table_to_string", DataTable.class);
-        JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookupForStaticMethod, new String[0]);
-        assertThat(definition.dataTableType().transform(dataTable.asLists()), is("static_convert_data_table_to_string=[[a, b], [c, d]]"));
+        Method method = JavaDataTableTypeDefinitionTest.class.getMethod("static_convert_data_table_to_string",
+            DataTable.class);
+        JavaDataTableTypeDefinition definition = new JavaDataTableTypeDefinition(method, lookupForStaticMethod,
+            new String[0]);
+        assertThat(definition.dataTableType().transform(dataTable.asLists()),
+            is("static_convert_data_table_to_string=[[a, b], [c, d]]"));
     }
-
 
 }

--- a/java/src/test/java/io/cucumber/java/JavaDefaultDataTableCellTransformerDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDefaultDataTableCellTransformerDefinitionTest.java
@@ -25,24 +25,30 @@ class JavaDefaultDataTableCellTransformerDefinitionTest {
 
     @Test
     void can_transform_string_to_type() throws Throwable {
-        Method method = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("transform_string_to_type", String.class, Type.class);
-        JavaDefaultDataTableCellTransformerDefinition definition = new JavaDefaultDataTableCellTransformerDefinition(method, lookup, new String[0]);
+        Method method = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("transform_string_to_type",
+            String.class, Type.class);
+        JavaDefaultDataTableCellTransformerDefinition definition = new JavaDefaultDataTableCellTransformerDefinition(
+            method, lookup, new String[0]);
         Object transformed = definition.tableCellByTypeTransformer().transform("something", String.class);
         assertThat(transformed, is("transform_string_to_type=something"));
     }
 
     @Test
     void can_transform_string_to_empty() throws Throwable {
-        Method method = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("transform_string_to_type", String.class, Type.class);
-        JavaDefaultDataTableCellTransformerDefinition definition = new JavaDefaultDataTableCellTransformerDefinition(method, lookup, new String[]{"[empty]"});
+        Method method = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("transform_string_to_type",
+            String.class, Type.class);
+        JavaDefaultDataTableCellTransformerDefinition definition = new JavaDefaultDataTableCellTransformerDefinition(
+            method, lookup, new String[] { "[empty]" });
         Object transformed = definition.tableCellByTypeTransformer().transform("[empty]", String.class);
         assertThat(transformed, is("transform_string_to_type="));
     }
 
     @Test
     void can_transform_null_while_using_replacement_patterns() throws Throwable {
-        Method method = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("transform_string_to_type", String.class, Type.class);
-        JavaDefaultDataTableCellTransformerDefinition definition = new JavaDefaultDataTableCellTransformerDefinition(method, lookup, new String[]{"[empty]"});
+        Method method = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("transform_string_to_type",
+            String.class, Type.class);
+        JavaDefaultDataTableCellTransformerDefinition definition = new JavaDefaultDataTableCellTransformerDefinition(
+            method, lookup, new String[] { "[empty]" });
         Object transformed = definition.tableCellByTypeTransformer().transform(null, String.class);
         assertThat(transformed, is("transform_string_to_type=null"));
     }
@@ -53,8 +59,10 @@ class JavaDefaultDataTableCellTransformerDefinitionTest {
 
     @Test
     void can_transform_object_to_type() throws Throwable {
-        Method method = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("transform_object_to_type", Object.class, Type.class);
-        JavaDefaultDataTableCellTransformerDefinition definition = new JavaDefaultDataTableCellTransformerDefinition(method, lookup, new String[0]);
+        Method method = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("transform_object_to_type",
+            Object.class, Type.class);
+        JavaDefaultDataTableCellTransformerDefinition definition = new JavaDefaultDataTableCellTransformerDefinition(
+            method, lookup, new String[0]);
         Object transformed = definition.tableCellByTypeTransformer().transform("something", String.class);
         assertThat(transformed, is("transform_object_to_type"));
     }
@@ -65,14 +73,15 @@ class JavaDefaultDataTableCellTransformerDefinitionTest {
 
     @Test
     void must_have_non_void_return() throws Throwable {
-        Method method = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("transforms_string_to_void", String.class, Type.class);
-        InvalidMethodSignatureException exception = assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableCellTransformerDefinition(method, lookup, new String[0]));
+        Method method = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("transforms_string_to_void",
+            String.class, Type.class);
+        InvalidMethodSignatureException exception = assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableCellTransformerDefinition(method, lookup, new String[0]));
         assertThat(exception.getMessage(), startsWith("" +
-            "A @DefaultDataTableCellTransformer annotated method must have one of these signatures:\n" +
-            " * public Object defaultDataTableCell(String fromValue, Type toValueType)\n" +
-            " * public Object defaultDataTableCell(Object fromValue, Type toValueType)\n" +
-            "at io.cucumber.java.JavaDefaultDataTableCellTransformerDefinitionTest.transforms_string_to_void(java.lang.String,java.lang.reflect.Type)"
-        ));
+                "A @DefaultDataTableCellTransformer annotated method must have one of these signatures:\n" +
+                " * public Object defaultDataTableCell(String fromValue, Type toValueType)\n" +
+                " * public Object defaultDataTableCell(Object fromValue, Type toValueType)\n" +
+                "at io.cucumber.java.JavaDefaultDataTableCellTransformerDefinitionTest.transforms_string_to_void(java.lang.String,java.lang.reflect.Type)"));
     }
 
     public void transforms_string_to_void(String fromValue, Type toValueType) {
@@ -81,9 +90,12 @@ class JavaDefaultDataTableCellTransformerDefinitionTest {
     @Test
     void must_have_two_arguments() throws Throwable {
         Method oneArg = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("one_argument", String.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableCellTransformerDefinition(oneArg, lookup, new String[0]));
-        Method threeArg = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("three_arguments", String.class, Type.class, Object.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableCellTransformerDefinition(threeArg, lookup, new String[0]));
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableCellTransformerDefinition(oneArg, lookup, new String[0]));
+        Method threeArg = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("three_arguments",
+            String.class, Type.class, Object.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableCellTransformerDefinition(threeArg, lookup, new String[0]));
     }
 
     public Object one_argument(String fromValue) {
@@ -96,10 +108,11 @@ class JavaDefaultDataTableCellTransformerDefinitionTest {
 
     @Test
     void must_have_string_or_object_as_from_value() throws Throwable {
-        Method threeArg = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("map_as_from_value", Map.class, Type.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableCellTransformerDefinition(threeArg, lookup, new String[0]));
+        Method threeArg = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("map_as_from_value",
+            Map.class, Type.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableCellTransformerDefinition(threeArg, lookup, new String[0]));
     }
-
 
     public Object map_as_from_value(Map<String, String> fromValue, Type toValueType) {
         return "map_as_from_value";
@@ -107,8 +120,10 @@ class JavaDefaultDataTableCellTransformerDefinitionTest {
 
     @Test
     void must_have_type_as_to_value_type() throws Throwable {
-        Method threeArg = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("object_as_to_value_type", String.class, Object.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableCellTransformerDefinition(threeArg, lookup, new String[0]));
+        Method threeArg = JavaDefaultDataTableCellTransformerDefinitionTest.class.getMethod("object_as_to_value_type",
+            String.class, Object.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableCellTransformerDefinition(threeArg, lookup, new String[0]));
     }
 
     public Object object_as_to_value_type(String fromValue, Object toValueType) {

--- a/java/src/test/java/io/cucumber/java/JavaDefaultDataTableEntryTransformerDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDefaultDataTableEntryTransformerDefinitionTest.java
@@ -34,34 +34,40 @@ class JavaDefaultDataTableEntryTransformerDefinitionTest {
 
     @Test
     void transforms_with_correct_method() throws Throwable {
-        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("correct_method", Map.class, Type.class);
-        JavaDefaultDataTableEntryTransformerDefinition definition =
-            new JavaDefaultDataTableEntryTransformerDefinition(method, lookup);
+        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("correct_method", Map.class,
+            Type.class);
+        JavaDefaultDataTableEntryTransformerDefinition definition = new JavaDefaultDataTableEntryTransformerDefinition(
+            method, lookup);
 
         assertThat(definition.tableEntryByTypeTransformer()
-            .transform(fromValue, String.class, cellTransformer), is("key=value"));
+                .transform(fromValue, String.class, cellTransformer),
+            is("key=value"));
     }
 
     @Test
     void transforms_empties_with_correct_method() throws Throwable {
         Map<String, String> fromValue = singletonMap("key", "[empty]");
-        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("correct_method", Map.class, Type.class);
-        JavaDefaultDataTableEntryTransformerDefinition definition =
-            new JavaDefaultDataTableEntryTransformerDefinition(method, lookup, false, new String[]{"[empty]"});
+        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("correct_method", Map.class,
+            Type.class);
+        JavaDefaultDataTableEntryTransformerDefinition definition = new JavaDefaultDataTableEntryTransformerDefinition(
+            method, lookup, false, new String[] { "[empty]" });
 
         assertThat(definition.tableEntryByTypeTransformer()
-            .transform(fromValue, String.class, cellTransformer), is("key="));
+                .transform(fromValue, String.class, cellTransformer),
+            is("key="));
     }
 
     @Test
     void transforms_nulls_with_correct_method() throws Throwable {
         Map<String, String> fromValue = singletonMap("key", null);
-        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("correct_method", Map.class, Type.class);
-        JavaDefaultDataTableEntryTransformerDefinition definition =
-            new JavaDefaultDataTableEntryTransformerDefinition(method, lookup, false, new String[]{"[empty]"});
+        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("correct_method", Map.class,
+            Type.class);
+        JavaDefaultDataTableEntryTransformerDefinition definition = new JavaDefaultDataTableEntryTransformerDefinition(
+            method, lookup, false, new String[] { "[empty]" });
 
         assertThat(definition.tableEntryByTypeTransformer()
-            .transform(fromValue, String.class, cellTransformer), is("key=null"));
+                .transform(fromValue, String.class, cellTransformer),
+            is("key=null"));
     }
 
     @Test
@@ -69,16 +75,17 @@ class JavaDefaultDataTableEntryTransformerDefinitionTest {
         Map<String, String> fromValue = new LinkedHashMap<>();
         fromValue.put("[empty]", "a");
         fromValue.put("[blank]", "b");
-        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("correct_method", Map.class, Type.class);
-        JavaDefaultDataTableEntryTransformerDefinition definition =
-            new JavaDefaultDataTableEntryTransformerDefinition(method, lookup, false, new String[]{"[empty]", "[blank]"});
+        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("correct_method", Map.class,
+            Type.class);
+        JavaDefaultDataTableEntryTransformerDefinition definition = new JavaDefaultDataTableEntryTransformerDefinition(
+            method, lookup, false, new String[] { "[empty]", "[blank]" });
 
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> definition.tableEntryByTypeTransformer().transform(fromValue, String.class, cellTransformer)
-        );
+            () -> definition.tableEntryByTypeTransformer().transform(fromValue, String.class, cellTransformer));
 
-        assertThat(exception.getMessage(), is("After replacing [empty] and [blank] with empty strings the datatable entry contains duplicate keys: {[empty]=a, [blank]=b}"));
+        assertThat(exception.getMessage(), is(
+            "After replacing [empty] and [blank] with empty strings the datatable entry contains duplicate keys: {[empty]=a, [blank]=b}"));
     }
 
     public <T> T correct_method(Map<String, String> fromValue, Type toValueType) {
@@ -87,29 +94,37 @@ class JavaDefaultDataTableEntryTransformerDefinitionTest {
 
     @SuppressWarnings("unchecked")
     private static <T> T join(Map<String, String> fromValue) {
-        return (T) fromValue.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining());
+        return (T) fromValue.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining());
     }
 
     @Test
     void transforms_with_correct_method_with_cell_transformer() throws Throwable {
-        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("correct_method_with_cell_transformer", Map.class, Type.class, TableCellByTypeTransformer.class);
-        JavaDefaultDataTableEntryTransformerDefinition definition =
-            new JavaDefaultDataTableEntryTransformerDefinition(method, lookup);
+        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod(
+            "correct_method_with_cell_transformer", Map.class, Type.class, TableCellByTypeTransformer.class);
+        JavaDefaultDataTableEntryTransformerDefinition definition = new JavaDefaultDataTableEntryTransformerDefinition(
+            method, lookup);
 
         assertThat(definition.tableEntryByTypeTransformer()
-            .transform(fromValue, String.class, cellTransformer), is("key=value"));
+                .transform(fromValue, String.class, cellTransformer),
+            is("key=value"));
     }
 
-    public <T> T correct_method_with_cell_transformer(Map<String, String> fromValue, Type toValueType, TableCellByTypeTransformer cellTransformer) {
+    public <T> T correct_method_with_cell_transformer(
+            Map<String, String> fromValue, Type toValueType, TableCellByTypeTransformer cellTransformer
+    ) {
         return join(fromValue);
     }
 
     @Test
     void method_must_have_2_or_3_arguments() throws Throwable {
         Method toFew = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("one_argument", Map.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableEntryTransformerDefinition(toFew, lookup));
-        Method toMany = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("four_arguments", Map.class, String.class, String.class, String.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableEntryTransformerDefinition(toMany, lookup));
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableEntryTransformerDefinition(toFew, lookup));
+        Method toMany = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("four_arguments", Map.class,
+            String.class, String.class, String.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableEntryTransformerDefinition(toMany, lookup));
     }
 
     public <T> T one_argument(Map<String, String> fromValue) {
@@ -122,8 +137,10 @@ class JavaDefaultDataTableEntryTransformerDefinitionTest {
 
     @Test
     void method_must_have_return_type() throws Throwable {
-        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("void_return_type", Map.class, Type.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableEntryTransformerDefinition(method, lookup));
+        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("void_return_type",
+            Map.class, Type.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableEntryTransformerDefinition(method, lookup));
     }
 
     public void void_return_type(Map<String, String> fromValue, Type toValueType) {
@@ -131,12 +148,18 @@ class JavaDefaultDataTableEntryTransformerDefinitionTest {
 
     @Test
     void method_must_have_map_as_first_argument() throws Throwable {
-        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("invalid_first_type", String.class, Type.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableEntryTransformerDefinition(method, lookup));
-        Method method2 = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("invalid_first_type", List.class, Type.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableEntryTransformerDefinition(method2, lookup));
-        Method method3 = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("invalid_first_type", Map.class, Type.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableEntryTransformerDefinition(method3, lookup));
+        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("invalid_first_type",
+            String.class, Type.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableEntryTransformerDefinition(method, lookup));
+        Method method2 = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("invalid_first_type",
+            List.class, Type.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableEntryTransformerDefinition(method2, lookup));
+        Method method3 = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("invalid_first_type",
+            Map.class, Type.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableEntryTransformerDefinition(method3, lookup));
     }
 
     public Object invalid_first_type(String fromValue, Type toValueType) {
@@ -153,8 +176,10 @@ class JavaDefaultDataTableEntryTransformerDefinitionTest {
 
     @Test
     void method_must_have_class_as_second_argument() throws Throwable {
-        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("invalid_second_type", Map.class, String.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableEntryTransformerDefinition(method, lookup));
+        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("invalid_second_type",
+            Map.class, String.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableEntryTransformerDefinition(method, lookup));
     }
 
     public Object invalid_second_type(Map<String, String> fromValue, String toValue) {
@@ -163,8 +188,10 @@ class JavaDefaultDataTableEntryTransformerDefinitionTest {
 
     @Test
     void method_must_have_cell_transformer_as_optional_third_argument() throws Throwable {
-        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class.getMethod("invalid_optional_third_type", Map.class, Type.class, String.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultDataTableEntryTransformerDefinition(method, lookup));
+        Method method = JavaDefaultDataTableEntryTransformerDefinitionTest.class
+                .getMethod("invalid_optional_third_type", Map.class, Type.class, String.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultDataTableEntryTransformerDefinition(method, lookup));
     }
 
     public Object invalid_optional_third_type(Map<String, String> fromValue, Type toValueType, String cellTransformer) {

--- a/java/src/test/java/io/cucumber/java/JavaDefaultParameterTransformerDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDefaultParameterTransformerDefinitionTest.java
@@ -25,8 +25,10 @@ class JavaDefaultParameterTransformerDefinitionTest {
 
     @Test
     void can_transform_string_to_type() throws Throwable {
-        Method method = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("transform_string_to_type", String.class, Type.class);
-        JavaDefaultParameterTransformerDefinition definition = new JavaDefaultParameterTransformerDefinition(method, lookup);
+        Method method = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("transform_string_to_type",
+            String.class, Type.class);
+        JavaDefaultParameterTransformerDefinition definition = new JavaDefaultParameterTransformerDefinition(method,
+            lookup);
         Object transformed = definition.parameterByTypeTransformer().transform("something", String.class);
         assertThat(transformed, is("transform_string_to_type"));
     }
@@ -37,8 +39,10 @@ class JavaDefaultParameterTransformerDefinitionTest {
 
     @Test
     void can_transform_object_to_type() throws Throwable {
-        Method method = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("transform_object_to_type", Object.class, Type.class);
-        JavaDefaultParameterTransformerDefinition definition = new JavaDefaultParameterTransformerDefinition(method, lookup);
+        Method method = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("transform_object_to_type",
+            Object.class, Type.class);
+        JavaDefaultParameterTransformerDefinition definition = new JavaDefaultParameterTransformerDefinition(method,
+            lookup);
         String transformed = (String) definition.parameterByTypeTransformer().transform("something", String.class);
         assertThat(transformed, is("transform_object_to_type"));
     }
@@ -49,14 +53,15 @@ class JavaDefaultParameterTransformerDefinitionTest {
 
     @Test
     void must_have_non_void_return() throws Throwable {
-        Method method = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("transforms_string_to_void", String.class, Type.class);
-        InvalidMethodSignatureException exception = assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultParameterTransformerDefinition(method, lookup));
+        Method method = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("transforms_string_to_void",
+            String.class, Type.class);
+        InvalidMethodSignatureException exception = assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultParameterTransformerDefinition(method, lookup));
         assertThat(exception.getMessage(), startsWith("" +
-            "A @DefaultParameterTransformer annotated method must have one of these signatures:\n" +
-            " * public Object defaultDataTableEntry(String fromValue, Type toValueType)\n" +
-            " * public Object defaultDataTableEntry(Object fromValue, Type toValueType)\n" +
-            "at io.cucumber.java.JavaDefaultParameterTransformerDefinitionTest.transforms_string_to_void(java.lang.String,java.lang.reflect.Type)"
-        ));
+                "A @DefaultParameterTransformer annotated method must have one of these signatures:\n" +
+                " * public Object defaultDataTableEntry(String fromValue, Type toValueType)\n" +
+                " * public Object defaultDataTableEntry(Object fromValue, Type toValueType)\n" +
+                "at io.cucumber.java.JavaDefaultParameterTransformerDefinitionTest.transforms_string_to_void(java.lang.String,java.lang.reflect.Type)"));
     }
 
     public void transforms_string_to_void(String fromValue, Type toValueType) {
@@ -65,9 +70,12 @@ class JavaDefaultParameterTransformerDefinitionTest {
     @Test
     void must_have_two_arguments() throws Throwable {
         Method oneArg = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("one_argument", String.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultParameterTransformerDefinition(oneArg, lookup));
-        Method threeArg = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("three_arguments", String.class, Type.class, Object.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultParameterTransformerDefinition(threeArg, lookup));
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultParameterTransformerDefinition(oneArg, lookup));
+        Method threeArg = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("three_arguments", String.class,
+            Type.class, Object.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultParameterTransformerDefinition(threeArg, lookup));
     }
 
     public Object one_argument(String fromValue) {
@@ -80,10 +88,11 @@ class JavaDefaultParameterTransformerDefinitionTest {
 
     @Test
     void must_have_string_or_object_as_from_value() throws Throwable {
-        Method threeArg = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("map_as_from_value", Map.class, Type.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultParameterTransformerDefinition(threeArg, lookup));
+        Method threeArg = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("map_as_from_value", Map.class,
+            Type.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultParameterTransformerDefinition(threeArg, lookup));
     }
-
 
     public Object map_as_from_value(Map<String, String> fromValue, Type toValueType) {
         return "map_as_from_value";
@@ -91,8 +100,10 @@ class JavaDefaultParameterTransformerDefinitionTest {
 
     @Test
     void must_have_type_as_to_value_type() throws Throwable {
-        Method threeArg = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("object_as_to_value_type", String.class, Object.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaDefaultParameterTransformerDefinition(threeArg, lookup));
+        Method threeArg = JavaDefaultParameterTransformerDefinitionTest.class.getMethod("object_as_to_value_type",
+            String.class, Object.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaDefaultParameterTransformerDefinition(threeArg, lookup));
     }
 
     public Object object_as_to_value_type(String fromValue, Object toValueType) {

--- a/java/src/test/java/io/cucumber/java/JavaDocStringTypeDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaDocStringTypeDefinitionTest.java
@@ -25,7 +25,8 @@ class JavaDocStringTypeDefinitionTest {
 
     private final DocString docString = DocString.create("some doc string", "text/plain");
     private final DocStringTypeRegistry registry = new DocStringTypeRegistry();
-    private final DocStringTypeRegistryDocStringConverter converter = new DocStringTypeRegistryDocStringConverter(registry);
+    private final DocStringTypeRegistryDocStringConverter converter = new DocStringTypeRegistryDocStringConverter(
+        registry);
 
     @Test
     void can_define_doc_string_converter() throws NoSuchMethodException {
@@ -43,7 +44,8 @@ class JavaDocStringTypeDefinitionTest {
     void must_have_exactly_one_argument() throws NoSuchMethodException {
         Method noArgs = JavaDocStringTypeDefinitionTest.class.getMethod("converts_nothing_to_string");
         assertThrows(InvalidMethodSignatureException.class, () -> new JavaDocStringTypeDefinition("", noArgs, lookup));
-        Method twoArgs = JavaDocStringTypeDefinitionTest.class.getMethod("converts_two_strings_to_string", String.class, String.class);
+        Method twoArgs = JavaDocStringTypeDefinitionTest.class.getMethod("converts_two_strings_to_string", String.class,
+            String.class);
         assertThrows(InvalidMethodSignatureException.class, () -> new JavaDocStringTypeDefinition("", twoArgs, lookup));
     }
 
@@ -60,12 +62,11 @@ class JavaDocStringTypeDefinitionTest {
         Method method = JavaDocStringTypeDefinitionTest.class.getMethod("converts_object_to_string", Object.class);
         InvalidMethodSignatureException exception = assertThrows(
             InvalidMethodSignatureException.class,
-            () -> new JavaDocStringTypeDefinition("", method, lookup)
-        );
+            () -> new JavaDocStringTypeDefinition("", method, lookup));
         assertThat(exception.getMessage(), startsWith("" +
-            "A @DocStringType annotated method must have one of these signatures:\n" +
-            " * public JsonNode json(String content)\n" +
-            "at io.cucumber.java.JavaDocStringTypeDefinitionTest.converts_object_to_string(java.lang.Object)"));
+                "A @DocStringType annotated method must have one of these signatures:\n" +
+                " * public JsonNode json(String content)\n" +
+                "at io.cucumber.java.JavaDocStringTypeDefinitionTest.converts_object_to_string(java.lang.Object)"));
     }
 
     public Object converts_object_to_string(Object object) {
@@ -82,4 +83,3 @@ class JavaDocStringTypeDefinitionTest {
     }
 
 }
-

--- a/java/src/test/java/io/cucumber/java/JavaHookDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaHookDefinitionTest.java
@@ -17,8 +17,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@SuppressWarnings({"WeakerAccess"})
-@ExtendWith({MockitoExtension.class})
+@SuppressWarnings({ "WeakerAccess" })
+@ExtendWith({ MockitoExtension.class })
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class JavaHookDefinitionTest {
 
@@ -44,7 +44,6 @@ public class JavaHookDefinitionTest {
         assertTrue(invoked);
     }
 
-
     @Before
     public void no_arguments() {
         invoked = true;
@@ -68,15 +67,13 @@ public class JavaHookDefinitionTest {
         Method method = JavaHookDefinitionTest.class.getMethod("invalid_parameter", String.class);
         InvalidMethodSignatureException exception = assertThrows(
             InvalidMethodSignatureException.class,
-            () -> new JavaHookDefinition(method, "", 0, lookup)
-        );
+            () -> new JavaHookDefinition(method, "", 0, lookup));
         assertThat(exception.getMessage(), startsWith("" +
-            "A method annotated with Before, After, BeforeStep or AfterStep must have one of these signatures:\n" +
-            " * public void before_or_after(io.cucumber.java.Scenario scenario)\n" +
-            " * public void before_or_after()\n" +
-            "at io.cucumber.java.JavaHookDefinitionTest.invalid_parameter(java.lang.String"));
+                "A method annotated with Before, After, BeforeStep or AfterStep must have one of these signatures:\n" +
+                " * public void before_or_after(io.cucumber.java.Scenario scenario)\n" +
+                " * public void before_or_after()\n" +
+                "at io.cucumber.java.JavaHookDefinitionTest.invalid_parameter(java.lang.String"));
     }
-
 
     public void invalid_parameter(String badType) {
 
@@ -87,10 +84,8 @@ public class JavaHookDefinitionTest {
         Method method = JavaHookDefinitionTest.class.getMethod("invalid_generic_parameter", List.class);
         assertThrows(
             InvalidMethodSignatureException.class,
-            () -> new JavaHookDefinition(method, "", 0, lookup)
-        );
+            () -> new JavaHookDefinition(method, "", 0, lookup));
     }
-
 
     public void invalid_generic_parameter(List<String> badType) {
 
@@ -101,10 +96,8 @@ public class JavaHookDefinitionTest {
         Method method = JavaHookDefinitionTest.class.getMethod("too_many_parameters", Scenario.class, String.class);
         assertThrows(
             InvalidMethodSignatureException.class,
-            () -> new JavaHookDefinition(method, "", 0, lookup)
-        );
+            () -> new JavaHookDefinition(method, "", 0, lookup));
     }
-
 
     public void too_many_parameters(Scenario arg1, String arg2) {
 

--- a/java/src/test/java/io/cucumber/java/JavaParameterTypeDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaParameterTypeDefinitionTest.java
@@ -32,10 +32,13 @@ class JavaParameterTypeDefinitionTest {
 
     @Test
     void can_define_parameter_type_converters_with_one_capture_group() throws NoSuchMethodException {
-        Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_one_capture_group_to_string", String.class);
-        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup);
+        Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_one_capture_group_to_string",
+            String.class);
+        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "(.*)", method, false, false,
+            false, lookup);
         registry.defineParameterType(definition.parameterType());
-        Expression cucumberExpression = new ExpressionFactory(registry).createExpression("{convert_one_capture_group_to_string}");
+        Expression cucumberExpression = new ExpressionFactory(registry)
+                .createExpression("{convert_one_capture_group_to_string}");
         List<Argument<?>> test = cucumberExpression.match("test");
         assertThat(test.get(0).getValue(), equalTo("convert_one_capture_group_to_string"));
     }
@@ -46,10 +49,13 @@ class JavaParameterTypeDefinitionTest {
 
     @Test
     void can_define_parameter_type_converters_with_two_capture_groups() throws NoSuchMethodException {
-        Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_two_capture_group_to_string", String.class, String.class);
-        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "([^ ]*) ([^ ]*)", method, false, false, false, lookup);
+        Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_two_capture_group_to_string",
+            String.class, String.class);
+        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "([^ ]*) ([^ ]*)", method, false,
+            false, false, lookup);
         registry.defineParameterType(definition.parameterType());
-        Expression cucumberExpression = new ExpressionFactory(registry).createExpression("{convert_two_capture_group_to_string}");
+        Expression cucumberExpression = new ExpressionFactory(registry)
+                .createExpression("{convert_two_capture_group_to_string}");
         List<Argument<?>> test = cucumberExpression.match("test test");
         assertThat(test.get(0).getValue(), equalTo("convert_two_capture_group_to_string"));
     }
@@ -60,10 +66,13 @@ class JavaParameterTypeDefinitionTest {
 
     @Test
     void can_define_parameter_type_converters_with_var_args() throws NoSuchMethodException {
-        Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_varargs_capture_group_to_string", String[].class);
-        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "([^ ]*) ([^ ]*)", method, false, false, false, lookup);
+        Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_varargs_capture_group_to_string",
+            String[].class);
+        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "([^ ]*) ([^ ]*)", method, false,
+            false, false, lookup);
         registry.defineParameterType(definition.parameterType());
-        Expression cucumberExpression = new ExpressionFactory(registry).createExpression("{convert_varargs_capture_group_to_string}");
+        Expression cucumberExpression = new ExpressionFactory(registry)
+                .createExpression("{convert_varargs_capture_group_to_string}");
         List<Argument<?>> test = cucumberExpression.match("test test");
         assertThat(test.get(0).getValue(), equalTo("convert_varargs_capture_group_to_string"));
     }
@@ -74,19 +83,22 @@ class JavaParameterTypeDefinitionTest {
 
     @Test
     void arguments_must_match_captured_groups() throws NoSuchMethodException {
-        Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_two_capture_group_to_string", String.class, String.class);
-        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", ".*", method, false, false, false, lookup);
+        Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_two_capture_group_to_string",
+            String.class, String.class);
+        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", ".*", method, false, false, false,
+            lookup);
         registry.defineParameterType(definition.parameterType());
-        Expression cucumberExpression = new ExpressionFactory(registry).createExpression("{convert_two_capture_group_to_string}");
+        Expression cucumberExpression = new ExpressionFactory(registry)
+                .createExpression("{convert_two_capture_group_to_string}");
         List<Argument<?>> test = cucumberExpression.match("test");
         assertThrows(CucumberExpressionException.class, () -> test.get(0).getValue());
     }
 
-
     @Test
     void converter_must_have_return_type() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_capture_group_to_void", String.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
     }
 
     public void convert_capture_group_to_void(String all) {
@@ -94,10 +106,13 @@ class JavaParameterTypeDefinitionTest {
 
     @Test
     void converter_may_have_non_generic_return_type() throws NoSuchMethodException {
-        Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_capture_group_to_optional_string", String.class);
-        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup);
+        Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_capture_group_to_optional_string",
+            String.class);
+        JavaParameterTypeDefinition definition = new JavaParameterTypeDefinition("", "(.*)", method, false, false,
+            false, lookup);
         registry.defineParameterType(definition.parameterType());
-        Expression cucumberExpression = new ExpressionFactory(registry).createExpression("{convert_capture_group_to_optional_string}");
+        Expression cucumberExpression = new ExpressionFactory(registry)
+                .createExpression("{convert_capture_group_to_optional_string}");
         List<Argument<?>> args = cucumberExpression.match("convert_capture_group_to_optional_string");
         assertThat(args.get(0).getValue(), is(Optional.of("convert_capture_group_to_optional_string")));
     }
@@ -109,7 +124,8 @@ class JavaParameterTypeDefinitionTest {
     @Test
     void converter_must_have_at_least_one_argument() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("convert_nothing_to_string");
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
     }
 
     public String convert_nothing_to_string() {
@@ -119,7 +135,8 @@ class JavaParameterTypeDefinitionTest {
     @Test
     void converter_must_have_string_arguments() throws NoSuchMethodException {
         Method method = JavaParameterTypeDefinitionTest.class.getMethod("converts_object_to_string", Object.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
     }
 
     public String converts_object_to_string(Object other) {
@@ -128,8 +145,10 @@ class JavaParameterTypeDefinitionTest {
 
     @Test
     void converter_must_have_all_string_arguments() throws NoSuchMethodException {
-        Method method = JavaParameterTypeDefinitionTest.class.getMethod("converts_objects_to_string", String.class, Object.class);
-        assertThrows(InvalidMethodSignatureException.class, () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
+        Method method = JavaParameterTypeDefinitionTest.class.getMethod("converts_objects_to_string", String.class,
+            Object.class);
+        assertThrows(InvalidMethodSignatureException.class,
+            () -> new JavaParameterTypeDefinition("", "(.*)", method, false, false, false, lookup));
     }
 
     public String converts_objects_to_string(String all, Object other) {

--- a/java/src/test/java/io/cucumber/java/JavaSnippetTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaSnippetTest.java
@@ -25,25 +25,26 @@ class JavaSnippetTest {
     @Test
     void generatesPlainSnippet() {
         String expected = "" +
-            "@Given(\"I have {int} cukes in my {string} belly\")\n" +
-            "public void i_have_cukes_in_my_belly(Integer int1, String string) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"I have {int} cukes in my {string} belly\")\n" +
+                "public void i_have_cukes_in_my_belly(Integer int1, String string) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetFor("I have 4 cukes in my \"big\" belly"), is(equalTo(expected)));
     }
 
     private String snippetFor(String stepText) {
         Step step = createStep(stepText);
-        List<String> snippet = new SnippetGenerator(new JavaSnippet(), new ParameterTypeRegistry(Locale.ENGLISH)).getSnippet(step, snippetType);
+        List<String> snippet = new SnippetGenerator(new JavaSnippet(), new ParameterTypeRegistry(Locale.ENGLISH))
+                .getSnippet(step, snippetType);
         return String.join("\n", snippet);
     }
 
     private Step createStep(String stepText) {
         String source = "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test Scenario\n" +
-            "    Given " + stepText + "\n";
+                "Feature: Test feature\n" +
+                "  Scenario: Test Scenario\n" +
+                "    Given " + stepText + "\n";
 
         Feature feature = TestFeatureParser.parse(source);
         return feature.getPickles().get(0).getSteps().get(0);
@@ -57,15 +58,14 @@ class JavaSnippetTest {
             Size.class,
             (String... groups) -> null,
             true,
-            false
-        );
+            false);
 
         String expected = "" +
-            "@Given(\"I have {double} cukes in my {size} belly\")\n" +
-            "public void i_have_cukes_in_my_belly(Double double1, Size size) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"I have {double} cukes in my {size} belly\")\n" +
+                "public void i_have_cukes_in_my_belly(Double double1, Size size) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetFor("I have 4.2 cukes in my large belly", customParameterType), is(equalTo(expected)));
     }
 
@@ -73,7 +73,8 @@ class JavaSnippetTest {
         Step step = createStep(stepText);
         ParameterTypeRegistry parameterTypeRegistry = new ParameterTypeRegistry(Locale.ENGLISH);
         parameterTypeRegistry.defineParameterType(parameterType);
-        List<String> snippet = new SnippetGenerator(new JavaSnippet(), parameterTypeRegistry).getSnippet(step, snippetType);
+        List<String> snippet = new SnippetGenerator(new JavaSnippet(), parameterTypeRegistry).getSnippet(step,
+            snippetType);
         return String.join("\n", snippet);
     }
 
@@ -86,120 +87,122 @@ class JavaSnippetTest {
             }.getType(),
             (String[] groups) -> null,
             true,
-            false
-        );
+            false);
 
         String expected = "" +
-            "@Given(\"I have {sizes} bellies\")\n" +
-            "public void i_have_bellies(java.util.List<io.cucumber.java.JavaSnippetTest$Size> sizes) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"I have {sizes} bellies\")\n" +
+                "public void i_have_bellies(java.util.List<io.cucumber.java.JavaSnippetTest$Size> sizes) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetFor("I have large and small bellies", customParameterType), is(equalTo(expected)));
     }
 
     @Test
     void generatesCopyPasteReadyStepSnippetForNumberParameters() {
         String expected = "" +
-            "@Given(\"before {int} after\")\n" +
-            "public void before_after(Integer int1) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"before {int} after\")\n" +
+                "public void before_after(Integer int1) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetFor("before 5 after"), is(equalTo(expected)));
     }
 
     @Test
     void generatesCopyPasteReadySnippetWhenStepHasIllegalJavaIdentifierChars() {
         String expected = "" +
-            "@Given(\"I have {int} cukes in: my {string} red-belly!\")\n" +
-            "public void i_have_cukes_in_my_red_belly(Integer int1, String string) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"I have {int} cukes in: my {string} red-belly!\")\n" +
+                "public void i_have_cukes_in_my_red_belly(Integer int1, String string) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetFor("I have 4 cukes in: my \"big\" red-belly!"), is(equalTo(expected)));
     }
 
     @Test
     void generatesCopyPasteReadySnippetWhenStepHasIntegersInsideStringParameter() {
         String expected = "" +
-            "@Given(\"the DI system receives a message saying {string}\")\n" +
-            "public void the_DI_system_receives_a_message_saying(String string) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
-        assertThat(expected, snippetFor("the DI system receives a message saying \"{ dataIngestion: { feeds: [ feed: { merchantId: 666, feedId: 1, feedFileLocation: feed.csv } ] }\""), is(equalTo(expected)));
+                "@Given(\"the DI system receives a message saying {string}\")\n" +
+                "public void the_DI_system_receives_a_message_saying(String string) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
+        assertThat(expected, snippetFor(
+            "the DI system receives a message saying \"{ dataIngestion: { feeds: [ feed: { merchantId: 666, feedId: 1, feedFileLocation: feed.csv } ] }\""),
+            is(equalTo(expected)));
     }
 
     @Test
     void generatesSnippetWithQuestionMarks() {
         String expected = "" +
-            "@Given(\"is there an error?:\")\n" +
-            "public void is_there_an_error() {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"is there an error?:\")\n" +
+                "public void is_there_an_error() {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetFor("is there an error?:"), is(equalTo(expected)));
     }
 
     @Test
     void generatesSnippetWithLotsOfNonIdentifierCharacters() {
         String expected = "" +
-            "@Given(\"\\\\([a-z]*)?.+\")\n" +
-            "public void a_z() {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"\\\\([a-z]*)?.+\")\n" +
+                "public void a_z() {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetFor("([a-z]*)?.+"), is(equalTo(expected)));
     }
 
     @Test
     void generatesSnippetWithParentheses() {
         String expected = "" +
-            "@Given(\"I have {int} cukes \\\\(maybe more)\")\n" +
-            "public void i_have_cukes_maybe_more(Integer int1) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"I have {int} cukes \\\\(maybe more)\")\n" +
+                "public void i_have_cukes_maybe_more(Integer int1) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetFor("I have 5 cukes (maybe more)"), is(equalTo(expected)));
     }
 
     @Test
     void generatesSnippetWithBrackets() {
         String expected = "" +
-            "@Given(\"I have {int} cukes [maybe more]\")\n" +
-            "public void i_have_cukes_maybe_more(Integer int1) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"I have {int} cukes [maybe more]\")\n" +
+                "public void i_have_cukes_maybe_more(Integer int1) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetFor("I have 5 cukes [maybe more]"), is(equalTo(expected)));
     }
 
     @Test
     void generatesSnippetWithDocString() {
         String expected = "" +
-            "@Given(\"I have:\")\n" +
-            "public void i_have(String docString) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"I have:\")\n" +
+                "public void i_have(String docString) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetForDocString("I have:", "hello"), is(equalTo(expected)));
     }
 
     private String snippetForDocString(String stepText, String docString) {
         Step step = createStepWithDocString(stepText, docString);
-        List<String> snippet = new SnippetGenerator(new JavaSnippet(), new ParameterTypeRegistry(Locale.ENGLISH)).getSnippet(step, snippetType);
+        List<String> snippet = new SnippetGenerator(new JavaSnippet(), new ParameterTypeRegistry(Locale.ENGLISH))
+                .getSnippet(step, snippetType);
         return String.join("\n", snippet);
     }
 
     private Step createStepWithDocString(String stepText, String docString) {
         String source = "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test Scenario\n" +
-            "    Given " + stepText + "\n" +
-            "      \"\"\"\n" +
-            "      " + docString + "\n" +
-            "      \"\"\"";
+                "Feature: Test feature\n" +
+                "  Scenario: Test Scenario\n" +
+                "    Given " + stepText + "\n" +
+                "      \"\"\"\n" +
+                "      " + docString + "\n" +
+                "      \"\"\"";
 
         Feature feature = TestFeatureParser.parse(source);
         return feature.getPickles().get(0).getSteps().get(0);
@@ -213,29 +216,30 @@ class JavaSnippetTest {
             String.class,
             (String[] groups) -> null,
             true,
-            false
-        );
+            false);
 
         String expected = "" +
-            "@Given(\"I have a {docString}:\")\n" +
-            "public void i_have_a(String docString, String docString1) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}" +
-            "\n" +
-            "@Given(\"I have a {string}:\")\n" +
-            "public void i_have_a(String string, String docString) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
-        assertThat(snippetForDocString("I have a \"Documentation String\":", "hello", customParameterType), is(equalTo(expected)));
+                "@Given(\"I have a {docString}:\")\n" +
+                "public void i_have_a(String docString, String docString1) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}" +
+                "\n" +
+                "@Given(\"I have a {string}:\")\n" +
+                "public void i_have_a(String string, String docString) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
+        assertThat(snippetForDocString("I have a \"Documentation String\":", "hello", customParameterType),
+            is(equalTo(expected)));
     }
 
     private String snippetForDocString(String stepText, String docString, ParameterType<String> parameterType) {
         Step step = createStepWithDocString(stepText, docString);
         ParameterTypeRegistry parameterTypeRegistry = new ParameterTypeRegistry(Locale.ENGLISH);
         parameterTypeRegistry.defineParameterType(parameterType);
-        List<String> snippet = new SnippetGenerator(new JavaSnippet(), parameterTypeRegistry).getSnippet(step, snippetType);
+        List<String> snippet = new SnippetGenerator(new JavaSnippet(), parameterTypeRegistry).getSnippet(step,
+            snippetType);
         return String.join("\n", snippet);
     }
 
@@ -243,43 +247,44 @@ class JavaSnippetTest {
     @Disabled("TODO issue tracked to within io.cucumber.cucumberexpressions.CucumberExpressionGenerator")
     void recognisesWordWithNumbers() {
         String expected = "" +
-            "@Given(\"Then it responds ([\\\"]*)\")\n" +
-            "public void Then_it_responds(String arg1) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "}";
+                "@Given(\"Then it responds ([\\\"]*)\")\n" +
+                "public void Then_it_responds(String arg1) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "}";
         assertThat(snippetFor("Then it responds UTF-8"), is(equalTo(expected)));
     }
 
     @Test
     void generatesSnippetWithDataTable() {
         String expected = "" +
-            "@Given(\"I have:\")\n" +
-            "public void i_have(io.cucumber.datatable.DataTable dataTable) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    // For automatic transformation, change DataTable to one of\n" +
-            "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
-            "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
-            "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
-            "    //\n" +
-            "    // For other transformations you can register a DataTableType.\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"I have:\")\n" +
+                "public void i_have(io.cucumber.datatable.DataTable dataTable) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    // For automatic transformation, change DataTable to one of\n" +
+                "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
+                "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
+                "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
+                "    //\n" +
+                "    // For other transformations you can register a DataTableType.\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetForDataTable("I have:"), is(equalTo(expected)));
     }
 
     private String snippetForDataTable(String stepText) {
         Step step = createStepWithDataTable(stepText);
-        List<String> snippet = new SnippetGenerator(new JavaSnippet(), new ParameterTypeRegistry(Locale.ENGLISH)).getSnippet(step, snippetType);
+        List<String> snippet = new SnippetGenerator(new JavaSnippet(), new ParameterTypeRegistry(Locale.ENGLISH))
+                .getSnippet(step, snippetType);
         return String.join("\n", snippet);
     }
 
     private Step createStepWithDataTable(String stepText) {
         String source = "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test Scenario\n" +
-            "    Given " + stepText + "\n" +
-            "      | key   | \n" +
-            "      | value | \n";
+                "Feature: Test feature\n" +
+                "  Scenario: Test Scenario\n" +
+                "    Given " + stepText + "\n" +
+                "      | key   | \n" +
+                "      | value | \n";
 
         Feature feature = TestFeatureParser.parse(source);
         return feature.getPickles().get(0).getSteps().get(0);
@@ -296,29 +301,29 @@ class JavaSnippetTest {
             false);
 
         String expected = "" +
-            "@Given(\"I have in table {dataTable}:\")\n" +
-            "public void i_have_in_table(String dataTable, io.cucumber.datatable.DataTable dataTable1) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    // For automatic transformation, change DataTable to one of\n" +
-            "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
-            "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
-            "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
-            "    //\n" +
-            "    // For other transformations you can register a DataTableType.\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}" +
-            "\n" +
-            "@Given(\"I have in table {string}:\")\n" +
-            "public void i_have_in_table(String string, io.cucumber.datatable.DataTable dataTable) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    // For automatic transformation, change DataTable to one of\n" +
-            "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
-            "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
-            "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
-            "    //\n" +
-            "    // For other transformations you can register a DataTableType.\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"I have in table {dataTable}:\")\n" +
+                "public void i_have_in_table(String dataTable, io.cucumber.datatable.DataTable dataTable1) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    // For automatic transformation, change DataTable to one of\n" +
+                "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
+                "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
+                "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
+                "    //\n" +
+                "    // For other transformations you can register a DataTableType.\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}" +
+                "\n" +
+                "@Given(\"I have in table {string}:\")\n" +
+                "public void i_have_in_table(String string, io.cucumber.datatable.DataTable dataTable) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    // For automatic transformation, change DataTable to one of\n" +
+                "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
+                "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
+                "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
+                "    //\n" +
+                "    // For other transformations you can register a DataTableType.\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetForDataTable("I have in table \"M6\":", customParameterType), is(equalTo(expected)));
     }
 
@@ -326,18 +331,19 @@ class JavaSnippetTest {
         Step step = createStepWithDataTable(stepText);
         ParameterTypeRegistry parameterTypeRegistry = new ParameterTypeRegistry(Locale.ENGLISH);
         parameterTypeRegistry.defineParameterType(parameterType);
-        List<String> snippet = new SnippetGenerator(new JavaSnippet(), parameterTypeRegistry).getSnippet(step, snippetType);
+        List<String> snippet = new SnippetGenerator(new JavaSnippet(), parameterTypeRegistry).getSnippet(step,
+            snippetType);
         return String.join("\n", snippet);
     }
 
     @Test
     void generateSnippetWithOutlineParam() {
         String expected = "" +
-            "@Given(\"Then it responds <param>\")\n" +
-            "public void then_it_responds_param() {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"Then it responds <param>\")\n" +
+                "public void then_it_responds_param() {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
 
         assertThat(snippetFor("Then it responds <param>"), is(equalTo(expected)));
     }
@@ -345,46 +351,48 @@ class JavaSnippetTest {
     @Test
     void generatesSnippetUsingFirstGivenWhenThenKeyWord() {
         String expected = "" +
-            "@When(\"I have {int} cukes in my {string} belly\")\n" +
-            "public void i_have_cukes_in_my_belly(Integer int1, String string) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@When(\"I have {int} cukes in my {string} belly\")\n" +
+                "public void i_have_cukes_in_my_belly(Integer int1, String string) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetForWhenAnd("I have 4 cukes in my \"big\" belly"), is(equalTo(expected)));
     }
 
     private String snippetForWhenAnd(String stepText) {
         String source = "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test Scenario\n" +
-            "    When some other step\n" +
-            "    And " + stepText + "\n";
+                "Feature: Test feature\n" +
+                "  Scenario: Test Scenario\n" +
+                "    When some other step\n" +
+                "    And " + stepText + "\n";
 
         Feature feature = TestFeatureParser.parse(source);
         Step step = feature.getPickles().get(0).getSteps().get(1);
-        List<String> snippet = new SnippetGenerator(new JavaSnippet(), new ParameterTypeRegistry(Locale.ENGLISH)).getSnippet(step, snippetType);
+        List<String> snippet = new SnippetGenerator(new JavaSnippet(), new ParameterTypeRegistry(Locale.ENGLISH))
+                .getSnippet(step, snippetType);
         return String.join("\n", snippet);
     }
 
     @Test
     void generatesSnippetDefaultsToGiven() {
         String expected = "" +
-            "@Given(\"I have {int} cukes in my {string} belly\")\n" +
-            "public void i_have_cukes_in_my_belly(Integer int1, String string) {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java.PendingException();\n" +
-            "}";
+                "@Given(\"I have {int} cukes in my {string} belly\")\n" +
+                "public void i_have_cukes_in_my_belly(Integer int1, String string) {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
         assertThat(snippetForWildCard("I have 4 cukes in my \"big\" belly"), is(equalTo(expected)));
     }
 
     private String snippetForWildCard(String stepText) {
         String source = "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test Scenario\n" +
-            "    * " + stepText + "\n";
+                "Feature: Test feature\n" +
+                "  Scenario: Test Scenario\n" +
+                "    * " + stepText + "\n";
         Feature feature = TestFeatureParser.parse(source);
         Step step = feature.getPickles().get(0).getSteps().get(0);
-        List<String> snippet = new SnippetGenerator(new JavaSnippet(), new ParameterTypeRegistry(Locale.ENGLISH)).getSnippet(step, snippetType);
+        List<String> snippet = new SnippetGenerator(new JavaSnippet(), new ParameterTypeRegistry(Locale.ENGLISH))
+                .getSnippet(step, snippetType);
         return String.join("\n", snippet);
     }
 

--- a/java/src/test/java/io/cucumber/java/JavaStepDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaStepDefinitionTest.java
@@ -30,7 +30,7 @@ class JavaStepDefinitionTest {
     void can_define_step() throws Throwable {
         Method method = JavaStepDefinitionTest.class.getMethod("one_string_argument", String.class);
         JavaStepDefinition definition = new JavaStepDefinition(method, "three (.*) mice", lookup);
-        definition.execute(new Object[]{"one_string_argument"});
+        definition.execute(new Object[] { "one_string_argument" });
         assertThat(argument, is("one_string_argument"));
     }
 
@@ -42,14 +42,15 @@ class JavaStepDefinitionTest {
     void can_provide_location_of_step() throws Throwable {
         Method method = JavaStepDefinitionTest.class.getMethod("method_throws");
         JavaStepDefinition definition = new JavaStepDefinition(method, "three (.*) mice", lookup);
-        CucumberInvocationTargetException exception = assertThrows(CucumberInvocationTargetException.class, () -> definition.execute(new Object[0]));
-        Optional<StackTraceElement> match = stream(exception.getInvocationTargetExceptionCause().getStackTrace()).filter(definition::isDefinedAt).findFirst();
+        CucumberInvocationTargetException exception = assertThrows(CucumberInvocationTargetException.class,
+            () -> definition.execute(new Object[0]));
+        Optional<StackTraceElement> match = stream(exception.getInvocationTargetExceptionCause().getStackTrace())
+                .filter(definition::isDefinedAt).findFirst();
         StackTraceElement stackTraceElement = match.get();
 
-        assertAll("Checking StackTraceElement",
+        assertAll(
             () -> assertThat(stackTraceElement.getMethodName(), is("method_throws")),
-            () -> assertThat(stackTraceElement.getClassName(), is(JavaStepDefinitionTest.class.getName()))
-        );
+            () -> assertThat(stackTraceElement.getClassName(), is(JavaStepDefinitionTest.class.getName())));
     }
 
     public void method_throws() {

--- a/java/src/test/java/io/cucumber/java/JavaStepDefinitionTransposeTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaStepDefinitionTransposeTest.java
@@ -39,7 +39,9 @@ class JavaStepDefinitionTransposeTest {
 
         }
 
-        public void transposedMapOfDoubleToListOfDouble(@Transpose Map<Double, List<Double>> mapOfDoubleToListOfDouble) {
+        public void transposedMapOfDoubleToListOfDouble(
+                @Transpose Map<Double, List<Double>> mapOfDoubleToListOfDouble
+        ) {
         }
 
     }

--- a/java/src/test/java/io/cucumber/java/MethodFormatTest.java
+++ b/java/src/test/java/io/cucumber/java/MethodFormatTest.java
@@ -25,17 +25,20 @@ class MethodFormatTest {
     @BeforeEach
     void lookupMethod() throws NoSuchMethodException {
         this.methodWithoutArgs = this.getClass().getMethod("methodWithoutArgs");
-        this.methodWithArgsAndException = this.getClass().getMethod("methodWithArgsAndException", String.class, Map.class);
+        this.methodWithArgsAndException = this.getClass().getMethod("methodWithArgsAndException", String.class,
+            Map.class);
     }
 
     @Test
     void shouldUseSimpleFormatWhenMethodHasException() {
-        assertThat(MethodFormat.FULL.format(methodWithoutArgs), startsWith("io.cucumber.java.MethodFormatTest.methodWithoutArgs()"));
+        assertThat(MethodFormat.FULL.format(methodWithoutArgs),
+            startsWith("io.cucumber.java.MethodFormatTest.methodWithoutArgs()"));
     }
 
     @Test
     void shouldUseSimpleFormatWhenMethodHasNoException() {
-        assertThat(MethodFormat.FULL.format(methodWithArgsAndException), startsWith("io.cucumber.java.MethodFormatTest.methodWithArgsAndException(java.lang.String,java.util.Map)"));
+        assertThat(MethodFormat.FULL.format(methodWithArgsAndException),
+            startsWith("io.cucumber.java.MethodFormatTest.methodWithArgsAndException(java.lang.String,java.util.Map)"));
     }
 
 }

--- a/java/src/test/java/io/cucumber/java/MethodScannerTest.java
+++ b/java/src/test/java/io/cucumber/java/MethodScannerTest.java
@@ -20,8 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class MethodScannerTest {
 
     private final List<Map.Entry<Method, Annotation>> scanResult = new ArrayList<>();
-    private final BiConsumer<Method, Annotation> backend = (method, annotation) ->
-        scanResult.add(new SimpleEntry<>(method, annotation));
+    private final BiConsumer<Method, Annotation> backend = (method, annotation) -> scanResult
+            .add(new SimpleEntry<>(method, annotation));
 
     @BeforeEach
     void createBackend() {
@@ -49,11 +49,11 @@ class MethodScannerTest {
 
     @Test
     void loadGlue_fails_when_class_is_not_method_declaring_class() {
-        InvalidMethodException exception = assertThrows(InvalidMethodException.class, () -> MethodScanner.scan(ExtendedSteps.class, backend));
+        InvalidMethodException exception = assertThrows(InvalidMethodException.class,
+            () -> MethodScanner.scan(ExtendedSteps.class, backend));
         assertThat(exception.getMessage(), is(
             "You're not allowed to extend classes that define Step Definitions or hooks. " +
-                "class io.cucumber.java.MethodScannerTest$ExtendedSteps extends class io.cucumber.java.MethodScannerTest$BaseSteps"
-        ));
+                    "class io.cucumber.java.MethodScannerTest$ExtendedSteps extends class io.cucumber.java.MethodScannerTest$BaseSteps"));
     }
 
     public static class ExtendedSteps extends BaseSteps {

--- a/java/src/test/java/io/cucumber/java/annotation/DataTableSteps.java
+++ b/java/src/test/java/io/cucumber/java/annotation/DataTableSteps.java
@@ -84,23 +84,27 @@ public class DataTableSteps {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
 
             Author author = (Author) o;
 
-            if (!firstName.equals(author.firstName)) return false;
-            if (!lastName.equals(author.lastName)) return false;
+            if (!firstName.equals(author.firstName))
+                return false;
+            if (!lastName.equals(author.lastName))
+                return false;
             return birthDate.equals(author.birthDate);
         }
 
         @Override
         public String toString() {
             return "Author{" +
-                "firstName='" + firstName + '\'' +
-                ", lastName='" + lastName + '\'' +
-                ", birthDate='" + birthDate + '\'' +
-                '}';
+                    "firstName='" + firstName + '\'' +
+                    ", lastName='" + lastName + '\'' +
+                    ", birthDate='" + birthDate + '\'' +
+                    '}';
         }
 
     }
@@ -122,14 +126,15 @@ public class DataTableSteps {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             Person person = (Person) o;
             return first.equals(person.first) &&
-                last.equals(person.last);
+                    last.equals(person.last);
         }
 
     }
-
 
 }

--- a/java/src/test/java/io/cucumber/java/annotation/SubstitutionSteps.java
+++ b/java/src/test/java/io/cucumber/java/annotation/SubstitutionSteps.java
@@ -11,10 +11,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SubstitutionSteps {
 
-    private static final Map<String, String> ROLES = new HashMap<String, String>() {{
-        put("Manager", "now able to manage your employee accounts");
-        put("Admin", "able to manage any user account on the system");
-    }};
+    private static final Map<String, String> ROLES = new HashMap<String, String>() {
+        {
+            put("Manager", "now able to manage your employee accounts");
+            put("Admin", "able to manage any user account on the system");
+        }
+    };
 
     private String name;
     private String role;
@@ -34,8 +36,9 @@ public class SubstitutionSteps {
     @Then("I should receive an email with the body:")
     public void I_should_receive_an_email_with_the_body(String body) {
         String expected = String.format("Dear %s,\n" +
-            "You have been granted %s rights.  You are %s. Please be responsible.\n" +
-            "-The Admins", name, role, details);
+                "You have been granted %s rights.  You are %s. Please be responsible.\n" +
+                "-The Admins",
+            name, role, details);
         assertEquals(expected, body);
     }
 

--- a/java/src/test/java/io/cucumber/java/annotation/TypeRegistryConfiguration.java
+++ b/java/src/test/java/io/cucumber/java/annotation/TypeRegistryConfiguration.java
@@ -9,12 +9,10 @@ import java.time.LocalDate;
 
 public class TypeRegistryConfiguration implements TypeRegistryConfigurer {
 
-    private final CaptureGroupTransformer<LocalDate> localDateParameterType =
-        (String[] args) -> LocalDate.of(
-            Integer.parseInt(args[0]),
-            Integer.parseInt(args[1]),
-            Integer.parseInt(args[2])
-        );
+    private final CaptureGroupTransformer<LocalDate> localDateParameterType = (String[] args) -> LocalDate.of(
+        Integer.parseInt(args[0]),
+        Integer.parseInt(args[1]),
+        Integer.parseInt(args[2]));
 
     @Override
     public void configureTypeRegistry(TypeRegistry typeRegistry) {
@@ -22,8 +20,7 @@ public class TypeRegistryConfiguration implements TypeRegistryConfigurer {
             "parameterTypeRegistryIso8601Date",
             "([0-9]{4})/([0-9]{2})/([0-9]{2})",
             LocalDate.class,
-            localDateParameterType
-        ));
+            localDateParameterType));
     }
 
 }

--- a/java/src/test/java/io/cucumber/java/defaultstransformer/DataTableSteps.java
+++ b/java/src/test/java/io/cucumber/java/defaultstransformer/DataTableSteps.java
@@ -46,7 +46,6 @@ public class DataTableSteps {
         assertThat(currency, is(Currency.getInstance("EUR")));
     }
 
-
     public static class Author {
 
         String firstName;
@@ -96,23 +95,27 @@ public class DataTableSteps {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
 
             Author author = (Author) o;
 
-            if (!firstName.equals(author.firstName)) return false;
-            if (!lastName.equals(author.lastName)) return false;
+            if (!firstName.equals(author.firstName))
+                return false;
+            if (!lastName.equals(author.lastName))
+                return false;
             return birthDate.equals(author.birthDate);
         }
 
         @Override
         public String toString() {
             return "Author{" +
-                "firstName='" + firstName + '\'' +
-                ", lastName='" + lastName + '\'' +
-                ", birthDate='" + birthDate + '\'' +
-                '}';
+                    "firstName='" + firstName + '\'' +
+                    ", lastName='" + lastName + '\'' +
+                    ", birthDate='" + birthDate + '\'' +
+                    '}';
         }
 
     }

--- a/java8/src/main/java/io/cucumber/java8/AbstractDatatableElementTransformerDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/AbstractDatatableElementTransformerDefinition.java
@@ -21,16 +21,16 @@ class AbstractDatatableElementTransformerDefinition extends AbstractGlueDefiniti
 
     DataTable replaceEmptyPatternsWithEmptyString(DataTable table) {
         List<List<String>> rawWithEmptyStrings = table.cells().stream()
-            .map(this::replaceEmptyPatternsWithEmptyString)
-            .collect(toList());
+                .map(this::replaceEmptyPatternsWithEmptyString)
+                .collect(toList());
 
         return create(rawWithEmptyStrings, table.getTableConverter());
     }
 
     List<String> replaceEmptyPatternsWithEmptyString(List<String> row) {
         return row.stream()
-            .map(this::replaceEmptyPatternsWithEmptyString)
-            .collect(toList());
+                .map(this::replaceEmptyPatternsWithEmptyString)
+                .collect(toList());
     }
 
     String replaceEmptyPatternsWithEmptyString(String t) {

--- a/java8/src/main/java/io/cucumber/java8/AbstractGlueDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/AbstractGlueDefinition.java
@@ -49,10 +49,10 @@ abstract class AbstractGlueDefinition implements ScenarioScoped {
         for (Class<?> aClass : rawArguments) {
             if (TypeResolver.Unknown.class.equals(aClass)) {
                 throw new IllegalStateException("" +
-                    "Could resolve the return type of the lambda at " + location.getFileName() + ":" + location.getLineNumber() + "\n" +
-                    "This version of cucumber-java8 is not compatible with Java 12+\n" +
-                    "See: https://github.com/cucumber/cucumber-jvm/issues/1817"
-                );
+                        "Could resolve the return type of the lambda at " + location.getFileName() + ":"
+                        + location.getLineNumber() + "\n" +
+                        "This version of cucumber-java8 is not compatible with Java 12+\n" +
+                        "See: https://github.com/cucumber/cucumber-jvm/issues/1817");
             }
         }
         return rawArguments;

--- a/java8/src/main/java/io/cucumber/java8/AbstractJavaSnippet.java
+++ b/java8/src/main/java/io/cucumber/java8/AbstractJavaSnippet.java
@@ -13,20 +13,23 @@ abstract class AbstractJavaSnippet implements Snippet {
     @Override
     public final String tableHint() {
         return "" +
-            "    // For automatic transformation, change DataTable to one of\n" +
-            "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
-            "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
-            "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
-            "    //\n" +
-            "    // For other transformations you can register a DataTableType.\n"; //TODO: Add doc URL
+                "    // For automatic transformation, change DataTable to one of\n" +
+                "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
+                "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
+                "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
+                "    //\n" +
+                "    // For other transformations you can register a DataTableType.\n"; // TODO:
+                                                                                        // Add
+                                                                                        // doc
+                                                                                        // URL
     }
 
     @Override
     public final String arguments(Map<String, Type> arguments) {
         return arguments.entrySet()
-            .stream()
-            .map(argType -> getArgType(argType.getValue()) + " " + argType.getKey())
-            .collect(joining(", "));
+                .stream()
+                .map(argType -> getArgType(argType.getValue()) + " " + argType.getKey())
+                .collect(joining(", "));
     }
 
     private String getArgType(Type argType) {

--- a/java8/src/main/java/io/cucumber/java8/Java8Backend.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8Backend.java
@@ -42,21 +42,22 @@ final class Java8Backend implements Backend {
         this.glue = glue;
         // Scan for Java8 style glue (lambdas)
         gluePaths.stream()
-            .filter(gluePath -> ClasspathSupport.CLASSPATH_SCHEME.equals(gluePath.getScheme()))
-            .map(ClasspathSupport::packageName)
-            .map(basePackageName -> classFinder.scanForSubClassesInPackage(basePackageName, LambdaGlue.class))
-            .flatMap(Collection::stream)
-            .filter(glueClass -> !glueClass.isInterface())
-            .filter(glueClass -> glueClass.getConstructors().length > 0)
-            .forEach(glueClass -> {
-                container.addClass(glueClass);
-                lambdaGlueClasses.add(glueClass);
-            });
+                .filter(gluePath -> ClasspathSupport.CLASSPATH_SCHEME.equals(gluePath.getScheme()))
+                .map(ClasspathSupport::packageName)
+                .map(basePackageName -> classFinder.scanForSubClassesInPackage(basePackageName, LambdaGlue.class))
+                .flatMap(Collection::stream)
+                .filter(glueClass -> !glueClass.isInterface())
+                .filter(glueClass -> glueClass.getConstructors().length > 0)
+                .forEach(glueClass -> {
+                    container.addClass(glueClass);
+                    lambdaGlueClasses.add(glueClass);
+                });
     }
 
     @Override
     public void buildWorld() {
-        // Instantiate all the stepdef classes for java8 - the stepdef will be initialised
+        // Instantiate all the stepdef classes for java8 - the stepdef will be
+        // initialised
         // in the constructor.
         LambdaGlueRegistry.INSTANCE.set(new GlueAdaptor(glue));
         for (Class<? extends LambdaGlue> lambdaGlueClass : lambdaGlueClasses) {
@@ -73,7 +74,6 @@ final class Java8Backend implements Backend {
     public Snippet getSnippet() {
         return new Java8Snippet();
     }
-
 
     private static final class GlueAdaptor implements LambdaGlueRegistry {
 
@@ -133,12 +133,16 @@ final class Java8Backend implements Backend {
         }
 
         @Override
-        public void addDefaultDataTableCellTransformer(DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer) {
+        public void addDefaultDataTableCellTransformer(
+                DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer
+        ) {
             glue.addDefaultDataTableCellTransformer(defaultDataTableCellTransformer);
         }
 
         @Override
-        public void addDefaultDataTableEntryTransformer(DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer) {
+        public void addDefaultDataTableEntryTransformer(
+                DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer
+        ) {
             glue.addDefaultDataTableEntryTransformer(defaultDataTableEntryTransformer);
         }
 

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableCellDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableCellDefinition.java
@@ -3,7 +3,8 @@ package io.cucumber.java8;
 import io.cucumber.core.backend.DataTableTypeDefinition;
 import io.cucumber.datatable.DataTableType;
 
-final class Java8DataTableCellDefinition extends AbstractDatatableElementTransformerDefinition implements DataTableTypeDefinition {
+final class Java8DataTableCellDefinition extends AbstractDatatableElementTransformerDefinition
+        implements DataTableTypeDefinition {
 
     private final DataTableType dataTableType;
 
@@ -12,8 +13,7 @@ final class Java8DataTableCellDefinition extends AbstractDatatableElementTransfo
         Class<?> returnType = resolveRawArguments(DataTableCellDefinitionBody.class, body.getClass())[0];
         this.dataTableType = new DataTableType(
             returnType,
-            (String cell) -> execute(replaceEmptyPatternsWithEmptyString(cell))
-        );
+            (String cell) -> execute(replaceEmptyPatternsWithEmptyString(cell)));
     }
 
     private Object execute(Object cell) {

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableDefinition.java
@@ -4,7 +4,8 @@ import io.cucumber.core.backend.DataTableTypeDefinition;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.datatable.DataTableType;
 
-final class Java8DataTableDefinition extends AbstractDatatableElementTransformerDefinition implements DataTableTypeDefinition {
+final class Java8DataTableDefinition extends AbstractDatatableElementTransformerDefinition
+        implements DataTableTypeDefinition {
 
     private final DataTableType dataTableType;
 
@@ -13,8 +14,7 @@ final class Java8DataTableDefinition extends AbstractDatatableElementTransformer
         Class<?> returnType = resolveRawArguments(DataTableDefinitionBody.class, body.getClass())[0];
         this.dataTableType = new DataTableType(
             returnType,
-            (DataTable table) -> execute(replaceEmptyPatternsWithEmptyString(table))
-        );
+            (DataTable table) -> execute(replaceEmptyPatternsWithEmptyString(table)));
     }
 
     private Object execute(DataTable table) {

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableEntryDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableEntryDefinition.java
@@ -5,7 +5,8 @@ import io.cucumber.datatable.DataTableType;
 
 import java.util.Map;
 
-final class Java8DataTableEntryDefinition extends AbstractDatatableElementTransformerDefinition implements DataTableTypeDefinition {
+final class Java8DataTableEntryDefinition extends AbstractDatatableElementTransformerDefinition
+        implements DataTableTypeDefinition {
 
     private final DataTableType dataTableType;
 
@@ -14,8 +15,7 @@ final class Java8DataTableEntryDefinition extends AbstractDatatableElementTransf
         Class<?> returnType = resolveRawArguments(DataTableEntryDefinitionBody.class, body.getClass())[0];
         this.dataTableType = new DataTableType(
             returnType,
-            (Map<String, String> entry) -> execute(replaceEmptyPatternsWithEmptyString(entry))
-        );
+            (Map<String, String> entry) -> execute(replaceEmptyPatternsWithEmptyString(entry)));
     }
 
     private Object execute(Map<String, String> entry) {

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableRowDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableRowDefinition.java
@@ -5,7 +5,8 @@ import io.cucumber.datatable.DataTableType;
 
 import java.util.List;
 
-final class Java8DataTableRowDefinition extends AbstractDatatableElementTransformerDefinition implements DataTableTypeDefinition {
+final class Java8DataTableRowDefinition extends AbstractDatatableElementTransformerDefinition
+        implements DataTableTypeDefinition {
 
     private final DataTableType dataTableType;
 
@@ -14,8 +15,7 @@ final class Java8DataTableRowDefinition extends AbstractDatatableElementTransfor
         Class<?> returnType = resolveRawArguments(DataTableRowDefinitionBody.class, body.getClass())[0];
         this.dataTableType = new DataTableType(
             returnType,
-            (List<String> row) -> execute(replaceEmptyPatternsWithEmptyString(row))
-        );
+            (List<String> row) -> execute(replaceEmptyPatternsWithEmptyString(row)));
     }
 
     private Object execute(List<String> row) {

--- a/java8/src/main/java/io/cucumber/java8/Java8DefaultDataTableCellTransformerDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DefaultDataTableCellTransformerDefinition.java
@@ -5,7 +5,8 @@ import io.cucumber.datatable.TableCellByTypeTransformer;
 
 import java.lang.reflect.Type;
 
-class Java8DefaultDataTableCellTransformerDefinition extends AbstractDatatableElementTransformerDefinition implements DefaultDataTableCellTransformerDefinition {
+class Java8DefaultDataTableCellTransformerDefinition extends AbstractDatatableElementTransformerDefinition
+        implements DefaultDataTableCellTransformerDefinition {
 
     Java8DefaultDataTableCellTransformerDefinition(String[] emptyPatterns, DefaultDataTableCellTransformerBody body) {
         super(body, new Exception().getStackTrace()[3], emptyPatterns);
@@ -15,8 +16,7 @@ class Java8DefaultDataTableCellTransformerDefinition extends AbstractDatatableEl
     public TableCellByTypeTransformer tableCellByTypeTransformer() {
         return (fromValue, toValueType) -> execute(
             replaceEmptyPatternsWithEmptyString(fromValue),
-            toValueType
-        );
+            toValueType);
     }
 
     private Object execute(String fromValue, Type toValueType) {

--- a/java8/src/main/java/io/cucumber/java8/Java8DefaultDataTableEntryTransformerDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DefaultDataTableEntryTransformerDefinition.java
@@ -6,7 +6,8 @@ import io.cucumber.datatable.TableEntryByTypeTransformer;
 import java.lang.reflect.Type;
 import java.util.Map;
 
-class Java8DefaultDataTableEntryTransformerDefinition extends AbstractDatatableElementTransformerDefinition implements DefaultDataTableEntryTransformerDefinition {
+class Java8DefaultDataTableEntryTransformerDefinition extends AbstractDatatableElementTransformerDefinition
+        implements DefaultDataTableEntryTransformerDefinition {
 
     Java8DefaultDataTableEntryTransformerDefinition(String[] emptyPatterns, DefaultDataTableEntryTransformerBody body) {
         super(body, new Exception().getStackTrace()[3], emptyPatterns);
@@ -21,8 +22,7 @@ class Java8DefaultDataTableEntryTransformerDefinition extends AbstractDatatableE
     public TableEntryByTypeTransformer tableEntryByTypeTransformer() {
         return (fromValue, toValueType, tableCellByTypeTransformer) -> execute(
             replaceEmptyPatternsWithEmptyString(fromValue),
-            toValueType
-        );
+            toValueType);
     }
 
     private Object execute(Map<String, String> fromValue, Type toValueType) {

--- a/java8/src/main/java/io/cucumber/java8/Java8DefaultParameterTypeDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DefaultParameterTypeDefinition.java
@@ -5,7 +5,8 @@ import io.cucumber.cucumberexpressions.ParameterByTypeTransformer;
 
 import java.lang.reflect.Type;
 
-class Java8DefaultParameterTypeDefinition extends AbstractGlueDefinition implements DefaultParameterTransformerDefinition {
+class Java8DefaultParameterTypeDefinition extends AbstractGlueDefinition
+        implements DefaultParameterTransformerDefinition {
 
     Java8DefaultParameterTypeDefinition(DefaultParameterTransformerBody body) {
         super(body, new Exception().getStackTrace()[3]);

--- a/java8/src/main/java/io/cucumber/java8/Java8DocStringTypeDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DocStringTypeDefinition.java
@@ -20,8 +20,7 @@ final class Java8DocStringTypeDefinition extends AbstractGlueDefinition implemen
         this.docStringType = new DocStringType(
             returnType,
             contentType,
-            this::execute
-        );
+            this::execute);
     }
 
     private Object execute(String content) {

--- a/java8/src/main/java/io/cucumber/java8/Java8HookDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8HookDefinition.java
@@ -30,7 +30,7 @@ final class Java8HookDefinition extends AbstractGlueDefinition implements HookDe
         if (method.getParameterCount() == 0) {
             args = new Object[0];
         } else {
-            args = new Object[]{new io.cucumber.java8.Scenario(state)};
+            args = new Object[] { new io.cucumber.java8.Scenario(state) };
         }
         Invoker.invoke(this, body, method, args);
     }

--- a/java8/src/main/java/io/cucumber/java8/Java8ParameterTypeDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8ParameterTypeDefinition.java
@@ -9,8 +9,10 @@ class Java8ParameterTypeDefinition extends AbstractGlueDefinition implements Par
 
     private final ParameterType<?> parameterType;
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    <T extends ParameterDefinitionBody> Java8ParameterTypeDefinition(String name, String regex, Class<T> bodyClass, T body) {
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    <T extends ParameterDefinitionBody> Java8ParameterTypeDefinition(
+            String name, String regex, Class<T> bodyClass, T body
+    ) {
         super(body, new Exception().getStackTrace()[3]);
         Class<?> returnType = resolveRawArguments(bodyClass, body.getClass())[0];
         this.parameterType = new ParameterType(name, Collections.singletonList(regex), returnType, this::execute);

--- a/java8/src/main/java/io/cucumber/java8/Java8Snippet.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8Snippet.java
@@ -7,10 +7,10 @@ final class Java8Snippet extends AbstractJavaSnippet {
     @Override
     public MessageFormat template() {
         return new MessageFormat("" +
-            "{0}(\"{1}\", ({3}) -> '{'\n" +
-            "    // {4}\n" +
-            "{5}    throw new " + PendingException.class.getName() + "();\n" +
-            "'}');");
+                "{0}(\"{1}\", ({3}) -> '{'\n" +
+                "    // {4}\n" +
+                "{5}    throw new " + PendingException.class.getName() + "();\n" +
+                "'}');");
     }
 
 }

--- a/java8/src/main/java/io/cucumber/java8/Java8StepDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8StepDefinition.java
@@ -15,23 +15,28 @@ final class Java8StepDefinition extends AbstractGlueDefinition implements StepDe
     private final List<ParameterInfo> parameterInfos;
     private final String expression;
 
-    private <T extends StepDefinitionBody> Java8StepDefinition(String expression,
-                                                               Class<T> bodyClass,
-                                                               T body) {
+    private <T extends StepDefinitionBody> Java8StepDefinition(
+            String expression,
+            Class<T> bodyClass,
+            T body
+    ) {
         super(body, new Exception().getStackTrace()[3]);
         this.expression = requireNonNull(expression, "cucumber-expression may not be null");
         this.parameterInfos = fromTypes(expression, location, resolveRawArguments(bodyClass, body.getClass()));
     }
 
-    private static List<ParameterInfo> fromTypes(String expression, StackTraceElement location, Type[] genericParameterTypes) {
+    private static List<ParameterInfo> fromTypes(
+            String expression, StackTraceElement location, Type[] genericParameterTypes
+    ) {
         return Arrays.stream(genericParameterTypes)
-            .map(type -> new LambdaTypeResolver(type, expression, location))
-            .map(Java8ParameterInfo::new)
-            .collect(toList());
+                .map(type -> new LambdaTypeResolver(type, expression, location))
+                .map(Java8ParameterInfo::new)
+                .collect(toList());
     }
 
     public static <T extends StepDefinitionBody> Java8StepDefinition create(
-        String expression, Class<T> bodyClass, T body) {
+            String expression, Class<T> bodyClass, T body
+    ) {
         return new Java8StepDefinition(expression, bodyClass, body);
     }
 

--- a/java8/src/main/java/io/cucumber/java8/LambdaGlue.java
+++ b/java8/src/main/java/io/cucumber/java8/LambdaGlue.java
@@ -16,35 +16,44 @@ public interface LambdaGlue {
      * @param body lambda to execute, takes {@link Scenario} as an argument
      */
     default void Before(final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_BEFORE_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_BEFORE_ORDER, body));
     }
 
     /**
      * Defines an before hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param body          lambda to execute, takes {@link Scenario} as an argument
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param body          lambda to execute, takes {@link Scenario} as an
+     *                      argument
      */
     default void Before(String tagExpression, final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_BEFORE_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_BEFORE_ORDER, body));
     }
 
     /**
      * Defines an before hook.
      *
-     * @param order the order in which this hook should run. Higher numbers are run first
+     * @param order the order in which this hook should run. Higher numbers are
+     *              run first
      * @param body  lambda to execute, takes {@link Scenario} as an argument
      */
     default void Before(int order, final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
     }
 
     /**
      * Defines an before hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param order         the order in which this hook should run. Higher numbers are run first
-     * @param body          lambda to execute, takes {@link Scenario} as an argument
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param order         the order in which this hook should run. Higher
+     *                      numbers are run first
+     * @param body          lambda to execute, takes {@link Scenario} as an
+     *                      argument
      */
     default void Before(String tagExpression, int order, final HookBody body) {
         LambdaGlueRegistry.INSTANCE.get().addBeforeHookDefinition(new Java8HookDefinition(tagExpression, order, body));
@@ -56,34 +65,41 @@ public interface LambdaGlue {
      * @param body lambda to execute, takes {@link Scenario} as an argument
      */
     default void Before(final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_BEFORE_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_BEFORE_ORDER, body));
     }
 
     /**
      * Defines an before hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
      * @param body          lambda to execute
      */
     default void Before(String tagExpression, final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_BEFORE_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_BEFORE_ORDER, body));
     }
 
     /**
      * Defines an before hook.
      *
-     * @param order the order in which this hook should run. Higher numbers are run first
+     * @param order the order in which this hook should run. Higher numbers are
+     *              run first
      * @param body  lambda to execute
      */
     default void Before(int order, final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
     }
 
     /**
      * Defines an before hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param order         the order in which this hook should run. Higher numbers are run first
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param order         the order in which this hook should run. Higher
+     *                      numbers are run first
      * @param body          lambda to execute
      */
     default void Before(String tagExpression, int order, final HookNoArgsBody body) {
@@ -96,38 +112,48 @@ public interface LambdaGlue {
      * @param body lambda to execute, takes {@link Scenario} as an argument
      */
     default void BeforeStep(final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_BEFORE_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_BEFORE_ORDER, body));
     }
 
     /**
      * Defines an before step hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param body          lambda to execute, takes {@link Scenario} as an argument
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param body          lambda to execute, takes {@link Scenario} as an
+     *                      argument
      */
     default void BeforeStep(String tagExpression, final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeStepHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_BEFORE_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeStepHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_BEFORE_ORDER, body));
     }
 
     /**
      * Defines an before step hook.
      *
-     * @param order the order in which this hook should run. Higher numbers are run first
+     * @param order the order in which this hook should run. Higher numbers are
+     *              run first
      * @param body  lambda to execute, takes {@link Scenario} as an argument
      */
     default void BeforeStep(int order, final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
     }
 
     /**
      * Defines an before step hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param order         the order in which this hook should run. Higher numbers are run first
-     * @param body          lambda to execute, takes {@link Scenario} as an argument
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param order         the order in which this hook should run. Higher
+     *                      numbers are run first
+     * @param body          lambda to execute, takes {@link Scenario} as an
+     *                      argument
      */
     default void BeforeStep(String tagExpression, int order, final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeStepHookDefinition(new Java8HookDefinition(tagExpression, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeStepHookDefinition(new Java8HookDefinition(tagExpression, order, body));
     }
 
     /**
@@ -136,38 +162,46 @@ public interface LambdaGlue {
      * @param body lambda to execute
      */
     default void BeforeStep(final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_BEFORE_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_BEFORE_ORDER, body));
     }
 
     /**
      * Defines an before step hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
      * @param body          lambda to execute
      */
     default void BeforeStep(String tagExpression, final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeStepHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_BEFORE_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeStepHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_BEFORE_ORDER, body));
     }
 
     /**
      * Defines an before step hook.
      *
-     * @param order the order in which this hook should run. Higher numbers are run first
+     * @param order the order in which this hook should run. Higher numbers are
+     *              run first
      * @param body  lambda to execute
      */
     default void BeforeStep(int order, final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
     }
 
     /**
      * Defines an before step hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param order         the order in which this hook should run. Higher numbers are run first
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param order         the order in which this hook should run. Higher
+     *                      numbers are run first
      * @param body          lambda to execute
      */
     default void BeforeStep(String tagExpression, int order, final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addBeforeStepHookDefinition(new Java8HookDefinition(tagExpression, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addBeforeStepHookDefinition(new Java8HookDefinition(tagExpression, order, body));
     }
 
     /**
@@ -176,35 +210,44 @@ public interface LambdaGlue {
      * @param body lambda to execute, takes {@link Scenario} as an argument
      */
     default void After(final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_AFTER_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_AFTER_ORDER, body));
     }
 
     /**
      * Defines an after hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param body          lambda to execute, takes {@link Scenario} as an argument
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param body          lambda to execute, takes {@link Scenario} as an
+     *                      argument
      */
     default void After(String tagExpression, final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_AFTER_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_AFTER_ORDER, body));
     }
 
     /**
      * Defines an after hook.
      *
-     * @param order the order in which this hook should run. Higher numbers are run first
+     * @param order the order in which this hook should run. Higher numbers are
+     *              run first
      * @param body  lambda to execute, takes {@link Scenario} as an argument
      */
     default void After(int order, final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
     }
 
     /**
      * Defines and after hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param order         the order in which this hook should run. Higher numbers are run first
-     * @param body          lambda to execute, takes {@link Scenario} as an argument
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param order         the order in which this hook should run. Higher
+     *                      numbers are run first
+     * @param body          lambda to execute, takes {@link Scenario} as an
+     *                      argument
      */
     default void After(String tagExpression, int order, final HookBody body) {
         LambdaGlueRegistry.INSTANCE.get().addAfterHookDefinition(new Java8HookDefinition(tagExpression, order, body));
@@ -216,34 +259,41 @@ public interface LambdaGlue {
      * @param body lambda to execute
      */
     default void After(final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_AFTER_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_AFTER_ORDER, body));
     }
 
     /**
      * Defines and after hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
      * @param body          lambda to execute
      */
     default void After(String tagExpression, final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_AFTER_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_AFTER_ORDER, body));
     }
 
     /**
      * Defines and after hook.
      *
-     * @param order the order in which this hook should run. Higher numbers are run first
+     * @param order the order in which this hook should run. Higher numbers are
+     *              run first
      * @param body  lambda to execute
      */
     default void After(int order, final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
     }
 
     /**
      * Defines and after hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param order         the order in which this hook should run. Higher numbers are run first
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param order         the order in which this hook should run. Higher
+     *                      numbers are run first
      * @param body          lambda to execute
      */
     default void After(String tagExpression, int order, final HookNoArgsBody body) {
@@ -256,38 +306,48 @@ public interface LambdaGlue {
      * @param body lambda to execute, takes {@link Scenario} as an argument
      */
     default void AfterStep(final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_AFTER_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_AFTER_ORDER, body));
     }
 
     /**
      * Defines and after step hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param body          lambda to execute, takes {@link Scenario} as an argument
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param body          lambda to execute, takes {@link Scenario} as an
+     *                      argument
      */
     default void AfterStep(String tagExpression, final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterStepHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_AFTER_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterStepHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_AFTER_ORDER, body));
     }
 
     /**
      * Defines and after step hook.
      *
-     * @param order the order in which this hook should run. Higher numbers are run first
+     * @param order the order in which this hook should run. Higher numbers are
+     *              run first
      * @param body  lambda to execute, takes {@link Scenario} as an argument
      */
     default void AfterStep(int order, final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
     }
 
     /**
      * Defines and after step hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param order         the order in which this hook should run. Higher numbers are run first
-     * @param body          lambda to execute, takes {@link Scenario} as an argument
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param order         the order in which this hook should run. Higher
+     *                      numbers are run first
+     * @param body          lambda to execute, takes {@link Scenario} as an
+     *                      argument
      */
     default void AfterStep(String tagExpression, int order, final HookBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterStepHookDefinition(new Java8HookDefinition(tagExpression, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterStepHookDefinition(new Java8HookDefinition(tagExpression, order, body));
     }
 
     /**
@@ -296,47 +356,55 @@ public interface LambdaGlue {
      * @param body lambda to execute
      */
     default void AfterStep(final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_AFTER_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, DEFAULT_AFTER_ORDER, body));
     }
 
     /**
      * Defines and after step hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
      * @param body          lambda to execute
      */
     default void AfterStep(String tagExpression, final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterStepHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_AFTER_ORDER, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterStepHookDefinition(new Java8HookDefinition(tagExpression, DEFAULT_AFTER_ORDER, body));
     }
 
     /**
      * Defines and after step hook.
      *
-     * @param order the order in which this hook should run. Higher numbers are run first
+     * @param order the order in which this hook should run. Higher numbers are
+     *              run first
      * @param body  lambda to execute
      */
     default void AfterStep(int order, final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterStepHookDefinition(new Java8HookDefinition(EMPTY_TAG_EXPRESSION, order, body));
     }
 
     /**
      * Defines and after step hook.
      *
-     * @param tagExpression a tag expression, if the expression applies to the current scenario this hook will be executed
-     * @param order         the order in which this hook should run. Higher numbers are run first
+     * @param tagExpression a tag expression, if the expression applies to the
+     *                      current scenario this hook will be executed
+     * @param order         the order in which this hook should run. Higher
+     *                      numbers are run first
      * @param body          lambda to execute
      */
     default void AfterStep(String tagExpression, int order, final HookNoArgsBody body) {
-        LambdaGlueRegistry.INSTANCE.get().addAfterStepHookDefinition(new Java8HookDefinition(tagExpression, order, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addAfterStepHookDefinition(new Java8HookDefinition(tagExpression, order, body));
     }
 
     /**
      * Register doc string type.
      *
      * @param contentType Name of the content type.
-     * @param body        a function that creates an instance of <code>type</code>
-     *                    from the doc string
-     * @see io.cucumber.docstring.DocStringType
+     * @param body        a function that creates an instance of
+     *                    <code>type</code> from the doc string
+     * @see               io.cucumber.docstring.DocStringType
      */
     default void DocStringType(String contentType, DocStringDefinitionBody<?> body) {
         LambdaGlueRegistry.INSTANCE.get().addDocStringType(new Java8DocStringTypeDefinition(contentType, body));
@@ -346,8 +414,8 @@ public interface LambdaGlue {
      * Register a data table type.
      *
      * @param <T>  the data table type
-     * @param body a function that creates an instance of <code>type</code> from the
-     *             data table
+     * @param body a function that creates an instance of <code>type</code> from
+     *             the data table
      */
     default <T> void DataTableType(DataTableEntryDefinitionBody<T> body) {
         LambdaGlueRegistry.INSTANCE.get().addDataTableType(new Java8DataTableEntryDefinition(NO_REPLACEMENT, body));
@@ -356,23 +424,26 @@ public interface LambdaGlue {
     /**
      * Register a data table type with a replacement.
      * <p>
-     * A data table can only represent absent and non-empty strings. By replacing
-     * a known value (for example [empty]) a data table can also represent
-     * empty strings.
+     * A data table can only represent absent and non-empty strings. By
+     * replacing a known value (for example [empty]) a data table can also
+     * represent empty strings.
      *
      * @param <T>                    the data table type
-     * @param replaceWithEmptyString a string that will be replaced with an empty string.
-     * @param body                   a function that creates an instance of <code>type</code> from the
-     *                               data table
+     * @param replaceWithEmptyString a string that will be replaced with an
+     *                               empty string.
+     * @param body                   a function that creates an instance of
+     *                               <code>type</code> from the data table
      */
     default <T> void DataTableType(String replaceWithEmptyString, DataTableEntryDefinitionBody<T> body) {
-        LambdaGlueRegistry.INSTANCE.get().addDataTableType(new Java8DataTableEntryDefinition(new String[]{replaceWithEmptyString}, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addDataTableType(new Java8DataTableEntryDefinition(new String[] { replaceWithEmptyString }, body));
     }
 
     /**
      * Register a data table type
      *
-     * @param body a function that creates an instance of <code>type</code> from the data table
+     * @param body a function that creates an instance of <code>type</code> from
+     *             the data table
      * @param <T>  the data table type
      */
     default <T> void DataTableType(DataTableRowDefinitionBody<T> body) {
@@ -382,23 +453,26 @@ public interface LambdaGlue {
     /**
      * Register a data table type with a replacement.
      * <p>
-     * A data table can only represent absent and non-empty strings. By replacing
-     * a known value (for example [empty]) a data table can also represent
-     * empty strings.
+     * A data table can only represent absent and non-empty strings. By
+     * replacing a known value (for example [empty]) a data table can also
+     * represent empty strings.
      *
      * @param <T>                    the data table type
-     * @param replaceWithEmptyString a string that will be replaced with an empty string.
-     * @param body                   a function that creates an instance of <code>type</code> from the
-     *                               data table
+     * @param replaceWithEmptyString a string that will be replaced with an
+     *                               empty string.
+     * @param body                   a function that creates an instance of
+     *                               <code>type</code> from the data table
      */
     default <T> void DataTableType(String replaceWithEmptyString, DataTableRowDefinitionBody<T> body) {
-        LambdaGlueRegistry.INSTANCE.get().addDataTableType(new Java8DataTableRowDefinition(new String[]{replaceWithEmptyString}, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addDataTableType(new Java8DataTableRowDefinition(new String[] { replaceWithEmptyString }, body));
     }
 
     /**
      * Register a data table type
      *
-     * @param body a function that creates an instance of <code>type</code> from the data table
+     * @param body a function that creates an instance of <code>type</code> from
+     *             the data table
      * @param <T>  the data table type
      */
     default <T> void DataTableType(DataTableCellDefinitionBody<T> body) {
@@ -408,23 +482,26 @@ public interface LambdaGlue {
     /**
      * Register a data table type with a replacement.
      * <p>
-     * A data table can only represent absent and non-empty strings. By replacing
-     * a known value (for example [empty]) a data table can also represent
-     * empty strings.
+     * A data table can only represent absent and non-empty strings. By
+     * replacing a known value (for example [empty]) a data table can also
+     * represent empty strings.
      *
      * @param <T>                    the data table type
-     * @param replaceWithEmptyString a string that will be replaced with an empty string.
-     * @param body                   a function that creates an instance of <code>type</code> from the
-     *                               data table
+     * @param replaceWithEmptyString a string that will be replaced with an
+     *                               empty string.
+     * @param body                   a function that creates an instance of
+     *                               <code>type</code> from the data table
      */
     default <T> void DataTableType(String replaceWithEmptyString, DataTableCellDefinitionBody<T> body) {
-        LambdaGlueRegistry.INSTANCE.get().addDataTableType(new Java8DataTableCellDefinition(new String[]{replaceWithEmptyString}, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addDataTableType(new Java8DataTableCellDefinition(new String[] { replaceWithEmptyString }, body));
     }
 
     /**
      * Register a data table type
      *
-     * @param body a function that creates an instance of <code>type</code> from the data table
+     * @param body a function that creates an instance of <code>type</code> from
+     *             the data table
      * @param <T>  the data table type
      */
     default <T> void DataTableType(DataTableDefinitionBody<T> body) {
@@ -434,17 +511,19 @@ public interface LambdaGlue {
     /**
      * Register a data table type with a replacement.
      * <p>
-     * A data table can only represent absent and non-empty strings. By replacing
-     * a known value (for example [empty]) a data table can also represent
-     * empty strings.
+     * A data table can only represent absent and non-empty strings. By
+     * replacing a known value (for example [empty]) a data table can also
+     * represent empty strings.
      *
      * @param <T>                    the data table type
-     * @param replaceWithEmptyString a string that will be replaced with an empty string.
-     * @param body                   a function that creates an instance of <code>type</code> from the
-     *                               data table
+     * @param replaceWithEmptyString a string that will be replaced with an
+     *                               empty string.
+     * @param body                   a function that creates an instance of
+     *                               <code>type</code> from the data table
      */
     default <T> void DataTableType(String replaceWithEmptyString, DataTableDefinitionBody<T> body) {
-        LambdaGlueRegistry.INSTANCE.get().addDataTableType(new Java8DataTableDefinition(new String[]{replaceWithEmptyString}, body));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addDataTableType(new Java8DataTableDefinition(new String[] { replaceWithEmptyString }, body));
     }
 
     /**
@@ -455,13 +534,16 @@ public interface LambdaGlue {
      * @param name           used as the type name in typed expressions
      *                       {@link io.cucumber.cucumberexpressions.ParameterType#getName()}
      * @param regex          expression to match
-     * @param definitionBody converts {@code String} argument to the target parameter type
-     * @see io.cucumber.cucumberexpressions.ParameterType
-     * @see <a href=https://cucumber.io/docs/cucumber/cucumber-expressions>Cucumber
-     * Expressions</a>
+     * @param definitionBody converts {@code String} argument to the target
+     *                       parameter type
+     * @see                  io.cucumber.cucumberexpressions.ParameterType
+     * @see                  <a
+     *                       href=https://cucumber.io/docs/cucumber/cucumber-expressions>Cucumber
+     *                       Expressions</a>
      */
     default <R> void ParameterType(String name, String regex, ParameterDefinitionBody.A1<R> definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addParameterType(new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A1.class, definitionBody));
+        LambdaGlueRegistry.INSTANCE.get().addParameterType(
+            new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A1.class, definitionBody));
     }
 
     /**
@@ -471,121 +553,156 @@ public interface LambdaGlue {
      *                       {@link io.cucumber.cucumberexpressions.ParameterType#getType()}
      * @param name           used as the type name in typed expressions.
      *                       {@link io.cucumber.cucumberexpressions.ParameterType#getName()}
-     * @param regex          expression to match. If the expression includes capture
-     *                       groups their captured strings will be provided as
-     *                       individual arguments.
-     * @param definitionBody converts {@code String} arguments to the target parameter type
-     * @see io.cucumber.cucumberexpressions.ParameterType
-     * @see <a href=https://cucumber.io/docs/cucumber/cucumber-expressions>Cucumber
-     * Expressions</a>
+     * @param regex          expression to match. If the expression includes
+     *                       capture groups their captured strings will be
+     *                       provided as individual arguments.
+     * @param definitionBody converts {@code String} arguments to the target
+     *                       parameter type
+     * @see                  io.cucumber.cucumberexpressions.ParameterType
+     * @see                  <a
+     *                       href=https://cucumber.io/docs/cucumber/cucumber-expressions>Cucumber
+     *                       Expressions</a>
      */
     default <R> void ParameterType(String name, String regex, ParameterDefinitionBody.A2<R> definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addParameterType(new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A2.class, definitionBody));
+        LambdaGlueRegistry.INSTANCE.get().addParameterType(
+            new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A2.class, definitionBody));
     }
 
     /**
-     * @see LambdaGlue#ParameterType(String, String, io.cucumber.java8.ParameterDefinitionBody.A2)
+     * @see LambdaGlue#ParameterType(String, String,
+     *      io.cucumber.java8.ParameterDefinitionBody.A2)
      */
     default <R> void ParameterType(String name, String regex, ParameterDefinitionBody.A3<R> definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addParameterType(new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A3.class, definitionBody));
+        LambdaGlueRegistry.INSTANCE.get().addParameterType(
+            new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A3.class, definitionBody));
     }
 
     /**
-     * @see LambdaGlue#ParameterType(String, String, io.cucumber.java8.ParameterDefinitionBody.A2)
+     * @see LambdaGlue#ParameterType(String, String,
+     *      io.cucumber.java8.ParameterDefinitionBody.A2)
      */
     default <R> void ParameterType(String name, String regex, ParameterDefinitionBody.A4<R> definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addParameterType(new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A4.class, definitionBody));
+        LambdaGlueRegistry.INSTANCE.get().addParameterType(
+            new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A4.class, definitionBody));
     }
 
     /**
-     * @see LambdaGlue#ParameterType(String, String, io.cucumber.java8.ParameterDefinitionBody.A2)
+     * @see LambdaGlue#ParameterType(String, String,
+     *      io.cucumber.java8.ParameterDefinitionBody.A2)
      */
     default <R> void ParameterType(String name, String regex, ParameterDefinitionBody.A5<R> definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addParameterType(new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A5.class, definitionBody));
+        LambdaGlueRegistry.INSTANCE.get().addParameterType(
+            new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A5.class, definitionBody));
     }
 
     /**
-     * @see LambdaGlue#ParameterType(String, String, io.cucumber.java8.ParameterDefinitionBody.A2)
+     * @see LambdaGlue#ParameterType(String, String,
+     *      io.cucumber.java8.ParameterDefinitionBody.A2)
      */
     default <R> void ParameterType(String name, String regex, ParameterDefinitionBody.A6<R> definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addParameterType(new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A6.class, definitionBody));
+        LambdaGlueRegistry.INSTANCE.get().addParameterType(
+            new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A6.class, definitionBody));
     }
 
     /**
-     * @see LambdaGlue#ParameterType(String, String, io.cucumber.java8.ParameterDefinitionBody.A2)
+     * @see LambdaGlue#ParameterType(String, String,
+     *      io.cucumber.java8.ParameterDefinitionBody.A2)
      */
     default <R> void ParameterType(String name, String regex, ParameterDefinitionBody.A7<R> definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addParameterType(new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A7.class, definitionBody));
+        LambdaGlueRegistry.INSTANCE.get().addParameterType(
+            new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A7.class, definitionBody));
     }
 
     /**
-     * @see LambdaGlue#ParameterType(String, String, io.cucumber.java8.ParameterDefinitionBody.A2)
+     * @see LambdaGlue#ParameterType(String, String,
+     *      io.cucumber.java8.ParameterDefinitionBody.A2)
      */
     default <R> void ParameterType(String name, String regex, ParameterDefinitionBody.A8<R> definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addParameterType(new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A8.class, definitionBody));
+        LambdaGlueRegistry.INSTANCE.get().addParameterType(
+            new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A8.class, definitionBody));
     }
 
     /**
-     * @see LambdaGlue#ParameterType(String, String, io.cucumber.java8.ParameterDefinitionBody.A2)
+     * @see LambdaGlue#ParameterType(String, String,
+     *      io.cucumber.java8.ParameterDefinitionBody.A2)
      */
     default <R> void ParameterType(String name, String regex, ParameterDefinitionBody.A9<R> definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addParameterType(new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A9.class, definitionBody));
+        LambdaGlueRegistry.INSTANCE.get().addParameterType(
+            new Java8ParameterTypeDefinition(name, regex, ParameterDefinitionBody.A9.class, definitionBody));
     }
 
     /**
      * Register default parameter type transformer.
      *
-     * @param definitionBody converts {@code String} argument to an instance of the {@code Type} argument
+     * @param definitionBody converts {@code String} argument to an instance of
+     *                       the {@code Type} argument
      */
     default void DefaultParameterTransformer(DefaultParameterTransformerBody definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addDefaultParameterTransformer(new Java8DefaultParameterTypeDefinition(definitionBody));
+        LambdaGlueRegistry.INSTANCE.get()
+                .addDefaultParameterTransformer(new Java8DefaultParameterTypeDefinition(definitionBody));
     }
 
     /**
      * Register default data table cell transformer.
      *
-     * @param definitionBody converts {@code String} argument to an instance of the {@code Type} argument
+     * @param definitionBody converts {@code String} argument to an instance of
+     *                       the {@code Type} argument
      */
     default void DefaultDataTableCellTransformer(DefaultDataTableCellTransformerBody definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addDefaultDataTableCellTransformer(new Java8DefaultDataTableCellTransformerDefinition(NO_REPLACEMENT, definitionBody));
+        LambdaGlueRegistry.INSTANCE.get().addDefaultDataTableCellTransformer(
+            new Java8DefaultDataTableCellTransformerDefinition(NO_REPLACEMENT, definitionBody));
     }
 
     /**
      * Register default data table cell transformer with a replacement.
      * <p>
-     * A data table can only represent absent and non-empty strings. By replacing
-     * a known value (for example [empty]) a data table can also represent
-     * empty strings.
-     * *
+     * A data table can only represent absent and non-empty strings. By
+     * replacing a known value (for example [empty]) a data table can also
+     * represent empty strings. *
      *
-     * @param replaceWithEmptyString a string that will be replaced with an empty string.
-     * @param definitionBody         converts {@code String} argument to an instance of the {@code Type} argument
+     * @param replaceWithEmptyString a string that will be replaced with an
+     *                               empty string.
+     * @param definitionBody         converts {@code String} argument to an
+     *                               instance of the {@code Type} argument
      */
-    default <T> void DefaultDataTableCellTransformer(String replaceWithEmptyString, DefaultDataTableCellTransformerBody definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addDefaultDataTableCellTransformer(new Java8DefaultDataTableCellTransformerDefinition(new String[]{replaceWithEmptyString}, definitionBody));
+    default <T> void DefaultDataTableCellTransformer(
+            String replaceWithEmptyString, DefaultDataTableCellTransformerBody definitionBody
+    ) {
+        LambdaGlueRegistry.INSTANCE.get().addDefaultDataTableCellTransformer(
+            new Java8DefaultDataTableCellTransformerDefinition(new String[] { replaceWithEmptyString },
+                definitionBody));
     }
 
     /**
      * Register default data table entry transformer.
      *
-     * @param definitionBody converts {@code Map<String,String>} argument to an instance of the {@code Type} argument
+     * @param definitionBody converts {@code Map<String,String>} argument to an
+     *                       instance of the {@code Type} argument
      */
     default void DefaultDataTableEntryTransformer(DefaultDataTableEntryTransformerBody definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addDefaultDataTableEntryTransformer(new Java8DefaultDataTableEntryTransformerDefinition(NO_REPLACEMENT, definitionBody));
+        LambdaGlueRegistry.INSTANCE.get().addDefaultDataTableEntryTransformer(
+            new Java8DefaultDataTableEntryTransformerDefinition(NO_REPLACEMENT, definitionBody));
     }
 
     /**
      * Register default data table cell transformer with a replacement.
      * <p>
-     * A data table can only represent absent and non-empty strings. By replacing
-     * a known value (for example [empty]) a data table can also represent
-     * empty strings.
+     * A data table can only represent absent and non-empty strings. By
+     * replacing a known value (for example [empty]) a data table can also
+     * represent empty strings.
      *
-     * @param replaceWithEmptyString a string that will be replaced with an empty string.
-     * @param definitionBody         converts {@code Map<String,String>} argument to an instance of the {@code Type} argument
+     * @param replaceWithEmptyString a string that will be replaced with an
+     *                               empty string.
+     * @param definitionBody         converts {@code Map<String,String>}
+     *                               argument to an instance of the {@code Type}
+     *                               argument
      */
-    default <T> void DefaultDataTableEntryTransformer(String replaceWithEmptyString, DefaultDataTableEntryTransformerBody definitionBody) {
-        LambdaGlueRegistry.INSTANCE.get().addDefaultDataTableEntryTransformer(new Java8DefaultDataTableEntryTransformerDefinition(new String[]{replaceWithEmptyString}, definitionBody));
+    default <T> void DefaultDataTableEntryTransformer(
+            String replaceWithEmptyString, DefaultDataTableEntryTransformerBody definitionBody
+    ) {
+        LambdaGlueRegistry.INSTANCE.get().addDefaultDataTableEntryTransformer(
+            new Java8DefaultDataTableEntryTransformerDefinition(new String[] { replaceWithEmptyString },
+                definitionBody));
     }
 
 }

--- a/java8/src/main/java/io/cucumber/java8/LambdaGlueRegistry.java
+++ b/java8/src/main/java/io/cucumber/java8/LambdaGlueRegistry.java
@@ -33,6 +33,8 @@ interface LambdaGlueRegistry {
 
     void addDefaultDataTableCellTransformer(DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer);
 
-    void addDefaultDataTableEntryTransformer(DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer);
+    void addDefaultDataTableEntryTransformer(
+            DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer
+    );
 
 }

--- a/java8/src/main/java/io/cucumber/java8/LambdaTypeResolver.java
+++ b/java8/src/main/java/io/cucumber/java8/LambdaTypeResolver.java
@@ -46,7 +46,7 @@ final class LambdaTypeResolver implements TypeResolver {
     }
 
     private CucumberBackendException withLocation(CucumberBackendException exception) {
-        exception.setStackTrace(new StackTraceElement[]{location});
+        exception.setStackTrace(new StackTraceElement[] { location });
         return exception;
     }
 

--- a/java8/src/main/java/io/cucumber/java8/ParameterDefinitionBody.java
+++ b/java8/src/main/java/io/cucumber/java8/ParameterDefinitionBody.java
@@ -57,14 +57,16 @@ public interface ParameterDefinitionBody {
     @FunctionalInterface
     interface A8<R> extends ParameterDefinitionBody {
 
-        R accept(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8) throws Throwable;
+        R accept(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8)
+                throws Throwable;
 
     }
 
     @FunctionalInterface
     interface A9<R> extends ParameterDefinitionBody {
 
-        R accept(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8, String p9) throws Throwable;
+        R accept(String p1, String p2, String p3, String p4, String p5, String p6, String p7, String p8, String p9)
+                throws Throwable;
 
     }
 

--- a/java8/src/main/java/io/cucumber/java8/PendingException.java
+++ b/java8/src/main/java/io/cucumber/java8/PendingException.java
@@ -8,7 +8,7 @@ import org.apiguardian.api.API;
  *
  * @see Java8Snippet
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings({ "WeakerAccess", "unused" })
 @Pending
 @API(status = API.Status.STABLE)
 public final class PendingException extends RuntimeException {

--- a/java8/src/main/java/io/cucumber/java8/Scenario.java
+++ b/java8/src/main/java/io/cucumber/java8/Scenario.java
@@ -7,12 +7,14 @@ import java.net.URI;
 import java.util.Collection;
 
 /**
- * Before or After Hooks that declare a parameter of this type will receive an instance of this class.
- * It allows writing text and embedding media into reports, as well as inspecting results (in an After block).
+ * Before or After Hooks that declare a parameter of this type will receive an
+ * instance of this class. It allows writing text and embedding media into
+ * reports, as well as inspecting results (in an After block).
  * <p>
- * Note: This class is not intended to be used to create reports. To create custom reports use
- * the {@code io.cucumber.plugin.Plugin} class. The plugin system provides a much richer access to Cucumbers then
- * hooks after could provide. For an example see {@code io.cucumber.core.plugin.PrettyFormatter}.
+ * Note: This class is not intended to be used to create reports. To create
+ * custom reports use the {@code io.cucumber.plugin.Plugin} class. The plugin
+ * system provides a much richer access to Cucumbers then hooks after could
+ * provide. For an example see {@code io.cucumber.core.plugin.PrettyFormatter}.
  */
 @API(status = API.Status.STABLE)
 public final class Scenario {
@@ -51,6 +53,7 @@ public final class Scenario {
 
     /**
      * Attach data to the report(s).
+     * 
      * <pre>
      * {@code
      * // Attach a screenshot. See your UI automation tool's docs for
@@ -63,7 +66,9 @@ public final class Scenario {
      * {@code mediaType} must be provided. For example: {@code text/plain},
      * {@code image/png}, {@code text/html;charset=utf-8}.
      * <p>
-     * Media types are defined in <a href= https://tools.ietf.org/html/rfc7231#section-3.1.1.1>RFC 7231 Section 3.1.1.1</a>.
+     * Media types are defined in <a href=
+     * https://tools.ietf.org/html/rfc7231#section-3.1.1.1>RFC 7231 Section
+     * 3.1.1.1</a>.
      *
      * @param data      what to attach, for example an image.
      * @param mediaType what is the data?
@@ -77,7 +82,7 @@ public final class Scenario {
      * @param data      what to attach, for example html.
      * @param mediaType what is the data?
      * @param name      attachment name
-     * @see #attach(byte[], String, String)
+     * @see             #attach(byte[], String, String)
      */
     public void attach(String data, String mediaType, String name) {
         delegate.attach(data, mediaType, name);
@@ -87,7 +92,7 @@ public final class Scenario {
      * Outputs some text into the report.
      *
      * @param text what to put in the report.
-     * @see #attach(byte[], String, String)
+     * @see        #attach(byte[], String, String)
      */
     public void log(String text) {
         delegate.log(text);
@@ -115,9 +120,9 @@ public final class Scenario {
     }
 
     /**
-     * @return the line in the feature file of the Scenario. If this is a Scenario
-     * from Scenario Outlines this will return the line of the example row in
-     * the Scenario Outline.
+     * @return the line in the feature file of the Scenario. If this is a
+     *         Scenario from Scenario Outlines this will return the line of the
+     *         example row in the Scenario Outline.
      */
     public Integer getLine() {
         return delegate.getLine();

--- a/java8/src/test/java/io/cucumber/java8/Java8AnonInnerClassStepDefinitionTest.java
+++ b/java8/src/test/java/io/cucumber/java8/Java8AnonInnerClassStepDefinitionTest.java
@@ -11,7 +11,8 @@ class Java8AnonInnerClassStepDefinitionTest {
 
     @Test
     void should_calculate_parameters_count_from_body_with_one_param() {
-        Java8StepDefinition java8StepDefinition = Java8StepDefinition.create("I have some step", StepDefinitionBody.A1.class, oneParamStep());
+        Java8StepDefinition java8StepDefinition = Java8StepDefinition.create("I have some step",
+            StepDefinitionBody.A1.class, oneParamStep());
         assertThat(java8StepDefinition.parameterInfos().size(), is(equalTo(1)));
     }
 
@@ -25,7 +26,8 @@ class Java8AnonInnerClassStepDefinitionTest {
 
     @Test
     void should_calculate_parameters_count_from_body_with_two_params() {
-        Java8StepDefinition java8StepDefinition = Java8StepDefinition.create("I have some step", StepDefinitionBody.A2.class, twoParamStep());
+        Java8StepDefinition java8StepDefinition = Java8StepDefinition.create("I have some step",
+            StepDefinitionBody.A2.class, twoParamStep());
         assertThat(java8StepDefinition.parameterInfos().size(), is(equalTo(2)));
     }
 

--- a/java8/src/test/java/io/cucumber/java8/Java8BackendTest.java
+++ b/java8/src/test/java/io/cucumber/java8/Java8BackendTest.java
@@ -15,7 +15,7 @@ import static java.lang.Thread.currentThread;
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({MockitoExtension.class})
+@ExtendWith({ MockitoExtension.class })
 class Java8BackendTest {
 
     @Mock

--- a/java8/src/test/java/io/cucumber/java8/Java8LambdaStepDefinitionMarksCorrectStackElementTest.java
+++ b/java8/src/test/java/io/cucumber/java8/Java8LambdaStepDefinitionMarksCorrectStackElementTest.java
@@ -27,17 +27,20 @@ class Java8LambdaStepDefinitionMarksCorrectStackElementTest {
         new SomeLambdaStepDefs();
         final StepDefinition stepDefinition = myLambdaGlueRegistry.getStepDefinition();
 
-        CucumberInvocationTargetException exception = assertThrows(CucumberInvocationTargetException.class, () -> stepDefinition.execute(new Object[0]));
-        assertThat(exception.getInvocationTargetExceptionCause(), new CustomTypeSafeMatcher<Throwable>("exception with matching stack trace") {
-            @Override
-            protected boolean matchesSafely(Throwable item) {
-                return Arrays.stream(item.getStackTrace())
-                    .filter(stepDefinition::isDefinedAt)
-                    .findFirst()
-                    .filter(stackTraceElement -> SomeLambdaStepDefs.class.getName().equals(stackTraceElement.getClassName()))
-                    .isPresent();
-            }
-        });
+        CucumberInvocationTargetException exception = assertThrows(CucumberInvocationTargetException.class,
+            () -> stepDefinition.execute(new Object[0]));
+        assertThat(exception.getInvocationTargetExceptionCause(),
+            new CustomTypeSafeMatcher<Throwable>("exception with matching stack trace") {
+                @Override
+                protected boolean matchesSafely(Throwable item) {
+                    return Arrays.stream(item.getStackTrace())
+                            .filter(stepDefinition::isDefinedAt)
+                            .findFirst()
+                            .filter(stackTraceElement -> SomeLambdaStepDefs.class.getName()
+                                    .equals(stackTraceElement.getClassName()))
+                            .isPresent();
+                }
+            });
     }
 
     private static class MyLambdaGlueRegistry implements LambdaGlueRegistry {
@@ -90,12 +93,16 @@ class Java8LambdaStepDefinitionMarksCorrectStackElementTest {
         }
 
         @Override
-        public void addDefaultDataTableCellTransformer(DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer) {
+        public void addDefaultDataTableCellTransformer(
+                DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer
+        ) {
 
         }
 
         @Override
-        public void addDefaultDataTableEntryTransformer(DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer) {
+        public void addDefaultDataTableEntryTransformer(
+                DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer
+        ) {
 
         }
 

--- a/java8/src/test/java/io/cucumber/java8/Java8LambdaStepDefinitionTest.java
+++ b/java8/src/test/java/io/cucumber/java8/Java8LambdaStepDefinitionTest.java
@@ -49,9 +49,8 @@ class Java8LambdaStepDefinitionTest {
         CucumberBackendException actualThrown = assertThrows(CucumberBackendException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
             "Can't use java.util.List in lambda step definition \"some step\". " +
-                "Declare a DataTable or DocString argument instead and convert " +
-                "manually with 'asList/asLists/asMap/asMaps' and 'convert' respectively"
-        )));
+                    "Declare a DataTable or DocString argument instead and convert " +
+                    "manually with 'asList/asLists/asMap/asMaps' and 'convert' respectively")));
     }
 
     @Test
@@ -64,9 +63,8 @@ class Java8LambdaStepDefinitionTest {
         CucumberBackendException actualThrown = assertThrows(CucumberBackendException.class, testMethod);
         assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
             "Can't use java.util.List in lambda step definition \"some step\". " +
-                "Declare a DataTable or DocString argument instead and convert " +
-                "manually with 'asList/asLists/asMap/asMaps' and 'convert' respectively"
-        )));
+                    "Declare a DataTable or DocString argument instead and convert " +
+                    "manually with 'asList/asLists/asMap/asMaps' and 'convert' respectively")));
     }
 
 }

--- a/java8/src/test/java/io/cucumber/java8/Java8SnippetTest.java
+++ b/java8/src/test/java/io/cucumber/java8/Java8SnippetTest.java
@@ -17,21 +17,19 @@ class Java8SnippetTest {
 
     private final SnippetGenerator snippetGenerator = new SnippetGenerator(
         new Java8Snippet(),
-        new ParameterTypeRegistry(Locale.ENGLISH)
-    );
+        new ParameterTypeRegistry(Locale.ENGLISH));
 
     @Test
     void generatesPlainSnippet() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my \"big\" belly\n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my \"big\" belly\n");
         String expected = "" +
-            "Given(\"I have {int} cukes in my {string} belly\", (Integer int1, String string) -> {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    throw new io.cucumber.java8.PendingException();\n" +
-            "});";
+                "Given(\"I have {int} cukes in my {string} belly\", (Integer int1, String string) -> {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java8.PendingException();\n" +
+                "});";
         assertThat(getSnippet(feature), is(equalTo(expected)));
     }
 
@@ -39,30 +37,29 @@ class Java8SnippetTest {
         Step step = feature.getPickles().get(0).getSteps().get(0);
         return String.join(
             "\n",
-            snippetGenerator.getSnippet(step, SnippetType.UNDERSCORE)
-        );
+            snippetGenerator.getSnippet(step, SnippetType.UNDERSCORE));
     }
 
     @Test
     void generatesDataTableSnippet() {
         Feature feature = TestFeatureParser.parse("" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test scenario\n" +
-            "     Given I have 4 cukes in my \"big\" belly\n" +
-            "      | data table cell | \n"
-        );
+                "Feature: Test feature\n" +
+                "  Scenario: Test scenario\n" +
+                "     Given I have 4 cukes in my \"big\" belly\n" +
+                "      | data table cell | \n");
 
         String expected = "" +
-            "Given(\"I have {int} cukes in my {string} belly\", (Integer int1, String string, io.cucumber.datatable.DataTable dataTable) -> {\n" +
-            "    // Write code here that turns the phrase above into concrete actions\n" +
-            "    // For automatic transformation, change DataTable to one of\n" +
-            "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
-            "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
-            "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
-            "    //\n" +
-            "    // For other transformations you can register a DataTableType.\n" +
-            "    throw new io.cucumber.java8.PendingException();\n" +
-            "});";
+                "Given(\"I have {int} cukes in my {string} belly\", (Integer int1, String string, io.cucumber.datatable.DataTable dataTable) -> {\n"
+                +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    // For automatic transformation, change DataTable to one of\n" +
+                "    // E, List<E>, List<List<E>>, List<Map<K,V>>, Map<K,V> or\n" +
+                "    // Map<K, List<V>>. E,K,V must be a String, Integer, Float,\n" +
+                "    // Double, Byte, Short, Long, BigInteger or BigDecimal.\n" +
+                "    //\n" +
+                "    // For other transformations you can register a DataTableType.\n" +
+                "    throw new io.cucumber.java8.PendingException();\n" +
+                "});";
         assertThat(getSnippet(feature), is(equalTo(expected)));
     }
 

--- a/java8/src/test/java/io/cucumber/java8/LambdaGlueTest.java
+++ b/java8/src/test/java/io/cucumber/java8/LambdaGlueTest.java
@@ -81,12 +81,16 @@ class LambdaGlueTest {
         }
 
         @Override
-        public void addDefaultDataTableCellTransformer(DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer) {
+        public void addDefaultDataTableCellTransformer(
+                DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer
+        ) {
 
         }
 
         @Override
-        public void addDefaultDataTableEntryTransformer(DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer) {
+        public void addDefaultDataTableEntryTransformer(
+                DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer
+        ) {
 
         }
     };

--- a/java8/src/test/java/io/cucumber/java8/LambdaStepDefinitions.java
+++ b/java8/src/test/java/io/cucumber/java8/LambdaStepDefinitions.java
@@ -39,23 +39,19 @@ public class LambdaStepDefinitions implements io.cucumber.java8.En {
             lastInstance = this;
         });
 
-
         AfterStep((Scenario scenario) -> {
             assertSame(this, lastInstance);
             lastInstance = this;
         });
-
 
         After((Scenario scenario) -> {
             assertSame(this, lastInstance);
             lastInstance = this;
         });
 
-
         Before(this::methodThatDeclaresException);
 
         Before(this::hookWithArgs);
-
 
         Given("this data table:", (DataTable peopleTable) -> {
             List<Person> people = peopleTable.asList(Person.class);
@@ -109,7 +105,8 @@ public class LambdaStepDefinitions implements io.cucumber.java8.En {
         Given("A constructor reference with an argument {string}", Contact::new);
         Given("A static method reference with an argument {int}", LambdaStepDefinitions::staticMethodWithAnArgument);
         Given("A method reference to an arbitrary object of a particular type {string}", Contact::call);
-        Given("A method reference to an arbitrary object of a particular type {string} with argument {string}", Contact::update);
+        Given("A method reference to an arbitrary object of a particular type {string} with argument {string}",
+            Contact::update);
 
     }
 
@@ -157,6 +154,5 @@ public class LambdaStepDefinitions implements io.cucumber.java8.En {
         }
 
     }
-
 
 }

--- a/java8/src/test/java/io/cucumber/java8/TypeDefinitionsStepDefinitions.java
+++ b/java8/src/test/java/io/cucumber/java8/TypeDefinitionsStepDefinitions.java
@@ -21,17 +21,14 @@ public class TypeDefinitionsStepDefinitions implements En {
             (StringBuilder builder) -> assertThat(builder.getClass(), equalTo(StringBuilder.class)));
         DocStringType("doc", (String docString) -> new StringBuilder(docString));
 
-        DataTableType((Map<String, String> entry) ->
-            new Author(entry.get("name"), entry.get("surname"), entry.get("famousBook")));
+        DataTableType((Map<String, String> entry) -> new Author(entry.get("name"), entry.get("surname"),
+            entry.get("famousBook")));
 
-        DataTableType((List<String> row) ->
-            new Book(row.get(0), row.get(1)));
+        DataTableType((List<String> row) -> new Book(row.get(0), row.get(1)));
 
-        DataTableType((String cellName) ->
-            new Cell(cellName));
+        DataTableType((String cellName) -> new Cell(cellName));
 
-        DataTableType((DataTable dataTable) ->
-            new Literature(dataTable));
+        DataTableType((DataTable dataTable) -> new Literature(dataTable));
 
         Given("single entry data table, defined by lambda", (Author author) -> {
             assertThat(author.name, equalTo("Fedor"));
@@ -40,7 +37,10 @@ public class TypeDefinitionsStepDefinitions implements En {
         });
 
         Given("data table, defined by lambda row transformer", (DataTable dataTable) -> {
-            List<Book> books = dataTable.subTable(1, 0).asList(Book.class); // throw away table headers
+            List<Book> books = dataTable.subTable(1, 0).asList(Book.class); // throw
+                                                                            // away
+                                                                            // table
+                                                                            // headers
             Book book1 = new Book("Crime and Punishment", "Raskolnikov");
             Book book2 = new Book("War and Peace", "Bolkonsky");
             assertThat(book1, equalTo(books.get(0)));
@@ -73,46 +73,46 @@ public class TypeDefinitionsStepDefinitions implements En {
         });
 
         // ParameterType with one argument
-        Given("{string-builder} parameter, defined by lambda", (StringBuilder builder) ->
-            assertThat(builder.toString(), equalTo("string builder")));
+        Given("{string-builder} parameter, defined by lambda",
+            (StringBuilder builder) -> assertThat(builder.toString(), equalTo("string builder")));
 
-        ParameterType("string-builder", ".*", (String str) ->
-            new StringBuilder(str));
+        ParameterType("string-builder", ".*", (String str) -> new StringBuilder(str));
 
         // ParameterType with two String arguments
-        Given("balloon coordinates {coordinates}, defined by lambda", (Point coordinates) ->
-            assertThat(coordinates.toString(), equalTo("Point[x=123,y=456]")));
+        Given("balloon coordinates {coordinates}, defined by lambda",
+            (Point coordinates) -> assertThat(coordinates.toString(), equalTo("Point[x=123,y=456]")));
 
         ParameterType("coordinates", "(.+),(.+)", (String x, String y) -> new Point(parseInt(x), parseInt(y)));
 
         // ParameterType with three arguments
-        Given("kebab made from {ingredients}, defined by lambda", (StringBuilder ingredients) ->
-            assertThat(ingredients.toString(), equalTo("-mushroom-meat-veg-")));
+        Given("kebab made from {ingredients}, defined by lambda",
+            (StringBuilder ingredients) -> assertThat(ingredients.toString(), equalTo("-mushroom-meat-veg-")));
 
-        ParameterType("ingredients", "(.+), (.+) and (.+)", (String x, String y, String z) ->
-            new StringBuilder().append('-').append(x).append('-').append(y).append('-').append(z).append('-'));
+        ParameterType("ingredients", "(.+), (.+) and (.+)", (String x, String y, String z) -> new StringBuilder()
+                .append('-').append(x).append('-').append(y).append('-').append(z).append('-'));
 
-        Given("kebab made from anonymous {}, defined by lambda", (StringBuilder coordinates) ->
-            assertThat(coordinates.toString(), equalTo("meat-class java.lang.StringBuilder")));
+        Given("kebab made from anonymous {}, defined by lambda",
+            (StringBuilder coordinates) -> assertThat(coordinates.toString(),
+                equalTo("meat-class java.lang.StringBuilder")));
 
-        DefaultParameterTransformer((String fromValue, Type toValueType) ->
-            new StringBuilder().append(fromValue).append('-').append(toValueType));
+        DefaultParameterTransformer((String fromValue, Type toValueType) -> new StringBuilder().append(fromValue)
+                .append('-').append(toValueType));
 
         Given("default data table cells, defined by lambda", (DataTable dataTable) -> {
             List<List<StringBuilder>> cells = dataTable.asLists(StringBuilder.class);
             assertThat(cells.get(0).get(0).toString(), equalTo("Kebab-class java.lang.StringBuilder"));
         });
 
-        DefaultDataTableCellTransformer((fromValue, toValueType) ->
-            new StringBuilder().append(fromValue).append('-').append(toValueType));
+        DefaultDataTableCellTransformer(
+            (fromValue, toValueType) -> new StringBuilder().append(fromValue).append('-').append(toValueType));
 
         Given("default data table entries, defined by lambda", (DataTable dataTable) -> {
             List<StringBuilder> cells = dataTable.asList(StringBuilder.class);
             assertThat(cells.get(0).toString(), equalTo("{dinner=Kebab}-class java.lang.StringBuilder"));
         });
 
-        DefaultDataTableEntryTransformer((fromValue, toValueType) ->
-            new StringBuilder().append(fromValue).append('-').append(toValueType));
+        DefaultDataTableEntryTransformer(
+            (fromValue, toValueType) -> new StringBuilder().append(fromValue).append('-').append(toValueType));
 
     }
 
@@ -135,21 +135,23 @@ public class TypeDefinitionsStepDefinitions implements En {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             Author author = (Author) o;
             return Objects.equals(name, author.name) &&
-                Objects.equals(surname, author.surname) &&
-                Objects.equals(famousBook, author.famousBook);
+                    Objects.equals(surname, author.surname) &&
+                    Objects.equals(famousBook, author.famousBook);
         }
 
         @Override
         public String toString() {
             return "Author{" +
-                "name='" + name + '\'' +
-                ", surname='" + surname + '\'' +
-                ", famousBook='" + famousBook + '\'' +
-                '}';
+                    "name='" + name + '\'' +
+                    ", surname='" + surname + '\'' +
+                    ", famousBook='" + famousBook + '\'' +
+                    '}';
         }
 
     }
@@ -190,19 +192,21 @@ public class TypeDefinitionsStepDefinitions implements En {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             Book book = (Book) o;
             return Objects.equals(name, book.name) &&
-                Objects.equals(mainCharacter, book.mainCharacter);
+                    Objects.equals(mainCharacter, book.mainCharacter);
         }
 
         @Override
         public String toString() {
             return "Book{" +
-                "name='" + name + '\'' +
-                ", mainCharacter='" + mainCharacter + '\'' +
-                '}';
+                    "name='" + name + '\'' +
+                    ", mainCharacter='" + mainCharacter + '\'' +
+                    '}';
         }
 
     }
@@ -217,8 +221,10 @@ public class TypeDefinitionsStepDefinitions implements En {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             Cell cell = (Cell) o;
             return Objects.equals(name, cell.name);
         }
@@ -226,8 +232,8 @@ public class TypeDefinitionsStepDefinitions implements En {
         @Override
         public String toString() {
             return "Cell{" +
-                "name='" + name + '\'' +
-                '}';
+                    "name='" + name + '\'' +
+                    '}';
         }
 
     }
@@ -250,19 +256,21 @@ public class TypeDefinitionsStepDefinitions implements En {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             Literature that = (Literature) o;
             return types.containsAll(that.types) &&
-                characters.containsAll(that.characters);
+                    characters.containsAll(that.characters);
         }
 
         @Override
         public String toString() {
             return "Literature{" +
-                "types=" + types +
-                ", characters=" + characters +
-                '}';
+                    "types=" + types +
+                    ", characters=" + characters +
+                    '}';
         }
 
     }

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -13,8 +13,8 @@ import static org.junit.platform.engine.support.hierarchical.DefaultParallelExec
 public final class Constants {
 
     /**
-     * Property name used to disable ansi colors in the output (not supported
-     * by all terminals): {@value}
+     * Property name used to disable ansi colors in the output (not supported by
+     * all terminals): {@value}
      * <p>
      * Ansi colors are enabled by default.
      */
@@ -38,9 +38,8 @@ public final class Constants {
      * Property name used to set tag filter: {@value}
      * <p>
      * Filters scenarios based on the provided tag expression e.g:
-     * {@code @Integration and not @Ignored}. Scenarios
-     * that did not match the expression will be rendered by JUnit
-     * as skipped.
+     * {@code @Integration and not @Ignored}. Scenarios that did not match the
+     * expression will be rendered by JUnit as skipped.
      * <p>
      * By default all scenarios are executed
      */
@@ -73,8 +72,8 @@ public final class Constants {
      * <li>testng</li>
      * </ul>
      * <p>
-     * {@code PLUGIN} can also be a fully qualified class name, allowing registration
-     * of 3rd party plugins.
+     * {@code PLUGIN} can also be a fully qualified class name, allowing
+     * registration of 3rd party plugins.
      */
     public static final String PLUGIN_PROPERTY_NAME = io.cucumber.core.options.Constants.PLUGIN_PROPERTY_NAME;
     /**
@@ -85,7 +84,8 @@ public final class Constants {
      */
     public static final String OBJECT_FACTORY_PROPERTY_NAME = io.cucumber.core.options.Constants.OBJECT_FACTORY_PROPERTY_NAME;
     /**
-     * Property name to control naming convention for generated snippets: {@value}
+     * Property name to control naming convention for generated snippets:
+     * {@value}
      * <p>
      * Valid values are {@code underscore} or {@code camelcase}.
      * <p>
@@ -103,72 +103,78 @@ public final class Constants {
 
     static final String READ_WRITE_SUFFIX = ".read-write";
     /**
-     * Property template used to describe a mapping of tags to exclusive resources: {@value}
+     * Property template used to describe a mapping of tags to exclusive
+     * resources: {@value}
      * <p>
      * This maps a tag to a resource with a read-write lock.
      * <p>
      * For example given these properties:
-     * <pre> {@code
+     * 
+     * <pre>
+     *  {@code
      * cucumber.execution.exclusive-resources.my-tag-ab-rw.read-write=resource-a,resource-b
      * cucumber.execution.exclusive-resources.my-tag-a-r.read=resource-a
      * }
      * </pre>
-     * A scenario tagged with {@code @my-tag-ab-rw} will lock
-     * resource {@code a} and {@code b} for reading and writing
-     * and will not be concurrently executed with other scenarios
-     * tagged with {@code @my-tag-ab-rw} as well as scenarios tagged
-     * with {@code @my-tag-a-r}.
-     * However a scenarios tagged with {@code @my-tag-a-r} will be concurrently
-     * executed with other scenarios with the same tag.
+     * 
+     * A scenario tagged with {@code @my-tag-ab-rw} will lock resource {@code a}
+     * and {@code b} for reading and writing and will not be concurrently
+     * executed with other scenarios tagged with {@code @my-tag-ab-rw} as well
+     * as scenarios tagged with {@code @my-tag-a-r}. However a scenarios tagged
+     * with {@code @my-tag-a-r} will be concurrently executed with other
+     * scenarios with the same tag.
      *
-     * @see <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution-synchronization">Junit 5 User Guide - Synchronization</a>
+     * @see <a href=
+     *      "https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution-synchronization">Junit
+     *      5 User Guide - Synchronization</a>
      */
-    public static final String EXECUTION_EXCLUSIVE_RESOURCES_READ_WRITE_TEMPLATE =
-        EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + EXECUTION_EXCLUSIVE_RESOURCES_TAG_TEMPLATE_VARIABLE + READ_WRITE_SUFFIX;
+    public static final String EXECUTION_EXCLUSIVE_RESOURCES_READ_WRITE_TEMPLATE = EXECUTION_EXCLUSIVE_RESOURCES_PREFIX
+            + EXECUTION_EXCLUSIVE_RESOURCES_TAG_TEMPLATE_VARIABLE + READ_WRITE_SUFFIX;
     static final String READ_SUFFIX = ".read";
     /**
-     * Property template used to describe a mapping of tags to exclusive resources: {@value}
+     * Property template used to describe a mapping of tags to exclusive
+     * resources: {@value}
      * <p>
      * This maps a tag to a resource with a read lock.
      *
      * @see #EXECUTION_EXCLUSIVE_RESOURCES_READ_WRITE_TEMPLATE
      */
-    public static final String EXECUTION_EXCLUSIVE_RESOURCES_READ_TEMPLATE =
-        EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + EXECUTION_EXCLUSIVE_RESOURCES_TAG_TEMPLATE_VARIABLE + READ_SUFFIX;
+    public static final String EXECUTION_EXCLUSIVE_RESOURCES_READ_TEMPLATE = EXECUTION_EXCLUSIVE_RESOURCES_PREFIX
+            + EXECUTION_EXCLUSIVE_RESOURCES_TAG_TEMPLATE_VARIABLE + READ_SUFFIX;
 
     static final String PARALLEL_CONFIG_PREFIX = "cucumber.execution.parallel.config.";
     /**
-     * Property name used to determine the desired configuration strategy: {@value}
-     *
-     * <p>Value must be one of {@code dynamic}, {@code fixed}, or
-     * {@code custom}.
+     * Property name used to determine the desired configuration strategy:
+     * {@value}
+     * <p>
+     * Value must be one of {@code dynamic}, {@code fixed}, or {@code custom}.
      */
     public static final String PARALLEL_CONFIG_STRATEGY_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
-        + CONFIG_STRATEGY_PROPERTY_NAME;
+            + CONFIG_STRATEGY_PROPERTY_NAME;
 
     /**
      * Property name used to determine the desired parallelism for the
-     * {@link DefaultParallelExecutionConfigurationStrategy#FIXED}
-     * configuration strategy: {@value}
-     *
-     * <p>No default value; must be an integer.
+     * {@link DefaultParallelExecutionConfigurationStrategy#FIXED} configuration
+     * strategy: {@value}
+     * <p>
+     * No default value; must be an integer.
      *
      * @see DefaultParallelExecutionConfigurationStrategy#FIXED
      */
     public static final String PARALLEL_CONFIG_FIXED_PARALLELISM_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
-        + CONFIG_FIXED_PARALLELISM_PROPERTY_NAME;
+            + CONFIG_FIXED_PARALLELISM_PROPERTY_NAME;
 
     /**
-     * Property name of the factor used to determine the desired parallelism
-     * for the {@link DefaultParallelExecutionConfigurationStrategy#DYNAMIC}
+     * Property name of the factor used to determine the desired parallelism for
+     * the {@link DefaultParallelExecutionConfigurationStrategy#DYNAMIC}
      * configuration strategy: {@value}
-     *
-     * <p>Value must be a decimal number; defaults to {@code 1}.
+     * <p>
+     * Value must be a decimal number; defaults to {@code 1}.
      *
      * @see DefaultParallelExecutionConfigurationStrategy#DYNAMIC
      */
     public static final String PARALLEL_CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
-        + CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME;
+            + CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME;
 
     /**
      * Property name used to specify the fully qualified class name of the
@@ -179,7 +185,7 @@ public final class Constants {
      * @see DefaultParallelExecutionConfigurationStrategy#CUSTOM
      */
     public static final String PARALLEL_CONFIG_CUSTOM_CLASS_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
-        + CONFIG_CUSTOM_CLASS_PROPERTY_NAME;
+            + CONFIG_CUSTOM_CLASS_PROPERTY_NAME;
 
     private Constants() {
 

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Cucumber.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Cucumber.java
@@ -12,13 +12,14 @@ import java.lang.annotation.Target;
  * Test discovery annotation. Marks the package of the annotated class for test
  * discovery.
  * <p>
- * Some build tools do not support the {@link org.junit.platform.engine.discovery.DiscoverySelectors}
- * used by Cucumber. As a work around Cucumber will scan the package of the
- * annotated class for feature files and execute them.
+ * Some build tools do not support the
+ * {@link org.junit.platform.engine.discovery.DiscoverySelectors} used by
+ * Cucumber. As a work around Cucumber will scan the package of the annotated
+ * class for feature files and execute them.
  * <p>
  * Note about Testable: While this class is annotated with @Testable the
- * recommended way for IDEs and other tooling use the selectors implemented
- * by Cucumber to discover feature files.
+ * recommended way for IDEs and other tooling use the selectors implemented by
+ * Cucumber to discover feature files.
  *
  * @see CucumberTestEngine
  */

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineDescriptor.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineDescriptor.java
@@ -20,8 +20,7 @@ class CucumberEngineDescriptor extends EngineDescriptor implements Node<Cucumber
         } else {
             byUniqueId.ifPresent(
                 existingParent -> descriptor.getChildren()
-                    .forEach(child -> recursivelyMerge(child, existingParent))
-            );
+                        .forEach(child -> recursivelyMerge(child, existingParent)));
         }
     }
 

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineExecutionContext.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineExecutionContext.java
@@ -46,7 +46,8 @@ public final class CucumberEngineExecutionContext implements EngineExecutionCont
         options = new CucumberEngineOptions(configurationParameters);
         ObjectFactoryServiceLoader objectFactoryServiceLoader = new ObjectFactoryServiceLoader(options);
         EventBus bus = synchronize(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
-        TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(classLoader, options);
+        TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(
+            classLoader, options);
         Plugins plugins = new Plugins(new PluginFactory(), options);
         ExitStatus exitStatus = new ExitStatus(options);
         plugins.addPlugin(exitStatus);
@@ -54,14 +55,18 @@ public final class CucumberEngineExecutionContext implements EngineExecutionCont
         RunnerSupplier runnerSupplier;
         if (options.isParallelExecutionEnabled()) {
             plugins.setSerialEventBusOnEventListenerPlugins(bus);
-            ObjectFactorySupplier objectFactorySupplier = new ThreadLocalObjectFactorySupplier(objectFactoryServiceLoader);
+            ObjectFactorySupplier objectFactorySupplier = new ThreadLocalObjectFactorySupplier(
+                objectFactoryServiceLoader);
             BackendSupplier backendSupplier = new BackendServiceLoader(classLoader, objectFactorySupplier);
-            runnerSupplier = new ThreadLocalRunnerSupplier(options, bus, backendSupplier, objectFactorySupplier, typeRegistryConfigurerSupplier);
+            runnerSupplier = new ThreadLocalRunnerSupplier(options, bus, backendSupplier, objectFactorySupplier,
+                typeRegistryConfigurerSupplier);
         } else {
             plugins.setEventBusOnEventListenerPlugins(bus);
-            ObjectFactorySupplier objectFactorySupplier = new SingletonObjectFactorySupplier(objectFactoryServiceLoader);
+            ObjectFactorySupplier objectFactorySupplier = new SingletonObjectFactorySupplier(
+                objectFactoryServiceLoader);
             BackendSupplier backendSupplier = new BackendServiceLoader(classLoader, objectFactorySupplier);
-            runnerSupplier = new SingletonRunnerSupplier(options, bus, backendSupplier, objectFactorySupplier, typeRegistryConfigurerSupplier);
+            runnerSupplier = new SingletonRunnerSupplier(options, bus, backendSupplier, objectFactorySupplier,
+                typeRegistryConfigurerSupplier);
         }
         this.context = new CucumberExecutionContext(bus, exitStatus, runnerSupplier);
     }
@@ -94,4 +99,3 @@ public final class CucumberEngineExecutionContext implements EngineExecutionCont
     }
 
 }
-

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
@@ -27,9 +27,9 @@ import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.SNIPPET_TYPE_PROPERTY_NAME;
 
 class CucumberEngineOptions implements
-    io.cucumber.core.plugin.Options,
-    io.cucumber.core.runner.Options,
-    io.cucumber.core.backend.Options {
+        io.cucumber.core.plugin.Options,
+        io.cucumber.core.runner.Options,
+        io.cucumber.core.backend.Options {
 
     private final ConfigurationParameters configurationParameters;
 
@@ -40,18 +40,18 @@ class CucumberEngineOptions implements
     @Override
     public List<Plugin> plugins() {
         return configurationParameters.get(PLUGIN_PROPERTY_NAME, s -> Arrays.stream(s.split(","))
-            .map(String::trim)
-            .map(PluginOption::parse)
-            .map(pluginOption -> (Plugin) pluginOption)
-            .collect(Collectors.toList()))
-            .orElse(Collections.emptyList());
+                .map(String::trim)
+                .map(PluginOption::parse)
+                .map(pluginOption -> (Plugin) pluginOption)
+                .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
     }
 
     @Override
     public boolean isMonochrome() {
         return configurationParameters
-            .getBoolean(ANSI_COLORS_DISABLED_PROPERTY_NAME)
-            .orElse(false);
+                .getBoolean(ANSI_COLORS_DISABLED_PROPERTY_NAME)
+                .orElse(false);
     }
 
     @Override
@@ -61,48 +61,47 @@ class CucumberEngineOptions implements
 
     public Expression tagFilter() {
         return new TagExpressionParser()
-            .parse(configurationParameters
-                .get(FILTER_TAGS_PROPERTY_NAME)
-                .orElse("")
-            );
+                .parse(configurationParameters
+                        .get(FILTER_TAGS_PROPERTY_NAME)
+                        .orElse(""));
     }
 
     @Override
     public List<URI> getGlue() {
         return configurationParameters
-            .get(GLUE_PROPERTY_NAME, s -> Arrays.asList(s.split(",")))
-            .orElse(Collections.singletonList(CLASSPATH_SCHEME_PREFIX))
-            .stream()
-            .map(String::trim)
-            .map(GluePath::parse)
-            .collect(Collectors.toList());
+                .get(GLUE_PROPERTY_NAME, s -> Arrays.asList(s.split(",")))
+                .orElse(Collections.singletonList(CLASSPATH_SCHEME_PREFIX))
+                .stream()
+                .map(String::trim)
+                .map(GluePath::parse)
+                .collect(Collectors.toList());
     }
 
     @Override
     public boolean isDryRun() {
         return configurationParameters
-            .getBoolean(EXECUTION_DRY_RUN_PROPERTY_NAME)
-            .orElse(false);
+                .getBoolean(EXECUTION_DRY_RUN_PROPERTY_NAME)
+                .orElse(false);
     }
 
     @Override
     public SnippetType getSnippetType() {
         return configurationParameters
-            .get(SNIPPET_TYPE_PROPERTY_NAME, SnippetTypeParser::parseSnippetType)
-            .orElse(SnippetType.UNDERSCORE);
+                .get(SNIPPET_TYPE_PROPERTY_NAME, SnippetTypeParser::parseSnippetType)
+                .orElse(SnippetType.UNDERSCORE);
     }
 
     @Override
     public Class<? extends ObjectFactory> getObjectFactoryClass() {
         return configurationParameters
-            .get(OBJECT_FACTORY_PROPERTY_NAME, ObjectFactoryParser::parseObjectFactory)
-            .orElse(null);
+                .get(OBJECT_FACTORY_PROPERTY_NAME, ObjectFactoryParser::parseObjectFactory)
+                .orElse(null);
     }
 
     boolean isParallelExecutionEnabled() {
         return configurationParameters
-            .get(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, Boolean::parseBoolean)
-            .orElse(false);
+                .get(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, Boolean::parseBoolean)
+                .orElse(false);
     }
 
 }

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberTestEngine.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberTestEngine.java
@@ -20,13 +20,13 @@ import static io.cucumber.junit.platform.engine.Constants.PARALLEL_EXECUTION_ENA
  * Supports discovery and execution of {@code .feature} files using the
  * following selectors:
  * <ul>
- *     <li>{@link org.junit.platform.engine.discovery.ClasspathRootSelector}</li>
- *     <li>{@link org.junit.platform.engine.discovery.ClasspathResourceSelector}</li>
- *     <li>{@link org.junit.platform.engine.discovery.PackageSelector}</li>
- *     <li>{@link org.junit.platform.engine.discovery.FileSelector}</li>
- *     <li>{@link org.junit.platform.engine.discovery.DirectorySelector}</li>
- *     <li>{@link org.junit.platform.engine.discovery.UniqueIdSelector}</li>
- *     <li>{@link org.junit.platform.engine.discovery.UriSelector}</li>
+ * <li>{@link org.junit.platform.engine.discovery.ClasspathRootSelector}</li>
+ * <li>{@link org.junit.platform.engine.discovery.ClasspathResourceSelector}</li>
+ * <li>{@link org.junit.platform.engine.discovery.PackageSelector}</li>
+ * <li>{@link org.junit.platform.engine.discovery.FileSelector}</li>
+ * <li>{@link org.junit.platform.engine.discovery.DirectorySelector}</li>
+ * <li>{@link org.junit.platform.engine.discovery.UniqueIdSelector}</li>
+ * <li>{@link org.junit.platform.engine.discovery.UriSelector}</li>
  * </ul>
  */
 @API(status = API.Status.STABLE)

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
@@ -32,8 +32,11 @@ class DiscoverySelectorResolver {
         return packageFilter.toPredicate();
     }
 
-    private void resolve(EngineDiscoveryRequest request, CucumberEngineDescriptor engineDescriptor, Predicate<String> packageFilter) {
-        FeatureResolver featureResolver = createFeatureResolver(request.getConfigurationParameters(), engineDescriptor, packageFilter);
+    private void resolve(
+            EngineDiscoveryRequest request, CucumberEngineDescriptor engineDescriptor, Predicate<String> packageFilter
+    ) {
+        FeatureResolver featureResolver = createFeatureResolver(request.getConfigurationParameters(), engineDescriptor,
+            packageFilter);
 
         request.getSelectorsByType(ClasspathRootSelector.class).forEach(featureResolver::resolveClasspathRoot);
         request.getSelectorsByType(ClasspathResourceSelector.class).forEach(featureResolver::resolveClasspathResource);
@@ -66,8 +69,8 @@ class DiscoverySelectorResolver {
 
     private boolean includePickle(PickleDescriptor pickleDescriptor, Predicate<String> packageFilter) {
         return pickleDescriptor.getPackage()
-            .map(packageFilter::test)
-            .orElse(true);
+                .map(packageFilter::test)
+                .orElse(true);
     }
 
 }

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureOrigin.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureOrigin.java
@@ -29,7 +29,8 @@ abstract class FeatureOrigin {
     static FeatureOrigin fromUri(URI uri) {
         if (ClasspathResourceSource.CLASSPATH_SCHEME.equals(uri.getScheme())) {
             if (!uri.getSchemeSpecificPart().startsWith("/")) {
-                // ClasspathResourceSource.from expects all resources to start with /
+                // ClasspathResourceSource.from expects all resources to start
+                // with a forward slash
                 uri = URI.create(CLASSPATH_SCHEME_PREFIX + "/" + uri.getSchemeSpecificPart());
             }
             ClasspathResourceSource source = ClasspathResourceSource.from(uri);
@@ -136,7 +137,8 @@ abstract class FeatureOrigin {
 
         @Override
         TestSource nodeSource(Node node) {
-            return ClasspathResourceSource.from(source.getClasspathResourceName(), createFilePosition(node.getLocation()));
+            return ClasspathResourceSource.from(source.getClasspathResourceName(),
+                createFilePosition(node.getLocation()));
         }
 
         @Override

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
@@ -39,20 +39,25 @@ final class FeatureResolver {
     private final ResourceScanner<Feature> featureScanner = new ResourceScanner<>(
         ClassLoaders::getDefaultClassLoader,
         FeatureIdentifier::isFeature,
-        featureParser::parseResource
-    );
+        featureParser::parseResource);
 
     private final CucumberEngineDescriptor engineDescriptor;
     private final Predicate<String> packageFilter;
     private final ConfigurationParameters parameters;
 
-    private FeatureResolver(ConfigurationParameters parameters, CucumberEngineDescriptor engineDescriptor, Predicate<String> packageFilter) {
+    private FeatureResolver(
+            ConfigurationParameters parameters, CucumberEngineDescriptor engineDescriptor,
+            Predicate<String> packageFilter
+    ) {
         this.parameters = parameters;
         this.engineDescriptor = engineDescriptor;
         this.packageFilter = packageFilter;
     }
 
-    static FeatureResolver createFeatureResolver(ConfigurationParameters parameters, CucumberEngineDescriptor engineDescriptor, Predicate<String> packageFilter) {
+    static FeatureResolver createFeatureResolver(
+            ConfigurationParameters parameters, CucumberEngineDescriptor engineDescriptor,
+            Predicate<String> packageFilter
+    ) {
         return new FeatureResolver(parameters, engineDescriptor, packageFilter);
     }
 
@@ -62,11 +67,11 @@ final class FeatureResolver {
 
     private void resolvePath(Path path) {
         featureScanner
-            .scanForResourcesPath(path)
-            .stream()
-            .sorted(comparing(Feature::getUri))
-            .map(this::createFeatureDescriptor)
-            .forEach(engineDescriptor::mergeFeature);
+                .scanForResourcesPath(path)
+                .stream()
+                .sorted(comparing(Feature::getUri))
+                .map(this::createFeatureDescriptor)
+                .forEach(engineDescriptor::mergeFeature);
     }
 
     private FeatureDescriptor createFeatureDescriptor(Feature feature) {
@@ -78,14 +83,12 @@ final class FeatureResolver {
                 source.featureSegment(parent.getUniqueId(), feature),
                 getNameOrKeyWord(self),
                 source.featureSource(),
-                feature
-            ),
+                feature),
             (Node.Rule node, TestDescriptor parent) -> {
                 TestDescriptor descriptor = new NodeDescriptor(
                     source.ruleSegment(parent.getUniqueId(), node),
                     getNameOrKeyWord(node),
-                    source.nodeSource(node)
-                );
+                    source.nodeSource(node));
                 parent.addChild(descriptor);
                 return descriptor;
             }, (Node.Scenario node, TestDescriptor parent) -> {
@@ -95,8 +98,7 @@ final class FeatureResolver {
                     source.scenarioSegment(parent.getUniqueId(), node),
                     getNameOrKeyWord(node),
                     source.nodeSource(node),
-                    pickle
-                );
+                    pickle);
                 parent.addChild(descriptor);
                 return descriptor;
             },
@@ -104,8 +106,7 @@ final class FeatureResolver {
                 TestDescriptor descriptor = new NodeDescriptor(
                     source.scenarioSegment(parent.getUniqueId(), node),
                     getNameOrKeyWord(node),
-                    source.nodeSource(node)
-                );
+                    source.nodeSource(node));
                 parent.addChild(descriptor);
                 return descriptor;
             },
@@ -113,8 +114,7 @@ final class FeatureResolver {
                 NodeDescriptor descriptor = new NodeDescriptor(
                     source.examplesSegment(parent.getUniqueId(), node),
                     getNameOrKeyWord(node),
-                    source.nodeSource(node)
-                );
+                    source.nodeSource(node));
                 parent.addChild(descriptor);
                 return descriptor;
             },
@@ -125,12 +125,10 @@ final class FeatureResolver {
                     source.exampleSegment(parent.getUniqueId(), node),
                     getNameOrKeyWord(node),
                     source.nodeSource(node),
-                    pickle
-                );
+                    pickle);
                 parent.addChild(descriptor);
                 return descriptor;
-            }
-        );
+            });
     }
 
     private String getNameOrKeyWord(Node node) {
@@ -148,11 +146,11 @@ final class FeatureResolver {
 
     private void resolvePackageResource(String packageName) {
         featureScanner
-            .scanForResourcesInPackage(packageName, packageFilter)
-            .stream()
-            .sorted(comparing(Feature::getUri))
-            .map(this::createFeatureDescriptor)
-            .forEach(engineDescriptor::mergeFeature);
+                .scanForResourcesInPackage(packageName, packageFilter)
+                .stream()
+                .sorted(comparing(Feature::getUri))
+                .map(this::createFeatureDescriptor)
+                .forEach(engineDescriptor::mergeFeature);
     }
 
     void resolveClass(ClassSelector classSelector) {
@@ -166,20 +164,20 @@ final class FeatureResolver {
     void resolveClasspathResource(ClasspathResourceSelector selector) {
         String classpathResourceName = selector.getClasspathResourceName();
         featureScanner
-            .scanForClasspathResource(classpathResourceName, packageFilter)
-            .stream()
-            .sorted(comparing(Feature::getUri))
-            .map(this::createFeatureDescriptor)
-            .forEach(engineDescriptor::mergeFeature);
+                .scanForClasspathResource(classpathResourceName, packageFilter)
+                .stream()
+                .sorted(comparing(Feature::getUri))
+                .map(this::createFeatureDescriptor)
+                .forEach(engineDescriptor::mergeFeature);
     }
 
     void resolveClasspathRoot(ClasspathRootSelector selector) {
         featureScanner
-            .scanForResourcesInClasspathRoot(selector.getClasspathRoot(), packageFilter)
-            .stream()
-            .sorted(comparing(Feature::getUri))
-            .map(this::createFeatureDescriptor)
-            .forEach(engineDescriptor::mergeFeature);
+                .scanForResourcesInClasspathRoot(selector.getClasspathRoot(), packageFilter)
+                .stream()
+                .sorted(comparing(Feature::getUri))
+                .map(this::createFeatureDescriptor)
+                .forEach(engineDescriptor::mergeFeature);
     }
 
     void resolveUniqueId(UniqueIdSelector uniqueIdSelector) {
@@ -189,60 +187,60 @@ final class FeatureResolver {
             return;
         }
 
-        Predicate<TestDescriptor> keepTestWithSelectedId = testDescriptor
-            -> uniqueId.equals(testDescriptor.getUniqueId());
+        Predicate<TestDescriptor> keepTestWithSelectedId = testDescriptor -> uniqueId
+                .equals(testDescriptor.getUniqueId());
 
         uniqueId.getSegments()
-            .stream()
-            .filter(FeatureOrigin::isFeatureSegment)
-            .map(UniqueId.Segment::getValue)
-            .map(URI::create)
-            .flatMap(this::resolveUri)
-            .forEach(featureDescriptor -> {
-                featureDescriptor.prune(keepTestWithSelectedId);
-                engineDescriptor.mergeFeature(featureDescriptor);
-            });
+                .stream()
+                .filter(FeatureOrigin::isFeatureSegment)
+                .map(UniqueId.Segment::getValue)
+                .map(URI::create)
+                .flatMap(this::resolveUri)
+                .forEach(featureDescriptor -> {
+                    featureDescriptor.prune(keepTestWithSelectedId);
+                    engineDescriptor.mergeFeature(featureDescriptor);
+                });
     }
 
     private Stream<FeatureDescriptor> resolveUri(URI uri) {
         return featureScanner
-            .scanForResourcesUri(uri)
-            .stream()
-            .sorted(comparing(Feature::getUri))
-            .map(this::createFeatureDescriptor);
+                .scanForResourcesUri(uri)
+                .stream()
+                .sorted(comparing(Feature::getUri))
+                .map(this::createFeatureDescriptor);
     }
 
     void resolveUri(UriSelector selector) {
         URI uri = selector.getUri();
 
         Predicate<TestDescriptor> keepTestOnSelectedLine = fromQuery(uri.getQuery())
-            .map(FilePosition::getLine)
-            .map(FeatureResolver::testDescriptorOnLine)
-            .orElse(testDescriptor -> true);
+                .map(FilePosition::getLine)
+                .map(FeatureResolver::testDescriptorOnLine)
+                .orElse(testDescriptor -> true);
 
         resolveUri(stripQuery(uri))
-            .forEach(featureDescriptor -> {
-                featureDescriptor.prune(keepTestOnSelectedLine);
-                engineDescriptor.mergeFeature(featureDescriptor);
-            });
+                .forEach(featureDescriptor -> {
+                    featureDescriptor.prune(keepTestOnSelectedLine);
+                    engineDescriptor.mergeFeature(featureDescriptor);
+                });
     }
 
     private static Predicate<TestDescriptor> testDescriptorOnLine(Integer line) {
         return descriptor -> descriptor.getSource()
-            .flatMap(testSource -> {
-                if (testSource instanceof FileSource) {
-                    FileSource fileSystemSource = (FileSource) testSource;
-                    return fileSystemSource.getPosition();
-                }
-                if (testSource instanceof ClasspathResourceSource) {
-                    ClasspathResourceSource classpathResourceSource = (ClasspathResourceSource) testSource;
-                    return classpathResourceSource.getPosition();
-                }
-                return Optional.empty();
-            })
-            .map(FilePosition::getLine)
-            .map(line::equals)
-            .orElse(false);
+                .flatMap(testSource -> {
+                    if (testSource instanceof FileSource) {
+                        FileSource fileSystemSource = (FileSource) testSource;
+                        return fileSystemSource.getPosition();
+                    }
+                    if (testSource instanceof ClasspathResourceSource) {
+                        ClasspathResourceSource classpathResourceSource = (ClasspathResourceSource) testSource;
+                        return classpathResourceSource.getPosition();
+                    }
+                    return Optional.empty();
+                })
+                .map(FilePosition::getLine)
+                .map(line::equals)
+                .orElse(false);
     }
 
     private static URI stripQuery(URI uri) {

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/PickleDescriptor.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/PickleDescriptor.java
@@ -34,29 +34,30 @@ class PickleDescriptor extends AbstractTestDescriptor implements Node<CucumberEn
     private final Set<TestTag> tags;
     private final Set<ExclusiveResource> exclusiveResources = new LinkedHashSet<>(0);
 
-    PickleDescriptor(ConfigurationParameters parameters, UniqueId uniqueId, String name, TestSource source, Pickle pickleEvent) {
+    PickleDescriptor(
+            ConfigurationParameters parameters, UniqueId uniqueId, String name, TestSource source, Pickle pickleEvent
+    ) {
         super(uniqueId, name, source);
         this.pickleEvent = pickleEvent;
         this.tags = getTags(pickleEvent);
         this.tags.forEach(tag -> {
-                ExclusiveResourceOptions exclusiveResourceOptions = new ExclusiveResourceOptions(parameters, tag);
-                exclusiveResourceOptions.exclusiveReadWriteResource()
+            ExclusiveResourceOptions exclusiveResourceOptions = new ExclusiveResourceOptions(parameters, tag);
+            exclusiveResourceOptions.exclusiveReadWriteResource()
                     .map(resource -> new ExclusiveResource(resource, LockMode.READ_WRITE))
                     .forEach(exclusiveResources::add);
-                exclusiveResourceOptions.exclusiveReadResource()
+            exclusiveResourceOptions.exclusiveReadResource()
                     .map(resource -> new ExclusiveResource(resource, LockMode.READ))
                     .forEach(exclusiveResources::add);
-            }
-        );
+        });
     }
 
     private Set<TestTag> getTags(Pickle pickleEvent) {
         return pickleEvent.getTags().stream()
-            .map(tag -> tag.substring(1))
-            .filter(TestTag::isValid)
-            .map(TestTag::create)
-            // Retain input order
-            .collect(collectingAndThen(toCollection(LinkedHashSet::new), Collections::unmodifiableSet));
+                .map(tag -> tag.substring(1))
+                .filter(TestTag::isValid)
+                .map(TestTag::create)
+                // Retain input order
+                .collect(collectingAndThen(toCollection(LinkedHashSet::new), Collections::unmodifiableSet));
     }
 
     @Override
@@ -71,11 +72,14 @@ class PickleDescriptor extends AbstractTestDescriptor implements Node<CucumberEn
         if (expression.evaluate(tags)) {
             return SkipResult.doNotSkip();
         }
-        return SkipResult.skip("'" + Constants.FILTER_TAGS_PROPERTY_NAME + "=" + expression + "' did not match this scenario");
+        return SkipResult
+                .skip("'" + Constants.FILTER_TAGS_PROPERTY_NAME + "=" + expression + "' did not match this scenario");
     }
 
     @Override
-    public CucumberEngineExecutionContext execute(CucumberEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor) {
+    public CucumberEngineExecutionContext execute(
+            CucumberEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor
+    ) {
         context.runTestCase(pickleEvent);
         return context;
     }
@@ -101,10 +105,10 @@ class PickleDescriptor extends AbstractTestDescriptor implements Node<CucumberEn
 
     Optional<String> getPackage() {
         return getSource()
-            .filter(ClasspathResourceSource.class::isInstance)
-            .map(ClasspathResourceSource.class::cast)
-            .map(ClasspathResourceSource::getClasspathResourceName)
-            .map(ClasspathSupport::packageNameOfResource);
+                .filter(ClasspathResourceSource.class::isInstance)
+                .map(ClasspathResourceSource.class::cast)
+                .map(ClasspathResourceSource::getClasspathResourceName)
+                .map(ClasspathSupport::packageNameOfResource);
     }
 
     private static final class ExclusiveResourceOptions {
@@ -114,20 +118,19 @@ class PickleDescriptor extends AbstractTestDescriptor implements Node<CucumberEn
         ExclusiveResourceOptions(ConfigurationParameters parameters, TestTag tag) {
             this.parameters = new PrefixedConfigurationParameters(
                 parameters,
-                EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + tag.getName()
-            );
+                EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + tag.getName());
         }
 
         public Stream<String> exclusiveReadWriteResource() {
             return parameters.get(READ_WRITE_SUFFIX, s -> Arrays.stream(s.split(","))
-                .map(String::trim))
-                .orElse(Stream.empty());
+                    .map(String::trim))
+                    .orElse(Stream.empty());
         }
 
         public Stream<String> exclusiveReadResource() {
             return parameters.get(READ_SUFFIX, s -> Arrays.stream(s.split(","))
-                .map(String::trim))
-                .orElse(Stream.empty());
+                    .map(String::trim))
+                    .orElse(Stream.empty());
         }
 
     }

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/TestCaseResultObserver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/TestCaseResultObserver.java
@@ -23,8 +23,7 @@ class TestCaseResultObserver implements AutoCloseable {
             TestAbortedException::new,
             Function.identity(),
             UndefinedStepException::new,
-            Function.identity()
-        );
+            Function.identity());
     }
 
     @Override

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/UndefinedStepException.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/UndefinedStepException.java
@@ -17,8 +17,8 @@ final class UndefinedStepException extends IncompleteExecutionException {
 
     private static String createMessage(List<Suggestion> suggestions) {
         return suggestions.stream()
-            .map(suggestion -> createStepMessage(suggestion.getStep(), suggestion.getSnippets()))
-            .collect(joining("\n", createPreAmble(suggestions), ""));
+                .map(suggestion -> createStepMessage(suggestion.getStep(), suggestion.getSnippets()))
+                .collect(joining("\n", createPreAmble(suggestions), ""));
     }
 
     private static String createStepMessage(String stepText, List<String> snippets) {

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberEngineOptionsTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberEngineOptionsTest.java
@@ -19,39 +19,34 @@ class CucumberEngineOptionsTest {
     void getPluginNames() {
         MapConfigurationParameters html = new MapConfigurationParameters(
             Constants.PLUGIN_PROPERTY_NAME,
-            "html:path/to/report.html"
-        );
+            "html:path/to/report.html");
 
         assertEquals(
             singletonList("html:path/to/report.html"),
             new CucumberEngineOptions(html).plugins().stream()
-                .map(Options.Plugin::pluginString)
-                .collect(toList())
-        );
+                    .map(Options.Plugin::pluginString)
+                    .collect(toList()));
 
         CucumberEngineOptions htmlAndJson = new CucumberEngineOptions(
-            new MapConfigurationParameters(Constants.PLUGIN_PROPERTY_NAME, "html:path/with spaces/to/report.html, message:path/with spaces/to/report.ndjson")
-        );
+            new MapConfigurationParameters(Constants.PLUGIN_PROPERTY_NAME,
+                "html:path/with spaces/to/report.html, message:path/with spaces/to/report.ndjson"));
         assertEquals(
             asList("html:path/with spaces/to/report.html", "message:path/with spaces/to/report.ndjson"),
             htmlAndJson.plugins().stream()
-                .map(Options.Plugin::pluginString)
-                .collect(toList())
-        );
+                    .map(Options.Plugin::pluginString)
+                    .collect(toList()));
     }
 
     @Test
     void isMonochrome() {
         MapConfigurationParameters ansiColors = new MapConfigurationParameters(
             Constants.ANSI_COLORS_DISABLED_PROPERTY_NAME,
-            "true"
-        );
+            "true");
         assertTrue(new CucumberEngineOptions(ansiColors).isMonochrome());
 
         MapConfigurationParameters noAnsiColors = new MapConfigurationParameters(
             Constants.ANSI_COLORS_DISABLED_PROPERTY_NAME,
-            "false"
-        );
+            "false");
         assertFalse(new CucumberEngineOptions(noAnsiColors).isMonochrome());
     }
 
@@ -59,26 +54,22 @@ class CucumberEngineOptionsTest {
     void getGlue() {
         MapConfigurationParameters glue = new MapConfigurationParameters(
             Constants.GLUE_PROPERTY_NAME,
-            "com.example.app, com.example.glue"
-        );
+            "com.example.app, com.example.glue");
         assertEquals(
             asList(URI.create("classpath:/com/example/app"), URI.create("classpath:/com/example/glue")),
-            new CucumberEngineOptions(glue).getGlue()
-        );
+            new CucumberEngineOptions(glue).getGlue());
     }
 
     @Test
     void isDryRun() {
         MapConfigurationParameters dryRun = new MapConfigurationParameters(
             Constants.EXECUTION_DRY_RUN_PROPERTY_NAME,
-            "true"
-        );
+            "true");
         assertTrue(new CucumberEngineOptions(dryRun).isDryRun());
 
         MapConfigurationParameters noDryRun = new MapConfigurationParameters(
             Constants.EXECUTION_DRY_RUN_PROPERTY_NAME,
-            "false"
-        );
+            "false");
         assertFalse(new CucumberEngineOptions(noDryRun).isDryRun());
     }
 
@@ -86,14 +77,12 @@ class CucumberEngineOptionsTest {
     void getSnippetType() {
         MapConfigurationParameters underscore = new MapConfigurationParameters(
             Constants.SNIPPET_TYPE_PROPERTY_NAME,
-            "underscore"
-        );
+            "underscore");
         assertEquals(SnippetType.UNDERSCORE, new CucumberEngineOptions(underscore).getSnippetType());
 
         MapConfigurationParameters camelcase = new MapConfigurationParameters(
             Constants.SNIPPET_TYPE_PROPERTY_NAME,
-            "camelcase"
-        );
+            "camelcase");
         assertEquals(SnippetType.CAMELCASE, new CucumberEngineOptions(camelcase).getSnippetType());
     }
 
@@ -101,18 +90,15 @@ class CucumberEngineOptionsTest {
     void isParallelExecutionEnabled() {
         MapConfigurationParameters enabled = new MapConfigurationParameters(
             Constants.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME,
-            "true"
-        );
+            "true");
         assertTrue(new CucumberEngineOptions(enabled).isParallelExecutionEnabled());
 
         MapConfigurationParameters disabled = new MapConfigurationParameters(
             Constants.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME,
-            "false"
-        );
+            "false");
         assertFalse(new CucumberEngineOptions(disabled).isParallelExecutionEnabled());
         MapConfigurationParameters absent = new MapConfigurationParameters(
-            "some key", "some value"
-        );
+            "some key", "some value");
         assertFalse(new CucumberEngineOptions(absent).isParallelExecutionEnabled());
 
     }

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
@@ -31,7 +31,6 @@ class CucumberTestEngineTest {
         assertEquals(Optional.of("DEVELOPMENT"), engine.getVersion());
     }
 
-
     @Test
     void createExecutionContext() {
         EngineExecutionListener listener = new EmptyEngineExecutionListener();
@@ -46,8 +45,8 @@ class CucumberTestEngineTest {
     @Test
     void selectAndExecuteSingleScenario() {
         EngineExecutionResults result = EngineTestKit.engine("cucumber")
-            .selectors(selectFile("src/test/resources/io/cucumber/junit/platform/engine/single.feature"))
-            .execute();
+                .selectors(selectFile("src/test/resources/io/cucumber/junit/platform/engine/single.feature"))
+                .execute();
         assertEquals(2, result.testEvents().count()); // test start and finished
         assertEquals(1, result.testEvents().succeeded().count());
     }
@@ -55,15 +54,19 @@ class CucumberTestEngineTest {
     @Test
     void selectAndSkipDisabledScenario() {
         EngineExecutionResults result = EngineTestKit.engine("cucumber")
-            .configurationParameter(FILTER_TAGS_PROPERTY_NAME, "@Integration and not @Disabled")
-            .selectors(selectFile("src/test/resources/io/cucumber/junit/platform/engine/disabled.feature"))
-            .execute();
+                .configurationParameter(FILTER_TAGS_PROPERTY_NAME, "@Integration and not @Disabled")
+                .selectors(selectFile("src/test/resources/io/cucumber/junit/platform/engine/disabled.feature"))
+                .execute();
         assertEquals(1, result.testEvents().count());
         assertEquals(1, result.testEvents().skipped().count());
-        assertEquals(Optional.of("'cucumber.filter.tags=( @Integration and not ( @Disabled ) )' did not match this scenario"), result.testEvents()
-            .skipped()
-            .map(event -> event.getPayload().get()) // replace with flatMap when above java 9
-            .findFirst());
+        assertEquals(
+            Optional.of("'cucumber.filter.tags=( @Integration and not ( @Disabled ) )' did not match this scenario"),
+            result.testEvents()
+                    .skipped()
+                    .map(event -> event.getPayload().get()) // replace with
+                                                            // flatMap when
+                                                            // above java 9
+                    .findFirst());
     }
 
 }

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
@@ -42,7 +42,6 @@ import static org.junit.platform.engine.discovery.DiscoverySelectors.selectPacka
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUniqueId;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectUri;
 
-
 class DiscoverySelectorResolverTest {
 
     private final DiscoverySelectorResolver resolver = new DiscoverySelectorResolver();
@@ -66,7 +65,8 @@ class DiscoverySelectorResolverTest {
     @Test
     void resolveRequestWithMultipleClasspathResourceSelector() {
         DiscoverySelector resource1 = selectClasspathResource("io/cucumber/junit/platform/engine/single.feature");
-        DiscoverySelector resource2 = selectClasspathResource("io/cucumber/junit/platform/engine/feature-with-outline.feature");
+        DiscoverySelector resource2 = selectClasspathResource(
+            "io/cucumber/junit/platform/engine/feature-with-outline.feature");
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource1, resource2);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
         assertEquals(2, testDescriptor.getChildren().size());
@@ -104,8 +104,8 @@ class DiscoverySelectorResolverTest {
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
         List<? extends TestDescriptor> tests = testDescriptor.getDescendants().stream()
-            .filter(TestDescriptor::isTest)
-            .collect(Collectors.toList());
+                .filter(TestDescriptor::isTest)
+                .collect(Collectors.toList());
         assertEquals(4, tests.size()); // 4 examples in the outline
     }
 
@@ -117,8 +117,8 @@ class DiscoverySelectorResolverTest {
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
         List<? extends TestDescriptor> tests = testDescriptor.getDescendants().stream()
-            .filter(TestDescriptor::isTest)
-            .collect(Collectors.toList());
+                .filter(TestDescriptor::isTest)
+                .collect(Collectors.toList());
         assertEquals(2, tests.size()); // 2 examples in the examples section
     }
 
@@ -130,8 +130,8 @@ class DiscoverySelectorResolverTest {
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
         List<? extends TestDescriptor> tests = testDescriptor.getDescendants().stream()
-            .filter(TestDescriptor::isTest)
-            .collect(Collectors.toList());
+                .filter(TestDescriptor::isTest)
+                .collect(Collectors.toList());
         assertEquals(1, tests.size());
     }
 
@@ -142,8 +142,8 @@ class DiscoverySelectorResolverTest {
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
         List<? extends TestDescriptor> tests = testDescriptor.getDescendants().stream()
-            .filter(TestDescriptor::isTest)
-            .collect(Collectors.toList());
+                .filter(TestDescriptor::isTest)
+                .collect(Collectors.toList());
         assertEquals(1, tests.size());
     }
 
@@ -203,10 +203,10 @@ class DiscoverySelectorResolverTest {
             @Override
             protected boolean matchesSafely(TestDescriptor descriptor) {
                 return descriptor.getDescendants()
-                    .stream()
-                    .filter(TestDescriptor::isTest)
-                    .map(TestDescriptor::getUniqueId)
-                    .allMatch(selectedId -> selectedId.hasPrefix(targetId));
+                        .stream()
+                        .filter(TestDescriptor::isTest)
+                        .map(TestDescriptor::getUniqueId)
+                        .allMatch(selectedId -> selectedId.hasPrefix(targetId));
             }
         };
     }
@@ -253,28 +253,28 @@ class DiscoverySelectorResolverTest {
     void resolveRequestWithMultipleUniqueIdSelector() {
         Set<UniqueId> selectors = new HashSet<>();
 
-        DiscoverySelector resource = selectDirectory("src/test/resources/io/cucumber/junit/platform/engine/feature-with-outline.feature");
+        DiscoverySelector resource = selectDirectory(
+            "src/test/resources/io/cucumber/junit/platform/engine/feature-with-outline.feature");
         selectSomePickle(resource).ifPresent(selectors::add);
 
-        DiscoverySelector resource2 = selectDirectory("src/test/resources/io/cucumber/junit/platform/engine/single.feature");
+        DiscoverySelector resource2 = selectDirectory(
+            "src/test/resources/io/cucumber/junit/platform/engine/single.feature");
         selectSomePickle(resource2).ifPresent(selectors::add);
 
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(
             selectors.stream()
-                .map(DiscoverySelectors::selectUniqueId)
-                .collect(Collectors.toList())
-        );
+                    .map(DiscoverySelectors::selectUniqueId)
+                    .collect(Collectors.toList()));
 
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
 
         assertEquals(
             selectors,
             testDescriptor.getDescendants()
-                .stream()
-                .filter(PickleDescriptor.class::isInstance)
-                .map(TestDescriptor::getUniqueId)
-                .collect(toSet())
-        );
+                    .stream()
+                    .filter(PickleDescriptor.class::isInstance)
+                    .map(TestDescriptor::getUniqueId)
+                    .collect(toSet()));
     }
 
     private Optional<UniqueId> selectSomePickle(DiscoverySelector resource) {
@@ -283,9 +283,9 @@ class DiscoverySelectorResolverTest {
         Set<? extends TestDescriptor> descendants = testDescriptor.getDescendants();
         resetTestDescriptor();
         return descendants.stream()
-            .filter(PickleDescriptor.class::isInstance)
-            .map(TestDescriptor::getUniqueId)
-            .findFirst();
+                .filter(PickleDescriptor.class::isInstance)
+                .map(TestDescriptor::getUniqueId)
+                .findFirst();
     }
 
     @Test

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
@@ -41,14 +41,17 @@ class FeatureResolverTest {
     void before() {
 
         ConfigurationParameters configurationParameters = new MapConfigurationParameters(
-            new HashMap<String, String>() {{
-                put(EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + "ResourceA" + READ_WRITE_SUFFIX, "resource-a");
-                put(EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + "ResourceAReadOnly" + READ_SUFFIX, "resource-a");
-            }});
+            new HashMap<String, String>() {
+                {
+                    put(EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + "ResourceA" + READ_WRITE_SUFFIX, "resource-a");
+                    put(EXECUTION_EXCLUSIVE_RESOURCES_PREFIX + "ResourceAReadOnly" + READ_SUFFIX, "resource-a");
+                }
+            });
         EmptyEngineDiscoveryRequest request = new EmptyEngineDiscoveryRequest(configurationParameters);
         id = UniqueId.forEngine(new CucumberTestEngine().getId());
         testDescriptor = new CucumberEngineDescriptor(id);
-        FeatureResolver featureResolver = createFeatureResolver(request.getConfigurationParameters(), testDescriptor, aPackage -> true);
+        FeatureResolver featureResolver = createFeatureResolver(request.getConfigurationParameters(), testDescriptor,
+            aPackage -> true);
         featureResolver.resolveClasspathResource(selectClasspathResource(featurePath));
     }
 
@@ -61,8 +64,7 @@ class FeatureResolverTest {
         assertEquals(CONTAINER, feature.getType());
         assertEquals(
             id.append("feature", featureSegmentValue),
-            feature.getUniqueId()
-        );
+            feature.getUniqueId());
     }
 
     private TestDescriptor getFeature() {
@@ -76,24 +78,20 @@ class FeatureResolverTest {
         assertEquals("A scenario", scenario.getDisplayName());
         assertEquals(
             asSet(create("FeatureTag"), create("ScenarioTag"), create("ResourceA"), create("ResourceAReadOnly")),
-            scenario.getTags()
-        );
+            scenario.getTags());
         assertEquals(of(from(featurePath, from(5, 3))), scenario.getSource());
         assertEquals(TEST, scenario.getType());
         assertEquals(
             id.append("feature", featureSegmentValue)
-                .append("scenario", "5"),
-            scenario.getUniqueId()
-        );
+                    .append("scenario", "5"),
+            scenario.getUniqueId());
         PickleDescriptor pickleDescriptor = (PickleDescriptor) scenario;
         assertEquals(Optional.of("io.cucumber.junit.platform.engine"), pickleDescriptor.getPackage());
         assertEquals(
             asSet(
                 new ExclusiveResource("resource-a", LockMode.READ_WRITE),
-                new ExclusiveResource("resource-a", LockMode.READ)
-            ),
-            pickleDescriptor.getExclusiveResources()
-        );
+                new ExclusiveResource("resource-a", LockMode.READ)),
+            pickleDescriptor.getExclusiveResources());
     }
 
     private TestDescriptor getScenario() {
@@ -111,15 +109,13 @@ class FeatureResolverTest {
         assertEquals("A scenario outline", outline.getDisplayName());
         assertEquals(
             emptySet(),
-            outline.getTags()
-        );
+            outline.getTags());
         assertEquals(of(from(featurePath, from(11, 3))), outline.getSource());
         assertEquals(CONTAINER, outline.getType());
         assertEquals(
             id.append("feature", featureSegmentValue)
-                .append("scenario", "11"),
-            outline.getUniqueId()
-        );
+                    .append("scenario", "11"),
+            outline.getUniqueId());
     }
 
     private TestDescriptor getOutline() {
@@ -134,18 +130,16 @@ class FeatureResolverTest {
         assertEquals("Example #1", example.getDisplayName());
         assertEquals(
             asSet(create("FeatureTag"), create("Example1Tag"), create("ScenarioOutlineTag")),
-            example.getTags()
-        );
+            example.getTags());
         assertEquals(of(from(featurePath, from(19, 7))), example.getSource());
         assertEquals(TEST, example.getType());
 
         assertEquals(
             id.append("feature", featureSegmentValue)
-                .append("scenario", "11")
-                .append("examples", "17")
-                .append("example", "19"),
-            example.getUniqueId()
-        );
+                    .append("scenario", "11")
+                    .append("examples", "17")
+                    .append("example", "19"),
+            example.getUniqueId());
 
         PickleDescriptor pickleDescriptor = (PickleDescriptor) example;
         assertEquals(Optional.of("io.cucumber.junit.platform.engine"), pickleDescriptor.getPackage());

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/StubBackendProviderService.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/StubBackendProviderService.java
@@ -1,6 +1,5 @@
 package io.cucumber.junit.platform.engine;
 
-
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.BackendProviderService;
 import io.cucumber.core.backend.Container;
@@ -78,7 +77,6 @@ public class StubBackendProviderService implements BackendProviderService {
                 }
             };
         }
-
 
         @Override
         public void buildWorld() {

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/TestCaseResultObserverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/TestCaseResultObserverTest.java
@@ -218,8 +218,7 @@ class TestCaseResultObserverTest {
             asList(
                 "mocked snippet 1",
                 "mocked snippet 2",
-                "mocked snippet 3"
-            )));
+                "mocked snippet 3")));
         Result result = new Result(Status.UNDEFINED, Duration.ZERO, null);
         bus.send(new TestStepFinished(Instant.now(), testCase, testStep, result));
         bus.send(new TestCaseFinished(Instant.now(), testCase, result));
@@ -227,13 +226,13 @@ class TestCaseResultObserverTest {
         assertThat(exception.getCause(), instanceOf(UndefinedStepException.class));
 
         assertThat(exception.getCause().getMessage(), is("" +
-            "The step \"mocked\" is undefined. You can implement it using the snippet(s) below:\n" +
-            "\n" +
-            "mocked snippet 1\n" +
-            "---\n" +
-            "mocked snippet 2\n" +
-            "---\n" +
-            "mocked snippet 3\n"));
+                "The step \"mocked\" is undefined. You can implement it using the snippet(s) below:\n" +
+                "\n" +
+                "mocked snippet 1\n" +
+                "---\n" +
+                "mocked snippet 2\n" +
+                "---\n" +
+                "mocked snippet 3\n"));
     }
 
     @Test

--- a/junit/src/main/java/io/cucumber/junit/Assertions.java
+++ b/junit/src/main/java/io/cucumber/junit/Assertions.java
@@ -15,12 +15,11 @@ final class Assertions {
             for (Annotation annotation : method.getAnnotations()) {
                 if (annotation.annotationType().getName().startsWith("io.cucumber")) {
                     throw new CucumberException("\n\n" +
-                        "Classes annotated with @RunWith(Cucumber.class) must not define any\n" +
-                        "Step Definition or Hook methods. Their sole purpose is to serve as\n" +
-                        "an entry point for JUnit. Step Definitions and Hooks should be defined\n" +
-                        "in their own classes. This allows them to be reused across features.\n" +
-                        "Offending class: " + clazz + "\n"
-                    );
+                            "Classes annotated with @RunWith(Cucumber.class) must not define any\n" +
+                            "Step Definition or Hook methods. Their sole purpose is to serve as\n" +
+                            "an entry point for JUnit. Step Definitions and Hooks should be defined\n" +
+                            "in their own classes. This allows them to be reused across features.\n" +
+                            "Offending class: " + clazz + "\n");
                 }
             }
         }

--- a/junit/src/main/java/io/cucumber/junit/Cucumber.java
+++ b/junit/src/main/java/io/cucumber/junit/Cucumber.java
@@ -49,19 +49,23 @@ import static java.util.stream.Collectors.toList;
 /**
  * Cucumber JUnit Runner.
  * <p>
- * A class annotated with {@code @RunWith(Cucumber.class)} will run feature files as junit tests.
- * In general, the runner class should be empty without any fields or methods.
- * For example:
- * <blockquote><pre>
+ * A class annotated with {@code @RunWith(Cucumber.class)} will run feature
+ * files as junit tests. In general, the runner class should be empty without
+ * any fields or methods. For example: <blockquote>
+ * 
+ * <pre>
  * &#64;RunWith(Cucumber.class)
  * &#64;CucumberOptions(plugin = "pretty")
  * public class RunCucumberTest {
  * }
- * </pre></blockquote>
+ * </pre>
+ * 
+ * </blockquote>
  * <p>
- * By default Cucumber will look for {@code .feature} and glue files on the classpath, using the same resource
- * path as the annotated class. For example, if the annotated class is {@code com.example.RunCucumber} then
- * features and glue are assumed to be located in {@code com.example}.
+ * By default Cucumber will look for {@code .feature} and glue files on the
+ * classpath, using the same resource path as the annotated class. For example,
+ * if the annotated class is {@code com.example.RunCucumber} then features and
+ * glue are assumed to be located in {@code com.example}.
  * <p>
  * Options can be provided in by (order of precedence):
  * <ol>
@@ -72,10 +76,12 @@ import static java.util.stream.Collectors.toList;
  * </ol>
  * For available properties see {@link Constants}.
  * <p>
- * Cucumber also supports JUnits {@link ClassRule}, {@link BeforeClass} and {@link AfterClass} annotations.
- * These will be executed before and after all scenarios. Using these is not recommended as it limits the portability
- * between different runners; they may not execute correctly when using the commandline, IntelliJ IDEA or
- * Cucumber-Eclipse. Instead it is recommended to use Cucumbers `Before` and `After` hooks.
+ * Cucumber also supports JUnits {@link ClassRule}, {@link BeforeClass} and
+ * {@link AfterClass} annotations. These will be executed before and after all
+ * scenarios. Using these is not recommended as it limits the portability
+ * between different runners; they may not execute correctly when using the
+ * commandline, IntelliJ IDEA or Cucumber-Eclipse. Instead it is recommended to
+ * use Cucumbers `Before` and `After` hooks.
  *
  * @see CucumberOptions
  */
@@ -95,57 +101,63 @@ public final class Cucumber extends ParentRunner<ParentRunner<?>> {
     /**
      * Constructor called by JUnit.
      *
-     * @param clazz the class with the @RunWith annotation.
-     * @throws org.junit.runners.model.InitializationError if there is another problem
+     * @param  clazz                                       the class with
+     *                                                     the @RunWith
+     *                                                     annotation.
+     * @throws org.junit.runners.model.InitializationError if there is another
+     *                                                     problem
      */
     public Cucumber(Class<?> clazz) throws InitializationError {
         super(clazz);
         Assertions.assertNoCucumberAnnotatedMethods(clazz);
 
-        // Parse the options early to provide fast feedback about invalid options
+        // Parse the options early to provide fast feedback about invalid
+        // options
         RuntimeOptions propertiesFileOptions = new CucumberPropertiesParser()
-            .parse(CucumberProperties.fromPropertiesFile())
-            .build();
+                .parse(CucumberProperties.fromPropertiesFile())
+                .build();
 
         RuntimeOptions annotationOptions = new CucumberOptionsAnnotationParser()
-            .withOptionsProvider(new JUnitCucumberOptionsProvider())
-            .parse(clazz)
-            .build(propertiesFileOptions);
+                .withOptionsProvider(new JUnitCucumberOptionsProvider())
+                .parse(clazz)
+                .build(propertiesFileOptions);
 
         RuntimeOptions environmentOptions = new CucumberPropertiesParser()
-            .parse(CucumberProperties.fromEnvironment())
-            .build(annotationOptions);
+                .parse(CucumberProperties.fromEnvironment())
+                .build(annotationOptions);
 
         RuntimeOptions runtimeOptions = new CucumberPropertiesParser()
-            .parse(CucumberProperties.fromSystemProperties())
-            .build(environmentOptions);
+                .parse(CucumberProperties.fromSystemProperties())
+                .build(environmentOptions);
 
         // Next parse the junit options
         JUnitOptions junitPropertiesFileOptions = new JUnitOptionsParser()
-            .parse(CucumberProperties.fromPropertiesFile())
-            .build();
+                .parse(CucumberProperties.fromPropertiesFile())
+                .build();
 
         JUnitOptions junitAnnotationOptions = new JUnitOptionsParser()
-            .parse(clazz)
-            .build(junitPropertiesFileOptions);
+                .parse(clazz)
+                .build(junitPropertiesFileOptions);
 
         JUnitOptions junitEnvironmentOptions = new JUnitOptionsParser()
-            .parse(CucumberProperties.fromEnvironment())
-            .build(junitAnnotationOptions);
+                .parse(CucumberProperties.fromEnvironment())
+                .build(junitAnnotationOptions);
 
         JUnitOptions junitOptions = new JUnitOptionsParser()
-            .parse(CucumberProperties.fromSystemProperties())
-            .build(junitEnvironmentOptions);
+                .parse(CucumberProperties.fromSystemProperties())
+                .build(junitEnvironmentOptions);
 
         this.bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
 
         // Parse the features early. Don't proceed when there are lexer errors
         FeatureParser parser = new FeatureParser(bus::generateId);
         Supplier<ClassLoader> classLoader = ClassLoaders::getDefaultClassLoader;
-        FeaturePathFeatureSupplier featureSupplier = new FeaturePathFeatureSupplier(classLoader, runtimeOptions, parser);
+        FeaturePathFeatureSupplier featureSupplier = new FeaturePathFeatureSupplier(classLoader, runtimeOptions,
+            parser);
         this.features = featureSupplier.get();
 
-        // Create plugins after feature parsing to avoid the creation of empty files on lexer errors.
+        // Create plugins after feature parsing to avoid the creation of empty
+        // files on lexer errors.
         this.plugins = new Plugins(new PluginFactory(), runtimeOptions);
         ExitStatus exitStatus = new ExitStatus(runtimeOptions);
         this.plugins.addPlugin(exitStatus);
@@ -153,14 +165,16 @@ public final class Cucumber extends ParentRunner<ParentRunner<?>> {
         ObjectFactoryServiceLoader objectFactoryServiceLoader = new ObjectFactoryServiceLoader(runtimeOptions);
         ObjectFactorySupplier objectFactorySupplier = new ThreadLocalObjectFactorySupplier(objectFactoryServiceLoader);
         BackendSupplier backendSupplier = new BackendServiceLoader(clazz::getClassLoader, objectFactorySupplier);
-        TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(classLoader, runtimeOptions);
-        ThreadLocalRunnerSupplier runnerSupplier = new ThreadLocalRunnerSupplier(runtimeOptions, bus, backendSupplier, objectFactorySupplier, typeRegistryConfigurerSupplier);
+        TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(
+            classLoader, runtimeOptions);
+        ThreadLocalRunnerSupplier runnerSupplier = new ThreadLocalRunnerSupplier(runtimeOptions, bus, backendSupplier,
+            objectFactorySupplier, typeRegistryConfigurerSupplier);
         this.context = new CucumberExecutionContext(bus, exitStatus, runnerSupplier);
         Predicate<Pickle> filters = new Filters(runtimeOptions);
         this.children = features.stream()
-            .map(feature -> FeatureRunner.create(feature, filters, runnerSupplier, junitOptions))
-            .filter(runner -> !runner.isEmpty())
-            .collect(toList());
+                .map(feature -> FeatureRunner.create(feature, filters, runnerSupplier, junitOptions))
+                .filter(runner -> !runner.isEmpty())
+                .collect(toList());
     }
 
     @Override

--- a/junit/src/main/java/io/cucumber/junit/CucumberOptions.java
+++ b/junit/src/main/java/io/cucumber/junit/CucumberOptions.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  * Configure Cucumbers options.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE})
+@Target({ ElementType.TYPE })
 @API(status = API.Status.STABLE)
 public @interface CucumberOptions {
 
@@ -22,35 +22,38 @@ public @interface CucumberOptions {
     boolean dryRun() default false;
 
     /**
-     * @return true if undefined and pending steps should be treated as errors.
+     * @return     true if undefined and pending steps should be treated as
+     *             errors.
      * @deprecated will be removed and cucumber will default to strict
      */
     @Deprecated
     boolean strict() default true;
 
     /**
-     * Either a URI or path to a directory of features or a URI or path to a single
-     * feature optionally followed by a colon and line numbers.
+     * Either a URI or path to a directory of features or a URI or path to a
+     * single feature optionally followed by a colon and line numbers.
      * <p>
-     * When no feature path is provided, Cucumber will use the package of the annotated
-     * class. For example, if the annotated class is {@code com.example.RunCucumber}
-     * then features are assumed to be located in {@code classpath:com/example}.
+     * When no feature path is provided, Cucumber will use the package of the
+     * annotated class. For example, if the annotated class is
+     * {@code com.example.RunCucumber} then features are assumed to be located
+     * in {@code classpath:com/example}.
      *
      * @return list of files or directories
-     * @see io.cucumber.core.feature.FeatureWithLines
+     * @see    io.cucumber.core.feature.FeatureWithLines
      */
     String[] features() default {};
 
     /**
-     * Package to load glue code (step definitions,
-     * hooks and plugins) from. E.g: {@code com.example.app}
+     * Package to load glue code (step definitions, hooks and plugins) from.
+     * E.g: {@code com.example.app}
      * <p>
      * When no glue is provided, Cucumber will use the package of the annotated
-     * class. For example, if the annotated class is {@code com.example.RunCucumber}
-     * then glue is assumed to be located in {@code com.example}.
+     * class. For example, if the annotated class is
+     * {@code com.example.RunCucumber} then glue is assumed to be located in
+     * {@code com.example}.
      *
      * @return list of package names
-     * @see io.cucumber.core.feature.GluePath
+     * @see    io.cucumber.core.feature.GluePath
      */
     String[] glue() default {};
 
@@ -58,7 +61,8 @@ public @interface CucumberOptions {
      * Package to load additional glue code (step definitions, hooks and
      * plugins) from. E.g: {@code com.example.app}
      * <p>
-     * These packages are used in addition to the default described in {@code #glue}.
+     * These packages are used in addition to the default described in
+     * {@code #glue}.
      *
      * @return list of package names
      */
@@ -74,19 +78,18 @@ public @interface CucumberOptions {
     String tags() default "";
 
     /**
-     * Register plugins.
-     * Built-in plugin types: {@code junit}, {@code html},
+     * Register plugins. Built-in plugin types: {@code junit}, {@code html},
      * {@code pretty}, {@code progress}, {@code json}, {@code usage},
      * {@code unused}, {@code rerun}, {@code testng}.
      * <p>
-     * Can also be a fully qualified class name, allowing
-     * registration of 3rd party plugins.
+     * Can also be a fully qualified class name, allowing registration of 3rd
+     * party plugins.
      * <p>
      * Plugins can be provided with an argument. For example
      * {@code json:target/cucumber-report.json}
      *
      * @return list of plugins
-     * @see Plugin
+     * @see    Plugin
      */
     String[] plugin() default {};
 
@@ -96,7 +99,8 @@ public @interface CucumberOptions {
     boolean monochrome() default false;
 
     /**
-     * Only run scenarios whose names match one of the provided regular expressions.
+     * Only run scenarios whose names match one of the provided regular
+     * expressions.
      *
      * @return a list of regular expressions
      */
@@ -113,8 +117,8 @@ public @interface CucumberOptions {
      * Make sure that the names of the test cases only is made up of
      * [A-Za-Z0-9_] so that the names for certain can be used as file names.
      * <p>
-     * Gradle for instance will use these names in the file names of
-     * the JUnit xml report files.
+     * Gradle for instance will use these names in the file names of the JUnit
+     * xml report files.
      *
      * @return true to enforce the use of well-formed file names
      */
@@ -123,11 +127,11 @@ public @interface CucumberOptions {
     /**
      * Provide step notifications.
      * <p>
-     * By default steps are not included in notifications and descriptions.
-     * This aligns test case in the Cucumber-JVM domain (Scenarios) with the
-     * test case in the JUnit domain (the leafs in the description tree),
-     * and works better with the report files of the notification listeners
-     * like maven surefire or gradle.
+     * By default steps are not included in notifications and descriptions. This
+     * aligns test case in the Cucumber-JVM domain (Scenarios) with the test
+     * case in the JUnit domain (the leafs in the description tree), and works
+     * better with the report files of the notification listeners like maven
+     * surefire or gradle.
      *
      * @return true to include steps should be included in notifications
      */
@@ -136,9 +140,9 @@ public @interface CucumberOptions {
     /**
      * Specify a custom ObjectFactory.
      * <p>
-     * In case a custom ObjectFactory is needed, the class can be specified here.
-     * A custom ObjectFactory might be needed when more granular control is needed
-     * over the dependency injection mechanism.
+     * In case a custom ObjectFactory is needed, the class can be specified
+     * here. A custom ObjectFactory might be needed when more granular control
+     * is needed over the dependency injection mechanism.
      *
      * @return an {@link io.cucumber.core.backend.ObjectFactory} implementation
      */

--- a/junit/src/main/java/io/cucumber/junit/FeatureRunner.java
+++ b/junit/src/main/java/io/cucumber/junit/FeatureRunner.java
@@ -28,20 +28,22 @@ final class FeatureRunner extends ParentRunner<PickleRunner> {
     private final JUnitOptions options;
     private Description description;
 
-    private FeatureRunner(Feature feature, Predicate<Pickle> filter, RunnerSupplier runners, JUnitOptions options) throws InitializationError {
+    private FeatureRunner(Feature feature, Predicate<Pickle> filter, RunnerSupplier runners, JUnitOptions options)
+            throws InitializationError {
         super((Class<?>) null);
         this.feature = feature;
         this.options = options;
         String name = feature.getName().orElse("EMPTY_NAME");
         this.children = feature.getPickles().stream()
-            .filter(filter).
-                map(pickle -> options.stepNotifications()
-                    ? withStepDescriptions(runners, pickle, options)
-                    : withNoStepDescriptions(name, runners, pickle, options))
-            .collect(toList());
+                .filter(filter).map(pickle -> options.stepNotifications()
+                        ? withStepDescriptions(runners, pickle, options)
+                        : withNoStepDescriptions(name, runners, pickle, options))
+                .collect(toList());
     }
 
-    static FeatureRunner create(Feature feature, Predicate<Pickle> filter, RunnerSupplier runners, JUnitOptions options) {
+    static FeatureRunner create(
+            Feature feature, Predicate<Pickle> filter, RunnerSupplier runners, JUnitOptions options
+    ) {
         try {
             return new FeatureRunner(feature, filter, runners, options);
         } catch (InitializationError e) {
@@ -69,8 +71,10 @@ final class FeatureRunner extends ParentRunner<PickleRunner> {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             FeatureId featureId = (FeatureId) o;
             return uri.equals(featureId.uri);
         }
@@ -119,6 +123,5 @@ final class FeatureRunner extends ParentRunner<PickleRunner> {
             notifier.fireTestFinished(describeChild(child));
         }
     }
-
 
 }

--- a/junit/src/main/java/io/cucumber/junit/JUnitOptionsParser.java
+++ b/junit/src/main/java/io/cucumber/junit/JUnitOptionsParser.java
@@ -5,14 +5,16 @@ import java.util.Map;
 final class JUnitOptionsParser {
 
     JUnitOptionsBuilder parse(Map<String, String> properties) {
-        // TODO: Nothing to parse yet. See https://github.com/cucumber/cucumber-jvm/issues/1675
+        // TODO: Nothing to parse yet. See
+        // https://github.com/cucumber/cucumber-jvm/issues/1675
         return new JUnitOptionsBuilder();
     }
 
     JUnitOptionsBuilder parse(Class<?> clazz) {
         JUnitOptionsBuilder args = new JUnitOptionsBuilder();
 
-        for (Class<?> classWithOptions = clazz; classWithOptions != Object.class; classWithOptions = classWithOptions.getSuperclass()) {
+        for (Class<?> classWithOptions = clazz; classWithOptions != Object.class; classWithOptions = classWithOptions
+                .getSuperclass()) {
             final CucumberOptions options = classWithOptions.getAnnotation(CucumberOptions.class);
 
             if (options == null) {
@@ -31,4 +33,3 @@ final class JUnitOptionsParser {
     }
 
 }
-

--- a/junit/src/main/java/io/cucumber/junit/JUnitReporter.java
+++ b/junit/src/main/java/io/cucumber/junit/JUnitReporter.java
@@ -54,11 +54,9 @@ final class JUnitReporter {
 
     private void handleSnippetSuggested(SnippetsSuggestedEvent snippetsSuggestedEvent) {
         snippetsPerStep.putIfAbsent(new StepLocation(
-                snippetsSuggestedEvent.getUri(),
-                snippetsSuggestedEvent.getStepLine()
-            ),
-            snippetsSuggestedEvent.getSnippets()
-        );
+            snippetsSuggestedEvent.getUri(),
+            snippetsSuggestedEvent.getStepLine()),
+            snippetsSuggestedEvent.getSnippets());
     }
 
     void finishExecutionUnit() {
@@ -126,13 +124,11 @@ final class JUnitReporter {
                 break;
             case UNDEFINED:
                 Collection<String> snippets = snippetsPerStep.remove(
-                    new StepLocation(testStep.getUri(), testStep.getStepLine())
-                );
+                    new StepLocation(testStep.getUri(), testStep.getStepLine()));
                 stepErrors.add(new UndefinedStepException(
                     testStep.getStepText(),
                     snippets,
-                    snippetsPerStep.values()
-                ));
+                    snippetsPerStep.values()));
                 stepNotifier.addFailure(error == null ? new UndefinedStepException(snippets) : error);
                 break;
             default:
@@ -158,14 +154,14 @@ final class JUnitReporter {
                     stepErrors.add(new SkippedThrowable(SCENARIO));
                 }
                 stepErrors.stream()
-                    .findFirst()
-                    .ifPresent(pickleRunnerNotifier::addFailedAssumption);
+                        .findFirst()
+                        .ifPresent(pickleRunnerNotifier::addFailedAssumption);
                 break;
             case PENDING:
             case UNDEFINED:
                 stepErrors.stream()
-                    .findFirst()
-                    .ifPresent(pickleRunnerNotifier::addFailure);
+                        .findFirst()
+                        .ifPresent(pickleRunnerNotifier::addFailure);
                 break;
             case AMBIGUOUS:
             case FAILED:

--- a/junit/src/main/java/io/cucumber/junit/PickleRunners.java
+++ b/junit/src/main/java/io/cucumber/junit/PickleRunners.java
@@ -19,7 +19,6 @@ import java.util.Map;
 
 import static io.cucumber.junit.FileNameCompatibleNames.createName;
 
-
 final class PickleRunners {
 
     static PickleRunner withStepDescriptions(RunnerSupplier runnerSupplier, Pickle pickle, JUnitOptions options) {
@@ -30,10 +29,11 @@ final class PickleRunners {
         }
     }
 
-    static PickleRunner withNoStepDescriptions(String featureName, RunnerSupplier runnerSupplier, Pickle pickle, JUnitOptions jUnitOptions) {
+    static PickleRunner withNoStepDescriptions(
+            String featureName, RunnerSupplier runnerSupplier, Pickle pickle, JUnitOptions jUnitOptions
+    ) {
         return new NoStepDescriptions(featureName, runnerSupplier, pickle, jUnitOptions);
     }
-
 
     interface PickleRunner {
 
@@ -53,7 +53,8 @@ final class PickleRunners {
         private final Map<Step, Description> stepDescriptions = new HashMap<>();
         private Description description;
 
-        WithStepDescriptions(RunnerSupplier runnerSupplier, Pickle pickle, JUnitOptions jUnitOptions) throws InitializationError {
+        WithStepDescriptions(RunnerSupplier runnerSupplier, Pickle pickle, JUnitOptions jUnitOptions)
+                throws InitializationError {
             super((Class<?>) null);
             this.runnerSupplier = runnerSupplier;
             this.pickle = pickle;
@@ -104,13 +105,14 @@ final class PickleRunners {
 
         @Override
         protected void runChild(Step step, RunNotifier notifier) {
-            // The way we override run(RunNotifier) causes this method to never be called.
-            // Instead it happens via cucumberScenario.run(jUnitReporter, jUnitReporter, runtime);
+            // The way we override run(RunNotifier) causes this method to never
+            // be called.
+            // Instead it happens via cucumberScenario.run(jUnitReporter,
+            // jUnitReporter, runtime);
             throw new UnsupportedOperationException();
         }
 
     }
-
 
     static final class NoStepDescriptions implements PickleRunner {
 
@@ -120,7 +122,9 @@ final class PickleRunners {
         private final JUnitOptions jUnitOptions;
         private Description description;
 
-        NoStepDescriptions(String featureName, RunnerSupplier runnerSupplier, Pickle pickle, JUnitOptions jUnitOptions) {
+        NoStepDescriptions(
+                String featureName, RunnerSupplier runnerSupplier, Pickle pickle, JUnitOptions jUnitOptions
+        ) {
             this.featureName = featureName;
             this.runnerSupplier = runnerSupplier;
             this.pickle = pickle;
@@ -178,8 +182,10 @@ final class PickleRunners {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             PickleId that = (PickleId) o;
             return pickleLine == that.pickleLine && uri.equals(that.uri);
         }
@@ -214,8 +220,10 @@ final class PickleRunners {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
             PickleStepId that = (PickleStepId) o;
             return pickleLine == that.pickleLine && pickleStepLine == that.pickleStepLine && uri.equals(that.uri);
         }

--- a/junit/src/main/java/io/cucumber/junit/UndefinedStepException.java
+++ b/junit/src/main/java/io/cucumber/junit/UndefinedStepException.java
@@ -34,10 +34,12 @@ final class UndefinedStepException extends RuntimeException {
         super(createMessage(stepText, snippets, otherSnippets), null, false, false);
     }
 
-    private static String createMessage(String stepText, Collection<String> snippets, Collection<Collection<String>> otherSnippets) {
+    private static String createMessage(
+            String stepText, Collection<String> snippets, Collection<Collection<String>> otherSnippets
+    ) {
         Set<String> otherUniqueSnippets = otherSnippets.stream()
-            .flatMap(Collection::stream)
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+                .flatMap(Collection::stream)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         otherUniqueSnippets.removeAll(snippets);
 

--- a/junit/src/test/java/io/cucumber/junit/AssertionsTest.java
+++ b/junit/src/test/java/io/cucumber/junit/AssertionsTest.java
@@ -19,7 +19,13 @@ class AssertionsTest {
     void should_throw_cucumber_exception_when_annotated() {
         Executable testMethod = () -> Assertions.assertNoCucumberAnnotatedMethods(WithCucumberMethod.class);
         CucumberException expectedThrown = assertThrows(CucumberException.class, testMethod);
-        assertThat(expectedThrown.getMessage(), is(equalTo("\n\nClasses annotated with @RunWith(Cucumber.class) must not define any\nStep Definition or Hook methods. Their sole purpose is to serve as\nan entry point for JUnit. Step Definitions and Hooks should be defined\nin their own classes. This allows them to be reused across features.\nOffending class: class io.cucumber.junit.AssertionsTest$WithCucumberMethod\n")));
+        assertThat(expectedThrown.getMessage(), is(equalTo(
+            "\n\n" +
+                    "Classes annotated with @RunWith(Cucumber.class) must not define any\n" +
+                    "Step Definition or Hook methods. Their sole purpose is to serve as\n" +
+                    "an entry point for JUnit. Step Definitions and Hooks should be defined\n" +
+                    "in their own classes. This allows them to be reused across features.\n" +
+                    "Offending class: class io.cucumber.junit.AssertionsTest$WithCucumberMethod\n")));
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/junit/src/test/java/io/cucumber/junit/CucumberTest.java
+++ b/junit/src/test/java/io/cucumber/junit/CucumberTest.java
@@ -69,27 +69,23 @@ class CucumberTest {
         Executable testMethod = () -> new Cucumber(LexerErrorFeature.class);
         FeatureParserException actualThrown = assertThrows(FeatureParserException.class, testMethod);
         assertThat(
-            actualThrown.getMessage(),
-            equalTo("" +
-                "Failed to parse resource at: classpath:io/cucumber/error/lexer_error.feature\n" +
-                "(1:1): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Feature  FA'\n" +
-                "(3:3): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Scenario SA'\n" +
-                "(4:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Given GA'\n" +
-                "(5:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'When GA'\n" +
-                "(6:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Then TA'"
-            )
-        );
+                actualThrown.getMessage(),
+                equalTo("" +
+                        "Failed to parse resource at: classpath:io/cucumber/error/lexer_error.feature\n" +
+                        "(1:1): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Feature  FA'\n" +
+                        "(3:3): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Scenario SA'\n" +
+                        "(4:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Given GA'\n" +
+                        "(5:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'When GA'\n" +
+                        "(6:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Then TA'"));
     }
 
     @Test
     void testThatFileIsNotCreatedOnParsingError() {
         assertThrows(FeatureParserException.class,
-            () -> new Cucumber(FormatterWithLexerErrorFeature.class)
-        );
+                () -> new Cucumber(FormatterWithLexerErrorFeature.class));
         assertFalse(
-            new File("target/lexor_error_feature.ndjson").exists(),
-            "File is created despite Lexor Error"
-        );
+                new File("target/lexor_error_feature.ndjson").exists(),
+                "File is created despite Lexor Error");
     }
 
     @Test
@@ -109,11 +105,14 @@ class CucumberTest {
         {
             InOrder order = Mockito.inOrder(listener);
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
-            order.verify(listener).testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
+            order.verify(listener)
+                    .testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
-            order.verify(listener).testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
+            order.verify(listener)
+                    .testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
-            order.verify(listener).testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
+            order.verify(listener)
+                    .testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
         }
         {
             InOrder order = Mockito.inOrder(listener);
@@ -151,7 +150,8 @@ class CucumberTest {
     void no_stepdefs_in_cucumber_runner_invalid() {
         Executable testMethod = () -> Assertions.assertNoCucumberAnnotatedMethods(Invalid.class);
         CucumberException expectedThrown = assertThrows(CucumberException.class, testMethod);
-        assertThat(expectedThrown.getMessage(), is(equalTo("\n\nClasses annotated with @RunWith(Cucumber.class) must not define any\nStep Definition or Hook methods. Their sole purpose is to serve as\nan entry point for JUnit. Step Definitions and Hooks should be defined\nin their own classes. This allows them to be reused across features.\nOffending class: class io.cucumber.junit.CucumberTest$Invalid\n")));
+        assertThat(expectedThrown.getMessage(), is(equalTo(
+                "\n\nClasses annotated with @RunWith(Cucumber.class) must not define any\nStep Definition or Hook methods. Their sole purpose is to serve as\nan entry point for JUnit. Step Definitions and Hooks should be defined\nin their own classes. This allows them to be reused across features.\nOffending class: class io.cucumber.junit.CucumberTest$Invalid\n")));
     }
 
     @Retention(RetentionPolicy.RUNTIME)
@@ -188,25 +188,27 @@ class CucumberTest {
     }
 
     @SuppressWarnings("WeakerAccess")
-    @CucumberOptions(features = {"classpath:io/cucumber/junit"})
+    @CucumberOptions(features = "classpath:io/cucumber/junit")
     public static class ExplicitFeaturePath {
 
     }
 
     @SuppressWarnings("WeakerAccess")
-    @CucumberOptions(features = {"classpath:gibber/ish"})
+    @CucumberOptions(features = "classpath:gibber/ish")
     public static class ExplicitFeaturePathWithNoFeatures {
 
     }
 
     @SuppressWarnings("WeakerAccess")
-    @CucumberOptions(features = {"classpath:io/cucumber/error/lexer_error.feature"})
+    @CucumberOptions(features = "classpath:io/cucumber/error/lexer_error.feature")
     public static class LexerErrorFeature {
 
     }
 
     @SuppressWarnings("WeakerAccess")
-    @CucumberOptions(features = {"classpath:io/cucumber/error/lexer_error.feature"}, plugin = {"message:target/lexor_error_feature.ndjson"})
+    @CucumberOptions(
+            features = "classpath:io/cucumber/error/lexer_error.feature",
+            plugin = "message:target/lexor_error_feature.ndjson")
     public static class FormatterWithLexerErrorFeature {
 
     }

--- a/junit/src/test/java/io/cucumber/junit/CucumberTest.java
+++ b/junit/src/test/java/io/cucumber/junit/CucumberTest.java
@@ -69,23 +69,23 @@ class CucumberTest {
         Executable testMethod = () -> new Cucumber(LexerErrorFeature.class);
         FeatureParserException actualThrown = assertThrows(FeatureParserException.class, testMethod);
         assertThat(
-                actualThrown.getMessage(),
-                equalTo("" +
-                        "Failed to parse resource at: classpath:io/cucumber/error/lexer_error.feature\n" +
-                        "(1:1): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Feature  FA'\n" +
-                        "(3:3): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Scenario SA'\n" +
-                        "(4:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Given GA'\n" +
-                        "(5:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'When GA'\n" +
-                        "(6:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Then TA'"));
+            actualThrown.getMessage(),
+            equalTo("" +
+                    "Failed to parse resource at: classpath:io/cucumber/error/lexer_error.feature\n" +
+                    "(1:1): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Feature  FA'\n" +
+                    "(3:3): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Scenario SA'\n" +
+                    "(4:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Given GA'\n" +
+                    "(5:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'When GA'\n" +
+                    "(6:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Then TA'"));
     }
 
     @Test
     void testThatFileIsNotCreatedOnParsingError() {
         assertThrows(FeatureParserException.class,
-                () -> new Cucumber(FormatterWithLexerErrorFeature.class));
+            () -> new Cucumber(FormatterWithLexerErrorFeature.class));
         assertFalse(
-                new File("target/lexor_error_feature.ndjson").exists(),
-                "File is created despite Lexor Error");
+            new File("target/lexor_error_feature.ndjson").exists(),
+            "File is created despite Lexor Error");
     }
 
     @Test
@@ -151,7 +151,7 @@ class CucumberTest {
         Executable testMethod = () -> Assertions.assertNoCucumberAnnotatedMethods(Invalid.class);
         CucumberException expectedThrown = assertThrows(CucumberException.class, testMethod);
         assertThat(expectedThrown.getMessage(), is(equalTo(
-                "\n\nClasses annotated with @RunWith(Cucumber.class) must not define any\nStep Definition or Hook methods. Their sole purpose is to serve as\nan entry point for JUnit. Step Definitions and Hooks should be defined\nin their own classes. This allows them to be reused across features.\nOffending class: class io.cucumber.junit.CucumberTest$Invalid\n")));
+            "\n\nClasses annotated with @RunWith(Cucumber.class) must not define any\nStep Definition or Hook methods. Their sole purpose is to serve as\nan entry point for JUnit. Step Definitions and Hooks should be defined\nin their own classes. This allows them to be reused across features.\nOffending class: class io.cucumber.junit.CucumberTest$Invalid\n")));
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/junit/src/test/java/io/cucumber/junit/FeatureRunnerTest.java
+++ b/junit/src/test/java/io/cucumber/junit/FeatureRunnerTest.java
@@ -47,7 +47,8 @@ class FeatureRunnerTest {
     }
 
     private static void assertDescriptionIsUnique(Description description, Set<Description> descriptions) {
-        // Note: JUnit uses the the serializable parameter as the unique id when comparing Descriptions
+        // Note: JUnit uses the the serializable parameter as the unique id when
+        // comparing Descriptions
         assertTrue(descriptions.add(description));
         for (Description each : description.getChildren()) {
             assertDescriptionIsUnique(each, descriptions);
@@ -57,20 +58,20 @@ class FeatureRunnerTest {
     @Test
     void should_not_create_step_descriptions_by_default() {
         Feature cucumberFeature = TestPickleBuilder.parseFeature("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Background:\n" +
-            "    Given background step\n" +
-            "  Scenario: A\n" +
-            "    Then scenario name\n" +
-            "  Scenario: B\n" +
-            "    Then scenario name\n" +
-            "  Scenario Outline: C\n" +
-            "    Then scenario <name>\n" +
-            "  Examples:\n" +
-            "    | name |\n" +
-            "    | C    |\n" +
-            "    | D    |\n" +
-            "    | E    |\n"
+                "Feature: feature name\n" +
+                "  Background:\n" +
+                "    Given background step\n" +
+                "  Scenario: A\n" +
+                "    Then scenario name\n" +
+                "  Scenario: B\n" +
+                "    Then scenario name\n" +
+                "  Scenario Outline: C\n" +
+                "    Then scenario <name>\n" +
+                "  Examples:\n" +
+                "    | name |\n" +
+                "    | C    |\n" +
+                "    | D    |\n" +
+                "    | E    |\n"
 
         );
 
@@ -90,7 +91,8 @@ class FeatureRunnerTest {
     }
 
     private FeatureRunner createFeatureRunner(Feature feature, JUnitOptions junitOption) {
-        ObjectFactoryServiceLoader objectFactoryServiceLoader = new ObjectFactoryServiceLoader(RuntimeOptions.defaultOptions());
+        ObjectFactoryServiceLoader objectFactoryServiceLoader = new ObjectFactoryServiceLoader(
+            RuntimeOptions.defaultOptions());
         ObjectFactorySupplier objectFactory = new SingletonObjectFactorySupplier(objectFactoryServiceLoader);
         final RuntimeOptions runtimeOptions = RuntimeOptions.defaultOptions();
 
@@ -115,27 +117,29 @@ class FeatureRunnerTest {
         EventBus bus = new TimeServiceEventBus(clockStub, UUID::randomUUID);
         Filters filters = new Filters(runtimeOptions);
         Supplier<ClassLoader> classLoader = FeatureRunnerTest.class::getClassLoader;
-        ScanningTypeRegistryConfigurerSupplier typeRegistrySupplier = new ScanningTypeRegistryConfigurerSupplier(classLoader, runtimeOptions);
-        ThreadLocalRunnerSupplier runnerSupplier = new ThreadLocalRunnerSupplier(runtimeOptions, bus, backendSupplier, objectFactory, typeRegistrySupplier);
+        ScanningTypeRegistryConfigurerSupplier typeRegistrySupplier = new ScanningTypeRegistryConfigurerSupplier(
+            classLoader, runtimeOptions);
+        ThreadLocalRunnerSupplier runnerSupplier = new ThreadLocalRunnerSupplier(runtimeOptions, bus, backendSupplier,
+            objectFactory, typeRegistrySupplier);
         return FeatureRunner.create(feature, filters, runnerSupplier, junitOption);
     }
 
     @Test
     void should_not_issue_notification_for_steps_by_default_scenario_outline_with_two_examples_table_and_background() {
         Feature feature = TestPickleBuilder.parseFeature("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Background: background\n" +
-            "    Given step #1\n" +
-            "  Scenario Outline: scenario <id>\n" +
-            "    When step #2 \n" +
-            "    Then step #3 \n" +
-            "    Examples: examples 1 name\n" +
-            "      | id | \n" +
-            "      | #1 |\n" +
-            "      | #2  |\n" +
-            "    Examples: examples 2 name\n" +
-            "      | id |\n" +
-            "      | #3 |\n");
+                "Feature: feature name\n" +
+                "  Background: background\n" +
+                "    Given step #1\n" +
+                "  Scenario Outline: scenario <id>\n" +
+                "    When step #2 \n" +
+                "    Then step #3 \n" +
+                "    Examples: examples 1 name\n" +
+                "      | id | \n" +
+                "      | #1 |\n" +
+                "      | #2  |\n" +
+                "    Examples: examples 2 name\n" +
+                "      | id |\n" +
+                "      | #3 |\n");
         RunNotifier notifier = runFeatureWithNotifier(feature, new JUnitOptions());
 
         InOrder order = inOrder(notifier);
@@ -161,14 +165,14 @@ class FeatureRunnerTest {
     @Test
     void should_not_issue_notification_for_steps_by_default_two_scenarios_with_background() {
         Feature feature = TestPickleBuilder.parseFeature("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Background: background\n" +
-            "    Given step #1\n" +
-            "  Scenario: scenario_1 name\n" +
-            "    When step #2\n" +
-            "    Then step #3\n" +
-            "  Scenario: scenario_2 name\n" +
-            "    Then step #2\n");
+                "Feature: feature name\n" +
+                "  Background: background\n" +
+                "    Given step #1\n" +
+                "  Scenario: scenario_1 name\n" +
+                "    When step #2\n" +
+                "    Then step #3\n" +
+                "  Scenario: scenario_2 name\n" +
+                "    Then step #2\n");
 
         RunNotifier notifier = runFeatureWithNotifier(feature, new JUnitOptions());
 
@@ -185,20 +189,20 @@ class FeatureRunnerTest {
     @Test
     void should_populate_descriptions_with_stable_unique_ids() {
         Feature feature = TestPickleBuilder.parseFeature("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Background:\n" +
-            "    Given background step\n" +
-            "  Scenario: A\n" +
-            "    Then scenario name\n" +
-            "  Scenario: B\n" +
-            "    Then scenario name\n" +
-            "  Scenario Outline: C\n" +
-            "    Then scenario <name>\n" +
-            "  Examples:\n" +
-            "    | name |\n" +
-            "    | C    |\n" +
-            "    | D    |\n" +
-            "    | E    |\n"
+                "Feature: feature name\n" +
+                "  Background:\n" +
+                "    Given background step\n" +
+                "  Scenario: A\n" +
+                "    Then scenario name\n" +
+                "  Scenario: B\n" +
+                "    Then scenario name\n" +
+                "  Scenario Outline: C\n" +
+                "    Then scenario <name>\n" +
+                "  Examples:\n" +
+                "    | name |\n" +
+                "    | C    |\n" +
+                "    | D    |\n" +
+                "    | E    |\n"
 
         );
 
@@ -215,20 +219,20 @@ class FeatureRunnerTest {
     @Test
     void step_descriptions_can_be_turned_on() {
         Feature cucumberFeature = TestPickleBuilder.parseFeature("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Background:\n" +
-            "    Given background step\n" +
-            "  Scenario: A\n" +
-            "    Then scenario name\n" +
-            "  Scenario: B\n" +
-            "    Then scenario name\n" +
-            "  Scenario Outline: C\n" +
-            "    Then scenario <name>\n" +
-            "  Examples:\n" +
-            "    | name |\n" +
-            "    | C    |\n" +
-            "    | D    |\n" +
-            "    | E    |\n"
+                "Feature: feature name\n" +
+                "  Background:\n" +
+                "    Given background step\n" +
+                "  Scenario: A\n" +
+                "    Then scenario name\n" +
+                "  Scenario: B\n" +
+                "    Then scenario name\n" +
+                "  Scenario Outline: C\n" +
+                "    Then scenario <name>\n" +
+                "  Examples:\n" +
+                "    | name |\n" +
+                "    | C    |\n" +
+                "    | D    |\n" +
+                "    | E    |\n"
 
         );
 
@@ -251,19 +255,19 @@ class FeatureRunnerTest {
     @Test
     void step_notification_can_be_turned_on_scenario_outline_with_two_examples_table_and_background() {
         Feature feature = TestPickleBuilder.parseFeature("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Background: background\n" +
-            "    Given step #1\n" +
-            "  Scenario Outline: scenario <id>\n" +
-            "    When step #2 \n" +
-            "    Then step #3 \n" +
-            "    Examples: examples 1 name\n" +
-            "      | id | \n" +
-            "      | #1 |\n" +
-            "      | #2  |\n" +
-            "    Examples: examples 2 name\n" +
-            "      | id |\n" +
-            "      | #3 |\n");
+                "Feature: feature name\n" +
+                "  Background: background\n" +
+                "    Given step #1\n" +
+                "  Scenario Outline: scenario <id>\n" +
+                "    When step #2 \n" +
+                "    Then step #3 \n" +
+                "    Examples: examples 1 name\n" +
+                "      | id | \n" +
+                "      | #1 |\n" +
+                "      | #2  |\n" +
+                "    Examples: examples 2 name\n" +
+                "      | id |\n" +
+                "      | #3 |\n");
 
         JUnitOptions junitOption = new JUnitOptionsBuilder().setStepNotifications(true).build();
         RunNotifier notifier = runFeatureWithNotifier(feature, junitOption);
@@ -310,14 +314,14 @@ class FeatureRunnerTest {
     @Test
     void step_notification_can_be_turned_on_two_scenarios_with_background() {
         Feature feature = TestPickleBuilder.parseFeature("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Background: background\n" +
-            "    Given step #1\n" +
-            "  Scenario: scenario_1 name\n" +
-            "    When step #2\n" +
-            "    Then step #3\n" +
-            "  Scenario: scenario_2 name\n" +
-            "    Then another step #2\n");
+                "Feature: feature name\n" +
+                "  Background: background\n" +
+                "    Given step #1\n" +
+                "  Scenario: scenario_1 name\n" +
+                "    When step #2\n" +
+                "    Then step #3\n" +
+                "  Scenario: scenario_2 name\n" +
+                "    Then another step #2\n");
 
         JUnitOptions junitOption = new JUnitOptionsBuilder().setStepNotifications(true).build();
         RunNotifier notifier = runFeatureWithNotifier(feature, junitOption);
@@ -341,7 +345,8 @@ class FeatureRunnerTest {
         order.verify(notifier).fireTestFailure(argThat(new FailureMatcher("step #1(scenario_2 name)")));
         order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("step #1(scenario_2 name)")));
         order.verify(notifier).fireTestStarted(argThat(new DescriptionMatcher("another step #2(scenario_2 name)")));
-        order.verify(notifier).fireTestAssumptionFailed(argThat(new FailureMatcher("another step #2(scenario_2 name)")));
+        order.verify(notifier)
+                .fireTestAssumptionFailed(argThat(new FailureMatcher("another step #2(scenario_2 name)")));
         order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("another step #2(scenario_2 name)")));
         order.verify(notifier).fireTestFinished(argThat(new DescriptionMatcher("scenario_2 name")));
     }
@@ -349,10 +354,9 @@ class FeatureRunnerTest {
     @Test
     void should_notify_of_failure_to_create_runners_and_request_test_execution_to_stop() {
         Feature feature = TestPickleBuilder.parseFeature("path/test.feature", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario_1 name\n" +
-            "    Given step #1\n"
-        );
+                "Feature: feature name\n" +
+                "  Scenario: scenario_1 name\n" +
+                "    Given step #1\n");
 
         Filters filters = new Filters(RuntimeOptions.defaultOptions());
 

--- a/junit/src/test/java/io/cucumber/junit/InvokeMethodsAroundEventsTest.java
+++ b/junit/src/test/java/io/cucumber/junit/InvokeMethodsAroundEventsTest.java
@@ -33,7 +33,7 @@ class InvokeMethodsAroundEventsTest {
         assertThat(events, contains("BeforeClass", "TestRunStarted", "TestRunFinished", "AfterClass"));
     }
 
-    @CucumberOptions(plugin = {"io.cucumber.junit.InvokeMethodsAroundEventsTest$TestRunStartedFinishedListener"})
+    @CucumberOptions(plugin = "io.cucumber.junit.InvokeMethodsAroundEventsTest$TestRunStartedFinishedListener")
     public static class BeforeAfterClass {
 
         @BeforeClass

--- a/junit/src/test/java/io/cucumber/junit/JUnitCucumberOptionsProviderTest.java
+++ b/junit/src/test/java/io/cucumber/junit/JUnitCucumberOptionsProviderTest.java
@@ -19,13 +19,15 @@ final class JUnitCucumberOptionsProviderTest {
 
     @Test
     void testObjectFactoryWhenNotSpecified() {
-        io.cucumber.core.options.CucumberOptionsAnnotationParser.CucumberOptions options = this.optionsProvider.getOptions(ClassWithDefault.class);
+        io.cucumber.core.options.CucumberOptionsAnnotationParser.CucumberOptions options = this.optionsProvider
+                .getOptions(ClassWithDefault.class);
         assertNull(options.objectFactory());
     }
 
     @Test
     void testObjectFactory() {
-        io.cucumber.core.options.CucumberOptionsAnnotationParser.CucumberOptions options = this.optionsProvider.getOptions(ClassWithCustomObjectFactory.class);
+        io.cucumber.core.options.CucumberOptionsAnnotationParser.CucumberOptions options = this.optionsProvider
+                .getOptions(ClassWithCustomObjectFactory.class);
         assertNotNull(options.objectFactory());
         assertEquals(TestObjectFactory.class, options.objectFactory());
     }

--- a/junit/src/test/java/io/cucumber/junit/JUnitReporterWithStepNotificationsTest.java
+++ b/junit/src/test/java/io/cucumber/junit/JUnitReporterWithStepNotificationsTest.java
@@ -56,12 +56,12 @@ class JUnitReporterWithStepNotificationsTest {
     private static final int scenarioLine = 0;
     private static final URI featureUri = URI.create("file:example.feature");
     private final EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
-    private final JUnitReporter jUnitReporter = new JUnitReporter(bus, new JUnitOptionsBuilder().setStepNotifications(true).build());
+    private final JUnitReporter jUnitReporter = new JUnitReporter(bus,
+        new JUnitOptionsBuilder().setStepNotifications(true).build());
     private final Feature feature = TestFeatureParser.parse("" +
-        "Feature: Test feature\n" +
-        "  Scenario: Test scenario\n" +
-        "     Given step name\n"
-    );
+            "Feature: Test feature\n" +
+            "  Scenario: Test scenario\n" +
+            "     Given step name\n");
     private final Step step = feature.getPickles().get(0).getSteps().get(0);
     @Mock
     private TestCase testCase;
@@ -112,8 +112,8 @@ class JUnitReporterWithStepNotificationsTest {
     void ignores_steps_when_step_notification_are_disabled() {
         EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
         JUnitReporter jUnitReporter = new JUnitReporter(bus, new JUnitOptionsBuilder()
-            .setStepNotifications(false)
-            .build());
+                .setStepNotifications(false)
+                .build());
 
         jUnitReporter.startExecutionUnit(pickleRunner, runNotifier);
 
@@ -228,7 +228,8 @@ class JUnitReporterWithStepNotificationsTest {
     void test_step_undefined_fires_test_failure_and_test_finished_for_undefined_step() {
         jUnitReporter.startExecutionUnit(pickleRunner, runNotifier);
 
-        bus.send(new SnippetsSuggestedEvent(now(), featureUri, scenarioLine, scenarioLine, singletonList("some snippet")));
+        bus.send(
+            new SnippetsSuggestedEvent(now(), featureUri, scenarioLine, scenarioLine, singletonList("some snippet")));
         bus.send(new TestCaseStarted(now(), testCase));
         bus.send(new TestStepStarted(now(), testCase, mockTestStep(step)));
         Throwable exception = new CucumberException("No step definitions found");
@@ -250,22 +251,22 @@ class JUnitReporterWithStepNotificationsTest {
         Failure pickleFailure = failureArgumentCaptor.getValue();
         assertThat(pickleFailure.getDescription(), is(equalTo(pickleRunner.getDescription())));
         assertThat(pickleFailure.getException().getMessage(), is("" +
-            "The step \"step name\" is undefined. You can implement it using the snippet(s) below:\n" +
-            "\n" +
-            "some snippet\n"
-        ));
+                "The step \"step name\" is undefined. You can implement it using the snippet(s) below:\n" +
+                "\n" +
+                "some snippet\n"));
     }
 
     @Test
     void test_step_undefined_fires_test_failure_and_test_finished_for_undefined_step_in_strict_mode() {
         EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
         JUnitReporter jUnitReporter = new JUnitReporter(bus, new JUnitOptionsBuilder()
-            .setStepNotifications(true)
-            .build());
+                .setStepNotifications(true)
+                .build());
 
         jUnitReporter.startExecutionUnit(pickleRunner, runNotifier);
 
-        bus.send(new SnippetsSuggestedEvent(now(), featureUri, scenarioLine, scenarioLine, singletonList("some snippet")));
+        bus.send(
+            new SnippetsSuggestedEvent(now(), featureUri, scenarioLine, scenarioLine, singletonList("some snippet")));
         bus.send(new TestCaseStarted(now(), testCase));
         bus.send(new TestStepStarted(now(), testCase, mockTestStep(step)));
         Throwable exception = new CucumberException("No step definitions found");
@@ -287,10 +288,9 @@ class JUnitReporterWithStepNotificationsTest {
         Failure pickleFailure = failureArgumentCaptor.getValue();
         assertThat(pickleFailure.getDescription(), is(equalTo(pickleRunner.getDescription())));
         assertThat(pickleFailure.getException().getMessage(), is("" +
-            "The step \"step name\" is undefined. You can implement it using the snippet(s) below:\n" +
-            "\n" +
-            "some snippet\n"
-        ));
+                "The step \"step name\" is undefined. You can implement it using the snippet(s) below:\n" +
+                "\n" +
+                "some snippet\n"));
     }
 
     @Test
@@ -357,8 +357,7 @@ class JUnitReporterWithStepNotificationsTest {
         bus.send(new TestStepStarted(now(), testCase, mockTestStep(step)));
         List<Throwable> failures = asList(
             new Exception("Oops"),
-            new Exception("I did it again")
-        );
+            new Exception("I did it again"));
         Throwable exception = new MultipleFailureException(failures);
         Result result = new Result(Status.FAILED, ZERO, exception);
         bus.send(new TestStepFinished(now(), testCase, mockTestStep(step), result));
@@ -389,6 +388,5 @@ class JUnitReporterWithStepNotificationsTest {
         assertThat(pickleFailure.get(5).getDescription(), is(equalTo(pickleRunner.getDescription())));
         assertThat(pickleFailure.get(5).getException(), is(equalTo(failures.get(1))));
     }
-
 
 }

--- a/junit/src/test/java/io/cucumber/junit/PickleRunnerWithNoStepDescriptionsTest.java
+++ b/junit/src/test/java/io/cucumber/junit/PickleRunnerWithNoStepDescriptionsTest.java
@@ -17,16 +17,15 @@ class PickleRunnerWithNoStepDescriptionsTest {
     @Test
     void shouldUseScenarioNameWithFeatureNameAsClassNameForDisplayName() {
         List<Pickle> pickles = TestPickleBuilder.picklesFromFeature("featurePath", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Then it works\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Then it works\n");
 
         PickleRunner runner = PickleRunners.withNoStepDescriptions(
             "feature name",
             mock(RunnerSupplier.class),
             pickles.get(0),
-            createJunitOptions()
-        );
+            createJunitOptions());
 
         assertThat(runner.getDescription().getDisplayName(), is(equalTo("scenario name(feature name)")));
     }
@@ -38,16 +37,15 @@ class PickleRunnerWithNoStepDescriptionsTest {
     @Test
     void shouldConvertTextFromFeatureFileForNamesWithFilenameCompatibleNameOption() {
         List<Pickle> pickles = TestPickleBuilder.picklesFromFeature("featurePath", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Then it works\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Then it works\n");
 
         PickleRunner runner = PickleRunners.withNoStepDescriptions(
             "feature name",
             mock(RunnerSupplier.class),
             pickles.get(0),
-            createFileNameCompatibleJUnitOptions()
-        );
+            createFileNameCompatibleJUnitOptions());
 
         assertThat(runner.getDescription().getDisplayName(), is(equalTo("scenario_name(feature_name)")));
     }
@@ -59,17 +57,16 @@ class PickleRunnerWithNoStepDescriptionsTest {
     @Test
     void shouldConvertTextFromFeatureFileWithRussianLanguage() {
         List<Pickle> pickles = TestPickleBuilder.picklesFromFeature("featurePath", "" +
-            "#language:ru\n" +
-            "Функция: имя функции\n" +
-            "  Сценарий: имя сценария\n" +
-            "    Тогда он работает\n");
+                "#language:ru\n" +
+                "Функция: имя функции\n" +
+                "  Сценарий: имя сценария\n" +
+                "    Тогда он работает\n");
 
         PickleRunner runner = PickleRunners.withNoStepDescriptions(
             "имя функции",
             mock(RunnerSupplier.class),
             pickles.get(0),
-            createFileNameCompatibleJUnitOptions()
-        );
+            createFileNameCompatibleJUnitOptions());
 
         assertThat(runner.getDescription().getDisplayName(), is(equalTo("____________(___________)")));
     }

--- a/junit/src/test/java/io/cucumber/junit/PickleRunnerWithStepDescriptionsTest.java
+++ b/junit/src/test/java/io/cucumber/junit/PickleRunnerWithStepDescriptionsTest.java
@@ -21,24 +21,23 @@ class PickleRunnerWithStepDescriptionsTest {
     @Test
     void shouldAssignUnequalDescriptionsToDifferentOccurrencesOfSameStepInAScenario() {
         List<Pickle> pickles = picklesFromFeature("path/test.feature", "" +
-            "Feature: FB\n" +
-            "# Scenario with same step occurring twice\n" +
-            "\n" +
-            "  Scenario: SB\n" +
-            "    When foo\n" +
-            "    Then bar\n" +
-            "\n" +
-            "    When foo\n" +
-            "    Then baz\n"
-        );
+                "Feature: FB\n" +
+                "# Scenario with same step occurring twice\n" +
+                "\n" +
+                "  Scenario: SB\n" +
+                "    When foo\n" +
+                "    Then bar\n" +
+                "\n" +
+                "    When foo\n" +
+                "    Then baz\n");
 
         WithStepDescriptions runner = (WithStepDescriptions) PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             pickles.get(0),
-            createJunitOptions()
-        );
+            createJunitOptions());
 
-        // fish out the two occurrences of the same step and check whether we really got them
+        // fish out the two occurrences of the same step and check whether we
+        // really got them
         Step stepOccurrence1 = runner.getChildren().get(0);
         Step stepOccurrence2 = runner.getChildren().get(2);
         assertEquals(stepOccurrence1.getText(), stepOccurrence2.getText());
@@ -59,20 +58,18 @@ class PickleRunnerWithStepDescriptionsTest {
     @Test
     void shouldAssignUnequalDescriptionsToDifferentStepsInAScenarioOutline() {
         Feature features = TestPickleBuilder.parseFeature("path/test.feature", "" +
-            "Feature: FB\n" +
-            "  Scenario Outline: SO\n" +
-            "    When <action>\n" +
-            "    Then <result>\n" +
-            "    Examples:\n" +
-            "    | action | result |\n" +
-            "    |   a1   |   r1   |\n"
-        );
+                "Feature: FB\n" +
+                "  Scenario Outline: SO\n" +
+                "    When <action>\n" +
+                "    Then <result>\n" +
+                "    Examples:\n" +
+                "    | action | result |\n" +
+                "    |   a1   |   r1   |\n");
 
         WithStepDescriptions runner = (WithStepDescriptions) PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             features.getPickles().get(0),
-            createJunitOptions()
-        );
+            createJunitOptions());
 
         Description runnerDescription = runner.getDescription();
         Description stepDescription1 = runnerDescription.getChildren().get(0);
@@ -84,21 +81,19 @@ class PickleRunnerWithStepDescriptionsTest {
     @Test
     void shouldIncludeScenarioNameAsClassNameInStepDescriptions() {
         Feature features = TestPickleBuilder.parseFeature("path/test.feature", "" +
-            "Feature: In cucumber.junit\n" +
-            "  Scenario: first\n" +
-            "    When step\n" +
-            "    Then another step\n" +
-            "\n" +
-            "  Scenario: second\n" +
-            "    When step\n" +
-            "    Then another step\n"
-        );
+                "Feature: In cucumber.junit\n" +
+                "  Scenario: first\n" +
+                "    When step\n" +
+                "    Then another step\n" +
+                "\n" +
+                "  Scenario: second\n" +
+                "    When step\n" +
+                "    Then another step\n");
 
         PickleRunner runner = PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             features.getPickles().get(0),
-            createJunitOptions()
-        );
+            createJunitOptions());
 
         // fish out the data from runner
         Description runnerDescription = runner.getDescription();
@@ -113,15 +108,14 @@ class PickleRunnerWithStepDescriptionsTest {
     @Test
     void shouldUseScenarioNameForDisplayName() {
         List<Pickle> pickles = picklesFromFeature("featurePath", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Then it works\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Then it works\n");
 
         PickleRunner runner = PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             pickles.get(0),
-            createJunitOptions()
-        );
+            createJunitOptions());
 
         assertEquals("scenario name", runner.getDescription().getDisplayName());
     }
@@ -129,15 +123,14 @@ class PickleRunnerWithStepDescriptionsTest {
     @Test
     void shouldUseStepKeyworkAndNameForChildName() {
         List<Pickle> pickles = picklesFromFeature("featurePath", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Then it works\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Then it works\n");
 
         PickleRunner runner = PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             pickles.get(0),
-            createJunitOptions()
-        );
+            createJunitOptions());
 
         assertEquals("it works", runner.getDescription().getChildren().get(0).getMethodName());
     }
@@ -145,15 +138,14 @@ class PickleRunnerWithStepDescriptionsTest {
     @Test
     void shouldConvertTextFromFeatureFileForNamesWithFilenameCompatibleNameOption() {
         List<Pickle> pickles = picklesFromFeature("featurePath", "" +
-            "Feature: feature name\n" +
-            "  Scenario: scenario name\n" +
-            "    Then it works\n");
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Then it works\n");
 
         PickleRunner runner = PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             pickles.get(0),
-            createFileNameCompatibleJunitOptions()
-        );
+            createFileNameCompatibleJunitOptions());
 
         assertEquals("scenario_name", runner.getDescription().getDisplayName());
         assertEquals("scenario_name", runner.getDescription().getChildren().get(0).getClassName());

--- a/junit/src/test/java/io/cucumber/junit/SanityTest.java
+++ b/junit/src/test/java/io/cucumber/junit/SanityTest.java
@@ -1,6 +1,5 @@
 package io.cucumber.junit;
 
-
 import org.junit.jupiter.api.Test;
 
 class SanityTest {

--- a/junit/src/test/java/io/cucumber/junit/StubBackendProviderService.java
+++ b/junit/src/test/java/io/cucumber/junit/StubBackendProviderService.java
@@ -1,6 +1,5 @@
 package io.cucumber.junit;
 
-
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.BackendProviderService;
 import io.cucumber.core.backend.Container;
@@ -33,7 +32,6 @@ public class StubBackendProviderService implements BackendProviderService {
         StubBackend() {
 
         }
-
 
         @Override
         public void loadGlue(Glue glue, List<URI> gluePaths) {
@@ -90,7 +88,6 @@ public class StubBackendProviderService implements BackendProviderService {
                 }
             };
         }
-
 
         @Override
         public void buildWorld() {

--- a/junit/src/test/java/io/cucumber/junit/UndefinedStepExceptionTest.java
+++ b/junit/src/test/java/io/cucumber/junit/UndefinedStepExceptionTest.java
@@ -13,10 +13,9 @@ class UndefinedStepExceptionTest {
     void should_generate_a_message_for_a_single_snippet() {
         UndefinedStepException exception = new UndefinedStepException(singletonList("snippet"));
         assertThat(exception.getMessage(), is("" +
-            "This step is undefined. You can implement it using the snippet(s) below:\n" +
-            "\n" +
-            "snippet\n"
-        ));
+                "This step is undefined. You can implement it using the snippet(s) below:\n" +
+                "\n" +
+                "snippet\n"));
     }
 
     @Test
@@ -24,13 +23,11 @@ class UndefinedStepExceptionTest {
         UndefinedStepException exception = new UndefinedStepException(
             "step text",
             singletonList("snippet"),
-            emptyList()
-        );
+            emptyList());
         assertThat(exception.getMessage(), is("" +
-            "The step \"step text\" is undefined. You can implement it using the snippet(s) below:\n" +
-            "\n" +
-            "snippet\n"
-        ));
+                "The step \"step text\" is undefined. You can implement it using the snippet(s) below:\n" +
+                "\n" +
+                "snippet\n"));
     }
 
     @Test
@@ -38,18 +35,16 @@ class UndefinedStepExceptionTest {
         UndefinedStepException exception = new UndefinedStepException(
             "step text",
             singletonList("snippet"),
-            singletonList(singletonList("additional snippet"))
-        );
+            singletonList(singletonList("additional snippet")));
         assertThat(exception.getMessage(), is("" +
-            "The step \"step text\" is undefined. You can implement it using the snippet(s) below:\n" +
-            "\n" +
-            "snippet\n" +
-            "\n" +
-            "\n" +
-            "Some other steps were also undefined:\n" +
-            "\n" +
-            "additional snippet\n"
-        ));
+                "The step \"step text\" is undefined. You can implement it using the snippet(s) below:\n" +
+                "\n" +
+                "snippet\n" +
+                "\n" +
+                "\n" +
+                "Some other steps were also undefined:\n" +
+                "\n" +
+                "additional snippet\n"));
     }
 
     @Test
@@ -57,13 +52,11 @@ class UndefinedStepExceptionTest {
         UndefinedStepException exception = new UndefinedStepException(
             "step text",
             singletonList("snippet"),
-            singletonList(singletonList("snippet"))
-        );
+            singletonList(singletonList("snippet")));
         assertThat(exception.getMessage(), is("" +
-            "The step \"step text\" is undefined. You can implement it using the snippet(s) below:\n" +
-            "\n" +
-            "snippet\n"
-        ));
+                "The step \"step text\" is undefined. You can implement it using the snippet(s) below:\n" +
+                "\n" +
+                "snippet\n"));
     }
 
 }

--- a/needle/src/main/java/io/cucumber/needle/CollectInjectionProvidersFromStepsInstance.java
+++ b/needle/src/main/java/io/cucumber/needle/CollectInjectionProvidersFromStepsInstance.java
@@ -27,8 +27,8 @@ enum CollectInjectionProvidersFromStepsInstance {
     /**
      * Collect providers direct in the step definition.
      *
-     * @param instance step definition instance
-     * @return collected injection providers.
+     * @param  instance step definition instance
+     * @return          collected injection providers.
      */
     final <T> InjectionProvider<?>[] apply(final T instance) {
         final Set<InjectionProvider<?>> providers = new LinkedHashSet<>();
@@ -44,7 +44,7 @@ enum CollectInjectionProvidersFromStepsInstance {
                     providers.addAll(((InjectionProviderInstancesSupplier) value).get());
                 } else {
                     throw new IllegalStateException("Fields annotated with NeedleInjectionProviders must be of type "
-                        + "InjectionProviderInstancesSupplier, InjectionProvider " + "or InjectionProvider[]");
+                            + "InjectionProviderInstancesSupplier, InjectionProvider " + "or InjectionProvider[]");
                 }
             } catch (final Exception e) {
                 throw new IllegalStateException(e);

--- a/needle/src/main/java/io/cucumber/needle/CucumberNeedleConfiguration.java
+++ b/needle/src/main/java/io/cucumber/needle/CucumberNeedleConfiguration.java
@@ -7,7 +7,8 @@ import java.util.ResourceBundle;
 import java.util.Set;
 
 /**
- * Reads cucumber-needle.properties to initialize additional {@link InjectionProvider}s.
+ * Reads cucumber-needle.properties to initialize additional
+ * {@link InjectionProvider}s.
  */
 class CucumberNeedleConfiguration {
 
@@ -19,7 +20,8 @@ class CucumberNeedleConfiguration {
     private final Set<InjectionProvider<?>> injectionProviders = new HashSet<>();
 
     /**
-     * Creates new instance from default resource {@link #RESOURCE_CUCUMBER_NEEDLE}.
+     * Creates new instance from default resource
+     * {@link #RESOURCE_CUCUMBER_NEEDLE}.
      */
     CucumberNeedleConfiguration() {
         this(RESOURCE_CUCUMBER_NEEDLE);
@@ -37,7 +39,7 @@ class CucumberNeedleConfiguration {
                     injectionProviders.add((InjectionProvider<?>) createInstance.apply(clazz));
                 } else if (isInjectionProviderInstanceSupplier(clazz)) {
                     final InjectionProviderInstancesSupplier supplier = (InjectionProviderInstancesSupplier) createInstance
-                        .apply(clazz);
+                            .apply(clazz);
                     final Set<InjectionProvider<?>> providers = supplier.get();
                     if (providers != null) {
                         injectionProviders.addAll(providers);
@@ -52,8 +54,9 @@ class CucumberNeedleConfiguration {
     /**
      * Checks if given class is an {@link InjectionProvider}
      *
-     * @param type Class to check
-     * @return <code>true</code> if type can be cast to {@link InjectionProvider}
+     * @param  type Class to check
+     * @return      <code>true</code> if type can be cast to
+     *              {@link InjectionProvider}
      */
     static boolean isInjectionProvider(final Class<?> type) {
         return InjectionProvider.class.isAssignableFrom(type);
@@ -62,8 +65,9 @@ class CucumberNeedleConfiguration {
     /**
      * Checks if given class is an {@link InjectionProviderInstancesSupplier}
      *
-     * @param type Class to check
-     * @return <code>true</code> if type can be cast to {@link InjectionProviderInstancesSupplier}
+     * @param  type Class to check
+     * @return      <code>true</code> if type can be cast to
+     *              {@link InjectionProviderInstancesSupplier}
      */
     static boolean isInjectionProviderInstanceSupplier(final Class<?> type) {
         return InjectionProviderInstancesSupplier.class.isAssignableFrom(type);

--- a/needle/src/main/java/io/cucumber/needle/InjectionProviderInstancesSupplier.java
+++ b/needle/src/main/java/io/cucumber/needle/InjectionProviderInstancesSupplier.java
@@ -7,15 +7,19 @@ import org.apiguardian.api.API;
 import java.util.Set;
 
 /**
- * <a href="http://javadocs.techempower.com/jdk18/api/java/util/function/Supplier.html">Supplies</a> a Set of
- * InjectionProvider instances that are created outside the {@link NeedleFactory} lifecycle.
+ * <a href=
+ * "http://javadocs.techempower.com/jdk18/api/java/util/function/Supplier.html">Supplies</a>
+ * a Set of InjectionProvider instances that are created outside the
+ * {@link NeedleFactory} lifecycle.
  */
 @API(status = API.Status.STABLE)
 public interface InjectionProviderInstancesSupplier {
 
     /**
-     * <a href="http://javadocs.techempower.com/jdk18/api/java/util/function/Supplier.html">Supplies</a> a Set of
-     * InjectionProvider instances that are created outside the {@link NeedleFactory} lifecycle.
+     * <a href=
+     * "http://javadocs.techempower.com/jdk18/api/java/util/function/Supplier.html">Supplies</a>
+     * a Set of InjectionProvider instances that are created outside the
+     * {@link NeedleFactory} lifecycle.
      *
      * @return InjectionProviders that can be added to {@link NeedleTestcase}
      */

--- a/needle/src/main/java/io/cucumber/needle/LoadResourceBundle.java
+++ b/needle/src/main/java/io/cucumber/needle/LoadResourceBundle.java
@@ -8,7 +8,8 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 /**
- * Null safe Resource Loader. If ResourceBundle does not exist, an empty Bundle is returned.
+ * Null safe Resource Loader. If ResourceBundle does not exist, an empty Bundle
+ * is returned.
  */
 enum LoadResourceBundle {
     INSTANCE;

--- a/needle/src/main/java/io/cucumber/needle/NeedleFactory.java
+++ b/needle/src/main/java/io/cucumber/needle/NeedleFactory.java
@@ -64,7 +64,8 @@ public final class NeedleFactory extends NeedleTestcase implements ObjectFactory
             for (Object stepsInstance : cachedStepsInstances.values()) {
                 addInjectionProvider(collectInjectionProvidersFromStepsInstance.apply(stepsInstance));
             }
-            // Now init all instances, having the injection providers from all other instances available
+            // Now init all instances, having the injection providers from all
+            // other instances available
             for (Object stepsInstance : cachedStepsInstances.values()) {
                 initTestcase(stepsInstance);
             }

--- a/needle/src/main/java/io/cucumber/needle/NeedleInjectionProvider.java
+++ b/needle/src/main/java/io/cucumber/needle/NeedleInjectionProvider.java
@@ -10,9 +10,10 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to mark InjectionProviders in the cucumber glue or cucumber steps.
- * Should be placed on fields of type {@link InjectionProvider} or an array of those.
+ * Should be placed on fields of type {@link InjectionProvider} or an array of
+ * those.
  */
-@Target({ElementType.FIELD})
+@Target({ ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 @API(status = API.Status.STABLE)
 public @interface NeedleInjectionProvider {

--- a/needle/src/main/java/io/cucumber/needle/package-info.java
+++ b/needle/src/main/java/io/cucumber/needle/package-info.java
@@ -1,8 +1,8 @@
 /**
  * Enables dependency injection by Needle
  * <p>
- * By including the <code>cucumber-needle</code> on your <code>CLASSPATH</code> your step definitions will be
- * instantiated by <a href="http://needle.spree.de">Needle</a>..
+ * By including the <code>cucumber-needle</code> on your <code>CLASSPATH</code>
+ * your step definitions will be instantiated by
+ * <a href="http://needle.spree.de">Needle</a>..
  */
 package io.cucumber.needle;
-

--- a/needle/src/test/java/io/cucumber/needle/CollectInjectionProvidersFromStepsInstanceTest.java
+++ b/needle/src/test/java/io/cucumber/needle/CollectInjectionProvidersFromStepsInstanceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+
 import java.util.HashSet;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/needle/src/test/java/io/cucumber/needle/CucumberNeedleConfigurationTest.java
+++ b/needle/src/test/java/io/cucumber/needle/CucumberNeedleConfigurationTest.java
@@ -16,19 +16,19 @@ class CucumberNeedleConfigurationTest {
     @Test
     void shouldReturnEmptyInstances() {
         final InjectionProvider<?>[] allInjectionProviders = new CucumberNeedleConfiguration("resource-bundles/empty")
-            .getInjectionProviders();
+                .getInjectionProviders();
         assertThat(allInjectionProviders, is(notNullValue()));
         assertThat(allInjectionProviders.length, is(0));
     }
 
     @Test
     void shouldEvaluateIfTypeIsInjectionProviderOrSupplier() {
-        assertAll("Checking Needle Configuration",
+        assertAll(
             () -> assertTrue(CucumberNeedleConfiguration.isInjectionProvider(SimpleNameGetterProvider.class)),
-            () -> assertFalse(CucumberNeedleConfiguration.isInjectionProviderInstanceSupplier(SimpleNameGetterProvider.class)),
+            () -> assertFalse(
+                CucumberNeedleConfiguration.isInjectionProviderInstanceSupplier(SimpleNameGetterProvider.class)),
             () -> assertFalse(CucumberNeedleConfiguration.isInjectionProvider(A.class)),
-            () -> assertTrue(CucumberNeedleConfiguration.isInjectionProviderInstanceSupplier(A.class))
-        );
+            () -> assertTrue(CucumberNeedleConfiguration.isInjectionProviderInstanceSupplier(A.class)));
     }
 
     public abstract static class A implements InjectionProviderInstancesSupplier {

--- a/needle/src/test/java/io/cucumber/needle/DefaultInstanceInjectionProvider.java
+++ b/needle/src/test/java/io/cucumber/needle/DefaultInstanceInjectionProvider.java
@@ -4,7 +4,8 @@ import de.akquinet.jbosscc.needle.injection.InjectionProvider;
 import de.akquinet.jbosscc.needle.injection.InjectionTargetInformation;
 
 /**
- * InjectionProvider that provides a singleton instance of type T whenever injection is required
+ * InjectionProvider that provides a singleton instance of type T whenever
+ * injection is required
  *
  * @param <T> target type
  */
@@ -16,7 +17,8 @@ public class DefaultInstanceInjectionProvider<T> implements InjectionProvider<T>
     private final T instance;
 
     /**
-     * Constructs an injection provider responsible for returning the same instance.
+     * Constructs an injection provider responsible for returning the same
+     * instance.
      *
      * @param instance instance to return.
      */
@@ -27,8 +29,8 @@ public class DefaultInstanceInjectionProvider<T> implements InjectionProvider<T>
     /**
      * Factory method.
      *
-     * @param instance returns a provider for given instance.
-     * @return injection provider.
+     * @param  instance returns a provider for given instance.
+     * @return          injection provider.
      */
     public static <T> DefaultInstanceInjectionProvider<T> providerFor(final T instance) {
         return new DefaultInstanceInjectionProvider<>(instance);

--- a/needle/src/test/java/io/cucumber/needle/LoadCucumberNeedleResourceBundleTest.java
+++ b/needle/src/test/java/io/cucumber/needle/LoadCucumberNeedleResourceBundleTest.java
@@ -23,10 +23,9 @@ class LoadCucumberNeedleResourceBundleTest {
     void shouldReturnEmptyResourceBundleWhenResourceDoesNotExist() {
         final ResourceBundle resourceBundle = function.apply("does-not-exist");
 
-        assertAll("Checking LoadResourceBundle",
+        assertAll(
             () -> assertThat(resourceBundle, is(notNullValue())),
-            () -> assertThat(resourceBundle, CoreMatchers.is(LoadResourceBundle.EMPTY_RESOURCE_BUNDLE))
-        );
+            () -> assertThat(resourceBundle, CoreMatchers.is(LoadResourceBundle.EMPTY_RESOURCE_BUNDLE)));
     }
 
     @Test
@@ -40,11 +39,10 @@ class LoadCucumberNeedleResourceBundleTest {
     void shouldAlwaysReturnEmptyForEmptyResourceBundle() {
         final ResourceBundle resourceBundle = LoadResourceBundle.EMPTY_RESOURCE_BUNDLE;
 
-        assertAll("Checking ResourceBundle",
+        assertAll(
             () -> assertThat(resourceBundle.getObject("foo"), is(notNullValue())),
             () -> assertThat(resourceBundle.getString("foo"), is("")),
-            () -> assertFalse(resourceBundle.getKeys().hasMoreElements())
-        );
+            () -> assertFalse(resourceBundle.getKeys().hasMoreElements()));
     }
 
     @Test

--- a/needle/src/test/java/io/cucumber/needle/NamedInjectionProvider.java
+++ b/needle/src/test/java/io/cucumber/needle/NamedInjectionProvider.java
@@ -35,9 +35,9 @@ public class NamedInjectionProvider<T> implements InjectionProvider<T> {
     /**
      * Factory method for creating the provider.
      *
-     * @param name  name of interest
-     * @param value value to encapsulate.
-     * @return provider encapsulating the value.
+     * @param  name  name of interest
+     * @param  value value to encapsulate.
+     * @return       provider encapsulating the value.
      */
     public static <T> NamedInjectionProvider<T> forNamedValue(final String name, final T value) {
         return new NamedInjectionProvider<>(name, value);
@@ -56,8 +56,8 @@ public class NamedInjectionProvider<T> implements InjectionProvider<T> {
     @Override
     public boolean verify(final InjectionTargetInformation injectionTargetInformation) {
         return injectionTargetInformation.isAnnotationPresent(Named.class)
-            && ((Named) injectionTargetInformation.getAnnotation(Named.class)).value().equals(name)
-            && value.getClass().isAssignableFrom(injectionTargetInformation.getType());
+                && ((Named) injectionTargetInformation.getAnnotation(Named.class)).value().equals(name)
+                && value.getClass().isAssignableFrom(injectionTargetInformation.getType());
     }
 
 }

--- a/needle/src/test/java/io/cucumber/needle/NeedleFactoryTest.java
+++ b/needle/src/test/java/io/cucumber/needle/NeedleFactoryTest.java
@@ -14,7 +14,7 @@ class NeedleFactoryTest {
     void shouldSetUpInjectionProviders() {
 
         final InjectionProvider<?>[] injectionProviders = NeedleFactory
-            .setUpInjectionProviders();
+                .setUpInjectionProviders();
 
         assertThat(injectionProviders, is(notNullValue()));
         assertThat(injectionProviders.length, is(1));

--- a/needle/src/test/java/io/cucumber/needle/ReadInjectionProviderClassNamesTest.java
+++ b/needle/src/test/java/io/cucumber/needle/ReadInjectionProviderClassNamesTest.java
@@ -61,10 +61,9 @@ class ReadInjectionProviderClassNamesTest {
     void shouldReturnTwoTrimmedClassNames() {
         final Set<String> classNames = function.apply(loadBundle("resource-bundles/two-classname"));
 
-        assertAll("Checking function",
+        assertAll(
             () -> assertThat(classNames.size(), is(2)),
-            () -> assertThat(classNames, hasItems("java.lang.String", "java.util.Set"))
-        );
+            () -> assertThat(classNames, hasItems("java.lang.String", "java.util.Set")));
     }
 
 }

--- a/needle/src/test/java/io/cucumber/needle/test/AtmWithdrawalSteps.java
+++ b/needle/src/test/java/io/cucumber/needle/test/AtmWithdrawalSteps.java
@@ -35,8 +35,8 @@ public class AtmWithdrawalSteps {
     @NeedleInjectionProvider
     private final InjectionProvider<?> valueProvider = new ValueInjectionProvider(VALUE);
     @NeedleInjectionProvider
-    private final InjectionProviderInstancesSupplier thisInjectionProviderSupplier =
-        () -> singleton(new DefaultInstanceInjectionProvider<>(AtmWithdrawalSteps.this));
+    private final InjectionProviderInstancesSupplier thisInjectionProviderSupplier = () -> singleton(
+        new DefaultInstanceInjectionProvider<>(AtmWithdrawalSteps.this));
     /*
      * Inject will be mocked.
      */

--- a/needle/src/test/java/io/cucumber/needle/test/MoreSteps.java
+++ b/needle/src/test/java/io/cucumber/needle/test/MoreSteps.java
@@ -11,7 +11,8 @@ import javax.inject.Inject;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Just here to show that injection providers from this class also work in other classes.
+ * Just here to show that injection providers from this class also work in other
+ * classes.
  *
  * @author Lars Bilger
  */
@@ -25,7 +26,8 @@ public class MoreSteps {
 
     @Before
     public void checkInjectionWorked() {
-        assertTrue(atmWithdrawalSteps.isThisReallyYouOrJustAMock(), "Got a mock injected instead of the real instance.");
+        assertTrue(atmWithdrawalSteps.isThisReallyYouOrJustAMock(),
+            "Got a mock injected instead of the real instance.");
     }
 
     @Given("i call a step that i don't really need")

--- a/openejb/src/main/java/io/cucumber/openejb/OpenEJBObjectFactory.java
+++ b/openejb/src/main/java/io/cucumber/openejb/OpenEJBObjectFactory.java
@@ -6,6 +6,7 @@ import org.apache.openejb.OpenEjbContainer;
 import org.apiguardian.api.API;
 
 import javax.ejb.embeddable.EJBContainer;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -23,7 +24,7 @@ public final class OpenEJBObjectFactory implements ObjectFactory {
     @Override
     public void start() {
         final StringBuilder callers = new StringBuilder();
-        for (Iterator<String> it = classes.iterator(); it.hasNext(); ) {
+        for (Iterator<String> it = classes.iterator(); it.hasNext();) {
             callers.append(it.next());
             if (it.hasNext()) {
                 callers.append(",");
@@ -65,4 +66,3 @@ public final class OpenEJBObjectFactory implements ObjectFactory {
     }
 
 }
-

--- a/openejb/src/main/java/io/cucumber/openejb/package-info.java
+++ b/openejb/src/main/java/io/cucumber/openejb/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Enables dependency injection by OpenEJB
  * <p>
- * By including the <code>cucumber-openejb</code> on your <code>CLASSPATH</code> your step definitions will be
- * instantiated by OpenEJB.
+ * By including the <code>cucumber-openejb</code> on your <code>CLASSPATH</code>
+ * your step definitions will be instantiated by OpenEJB.
  */
 package io.cucumber.openejb;

--- a/picocontainer/src/main/java/io/cucumber/picocontainer/PicoFactory.java
+++ b/picocontainer/src/main/java/io/cucumber/picocontainer/PicoFactory.java
@@ -18,14 +18,15 @@ public final class PicoFactory implements ObjectFactory {
 
     private static boolean isInstantiable(Class<?> clazz) {
         boolean isNonStaticInnerClass = !Modifier.isStatic(clazz.getModifiers()) && clazz.getEnclosingClass() != null;
-        return Modifier.isPublic(clazz.getModifiers()) && !Modifier.isAbstract(clazz.getModifiers()) && !isNonStaticInnerClass;
+        return Modifier.isPublic(clazz.getModifiers()) && !Modifier.isAbstract(clazz.getModifiers())
+                && !isNonStaticInnerClass;
     }
 
     public void start() {
         pico = new PicoBuilder()
-            .withCaching()
-            .withLifecycle()
-            .build();
+                .withCaching()
+                .withLifecycle()
+                .build();
         for (Class<?> clazz : classes) {
             pico.addComponent(clazz);
         }

--- a/picocontainer/src/main/java/io/cucumber/picocontainer/package-info.java
+++ b/picocontainer/src/main/java/io/cucumber/picocontainer/package-info.java
@@ -1,8 +1,8 @@
 /**
  * Enables dependency injection by PicoContainer
  * <p>
- * By including the <code>cucumber-picocontainer</code> on your <code>CLASSPATH</code> your step definitions will be
- * instantiated by PicoContainer.
+ * By including the <code>cucumber-picocontainer</code> on your
+ * <code>CLASSPATH</code> your step definitions will be instantiated by
+ * PicoContainer.
  */
 package io.cucumber.picocontainer;
-

--- a/picocontainer/src/test/java/io/cucumber/picocontainer/DisposableCucumberBelly.java
+++ b/picocontainer/src/test/java/io/cucumber/picocontainer/DisposableCucumberBelly.java
@@ -5,13 +5,13 @@ import org.picocontainer.Disposable;
 import java.util.List;
 
 /**
- * A test helper class which simulates a class that holds system resources
- * which need disposing at the end of the test.
+ * A test helper class which simulates a class that holds system resources which
+ * need disposing at the end of the test.
  * <p>
  * In a real app, this could be a database connector or similar.
  */
 public class DisposableCucumberBelly
-    implements Disposable {
+        implements Disposable {
 
     private List<String> contents;
     private boolean isDisposed = false;

--- a/picocontainer/src/test/java/io/cucumber/picocontainer/PicoFactoryTest.java
+++ b/picocontainer/src/test/java/io/cucumber/picocontainer/PicoFactoryTest.java
@@ -30,11 +30,10 @@ class PicoFactoryTest {
         StepDefinitions o2 = factory.getInstance(StepDefinitions.class);
         factory.stop();
 
-        assertAll("Checking StepDefs",
+        assertAll(
             () -> assertThat(o1, is(notNullValue())),
             () -> assertThat(o1, is(not(equalTo(o2)))),
-            () -> assertThat(o2, is(not(equalTo(o1))))
-        );
+            () -> assertThat(o2, is(not(equalTo(o1)))));
     }
 
     @Test

--- a/picocontainer/src/test/java/io/cucumber/picocontainer/RunCucumberTest.java
+++ b/picocontainer/src/test/java/io/cucumber/picocontainer/RunCucumberTest.java
@@ -3,7 +3,6 @@ package io.cucumber.picocontainer;
 import io.cucumber.junit.Cucumber;
 import org.junit.runner.RunWith;
 
-
 @RunWith(Cucumber.class)
 public class RunCucumberTest {
 

--- a/picocontainer/src/test/java/io/cucumber/picocontainer/StepDefinitions.java
+++ b/picocontainer/src/test/java/io/cucumber/picocontainer/StepDefinitions.java
@@ -35,7 +35,8 @@ public class StepDefinitions {
 
     @After
     public void after() {
-        // We might need to clean up the belly here, if it represented an external resource.
+        // We might need to clean up the belly here, if it represented an
+        // external resource.
         assert !belly.isDisposed();
     }
 
@@ -51,7 +52,8 @@ public class StepDefinitions {
     @Given("something pending")
     public void throw_pending() {
         throw new TestAbortedException("Skip this!");
-//        throw new PendingException("This should not fail (seeing this output is ok)");
+        // throw new PendingException("This should not fail (seeing this output
+        // is ok)");
     }
 
     @Then("there are {int} cukes in my belly")
@@ -73,7 +75,6 @@ public class StepDefinitions {
     public void I_should_be(String mood) {
         assertEquals("happy", mood);
     }
-
 
     @When("foo")
     public void foo() {

--- a/plugin/src/main/java/io/cucumber/plugin/ConcurrentEventListener.java
+++ b/plugin/src/main/java/io/cucumber/plugin/ConcurrentEventListener.java
@@ -4,28 +4,25 @@ import io.cucumber.plugin.event.EventPublisher;
 import org.apiguardian.api.API;
 
 /**
- * Listens to pickle execution events. Can be used to
- * implement reporters.
+ * Listens to pickle execution events. Can be used to implement reporters.
  * <p>
- * When cucumber executes test in parallel or in a framework
- * that supports parallel execution (e.g. JUnit or TestNG)
- * {@link io.cucumber.plugin.event.TestCase} events from different
- * pickles may interleave.
+ * When cucumber executes test in parallel or in a framework that supports
+ * parallel execution (e.g. JUnit or TestNG)
+ * {@link io.cucumber.plugin.event.TestCase} events from different pickles may
+ * interleave.
  * <p>
- * This interface marks an {@link EventListener} as capable of
- * understanding interleaved pickle events.
+ * This interface marks an {@link EventListener} as capable of understanding
+ * interleaved pickle events.
  * <p>
- * While running tests in parallel cucumber makes the
- * following guarantees:
+ * While running tests in parallel cucumber makes the following guarantees:
  * <ol>
- * <li>The event publisher is synchronized. Events are not
- * published concurrently.</li>
- * <li>For test cases executed on different threads a callback
- * registered on the event publisher will be called by
- * different threads. I.e. {@code Thread.currentThread()}
- * will return a different thread for two test cases
- * executed on a different thread (but not necessarily the
- * executing thread).</li>
+ * <li>The event publisher is synchronized. Events are not published
+ * concurrently.</li>
+ * <li>For test cases executed on different threads a callback registered on the
+ * event publisher will be called by different threads. I.e.
+ * {@code Thread.currentThread()} will return a different thread for two test
+ * cases executed on a different thread (but not necessarily the executing
+ * thread).</li>
  * </ol>
  *
  * @see io.cucumber.plugin.event.Event
@@ -34,7 +31,8 @@ import org.apiguardian.api.API;
 public interface ConcurrentEventListener extends Plugin {
 
     /**
-     * Set the event publisher. The plugin can register event listeners with the publisher.
+     * Set the event publisher. The plugin can register event listeners with the
+     * publisher.
      *
      * @param publisher the event publisher
      */

--- a/plugin/src/main/java/io/cucumber/plugin/EventListener.java
+++ b/plugin/src/main/java/io/cucumber/plugin/EventListener.java
@@ -4,13 +4,12 @@ import io.cucumber.plugin.event.EventPublisher;
 import org.apiguardian.api.API;
 
 /**
- * Listens to pickle execution events. Can be used to
- * implement reporters.
+ * Listens to pickle execution events. Can be used to implement reporters.
  * <p>
- * When cucumber executes test in parallel or in a framework
- * that supports parallel execution (e.g. JUnit or TestNG)
- * {@link io.cucumber.plugin.event.Event}s are stored and published in
- * canonical order after the test run has completed.
+ * When cucumber executes test in parallel or in a framework that supports
+ * parallel execution (e.g. JUnit or TestNG)
+ * {@link io.cucumber.plugin.event.Event}s are stored and published in canonical
+ * order after the test run has completed.
  *
  * @see io.cucumber.plugin.event.Event
  * @see ConcurrentEventListener
@@ -19,7 +18,8 @@ import org.apiguardian.api.API;
 public interface EventListener extends Plugin {
 
     /**
-     * Set the event publisher. The plugin can register event listeners with the publisher.
+     * Set the event publisher. The plugin can register event listeners with the
+     * publisher.
      *
      * @param publisher the event publisher
      */

--- a/plugin/src/main/java/io/cucumber/plugin/Plugin.java
+++ b/plugin/src/main/java/io/cucumber/plugin/Plugin.java
@@ -25,7 +25,8 @@ import java.net.URL;
  * <li>{@link File}</li>
  * </ul>
  * <p>
- * To make the parameter optional the plugin must also have a public default constructor.
+ * To make the parameter optional the plugin must also have a public default
+ * constructor.
  * <p>
  * Plugins may also implement one of these interfaces:
  * <ul>

--- a/plugin/src/main/java/io/cucumber/plugin/event/Argument.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/Argument.java
@@ -5,10 +5,9 @@ import org.apiguardian.api.API;
 /**
  * Represents an argument in a cucumber or regular expressions
  * <p>
- * The step definition {@code I have {long} cukes in my belly}
- * when matched with {@code I have 7 cukes in my belly} will produce
- * one argument with value {@code "4"}, starting at {@code 7} and
- * ending at {@code 8}.
+ * The step definition {@code I have {long} cukes in my belly} when matched with
+ * {@code I have 7 cukes in my belly} will produce one argument with value
+ * {@code "4"}, starting at {@code 7} and ending at {@code 8}.
  */
 @API(status = API.Status.STABLE)
 public interface Argument {

--- a/plugin/src/main/java/io/cucumber/plugin/event/EmbedEvent.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/EmbedEvent.java
@@ -33,7 +33,7 @@ public final class EmbedEvent extends TestCaseEvent {
     }
 
     /**
-     * @return media type of the embedding.
+     * @return     media type of the embedding.
      * @deprecated use {@link #getMediaType()}
      */
     @Deprecated

--- a/plugin/src/main/java/io/cucumber/plugin/event/Event.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/Event.java
@@ -11,7 +11,7 @@ public interface Event {
      * Returns instant from epoch.
      *
      * @return time instant in Instant
-     * @see Instant#now()
+     * @see    Instant#now()
      */
     Instant getInstant();
 

--- a/plugin/src/main/java/io/cucumber/plugin/event/EventPublisher.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/EventPublisher.java
@@ -12,22 +12,31 @@ public interface EventPublisher {
      * <ul>
      * <li>{@link Event} - all events.
      * <li>{@link TestRunStarted} - the first event sent.
-     * <li>{@link TestSourceRead} - sent for each feature file read, contains the feature file source.
-     * <li>{@link SnippetsSuggestedEvent} - sent for each step that could not be matched to a step definition, contains the raw snippets for the step.
-     * <li>{@link StepDefinedEvent} - sent for each step definition as it is loaded, contains the StepDefinition
-     * <li>{@link TestCaseStarted} - sent before starting the execution of a Test Case(/Pickle/Scenario), contains the Test Case
-     * <li>{@link TestStepStarted} - sent before starting the execution of a Test Step, contains the Test Step
-     * <li>{@link EmbedEvent} - calling scenario.embed in a hook triggers this event.
-     * <li>{@link WriteEvent} - calling scenario.write in a hook triggers this event.
-     * <li>{@link TestStepFinished} - sent after the execution of a Test Step, contains the Test Step and its Result.
-     * <li>{@link TestCaseFinished} - sent after the execution of a Test Case(/Pickle/Scenario), contains the Test Case and its Result.
+     * <li>{@link TestSourceRead} - sent for each feature file read, contains
+     * the feature file source.
+     * <li>{@link SnippetsSuggestedEvent} - sent for each step that could not be
+     * matched to a step definition, contains the raw snippets for the step.
+     * <li>{@link StepDefinedEvent} - sent for each step definition as it is
+     * loaded, contains the StepDefinition
+     * <li>{@link TestCaseStarted} - sent before starting the execution of a
+     * Test Case(/Pickle/Scenario), contains the Test Case
+     * <li>{@link TestStepStarted} - sent before starting the execution of a
+     * Test Step, contains the Test Step
+     * <li>{@link EmbedEvent} - calling scenario.embed in a hook triggers this
+     * event.
+     * <li>{@link WriteEvent} - calling scenario.write in a hook triggers this
+     * event.
+     * <li>{@link TestStepFinished} - sent after the execution of a Test Step,
+     * contains the Test Step and its Result.
+     * <li>{@link TestCaseFinished} - sent after the execution of a Test
+     * Case(/Pickle/Scenario), contains the Test Case and its Result.
      * <li>{@link TestRunFinished} - the last event sent.
      * </ul>
      *
      * @param eventType the event type for which the handler is being registered
      * @param handler   the event handler
      * @param <T>       the event type
-     * @see Event
+     * @see             Event
      */
     <T> void registerHandlerFor(Class<T> eventType, EventHandler<T> handler);
 

--- a/plugin/src/main/java/io/cucumber/plugin/event/HookTestStep.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/HookTestStep.java
@@ -3,8 +3,8 @@ package io.cucumber.plugin.event;
 import org.apiguardian.api.API;
 
 /**
- * Hooks are invoked before and after each scenario and before and
- * after each gherkin step in a scenario.
+ * Hooks are invoked before and after each scenario and before and after each
+ * gherkin step in a scenario.
  *
  * @see TestCaseStarted
  * @see TestCaseFinished

--- a/plugin/src/main/java/io/cucumber/plugin/event/Location.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/Location.java
@@ -30,11 +30,13 @@ public final class Location {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         Location location = (Location) o;
         return line == location.line &&
-            column == location.column;
+                column == location.column;
     }
 
 }

--- a/plugin/src/main/java/io/cucumber/plugin/event/Node.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/Node.java
@@ -27,11 +27,11 @@ import static java.util.Collections.singletonList;
  * root node to a node with the same location as a test case.
  *
  * <pre>
- * {@code
- *       Location location = testCase.getLocation();
- *       Predicate<Node> withLocation = candidate ->
- *          location.equals(candidate.getLocation());
- *       Optional<List<Node>> path = node.findPathTo(withLocation);
+ * {
+ *     &#64;code
+ *     Location location = testCase.getLocation();
+ *     Predicate<Node> withLocation = candidate -> location.equals(candidate.getLocation());
+ *     Optional<List<Node>> path = node.findPathTo(withLocation);
  * }
  * </pre>
  */
@@ -47,23 +47,30 @@ public interface Node {
     /**
      * Recursively maps a node into another tree-like structure.
      *
-     * @param parent             the parent node of the target structure
-     * @param mapFeature         a function that takes a feature and a parent node and returns a mapped feature
-     * @param mapRule            a function that takes a rule and a parent node and returns a mapped rule
-     * @param mapScenario        a function that takes a scenario and a parent node and returns a mapped scenario
-     * @param mapScenarioOutline a function that takes a scenario outline and a parent node and returns a mapped scenario outline
-     * @param mapExamples        a function that takes an examples and a parent node and returns a mapped examples
-     * @param mapExample         a function that takes an example and a parent node and returns a mapped example
-     * @param <T>                the type of the target structure
-     * @return the mapped version of this instance
+     * @param  parent             the parent node of the target structure
+     * @param  mapFeature         a function that takes a feature and a parent
+     *                            node and returns a mapped feature
+     * @param  mapRule            a function that takes a rule and a parent node
+     *                            and returns a mapped rule
+     * @param  mapScenario        a function that takes a scenario and a parent
+     *                            node and returns a mapped scenario
+     * @param  mapScenarioOutline a function that takes a scenario outline and a
+     *                            parent node and returns a mapped scenario
+     *                            outline
+     * @param  mapExamples        a function that takes an examples and a parent
+     *                            node and returns a mapped examples
+     * @param  mapExample         a function that takes an example and a parent
+     *                            node and returns a mapped example
+     * @param  <T>                the type of the target structure
+     * @return                    the mapped version of this instance
      */
     default <T> T map(
-        T parent,
-        BiFunction<Feature, T, T> mapFeature,
-        BiFunction<Rule, T, T> mapRule, BiFunction<Scenario, T, T> mapScenario,
-        BiFunction<ScenarioOutline, T, T> mapScenarioOutline,
-        BiFunction<Examples, T, T> mapExamples,
-        BiFunction<Example, T, T> mapExample
+            T parent,
+            BiFunction<Feature, T, T> mapFeature,
+            BiFunction<Rule, T, T> mapRule, BiFunction<Scenario, T, T> mapScenario,
+            BiFunction<ScenarioOutline, T, T> mapScenarioOutline,
+            BiFunction<Examples, T, T> mapExamples,
+            BiFunction<Example, T, T> mapExample
     ) {
         if (this instanceof Scenario) {
             return mapScenario.apply((Scenario) this, parent);
@@ -83,7 +90,8 @@ public interface Node {
                 throw new IllegalArgumentException(this.getClass().getName());
             }
             Container<?> container = (Container<?>) this;
-            container.elements().forEach(node -> node.map(mapped, mapFeature, mapRule, mapScenario, mapScenarioOutline, mapExamples, mapExample));
+            container.elements().forEach(node -> node.map(mapped, mapFeature, mapRule, mapScenario, mapScenarioOutline,
+                mapExamples, mapExample));
             return mapped;
         } else {
             throw new IllegalArgumentException(this.getClass().getName());
@@ -94,8 +102,9 @@ public interface Node {
      * Finds a path down tree starting at this node to the first node that
      * matches the predicate using depth first search.
      *
-     * @param predicate to match the target node.
-     * @return a path to the first node or an empty optional if none was found.
+     * @param  predicate to match the target node.
+     * @return           a path to the first node or an empty optional if none
+     *                   was found.
      */
     default Optional<List<Node>> findPathTo(Predicate<Node> predicate) {
         if (predicate.test(this)) {

--- a/plugin/src/main/java/io/cucumber/plugin/event/PickleStepTestStep.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/PickleStepTestStep.java
@@ -12,7 +12,8 @@ import java.util.List;
 public interface PickleStepTestStep extends TestStep {
 
     /**
-     * The pattern or expression used to match the glue code to the Gherkin step.
+     * The pattern or expression used to match the glue code to the Gherkin
+     * step.
      *
      * @return a pattern or expression
      */
@@ -28,19 +29,19 @@ public interface PickleStepTestStep extends TestStep {
     /**
      * Returns the arguments provided to the step definition.
      * <p>
-     * For example the step definition <code>Given (.*) pickles</code>
-     * when matched with <code>Given 15 pickles</code> will receive
-     * as argument <code>"15"</code>.
+     * For example the step definition <code>Given (.*) pickles</code> when
+     * matched with <code>Given 15 pickles</code> will receive as argument
+     * <code>"15"</code>.
      *
      * @return argument provided to the step definition
      */
     List<Argument> getDefinitionArgument();
 
     /**
-     * Returns arguments provided to the Gherkin step. E.g:
-     * a data table or doc string.
+     * Returns arguments provided to the Gherkin step. E.g: a data table or doc
+     * string.
      *
-     * @return arguments provided to the gherkin step.
+     * @return     arguments provided to the gherkin step.
      * @deprecated use {@link #getStep()}
      */
     @Deprecated
@@ -49,7 +50,7 @@ public interface PickleStepTestStep extends TestStep {
     /**
      * The line in the feature file defining this step.
      *
-     * @return a line number
+     * @return     a line number
      * @deprecated use {@link #getStep()}
      */
     @Deprecated
@@ -65,7 +66,7 @@ public interface PickleStepTestStep extends TestStep {
     /**
      * The full text of the Gherkin step.
      *
-     * @return the step text
+     * @return     the step text
      * @deprecated use {@code #getStep()}
      */
     @Deprecated

--- a/plugin/src/main/java/io/cucumber/plugin/event/Result.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/Result.java
@@ -39,11 +39,11 @@ public final class Result {
     }
 
     /**
-     * Returns the error encountered while executing a step, scenario or
-     * test run.
+     * Returns the error encountered while executing a step, scenario or test
+     * run.
      * <p>
-     * Will return null when passed. May return null when status is undefined
-     * or when skipped due to a failing prior step.
+     * Will return null when passed. May return null when status is undefined or
+     * when skipped due to a failing prior step.
      *
      * @return the error encountered while executing a step or scenario or null.
      */
@@ -58,21 +58,23 @@ public final class Result {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         Result result = (Result) o;
         return status == result.status &&
-            Objects.equals(duration, result.duration) &&
-            Objects.equals(error, result.error);
+                Objects.equals(duration, result.duration) &&
+                Objects.equals(error, result.error);
     }
 
     @Override
     public String toString() {
         return "Result{" +
-            "status=" + status +
-            ", duration=" + duration.getSeconds() +
-            ", error=" + error +
-            '}';
+                "status=" + status +
+                ", duration=" + duration.getSeconds() +
+                ", error=" + error +
+                '}';
     }
 
 }

--- a/plugin/src/main/java/io/cucumber/plugin/event/SnippetsSuggestedEvent.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/SnippetsSuggestedEvent.java
@@ -22,7 +22,9 @@ public final class SnippetsSuggestedEvent extends TimeStampedEvent {
         this(timeInstant, uri, new Location(scenarioLine, -1), new Location(stepLine, -1), snippets);
     }
 
-    public SnippetsSuggestedEvent(Instant instant, URI uri, Location scenarioLocation, Location stepLocation, List<String> snippets) {
+    public SnippetsSuggestedEvent(
+            Instant instant, URI uri, Location scenarioLocation, Location stepLocation, List<String> snippets
+    ) {
         super(instant);
         this.uri = requireNonNull(uri);
         this.scenarioLocation = scenarioLocation;

--- a/plugin/src/main/java/io/cucumber/plugin/event/Status.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/Status.java
@@ -15,9 +15,9 @@ public enum Status {
     /**
      * Does this state allow the build to pass
      *
-     * @param isStrict should this result be evaluated strictly? Ignored.
-     * @return true if this result does not fail the build
-     * @deprecated please use {@link #isOk()}}
+     * @param      isStrict should this result be evaluated strictly? Ignored.
+     * @return              true if this result does not fail the build
+     * @deprecated          please use {@link #isOk()}}
      */
     @Deprecated
     public boolean isOk(boolean isStrict) {

--- a/plugin/src/main/java/io/cucumber/plugin/event/Step.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/Step.java
@@ -19,7 +19,7 @@ public interface Step {
     /**
      * Returns this steps keyword. I.e. Given, When, Then.
      *
-     * @return step key word
+     * @return     step key word
      * @deprecated use {@link #getKeyword()} instead
      */
     default String getKeyWord() {

--- a/plugin/src/main/java/io/cucumber/plugin/event/StepDefinedEvent.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/StepDefinedEvent.java
@@ -1,6 +1,5 @@
 package io.cucumber.plugin.event;
 
-
 import org.apiguardian.api.API;
 
 import java.time.Instant;

--- a/plugin/src/main/java/io/cucumber/plugin/event/StepDefinition.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/StepDefinition.java
@@ -1,6 +1,5 @@
 package io.cucumber.plugin.event;
 
-
 import org.apiguardian.api.API;
 
 @API(status = API.Status.STABLE)
@@ -15,8 +14,8 @@ public final class StepDefinition {
     }
 
     /**
-     * The source line where the step definition is defined.
-     * Example: com/example/app/Cucumber.test():42
+     * The source line where the step definition is defined. Example:
+     * com/example/app/Cucumber.test():42
      *
      * @return The source line of the step definition.
      */
@@ -25,7 +24,8 @@ public final class StepDefinition {
     }
 
     /**
-     * @return the pattern associated with this instance. Used for error reporting only.
+     * @return the pattern associated with this instance. Used for error
+     *         reporting only.
      */
     public String getPattern() {
         return pattern;

--- a/plugin/src/main/java/io/cucumber/plugin/event/TestCase.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/TestCase.java
@@ -11,8 +11,8 @@ public interface TestCase {
 
     /**
      * Returns the line of this Scenario in the feature file. If this Scenario
-     * is an example in a Scenario Outline the method wil return the line of
-     * the example.
+     * is an example in a Scenario Outline the method wil return the line of the
+     * example.
      *
      * @return the line of this scenario.
      */
@@ -20,9 +20,9 @@ public interface TestCase {
     Integer getLine();
 
     /**
-     * Returns the location of this Scenario in the feature file. If this Scenario
-     * is an example in a Scenario Outline the method wil return the location of
-     * the example.
+     * Returns the location of this Scenario in the feature file. If this
+     * Scenario is an example in a Scenario Outline the method wil return the
+     * location of the example.
      *
      * @return the location of this scenario.
      */

--- a/plugin/src/main/java/io/cucumber/plugin/event/TestStep.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/TestStep.java
@@ -5,8 +5,8 @@ import org.apiguardian.api.API;
 import java.util.UUID;
 
 /**
- * A test step can either represent the execution of a hook
- * or a pickle step. Each step is tied to some glue code.
+ * A test step can either represent the execution of a hook or a pickle step.
+ * Each step is tied to some glue code.
  *
  * @see TestCaseStarted
  * @see TestCaseFinished

--- a/plugin/src/main/java/io/cucumber/plugin/event/TestStepFinished.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/TestStepFinished.java
@@ -8,12 +8,13 @@ import java.util.Objects;
 /**
  * A test step finished event is broadcast when ever a step finishes.
  * <p>
- * A step can either be a {@link PickleStepTestStep} or a
- * {@link HookTestStep} depending on what step was executed.
+ * A step can either be a {@link PickleStepTestStep} or a {@link HookTestStep}
+ * depending on what step was executed.
  * <p>
  * Each test step finished event is followed by an matching
- * {@link TestStepStarted} event for the same step.The order in which
- * these events may be expected is:
+ * {@link TestStepStarted} event for the same step.The order in which these
+ * events may be expected is:
+ * 
  * <pre>
  *     [before hook,]* [[before step hook,]* test step, [after step hook,]*]+, [after hook,]*
  * </pre>

--- a/plugin/src/main/java/io/cucumber/plugin/event/TestStepStarted.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/TestStepStarted.java
@@ -8,12 +8,12 @@ import java.util.Objects;
 /**
  * A test step started event is broadcast when ever a step starts.
  * <p>
- * A step can either be a {@link PickleStepTestStep} or a
- * {@link HookTestStep} depending on what step was executed.
+ * A step can either be a {@link PickleStepTestStep} or a {@link HookTestStep}
+ * depending on what step was executed.
  * <p>
  * Each test step started event is followed by an matching
- * {@link TestStepFinished} event for the same step.The order in
- * which these events may be expected is:
+ * {@link TestStepFinished} event for the same step.The order in which these
+ * events may be expected is:
  *
  * <pre>
  *     [before hook,]* [[before step hook,]* test step, [after step hook,]*]+, [after hook,]*

--- a/plugin/src/main/java/io/cucumber/plugin/event/TimeStampedEvent.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/TimeStampedEvent.java
@@ -3,7 +3,6 @@ package io.cucumber.plugin.event;
 import java.time.Instant;
 import java.util.Objects;
 
-
 abstract class TimeStampedEvent implements Event {
 
     private final Instant instant;

--- a/plugin/src/test/java/io/cucumber/plugin/event/NodeTest.java
+++ b/plugin/src/test/java/io/cucumber/plugin/event/NodeTest.java
@@ -1,6 +1,5 @@
 package io.cucumber.plugin.event;
 
-
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
@@ -50,7 +49,6 @@ class NodeTest {
         public Optional<String> getName() {
             return Optional.of(toString());
         }
-
 
         @Override
         public String toString() {
@@ -300,7 +298,8 @@ class NodeTest {
 
     @Test
     void findEmptyExamplesA() {
-        Optional<List<Node>> pathTo = emptyOutline.findPathTo(node -> Optional.of("Empty Examples A").equals(node.getName()));
+        Optional<List<Node>> pathTo = emptyOutline
+                .findPathTo(node -> Optional.of("Empty Examples A").equals(node.getName()));
         assertEquals(Optional.of(asList(emptyOutline, emptyExamplesA)), pathTo);
     }
 
@@ -312,7 +311,8 @@ class NodeTest {
 
     @Test
     void findEmptyExamplesB() {
-        Optional<List<Node>> pathTo = emptyOutline.findPathTo(node -> Optional.of("Empty Examples B").equals(node.getName()));
+        Optional<List<Node>> pathTo = emptyOutline
+                .findPathTo(node -> Optional.of("Empty Examples B").equals(node.getName()));
         assertEquals(Optional.of(asList(emptyOutline, emptyExamplesB)), pathTo);
     }
 
@@ -324,7 +324,8 @@ class NodeTest {
 
     @Test
     void findEmptyOutline() {
-        Optional<List<Node>> pathTo = emptyOutline.findPathTo(node -> Optional.of("Empty Outline").equals(node.getName()));
+        Optional<List<Node>> pathTo = emptyOutline
+                .findPathTo(node -> Optional.of("Empty Outline").equals(node.getName()));
         assertEquals(Optional.of(asList(emptyOutline)), pathTo);
     }
 
@@ -351,6 +352,5 @@ class NodeTest {
         Optional<List<Node>> pathTo = example1.findPathTo(node -> Optional.of("Nothing").equals(node.getName()));
         assertEquals(Optional.empty(), pathTo);
     }
-
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,33 @@
         </profile>
 
         <profile>
+            <id>spotless-apply</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <!-- Apply code format by default -->
+                        <plugin>
+                            <groupId>com.diffplug.spotless</groupId>
+                            <artifactId>spotless-maven-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>spotless-apply</id>
+                                    <phase>compile</phase>
+                                    <goals>
+                                        <goal>apply</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
+        <profile>
             <id>check-semantic-version</id>
             <build>
                 <plugins>
@@ -321,6 +348,39 @@
                     <execution>
                         <id>java11</id>
                         <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.commonjava.maven.plugins</groupId>
+                <artifactId>directory-maven-plugin</artifactId>
+                <version>0.3</version>
+                <executions>
+                    <execution>
+                        <id>directories</id>
+                        <goals>
+                            <goal>highest-basedir</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <property>main.basedir</property>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Check code format -->
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>spotless-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -543,6 +603,22 @@
                             <version>2.3.1</version>
                         </dependency>
                     </dependencies>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>1.31.0</version>
+                    <configuration>
+                        <java>
+                            <eclipse>
+                                <file>${main.basedir}/.spotless/eclipse-formatter-settings.xml</file>
+                            </eclipse>
+                            <importOrder>
+                                <file>${main.basedir}/.spotless/intelij-idea.importorder</file>
+                            </importOrder>
+                        </java>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/spring/src/main/java/io/cucumber/spring/GlueCodeContext.java
+++ b/spring/src/main/java/io/cucumber/spring/GlueCodeContext.java
@@ -5,8 +5,7 @@ import java.util.Map;
 
 class GlueCodeContext {
 
-    private static final ThreadLocal<GlueCodeContext> localContext =
-        ThreadLocal.withInitial(GlueCodeContext::new);
+    private static final ThreadLocal<GlueCodeContext> localContext = ThreadLocal.withInitial(GlueCodeContext::new);
 
     private final Map<String, Object> objects = new HashMap<>();
     private final Map<String, Runnable> callbacks = new HashMap<>();

--- a/spring/src/main/java/io/cucumber/spring/SpringBackend.java
+++ b/spring/src/main/java/io/cucumber/spring/SpringBackend.java
@@ -27,12 +27,12 @@ final class SpringBackend implements Backend {
     @Override
     public void loadGlue(Glue glue, List<URI> gluePaths) {
         gluePaths.stream()
-            .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
-            .map(ClasspathSupport::packageName)
-            .map(classFinder::scanForClassesInPackage)
-            .flatMap(Collection::stream)
-            .filter((Class clazz) -> clazz.getAnnotation(CucumberContextConfiguration.class) != null)
-            .forEach(container::addClass);
+                .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
+                .map(ClasspathSupport::packageName)
+                .map(classFinder::scanForClassesInPackage)
+                .flatMap(Collection::stream)
+                .filter((Class clazz) -> clazz.getAnnotation(CucumberContextConfiguration.class) != null)
+                .forEach(container::addClass);
     }
 
     @Override

--- a/spring/src/main/java/io/cucumber/spring/SpringFactory.java
+++ b/spring/src/main/java/io/cucumber/spring/SpringFactory.java
@@ -28,26 +28,23 @@ import static io.cucumber.spring.TestContextAdaptor.createTestContextManagerAdap
  * Application beans are accessible from the step definitions using autowiring
  * (with annotations).
  * <p>
- * The spring context can be configured by annotating one glue class with a @{@link CucumberContextConfiguration} and
- * any one of the following @{@link ContextConfiguration}, @{@link ContextHierarchy} or @{@link BootstrapWith}.
- * This glue class can also be annotated with @{@link WebAppConfiguration} or @{@link DirtiesContext} annotation.
+ * The spring context can be configured by annotating one glue class with
+ * a @{@link CucumberContextConfiguration} and any one of the
+ * following @{@link ContextConfiguration}, @{@link ContextHierarchy}
+ * or @{@link BootstrapWith}. This glue class can also be annotated
+ * with @{@link WebAppConfiguration} or @{@link DirtiesContext} annotation.
  * <p>
  * Notes:
  * <ul>
- *     <li>
- *          SpringFactory uses Springs TestContextManager framework to manage the spring context. The class annotated
- *          with {@code CucumberContextConfiguration} will be use to instantiate the {@link TestContextManager}.
- *     </li>
- *      <li>
- *          If not exactly one glue class is annotated with {@code CucumberContextConfiguration} an exception will be
- *          thrown.
- *      </li>
- *
- *      <li>
- *          Step definitions should not be annotated with @{@link Component} or other annotations that mark it as
- *          eligible for detection by classpath scanning. When a step definition class is annotated by @Component or an
- *          annotation that has the @Component stereotype an exception will be thrown
- *      </li>
+ * <li>SpringFactory uses Springs TestContextManager framework to manage the
+ * spring context. The class annotated with {@code CucumberContextConfiguration}
+ * will be use to instantiate the {@link TestContextManager}.</li>
+ * <li>If not exactly one glue class is annotated with
+ * {@code CucumberContextConfiguration} an exception will be thrown.</li>
+ * <li>Step definitions should not be annotated with @{@link Component} or other
+ * annotations that mark it as eligible for detection by classpath scanning.
+ * When a step definition class is annotated by @Component or an annotation that
+ * has the @Component stereotype an exception will be thrown</li>
  * </ul>
  */
 @API(status = API.Status.STABLE)
@@ -77,7 +74,8 @@ public final class SpringFactory implements ObjectFactory {
             if (hasComponentAnnotation(annotation)) {
                 throw new CucumberBackendException(String.format("" +
                         "Glue class %1$s was annotated with @%2$s; marking it as a candidate for auto-detection by " +
-                        "Spring. Glue classes are detected and registered by Cucumber. Auto-detection of glue classes by " +
+                        "Spring. Glue classes are detected and registered by Cucumber. Auto-detection of glue classes by "
+                        +
                         "spring may lead to duplicate bean definitions. Please remove the @%2$s annotation",
                     type.getName(),
                     annotation.annotationType().getSimpleName()));
@@ -95,8 +93,7 @@ public final class SpringFactory implements ObjectFactory {
                     "Glue class %1$s and %2$s are both annotated with @CucumberContextConfiguration.\n" +
                     "Please ensure only one class configures the spring context",
                 stepClass,
-                withCucumberContextConfiguration
-            ));
+                withCucumberContextConfiguration));
         }
     }
 
@@ -130,20 +127,19 @@ public final class SpringFactory implements ObjectFactory {
     public void start() {
         if (withCucumberContextConfiguration == null) {
             throw new CucumberBackendException("" +
-                "Please annotate a glue class with some context configuration.\n" +
-                "\n" +
-                "For example:\n" +
-                "\n" +
-                "   @CucumberContextConfiguration\n" +
-                "   @SpringBootTest(classes = TestConfig.class)\n" +
-                "   public class CucumberSpringConfiguration { }" +
-                "\n" +
-                "Or: \n" +
-                "\n" +
-                "   @CucumberContextConfiguration\n" +
-                "   @ContextConfiguration( ... )\n" +
-                "   public class CucumberSpringConfiguration { }"
-            );
+                    "Please annotate a glue class with some context configuration.\n" +
+                    "\n" +
+                    "For example:\n" +
+                    "\n" +
+                    "   @CucumberContextConfiguration\n" +
+                    "   @SpringBootTest(classes = TestConfig.class)\n" +
+                    "   public class CucumberSpringConfiguration { }" +
+                    "\n" +
+                    "Or: \n" +
+                    "\n" +
+                    "   @CucumberContextConfiguration\n" +
+                    "   @ContextConfiguration( ... )\n" +
+                    "   public class CucumberSpringConfiguration { }");
         }
 
         // The application context created by the TestContextManager is

--- a/spring/src/main/java/io/cucumber/spring/TestContextAdaptor.java
+++ b/spring/src/main/java/io/cucumber/spring/TestContextAdaptor.java
@@ -20,20 +20,24 @@ abstract class TestContextAdaptor {
     private final ConfigurableApplicationContext applicationContext;
     private final Collection<Class<?>> glueClasses;
 
-    protected TestContextAdaptor(TestContextManager delegate, ConfigurableApplicationContext applicationContext,
-                                 Collection<Class<?>> glueClasses) {
+    protected TestContextAdaptor(
+            TestContextManager delegate,
+            ConfigurableApplicationContext applicationContext,
+            Collection<Class<?>> glueClasses
+    ) {
         this.delegate = delegate;
         this.applicationContext = applicationContext;
         this.glueClasses = glueClasses;
     }
 
-    static TestContextAdaptor createTestContextManagerAdaptor(TestContextManager delegate,
-                                                              Collection<Class<?>> glueClasses) {
+    static TestContextAdaptor createTestContextManagerAdaptor(
+            TestContextManager delegate,
+            Collection<Class<?>> glueClasses
+    ) {
         TestContext testContext = delegate.getTestContext();
-        ConfigurableApplicationContext applicationContext =
-            (ConfigurableApplicationContext) testContext.getApplicationContext();
+        ConfigurableApplicationContext applicationContext = (ConfigurableApplicationContext) testContext
+                .getApplicationContext();
         return new TestContextAdaptor(delegate, applicationContext, glueClasses) {
-
 
         };
     }
@@ -81,10 +85,9 @@ abstract class TestContextAdaptor {
             return;
         }
         registry.registerBeanDefinition(beanName, BeanDefinitionBuilder
-            .genericBeanDefinition(glueClass)
-            .setScope(SCOPE_CUCUMBER_GLUE)
-            .getBeanDefinition()
-        );
+                .genericBeanDefinition(glueClass)
+                .setScope(SCOPE_CUCUMBER_GLUE)
+                .getBeanDefinition());
     }
 
     public final void stop() {

--- a/spring/src/main/java/io/cucumber/spring/package-info.java
+++ b/spring/src/main/java/io/cucumber/spring/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Enables dependency injection by Spring
  * <p>
- * By including the <code>cucumber-spring</code> on your <code>CLASSPATH</code> your step definitions will be
- * instantiated by Spring.
+ * By including the <code>cucumber-spring</code> on your <code>CLASSPATH</code>
+ * your step definitions will be instantiated by Spring.
  */
 package io.cucumber.spring;

--- a/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
+++ b/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
@@ -50,12 +50,11 @@ class SpringFactoryTest {
         final BellyStepDefinitions o2 = factory.getInstance(BellyStepDefinitions.class);
         factory.stop();
 
-        assertAll("Checking BellyStepdefs",
+        assertAll(
             () -> assertThat(o1, is(notNullValue())),
             () -> assertThat(o2, is(notNullValue())),
             () -> assertThat(o1, is(not(equalTo(o2)))),
-            () -> assertThat(o2, is(not(equalTo(o1))))
-        );
+            () -> assertThat(o2, is(not(equalTo(o1)))));
     }
 
     @Test
@@ -74,12 +73,11 @@ class SpringFactoryTest {
         final BellyBean o2 = factory2.getInstance(BellyStepDefinitions.class).getBellyBean();
         factory2.stop();
 
-        assertAll("Checking BellyBean",
+        assertAll(
             () -> assertThat(o1, is(notNullValue())),
             () -> assertThat(o2, is(notNullValue())),
             () -> assertThat(o1, is(equalTo(o1))),
-            () -> assertThat(o2, is(equalTo(o2)))
-        );
+            () -> assertThat(o2, is(equalTo(o2))));
     }
 
     @Test
@@ -98,12 +96,11 @@ class SpringFactoryTest {
         final BellyBean o2 = factory2.getInstance(BellyMetaStepDefinitions.class).getBellyBean();
         factory2.stop();
 
-        assertAll("Checking BellyBean",
+        assertAll(
             () -> assertThat(o1, is(notNullValue())),
             () -> assertThat(o2, is(notNullValue())),
             () -> assertThat(o1, is(equalTo(o1))),
-            () -> assertThat(o2, is(equalTo(o2)))
-        );
+            () -> assertThat(o2, is(equalTo(o2))));
     }
 
     @Test
@@ -118,12 +115,11 @@ class SpringFactoryTest {
         final ThirdStepDef o2 = factory1.getInstance(ThirdStepDef.class);
         factory1.stop();
 
-        assertAll("Checking ThirdStepDef",
+        assertAll(
             () -> assertThat(o1.getThirdStepDef(), is(notNullValue())),
             () -> assertThat(o2, is(notNullValue())),
             () -> assertThat(o1.getThirdStepDef(), is(equalTo(o2))),
-            () -> assertThat(o2, is(equalTo(o1.getThirdStepDef())))
-        );
+            () -> assertThat(o2, is(equalTo(o1.getThirdStepDef()))));
     }
 
     @Test
@@ -138,12 +134,11 @@ class SpringFactoryTest {
         final AutowiresThirdStepDef o3 = factory1.getInstance(AutowiresThirdStepDef.class);
         factory1.stop();
 
-        assertAll("Checking AutowiresThirdStepDef",
+        assertAll(
             () -> assertThat(o1.getThirdStepDef(), is(notNullValue())),
             () -> assertThat(o3.getThirdStepDef(), is(notNullValue())),
             () -> assertThat(o1.getThirdStepDef(), is(equalTo(o3.getThirdStepDef()))),
-            () -> assertThat(o3.getThirdStepDef(), is(equalTo(o1.getThirdStepDef())))
-        );
+            () -> assertThat(o3.getThirdStepDef(), is(equalTo(o1.getThirdStepDef()))));
     }
 
     @Test
@@ -186,12 +181,11 @@ class SpringFactoryTest {
         final BellyBean o2 = factory.getInstance(DirtiesContextBellyStepDefinitions.class).getBellyBean();
         factory.stop();
 
-        assertAll("Checking BellyBean",
+        assertAll(
             () -> assertThat(o1, is(notNullValue())),
             () -> assertThat(o2, is(notNullValue())),
             () -> assertThat(o1, is(not(equalTo(o2)))),
-            () -> assertThat(o2, is(not(equalTo(o1))))
-        );
+            () -> assertThat(o2, is(not(equalTo(o1)))));
     }
 
     @Test
@@ -210,12 +204,11 @@ class SpringFactoryTest {
         final BellyBean o2 = factory.getInstance(DirtiesContextBellyMetaStepDefinitions.class).getBellyBean();
         factory.stop();
 
-        assertAll("Checking BellyBean",
+        assertAll(
             () -> assertThat(o1, is(notNullValue())),
             () -> assertThat(o2, is(notNullValue())),
             () -> assertThat(o1, is(not(equalTo(o2)))),
-            () -> assertThat(o2, is(not(equalTo(o1))))
-        );
+            () -> assertThat(o2, is(not(equalTo(o1)))));
     }
 
     @Test
@@ -236,10 +229,10 @@ class SpringFactoryTest {
 
         Executable testMethod = () -> factory.addClass(BellyStepDefinitions.class);
         CucumberBackendException actualThrown = assertThrows(CucumberBackendException.class, testMethod);
-        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "Glue class class io.cucumber.spring.contextconfig.BellyStepDefinitions and class io.cucumber.spring.SpringFactoryTest$WithSpringAnnotations are both annotated with @CucumberContextConfiguration.\n" +
-                "Please ensure only one class configures the spring context"
-        )));
+        assertThat(actualThrown.getMessage(), is(equalTo(
+            "Glue class class io.cucumber.spring.contextconfig.BellyStepDefinitions and class io.cucumber.spring.SpringFactoryTest$WithSpringAnnotations are both annotated with @CucumberContextConfiguration.\n"
+                    +
+                    "Please ensure only one class configures the spring context")));
     }
 
     @Test
@@ -248,9 +241,8 @@ class SpringFactoryTest {
 
         Executable testMethod = () -> factory.addClass(WithComponentAnnotation.class);
         CucumberBackendException actualThrown = assertThrows(CucumberBackendException.class, testMethod);
-        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "Glue class io.cucumber.spring.componentannotation.WithComponentAnnotation was annotated with @Component; marking it as a candidate for auto-detection by Spring. Glue classes are detected and registered by Cucumber. Auto-detection of glue classes by spring may lead to duplicate bean definitions. Please remove the @Component annotation"
-        )));
+        assertThat(actualThrown.getMessage(), is(equalTo(
+            "Glue class io.cucumber.spring.componentannotation.WithComponentAnnotation was annotated with @Component; marking it as a candidate for auto-detection by Spring. Glue classes are detected and registered by Cucumber. Auto-detection of glue classes by spring may lead to duplicate bean definitions. Please remove the @Component annotation")));
     }
 
     @Test
@@ -259,9 +251,8 @@ class SpringFactoryTest {
 
         Executable testMethod = () -> factory.addClass(WithControllerAnnotation.class);
         CucumberBackendException actualThrown = assertThrows(CucumberBackendException.class, testMethod);
-        assertThat("Unexpected exception message", actualThrown.getMessage(), is(equalTo(
-            "Glue class io.cucumber.spring.componentannotation.WithControllerAnnotation was annotated with @Controller; marking it as a candidate for auto-detection by Spring. Glue classes are detected and registered by Cucumber. Auto-detection of glue classes by spring may lead to duplicate bean definitions. Please remove the @Controller annotation"
-        )));
+        assertThat(actualThrown.getMessage(), is(equalTo(
+            "Glue class io.cucumber.spring.componentannotation.WithControllerAnnotation was annotated with @Controller; marking it as a candidate for auto-detection by Spring. Glue classes are detected and registered by Cucumber. Auto-detection of glue classes by spring may lead to duplicate bean definitions. Please remove the @Controller annotation")));
     }
 
     @Test
@@ -274,10 +265,9 @@ class SpringFactoryTest {
         final Belly belly1 = factory.getInstance(Belly.class);
         final GlueScopedComponent glue1 = factory.getInstance(GlueScopedComponent.class);
 
-        assertAll("Checking factory.getInstance(Class)",
+        assertAll(
             () -> assertThat(belly1, is(notNullValue())),
-            () -> assertThat(glue1, is(notNullValue()))
-        );
+            () -> assertThat(glue1, is(notNullValue())));
 
         factory.stop();
 
@@ -285,14 +275,13 @@ class SpringFactoryTest {
         final Belly belly2 = factory.getInstance(Belly.class);
         final GlueScopedComponent glue2 = factory.getInstance(GlueScopedComponent.class);
 
-        assertAll("Checking factory.getInstance(Class)",
+        assertAll(
             () -> assertThat(belly2, is(notNullValue())),
             () -> assertThat(glue2, is(notNullValue())),
             () -> assertThat(glue1, is(not(equalTo(glue2)))),
             () -> assertThat(glue2, is(not(equalTo(glue1)))),
             () -> assertThat(belly1, is(equalTo(belly2))),
-            () -> assertThat(belly2, is(equalTo(belly1)))
-        );
+            () -> assertThat(belly2, is(equalTo(belly1))));
     }
 
     @Test
@@ -301,7 +290,8 @@ class SpringFactoryTest {
         factory.addClass(WithEmptySpringAnnotations.class);
 
         IllegalStateException exception = assertThrows(IllegalStateException.class, factory::start);
-        assertThat(exception.getMessage(), containsString("DelegatingSmartContextLoader was unable to detect defaults"));
+        assertThat(exception.getMessage(),
+            containsString("DelegatingSmartContextLoader was unable to detect defaults"));
         assertDoesNotThrow(factory::stop);
     }
 

--- a/spring/src/test/java/io/cucumber/spring/annotationconfig/AnnotationContextConfiguration.java
+++ b/spring/src/test/java/io/cucumber/spring/annotationconfig/AnnotationContextConfiguration.java
@@ -1,6 +1,5 @@
 package io.cucumber.spring.annotationconfig;
 
-
 import io.cucumber.spring.CucumberContextConfiguration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;

--- a/spring/src/test/java/io/cucumber/spring/annotationconfig/RunCucumberContextConfigurationTest.java
+++ b/spring/src/test/java/io/cucumber/spring/annotationconfig/RunCucumberContextConfigurationTest.java
@@ -6,9 +6,8 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-    glue = {"io.cucumber.spring.annotationconfig"},
-    features = {"classpath:io/cucumber/spring/annotationContextConfiguration.feature"}
-)
+        glue = "io.cucumber.spring.annotationconfig",
+        features = "classpath:io/cucumber/spring/annotationContextConfiguration.feature")
 public class RunCucumberContextConfigurationTest {
 
 }

--- a/spring/src/test/java/io/cucumber/spring/beans/BellyBean.java
+++ b/spring/src/test/java/io/cucumber/spring/beans/BellyBean.java
@@ -1,6 +1,5 @@
 package io.cucumber.spring.beans;
 
-
 public class BellyBean {
 
     private int cukes = 0;

--- a/spring/src/test/java/io/cucumber/spring/contextcaching/ContextCachingSteps.java
+++ b/spring/src/test/java/io/cucumber/spring/contextcaching/ContextCachingSteps.java
@@ -10,7 +10,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @CucumberContextConfiguration
-@ContextConfiguration(classes = {ContextConfig.class})
+@ContextConfiguration(classes = ContextConfig.class)
 public class ContextCachingSteps {
 
     @Autowired

--- a/spring/src/test/java/io/cucumber/spring/contextcaching/ContextConfig.java
+++ b/spring/src/test/java/io/cucumber/spring/contextcaching/ContextConfig.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan({"io.cucumber.spring.contextcaching"})
+@ComponentScan("io.cucumber.spring.contextcaching")
 public class ContextConfig {
 
 }

--- a/spring/src/test/java/io/cucumber/spring/contextcaching/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/contextcaching/RunCucumberTest.java
@@ -6,8 +6,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-    features = {"classpath:io/cucumber/spring/contextCaching.feature"}
-)
+        features = "classpath:io/cucumber/spring/contextCaching.feature")
 public class RunCucumberTest {
 
 }

--- a/spring/src/test/java/io/cucumber/spring/contextcaching/SharedContextTest.java
+++ b/spring/src/test/java/io/cucumber/spring/contextcaching/SharedContextTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = {ContextConfig.class})
+@ContextConfiguration(classes = ContextConfig.class)
 class SharedContextTest {
 
     @Autowired

--- a/spring/src/test/java/io/cucumber/spring/contextconfig/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/contextconfig/RunCucumberTest.java
@@ -6,15 +6,12 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-    glue = {
-        "io.cucumber.spring.contextconfig",
-        "io.cucumber.spring.commonglue",
-        "io.cucumber.spring.api"
-    },
-    features = {
-        "classpath:io/cucumber/spring/stepdefInjection.feature",
-    }
-)
+        glue = {
+                "io.cucumber.spring.contextconfig",
+                "io.cucumber.spring.commonglue",
+                "io.cucumber.spring.api"
+        },
+        features = "classpath:io/cucumber/spring/stepdefInjection.feature")
 public class RunCucumberTest {
 
 }

--- a/spring/src/test/java/io/cucumber/spring/contexthierarchyconfig/WithContextHierarchyAnnotation.java
+++ b/spring/src/test/java/io/cucumber/spring/contexthierarchyconfig/WithContextHierarchyAnnotation.java
@@ -8,9 +8,8 @@ import org.springframework.test.context.ContextHierarchy;
 
 @CucumberContextConfiguration
 @ContextHierarchy({
-    @ContextConfiguration("classpath:cucumber2.xml"),
-    @ContextConfiguration("classpath:cucumber.xml")
-})
+        @ContextConfiguration("classpath:cucumber2.xml"),
+        @ContextConfiguration("classpath:cucumber.xml") })
 public class WithContextHierarchyAnnotation {
 
     private boolean autowired;

--- a/spring/src/test/java/io/cucumber/spring/dirtiescontextconfig/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/dirtiescontextconfig/RunCucumberTest.java
@@ -6,9 +6,8 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-    glue = {"io.cucumber.spring.dirtiescontextconfig"},
-    features = {"classpath:io/cucumber/spring/dirtyCukes.feature"}
-)
+        glue = "io.cucumber.spring.dirtiescontextconfig",
+        features = "classpath:io/cucumber/spring/dirtyCukes.feature")
 public class RunCucumberTest {
 
 }

--- a/spring/src/test/java/io/cucumber/spring/metaconfig/dirties/DirtiesMetaConfiguration.java
+++ b/spring/src/test/java/io/cucumber/spring/metaconfig/dirties/DirtiesMetaConfiguration.java
@@ -8,7 +8,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 

--- a/spring/src/test/java/io/cucumber/spring/metaconfig/dirties/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/metaconfig/dirties/RunCucumberTest.java
@@ -6,9 +6,8 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-    glue = {"io.cucumber.spring.metaconfig.dirties"},
-    features = {"classpath:io/cucumber/spring/dirtyCukesWithMetaConfiguration.feature"}
-)
+        glue = "io.cucumber.spring.metaconfig.dirties",
+        features = "classpath:io/cucumber/spring/dirtyCukesWithMetaConfiguration.feature")
 public class RunCucumberTest {
 
 }

--- a/spring/src/test/java/io/cucumber/spring/metaconfig/general/MetaConfiguration.java
+++ b/spring/src/test/java/io/cucumber/spring/metaconfig/general/MetaConfiguration.java
@@ -7,7 +7,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 

--- a/spring/src/test/java/io/cucumber/spring/metaconfig/general/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/metaconfig/general/RunCucumberTest.java
@@ -6,15 +6,12 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-    glue = {
-        "io.cucumber.spring.metaconfig.general",
-        "io.cucumber.spring.commonglue",
-        "cucumber.api.spring"
-    },
-    features = {
-        "classpath:io/cucumber/spring/springBeanInjectionWithMetaConfiguration.feature"
-    }
-)
+        glue = {
+                "io.cucumber.spring.metaconfig.general",
+                "io.cucumber.spring.commonglue",
+                "cucumber.api.spring"
+        },
+        features = "classpath:io/cucumber/spring/springBeanInjectionWithMetaConfiguration.feature")
 public class RunCucumberTest {
 
 }

--- a/spring/src/test/java/io/cucumber/spring/threading/RunParallelCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/threading/RunParallelCucumberTest.java
@@ -21,12 +21,11 @@ class RunParallelCucumberTest {
         Callable<Byte> runCucumber = () -> {
             ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             String[] args = {
-                "--glue", "io.cucumber.spring.threading",
-                "classpath:io/cucumber/spring/threadingCukes.feature"
+                    "--glue", "io.cucumber.spring.threading",
+                    "classpath:io/cucumber/spring/threadingCukes.feature"
             };
             return Main.run(args, classLoader);
         };
-
 
         ExecutorService executorService = newFixedThreadPool(ThreadingStepDefinitions.concurrency);
         List<Future<Byte>> results = new ArrayList<>();

--- a/spring/src/test/java/io/cucumber/spring/webappconfig/RunCucumberTest.java
+++ b/spring/src/test/java/io/cucumber/spring/webappconfig/RunCucumberTest.java
@@ -6,9 +6,8 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-    glue = {"io.cucumber.spring.webappconfig"},
-    features = {"classpath:io/cucumber/spring/springWebContextInjection.feature"}
-)
+        glue = "io.cucumber.spring.webappconfig",
+        features = "classpath:io/cucumber/spring/springWebContextInjection.feature")
 public class RunCucumberTest {
 
 }

--- a/testng/src/main/java/io/cucumber/testng/AbstractTestNGCucumberTests.java
+++ b/testng/src/main/java/io/cucumber/testng/AbstractTestNGCucumberTests.java
@@ -26,13 +26,14 @@ public abstract class AbstractTestNGCucumberTests {
     @SuppressWarnings("unused")
     @Test(groups = "cucumber", description = "Runs Cucumber Scenarios", dataProvider = "scenarios")
     public void runScenario(PickleWrapper pickleWrapper, FeatureWrapper featureWrapper) {
-        // the 'featureWrapper' parameter solely exists to display the feature file in a test report
+        // the 'featureWrapper' parameter solely exists to display the feature
+        // file in a test report
         testNGCucumberRunner.runScenario(pickleWrapper.getPickle());
     }
 
     /**
-     * Returns two dimensional array of {@link PickleWrapper}s
-     * with their associated {@link FeatureWrapper}s.
+     * Returns two dimensional array of {@link PickleWrapper}s with their
+     * associated {@link FeatureWrapper}s.
      *
      * @return a two dimensional array of scenarios features.
      */

--- a/testng/src/main/java/io/cucumber/testng/CucumberOptions.java
+++ b/testng/src/main/java/io/cucumber/testng/CucumberOptions.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  * Configure Cucumbers options.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE})
+@Target({ ElementType.TYPE })
 @API(status = API.Status.STABLE)
 public @interface CucumberOptions {
 
@@ -22,35 +22,38 @@ public @interface CucumberOptions {
     boolean dryRun() default false;
 
     /**
-     * @return true if undefined and pending steps should be treated as errors.
+     * @return     true if undefined and pending steps should be treated as
+     *             errors.
      * @deprecated will be removed and cucumber will default to strict
      */
     @Deprecated
     boolean strict() default true;
 
     /**
-     * Either a URI or path to a directory of features or a URI or path to a single
-     * feature optionally followed by a colon and line numbers.
+     * Either a URI or path to a directory of features or a URI or path to a
+     * single feature optionally followed by a colon and line numbers.
      * <p>
-     * When no feature path is provided, Cucumber will use the package of the annotated
-     * class. For example, if the annotated class is {@code com.example.RunCucumber}
-     * then features are assumed to be located in {@code classpath:com/example}.
+     * When no feature path is provided, Cucumber will use the package of the
+     * annotated class. For example, if the annotated class is
+     * {@code com.example.RunCucumber} then features are assumed to be located
+     * in {@code classpath:com/example}.
      *
      * @return list of files or directories
-     * @see io.cucumber.core.feature.FeatureWithLines
+     * @see    io.cucumber.core.feature.FeatureWithLines
      */
     String[] features() default {};
 
     /**
-     * Package to load glue code (step definitions,
-     * hooks and plugins) from. E.g: {@code com.example.app}
+     * Package to load glue code (step definitions, hooks and plugins) from.
+     * E.g: {@code com.example.app}
      * <p>
      * When no glue is provided, Cucumber will use the package of the annotated
-     * class. For example, if the annotated class is {@code com.example.RunCucumber}
-     * then glue is assumed to be located in {@code com.example}.
+     * class. For example, if the annotated class is
+     * {@code com.example.RunCucumber} then glue is assumed to be located in
+     * {@code com.example}.
      *
      * @return list of package names
-     * @see io.cucumber.core.feature.GluePath
+     * @see    io.cucumber.core.feature.GluePath
      */
     String[] glue() default {};
 
@@ -58,7 +61,8 @@ public @interface CucumberOptions {
      * Package to load additional glue code (step definitions, hooks and
      * plugins) from. E.g: {@code com.example.app}
      * <p>
-     * These packages are used in addition to the default described in {@code #glue}.
+     * These packages are used in addition to the default described in
+     * {@code #glue}.
      *
      * @return list of package names
      */
@@ -74,19 +78,18 @@ public @interface CucumberOptions {
     String tags() default "";
 
     /**
-     * Register plugins.
-     * Built-in plugin types: {@code junit}, {@code html},
+     * Register plugins. Built-in plugin types: {@code junit}, {@code html},
      * {@code pretty}, {@code progress}, {@code json}, {@code usage},
      * {@code unused}, {@code rerun}, {@code testng}.
      * <p>
-     * Can also be a fully qualified class name, allowing
-     * registration of 3rd party plugins.
+     * Can also be a fully qualified class name, allowing registration of 3rd
+     * party plugins.
      * <p>
      * Plugins can be provided with an argument. For example
      * {@code json:target/cucumber-report.json}
      *
      * @return list of plugins
-     * @see Plugin
+     * @see    Plugin
      */
     String[] plugin() default {};
 
@@ -96,7 +99,8 @@ public @interface CucumberOptions {
     boolean monochrome() default false;
 
     /**
-     * Only run scenarios whose names match one of the provided regular expressions.
+     * Only run scenarios whose names match one of the provided regular
+     * expressions.
      *
      * @return a list of regular expressions
      */
@@ -110,14 +114,13 @@ public @interface CucumberOptions {
     /**
      * Specify a custom ObjectFactory.
      * <p>
-     * In case a custom ObjectFactory is needed, the class can be specified here.
-     * A custom ObjectFactory might be needed when more granular control is needed
-     * over the dependency injection mechanism.
+     * In case a custom ObjectFactory is needed, the class can be specified
+     * here. A custom ObjectFactory might be needed when more granular control
+     * is needed over the dependency injection mechanism.
      *
      * @return an {@link io.cucumber.core.backend.ObjectFactory} implementation
      */
     Class<? extends io.cucumber.core.backend.ObjectFactory> objectFactory() default NoObjectFactory.class;
-
 
     enum SnippetType {
         UNDERSCORE, CAMELCASE

--- a/testng/src/main/java/io/cucumber/testng/FeatureWrapper.java
+++ b/testng/src/main/java/io/cucumber/testng/FeatureWrapper.java
@@ -3,8 +3,8 @@ package io.cucumber.testng;
 import org.apiguardian.api.API;
 
 /**
- * The only purpose of this interface is to be able to provide a custom
- * <pre>toString()</pre>, making TestNG reports look more descriptive.
+ * The only purpose of this interface is to be able to provide a custom string
+ * representation, making TestNG reports look more descriptive.
  *
  * @see AbstractTestNGCucumberTests#runScenario(PickleWrapper, FeatureWrapper)
  */

--- a/testng/src/main/java/io/cucumber/testng/PickleWrapper.java
+++ b/testng/src/main/java/io/cucumber/testng/PickleWrapper.java
@@ -3,8 +3,8 @@ package io.cucumber.testng;
 import org.apiguardian.api.API;
 
 /**
- * The only purpose of this interface is to be able to provide a custom
- * <pre>toString()</pre>, making TestNG reports look more descriptive.
+ * The only purpose of this interface is to be able to provide a custom string
+ * representation, making TestNG reports look more descriptive.
  *
  * @see AbstractTestNGCucumberTests#runScenario(PickleWrapper, FeatureWrapper)
  */

--- a/testng/src/main/java/io/cucumber/testng/TestCaseResultObserver.java
+++ b/testng/src/main/java/io/cucumber/testng/TestCaseResultObserver.java
@@ -23,11 +23,10 @@ class TestCaseResultObserver implements AutoCloseable {
         delegate.assertTestCasePassed(
             () -> new SkipException(SKIP_MESSAGE),
             (exception) -> exception instanceof SkipException
-                ? exception
-                : new SkipException(exception.getMessage(), exception),
+                    ? exception
+                    : new SkipException(exception.getMessage(), exception),
             UndefinedStepException::new,
-            Function.identity()
-        );
+            Function.identity());
     }
 
     @Override
@@ -36,4 +35,3 @@ class TestCaseResultObserver implements AutoCloseable {
     }
 
 }
-

--- a/testng/src/main/java/io/cucumber/testng/TestNGCucumberRunner.java
+++ b/testng/src/main/java/io/cucumber/testng/TestNGCucumberRunner.java
@@ -58,33 +58,35 @@ public final class TestNGCucumberRunner {
     /**
      * Bootstrap the cucumber runtime
      *
-     * @param clazz Which has the {@link CucumberOptions}
-     *              and {@link org.testng.annotations.Test} annotations
+     * @param clazz Which has the {@link CucumberOptions} and
+     *              {@link org.testng.annotations.Test} annotations
      */
     public TestNGCucumberRunner(Class<?> clazz) {
-        // Parse the options early to provide fast feedback about invalid options
+        // Parse the options early to provide fast feedback about invalid
+        // options
         RuntimeOptions propertiesFileOptions = new CucumberPropertiesParser()
-            .parse(CucumberProperties.fromPropertiesFile())
-            .build();
+                .parse(CucumberProperties.fromPropertiesFile())
+                .build();
 
         RuntimeOptions annotationOptions = new CucumberOptionsAnnotationParser()
-            .withOptionsProvider(new TestNGCucumberOptionsProvider())
-            .parse(clazz)
-            .build(propertiesFileOptions);
+                .withOptionsProvider(new TestNGCucumberOptionsProvider())
+                .parse(clazz)
+                .build(propertiesFileOptions);
 
         RuntimeOptions environmentOptions = new CucumberPropertiesParser()
-            .parse(CucumberProperties.fromEnvironment())
-            .build(annotationOptions);
+                .parse(CucumberProperties.fromEnvironment())
+                .build(annotationOptions);
 
         RuntimeOptions runtimeOptions = new CucumberPropertiesParser()
-            .parse(CucumberProperties.fromSystemProperties())
-            .build(environmentOptions);
+                .parse(CucumberProperties.fromSystemProperties())
+                .build(environmentOptions);
 
         EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
 
         Supplier<ClassLoader> classLoader = ClassLoaders::getDefaultClassLoader;
         FeatureParser parser = new FeatureParser(bus::generateId);
-        FeaturePathFeatureSupplier featureSupplier = new FeaturePathFeatureSupplier(classLoader, runtimeOptions, parser);
+        FeaturePathFeatureSupplier featureSupplier = new FeaturePathFeatureSupplier(classLoader, runtimeOptions,
+            parser);
 
         Plugins plugins = new Plugins(new PluginFactory(), runtimeOptions);
         ExitStatus exitStatus = new ExitStatus(runtimeOptions);
@@ -93,8 +95,10 @@ public final class TestNGCucumberRunner {
         ObjectFactorySupplier objectFactorySupplier = new ThreadLocalObjectFactorySupplier(objectFactoryServiceLoader);
         BackendServiceLoader backendSupplier = new BackendServiceLoader(clazz::getClassLoader, objectFactorySupplier);
         this.filters = new Filters(runtimeOptions);
-        TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(classLoader, runtimeOptions);
-        ThreadLocalRunnerSupplier runnerSupplier = new ThreadLocalRunnerSupplier(runtimeOptions, bus, backendSupplier, objectFactorySupplier, typeRegistryConfigurerSupplier);
+        TypeRegistryConfigurerSupplier typeRegistryConfigurerSupplier = new ScanningTypeRegistryConfigurerSupplier(
+            classLoader, runtimeOptions);
+        ThreadLocalRunnerSupplier runnerSupplier = new ThreadLocalRunnerSupplier(runtimeOptions, bus, backendSupplier,
+            objectFactorySupplier, typeRegistryConfigurerSupplier);
         this.context = new CucumberExecutionContext(bus, exitStatus, runnerSupplier);
 
         // Start test execution now.
@@ -123,23 +127,22 @@ public final class TestNGCucumberRunner {
 
     /**
      * @return returns the cucumber scenarios as a two dimensional array of
-     * {@link PickleWrapper} scenarios combined with their
-     * {@link FeatureWrapper} feature.
+     *         {@link PickleWrapper} scenarios combined with their
+     *         {@link FeatureWrapper} feature.
      */
     public Object[][] provideScenarios() {
-        //Possibly invoked in a multi-threaded context
+        // Possibly invoked in a multi-threaded context
         try {
             return features.stream()
-                .flatMap(feature ->
-                    feature.getPickles().stream()
-                        .filter(filters)
-                        .map(cucumberPickle -> new Object[]{
-                            new PickleWrapperImpl(new io.cucumber.testng.Pickle(cucumberPickle)),
-                            new FeatureWrapperImpl(feature)}))
-                .collect(toList())
-                .toArray(new Object[0][0]);
+                    .flatMap(feature -> feature.getPickles().stream()
+                            .filter(filters)
+                            .map(cucumberPickle -> new Object[] {
+                                    new PickleWrapperImpl(new io.cucumber.testng.Pickle(cucumberPickle)),
+                                    new FeatureWrapperImpl(feature) }))
+                    .collect(toList())
+                    .toArray(new Object[0][0]);
         } catch (CucumberException e) {
-            return new Object[][]{new Object[]{new CucumberExceptionWrapper(e), null}};
+            return new Object[][] { new Object[] { new CucumberExceptionWrapper(e), null } };
         }
     }
 

--- a/testng/src/main/java/io/cucumber/testng/UndefinedStepException.java
+++ b/testng/src/main/java/io/cucumber/testng/UndefinedStepException.java
@@ -17,8 +17,8 @@ final class UndefinedStepException extends SkipException {
 
     private static String createMessage(List<Suggestion> suggestions) {
         return suggestions.stream()
-            .map(suggestion -> createStepMessage(suggestion.getStep(), suggestion.getSnippets()))
-            .collect(joining("\n", createPreAmble(suggestions), ""));
+                .map(suggestion -> createStepMessage(suggestion.getStep(), suggestion.getSnippets()))
+                .collect(joining("\n", createPreAmble(suggestions), ""));
     }
 
     private static String createStepMessage(String stepText, List<String> snippets) {

--- a/testng/src/test/java/io/cucumber/testng/AbstractTestNGCucumberTestsTest.java
+++ b/testng/src/test/java/io/cucumber/testng/AbstractTestNGCucumberTestsTest.java
@@ -20,7 +20,7 @@ public final class AbstractTestNGCucumberTestsTest {
         TestNG testNG = new TestNG();
         testNG.addListener(icml);
         testNG.setGroups("cucumber");
-        testNG.setTestClasses(new Class[]{RunFeatureWithThreeScenariosTest.class});
+        testNG.setTestClasses(new Class[] { RunFeatureWithThreeScenariosTest.class });
         testNG.run();
         invokedConfigurationMethodNames = icml.getInvokedConfigurationMethodNames();
         invokedTestMethodNames = icml.getInvokedTestMethodNames();

--- a/testng/src/test/java/io/cucumber/testng/RunFeatureWithThreeScenariosTest.java
+++ b/testng/src/test/java/io/cucumber/testng/RunFeatureWithThreeScenariosTest.java
@@ -1,8 +1,6 @@
 package io.cucumber.testng;
 
-@CucumberOptions(
-        features = "classpath:io/cucumber/testng/three-scenarios.feature"
-)
+@CucumberOptions(features = "classpath:io/cucumber/testng/three-scenarios.feature")
 public class RunFeatureWithThreeScenariosTest extends AbstractTestNGCucumberTests {
 
 }

--- a/testng/src/test/java/io/cucumber/testng/RunFeatureWithThreeScenariosTest.java
+++ b/testng/src/test/java/io/cucumber/testng/RunFeatureWithThreeScenariosTest.java
@@ -1,8 +1,7 @@
 package io.cucumber.testng;
 
-
 @CucumberOptions(
-    features = "classpath:io/cucumber/testng/three-scenarios.feature"
+        features = "classpath:io/cucumber/testng/three-scenarios.feature"
 )
 public class RunFeatureWithThreeScenariosTest extends AbstractTestNGCucumberTests {
 

--- a/testng/src/test/java/io/cucumber/testng/ScenariosInDifferentGroupsTest.java
+++ b/testng/src/test/java/io/cucumber/testng/ScenariosInDifferentGroupsTest.java
@@ -10,8 +10,7 @@ import java.util.function.Predicate;
 
 @CucumberOptions(
         features = "classpath:io/cucumber/testng/scenarios-with-tags.feature",
-        plugin = "timeline:target/timeline"
-)
+        plugin = "timeline:target/timeline")
 public class ScenariosInDifferentGroupsTest {
 
     private static final Predicate<Pickle> isSerial = pickle -> pickle.getTags().contains("@Serial");
@@ -46,8 +45,7 @@ public class ScenariosInDifferentGroupsTest {
     @Test(
             groups = "cucumber",
             description = "Runs Cucumber Scenarios in the Serial group",
-            dataProvider = "serialScenarios"
-    )
+            dataProvider = "serialScenarios")
     public void runSerialScenario(PickleWrapper pickleWrapper, FeatureWrapper featureWrapper) {
         testNGCucumberRunner.runScenario(pickleWrapper.getPickle());
     }

--- a/testng/src/test/java/io/cucumber/testng/ScenariosInDifferentGroupsTest.java
+++ b/testng/src/test/java/io/cucumber/testng/ScenariosInDifferentGroupsTest.java
@@ -8,7 +8,10 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
-@CucumberOptions(features = "classpath:io/cucumber/testng/scenarios-with-tags.feature", plugin = "timeline:target/timeline")
+@CucumberOptions(
+        features = "classpath:io/cucumber/testng/scenarios-with-tags.feature",
+        plugin = "timeline:target/timeline"
+)
 public class ScenariosInDifferentGroupsTest {
 
     private static final Predicate<Pickle> isSerial = pickle -> pickle.getTags().contains("@Serial");
@@ -40,7 +43,11 @@ public class ScenariosInDifferentGroupsTest {
         }).toArray(Object[][]::new);
     }
 
-    @Test(groups = "cucumber", description = "Runs Cucumber Scenarios in the Serial group", dataProvider = "serialScenarios")
+    @Test(
+            groups = "cucumber",
+            description = "Runs Cucumber Scenarios in the Serial group",
+            dataProvider = "serialScenarios"
+    )
     public void runSerialScenario(PickleWrapper pickleWrapper, FeatureWrapper featureWrapper) {
         testNGCucumberRunner.runScenario(pickleWrapper.getPickle());
     }

--- a/testng/src/test/java/io/cucumber/testng/StubBackendProviderService.java
+++ b/testng/src/test/java/io/cucumber/testng/StubBackendProviderService.java
@@ -1,6 +1,5 @@
 package io.cucumber.testng;
 
-
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.BackendProviderService;
 import io.cucumber.core.backend.Container;

--- a/testng/src/test/java/io/cucumber/testng/TestCaseResultObserverTest.java
+++ b/testng/src/test/java/io/cucumber/testng/TestCaseResultObserverTest.java
@@ -109,10 +109,9 @@ public class TestCaseResultObserverTest {
         SkipException skipException = (SkipException) exception.getCause();
         assertThat(skipException.isSkip(), is(false));
         assertThat(skipException.getMessage(), is("" +
-            "The step \"some step\" is undefined. You can implement it using the snippet(s) below:\n" +
-            "\n" +
-            "stub snippet\n"
-        ));
+                "The step \"some step\" is undefined. You can implement it using the snippet(s) below:\n" +
+                "\n" +
+                "stub snippet\n"));
     }
 
     @Test
@@ -132,10 +131,9 @@ public class TestCaseResultObserverTest {
         SkipException skipException = (SkipException) exception.getCause();
         assertThat(skipException.isSkip(), is(false));
         assertThat(skipException.getMessage(), is("" +
-            "The step \"some step\" is undefined. You can implement it using the snippet(s) below:\n" +
-            "\n" +
-            "stub snippet\n"
-        ));
+                "The step \"some step\" is undefined. You can implement it using the snippet(s) below:\n" +
+                "\n" +
+                "stub snippet\n"));
     }
 
     @Test

--- a/testng/src/test/java/io/cucumber/testng/TestNGCucumberOptionsProviderTest.java
+++ b/testng/src/test/java/io/cucumber/testng/TestNGCucumberOptionsProviderTest.java
@@ -1,6 +1,5 @@
 package io.cucumber.testng;
 
-
 import io.cucumber.core.backend.ObjectFactory;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -8,7 +7,6 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
-
 
 final class TestNGCucumberOptionsProviderTest {
 
@@ -21,13 +19,15 @@ final class TestNGCucumberOptionsProviderTest {
 
     @Test
     void testObjectFactoryWhenNotSpecified() {
-        io.cucumber.core.options.CucumberOptionsAnnotationParser.CucumberOptions options = this.optionsProvider.getOptions(ClassWithDefault.class);
+        io.cucumber.core.options.CucumberOptionsAnnotationParser.CucumberOptions options = this.optionsProvider
+                .getOptions(ClassWithDefault.class);
         assertNull(options.objectFactory());
     }
 
     @Test
     void testObjectFactory() {
-        io.cucumber.core.options.CucumberOptionsAnnotationParser.CucumberOptions options = this.optionsProvider.getOptions(ClassWithCustomObjectFactory.class);
+        io.cucumber.core.options.CucumberOptionsAnnotationParser.CucumberOptions options = this.optionsProvider
+                .getOptions(ClassWithCustomObjectFactory.class);
         assertNotNull(options.objectFactory());
         assertEquals(TestObjectFactory.class, options.objectFactory());
     }

--- a/testng/src/test/java/io/cucumber/testng/TestNGCucumberRunnerTest.java
+++ b/testng/src/test/java/io/cucumber/testng/TestNGCucumberRunnerTest.java
@@ -74,8 +74,7 @@ public class TestNGCucumberRunnerTest {
     }
 
     @CucumberOptions(
-            features = "classpath:io/cucumber/undefined/undefined_steps.feature"
-    )
+            features = "classpath:io/cucumber/undefined/undefined_steps.feature")
     static class RunScenarioWithUndefinedStepsStrict extends AbstractTestNGCucumberTests {
 
     }

--- a/testng/src/test/java/io/cucumber/testng/TestNGCucumberRunnerTest.java
+++ b/testng/src/test/java/io/cucumber/testng/TestNGCucumberRunnerTest.java
@@ -42,8 +42,7 @@ public class TestNGCucumberRunnerTest {
 
         assertThrows(
             UndefinedStepException.class,
-            () -> testNGCucumberRunner.runScenario(wrapper.getPickle())
-        );
+            () -> testNGCucumberRunner.runScenario(wrapper.getPickle()));
     }
 
     @Test
@@ -54,8 +53,7 @@ public class TestNGCucumberRunnerTest {
         } catch (FeatureParserException e) {
             assertEquals(e.getMessage(),
                 "Failed to parse resource at: classpath:io/cucumber/error/parse-error.feature\n" +
-                    "(1:1): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Invalid syntax'"
-            );
+                        "(1:1): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Invalid syntax'");
         }
     }
 
@@ -68,15 +66,15 @@ public class TestNGCucumberRunnerTest {
         testNGCucumberRunner.finish();
 
         assertEquals(1, events.stream()
-            .map(Object::getClass)
-            .filter(TestRunStarted.class::isAssignableFrom).count());
+                .map(Object::getClass)
+                .filter(TestRunStarted.class::isAssignableFrom).count());
         assertEquals(1, events.stream()
-            .map(Object::getClass)
-            .filter(TestRunFinished.class::isAssignableFrom).count());
+                .map(Object::getClass)
+                .filter(TestRunFinished.class::isAssignableFrom).count());
     }
 
     @CucumberOptions(
-        features = "classpath:io/cucumber/undefined/undefined_steps.feature"
+            features = "classpath:io/cucumber/undefined/undefined_steps.feature"
     )
     static class RunScenarioWithUndefinedStepsStrict extends AbstractTestNGCucumberTests {
 
@@ -95,7 +93,6 @@ public class TestNGCucumberRunnerTest {
     public static class Plugin implements ConcurrentEventListener {
 
         static List<Event> events = new ArrayList<>();
-
 
         @Override
         public void setEventPublisher(EventPublisher publisher) {

--- a/weld/src/main/java/io/cucumber/weld/WeldFactory.java
+++ b/weld/src/main/java/io/cucumber/weld/WeldFactory.java
@@ -14,20 +14,20 @@ public final class WeldFactory implements ObjectFactory {
     private static final Logger log = LoggerFactory.getLogger(WeldFactory.class);
 
     private static final String START_EXCEPTION_MESSAGE = "\n" +
-        "It looks like you're running on a single-core machine, and Weld doesn't like that. See:\n" +
-        "* http://in.relation.to/Bloggers/Weld200Alpha2Released\n" +
-        "* https://issues.jboss.org/browse/WELD-1119\n" +
-        "\n" +
-        "The workaround is to add enabled=false to a org.jboss.weld.executor.properties file on\n" +
-        "your CLASSPATH. Beware that this will trigger another Weld bug - startup will now work,\n" +
-        "but shutdown will fail with a NullPointerException. This exception will be printed and\n" +
-        "not rethrown. It's the best Cucumber-JVM can do until this bug is fixed in Weld.\n" +
-        "\n";
+            "It looks like you're running on a single-core machine, and Weld doesn't like that. See:\n" +
+            "* http://in.relation.to/Bloggers/Weld200Alpha2Released\n" +
+            "* https://issues.jboss.org/browse/WELD-1119\n" +
+            "\n" +
+            "The workaround is to add enabled=false to a org.jboss.weld.executor.properties file on\n" +
+            "your CLASSPATH. Beware that this will trigger another Weld bug - startup will now work,\n" +
+            "but shutdown will fail with a NullPointerException. This exception will be printed and\n" +
+            "not rethrown. It's the best Cucumber-JVM can do until this bug is fixed in Weld.\n" +
+            "\n";
 
     private static final String STOP_EXCEPTION_MESSAGE = "\n" +
-        "If you have set enabled=false in org.jboss.weld.executor.properties and you are seeing\n" +
-        "this message, it means your weld container didn't shut down properly. It's a Weld bug\n" +
-        "and we can't do much to fix it in Cucumber-JVM.\n";
+            "If you have set enabled=false in org.jboss.weld.executor.properties and you are seeing\n" +
+            "this message, it means your weld container didn't shut down properly. It's a Weld bug\n" +
+            "and we can't do much to fix it in Cucumber-JVM.\n";
 
     private WeldContainer containerInstance;
 

--- a/weld/src/main/java/io/cucumber/weld/package-info.java
+++ b/weld/src/main/java/io/cucumber/weld/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Enables dependency injection by Weld
  * <p>
- * By including the <code>cucumber-weld</code> on your <code>CLASSPATH</code> your step definitions will be
- * instantiated by Weld.
+ * By including the <code>cucumber-weld</code> on your <code>CLASSPATH</code>
+ * your step definitions will be instantiated by Weld.
  */
 package io.cucumber.weld;

--- a/weld/src/test/java/io/cucumber/weld/WeldFactoryTest.java
+++ b/weld/src/test/java/io/cucumber/weld/WeldFactoryTest.java
@@ -46,11 +46,10 @@ class WeldFactoryTest {
         final BellyStepDefinitions o2 = factory.getInstance(BellyStepDefinitions.class);
         factory.stop();
 
-        assertAll("Checking BellyStepdefs",
+        assertAll(
             () -> assertThat(o1, is(notNullValue())),
             () -> assertThat(o1, is(not(equalTo(o2)))),
-            () -> assertThat(o2, is(not(equalTo(o1))))
-        );
+            () -> assertThat(o2, is(not(equalTo(o1)))));
     }
 
     @Test


### PR DESCRIPTION
Cucumber has been edited by many people with different
IDE settings. This occasionally causes the blast radius
of changes to be larger then necesary. Especially when
automated formatting tools are involved.

By making automated formatting part of the build we can
avoid most of these problems.

The settings in `.spotless` somewhat approximate the
current code style used. Though it is hard to replicate
it exactly due to the difference between IDEA and Eclipse
formatter implemetnations.

By running `mvn spotless:apply` all source code can be
automatically formatted.

Partial fix for: https://github.com/cucumber/cucumber-jvm/issues/1947