### PR TITLE
[Core] cucumber.feature preserves tags when used with a feature argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
  * [Spring] Require an active scenario before creating beans ([#1974](https://github.com/cucumber/cucumber-jvm/issues/1974) M.P. Korstanje)
  * [Core] Fix NPE in `CucumberExecutionContext.emitMeta` when in a shaded jar (M.P. Korstanje)
  * [Core] Fix line filter for scenario outlines ([#1981](https://github.com/cucumber/cucumber-jvm/issues/1981) M.P. Korstanje)
+ * [Core] cucumber.feature preserves tags when used with a feature argument  ([#1986](https://github.com/cucumber/cucumber-jvm/issues/1986) M.P. Korstanje)
+
 ## [6.0.0-RC2] (2020-05-03)
 
 ### Added

--- a/core/src/main/java/io/cucumber/core/options/CucumberPropertiesParser.java
+++ b/core/src/main/java/io/cucumber/core/options/CucumberPropertiesParser.java
@@ -67,7 +67,7 @@ public final class CucumberPropertiesParser {
             builder::addFeature);
         parseAll(properties,
             FEATURES_PROPERTY_NAME,
-            splitAndMap(CucumberPropertiesParser::parseRerunFile),
+            splitAndThenFlatMap(CucumberPropertiesParser::parseRerunFile),
             builder::addRerun);
 
         parse(properties,
@@ -159,12 +159,12 @@ public final class CucumberPropertiesParser {
                 .collect(toList());
     }
 
-    private static Collection<FeatureWithLines> parseRerunFile(String property) {
+    private static Stream<Collection<FeatureWithLines>> parseRerunFile(String property) {
         if (property.startsWith("@")) {
             Path rerunFile = Paths.get(property.substring(1));
-            return parseFeatureWithLinesFile(rerunFile);
+            return Stream.of(parseFeatureWithLinesFile(rerunFile));
         }
-        return Collections.emptyList();
+        return Stream.empty();
     }
 
 }


### PR DESCRIPTION
The feature option can be used with either a rerun file or a feature path. For
example when used as a property:

```
cucumber.feature=path/to/features
cucumber.feature=@path/to/rerun.txt
```

Cucumber options consist of a hierarchy of options. When the feature options is
used with a rerun file; tag and name filters from the previous level should be
removed. This ensures that all scenarios in the rerun file and only the
scenarios in the rerun file should be executed (unless the selection is filtered
more at this or the next level).

When used with a feature argument without a line filter this should not be the case.
However `builder::addRerun` would be invoked anyway.

When parsing `cucumber.feature` for rerun files, when no rerun files are present an
empty collection is returned. Because `splitAndMap` was used rather then
`splitAndThenFlatMap`, `builder::addRerun` would always be invoked.

Fixes: #1985