### PR TITLE
[Core] Correct issue with usage report durations >= 1 second

### DIFF
--- a/core/src/main/java/io/cucumber/core/plugin/UsageFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/UsageFormatter.java
@@ -86,7 +86,7 @@ public final class UsageFormatter implements Plugin, ConcurrentEventListener {
 
     private Gson gson() {
         JsonSerializer<Duration> durationJsonSerializer = (duration, returnVal,
-                jsonSerializationContext) -> new JsonPrimitive((double) duration.getNano() / NANOS_PER_SECOND);
+                jsonSerializationContext) -> new JsonPrimitive((double) duration.toNanos() / NANOS_PER_SECOND);
 
         return new GsonBuilder()
                 .registerTypeAdapter(Duration.class, durationJsonSerializer)

--- a/core/src/test/java/io/cucumber/core/plugin/UsageFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/UsageFormatterTest.java
@@ -122,7 +122,7 @@ class UsageFormatterTest {
         OutputStream out = new ByteArrayOutputStream();
         UsageFormatter usageFormatter = new UsageFormatter(out);
         UsageFormatter.StepContainer stepContainer = new UsageFormatter.StepContainer("a step");
-        UsageFormatter.StepDuration stepDuration = new UsageFormatter.StepDuration(Duration.ofNanos(12345678L),
+        UsageFormatter.StepDuration stepDuration = new UsageFormatter.StepDuration(Duration.ofNanos(1234567800L),
             "location.feature");
         stepContainer.getDurations().addAll(singletonList(stepDuration));
         usageFormatter.usageMap.put("a (.*)", singletonList(stepContainer));
@@ -137,12 +137,12 @@ class UsageFormatterTest {
                 "      {\n" +
                 "        \"name\": \"a step\",\n" +
                 "        \"aggregatedDurations\": {\n" +
-                "          \"median\": 0.012345678,\n" +
-                "          \"average\": 0.012345678\n" +
+                "          \"median\": 1.2345678,\n" +
+                "          \"average\": 1.2345678\n" +
                 "        },\n" +
                 "        \"durations\": [\n" +
                 "          {\n" +
-                "            \"duration\": 0.012345678,\n" +
+                "            \"duration\": 1.2345678,\n" +
                 "            \"location\": \"location.feature\"\n" +
                 "          }\n" +
                 "        ]\n" +


### PR DESCRIPTION
Updated durationJsonSerializer to use toNanos() instead of getNano(). This was causing the durations to only show the nanosecond portion of the duration, dropping the second portion. The result is all durations in the report indicate times less than a second for all step defnition executions.

#1988 Durations in the Usage report are always less than 1 second, even when the known times for the steps are over 1 second, so the report is invalid.

**Describe the solution you have implemented**
As listed above, I changed the getNano() call to toNanos() to get the correct value. Updated the test to use a number of nanoseconds greater than 1 second and verify the correct result.

**Additional context**
n/a