### PR TITLE
ensure user locale does not make DefaultSummaryPrinterTest failling

### DIFF
--- a/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
@@ -4,6 +4,7 @@ import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent;
 import io.cucumber.plugin.event.TestRunFinished;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -11,6 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.time.Clock;
 import java.time.ZoneId;
+import java.util.Locale;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -22,14 +24,23 @@ import static org.hamcrest.text.IsEqualCompressingWhiteSpace.equalToCompressingW
 class DefaultSummaryPrinterTest {
 
     private final ByteArrayOutputStream out = new ByteArrayOutputStream();
-    private final DefaultSummaryPrinter summaryPrinter = new DefaultSummaryPrinter(out);
+    private DefaultSummaryPrinter summaryPrinter;
     private final EventBus bus = new TimeServiceEventBus(
-        Clock.fixed(ofEpochSecond(0), ZoneId.of("UTC")),
-        UUID::randomUUID);
+            Clock.fixed(ofEpochSecond(0), ZoneId.of("UTC")),
+            UUID::randomUUID);
+    private Locale originalLocale;
 
     @BeforeEach
     void setup() {
+        originalLocale = Locale.getDefault();
+        Locale.setDefault(Locale.ENGLISH);
+        summaryPrinter = new DefaultSummaryPrinter(out);
         summaryPrinter.setEventPublisher(bus);
+    }
+
+    @AfterEach
+    void teardown() {
+        Locale.setDefault(originalLocale);
     }
 
     @Test


### PR DESCRIPTION
I'm in french locale by default so decimal separator is "," and not "." so DefaultSummaryPrinterTest fails because 0.00 != 0,00 whereas the test actually functionally worked.

this pr enforces the locale for the test to ensure the assert will pass.