### PR TITLE
[JUnit] Make duplicate pickle names unique

### DIFF
--- a/junit/src/main/java/io/cucumber/junit/FeatureRunner.java
+++ b/junit/src/main/java/io/cucumber/junit/FeatureRunner.java
@@ -14,11 +14,14 @@ import org.junit.runners.model.InitializationError;
 import java.io.Serializable;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import static io.cucumber.junit.FileNameCompatibleNames.createName;
+import static io.cucumber.junit.FileNameCompatibleNames.uniqueSuffix;
 import static io.cucumber.junit.PickleRunners.withNoStepDescriptions;
 import static io.cucumber.junit.PickleRunners.withStepDescriptions;
+import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 
 final class FeatureRunner extends ParentRunner<PickleRunner> {
@@ -26,26 +29,40 @@ final class FeatureRunner extends ParentRunner<PickleRunner> {
     private final List<PickleRunner> children;
     private final Feature feature;
     private final JUnitOptions options;
+    private final Integer uniqueSuffix;
     private Description description;
 
-    private FeatureRunner(Feature feature, Predicate<Pickle> filter, RunnerSupplier runners, JUnitOptions options)
+    private FeatureRunner(
+            Feature feature, Integer uniqueSuffix, Predicate<Pickle> filter, RunnerSupplier runners,
+            JUnitOptions options
+    )
             throws InitializationError {
         super((Class<?>) null);
         this.feature = feature;
+        this.uniqueSuffix = uniqueSuffix;
         this.options = options;
-        String name = feature.getName().orElse("EMPTY_NAME");
-        this.children = feature.getPickles().stream()
-                .filter(filter).map(pickle -> options.stepNotifications()
-                        ? withStepDescriptions(runners, pickle, options)
-                        : withNoStepDescriptions(name, runners, pickle, options))
+
+        Map<String, List<Pickle>> groupedByName = feature.getPickles().stream()
+                .filter(filter)
+                .collect(groupingBy(Pickle::getName));
+        this.children = feature.getPickles()
+                .stream()
+                .map(pickle -> {
+                    String featureName = getName();
+                    Integer exampleId = uniqueSuffix(groupedByName, pickle, Pickle::getName);
+                    return options.stepNotifications()
+                            ? withStepDescriptions(runners, pickle, exampleId, options)
+                            : withNoStepDescriptions(featureName, runners, pickle, exampleId, options);
+                })
                 .collect(toList());
     }
 
     static FeatureRunner create(
-            Feature feature, Predicate<Pickle> filter, RunnerSupplier runners, JUnitOptions options
+            Feature feature, Integer uniqueSuffix, Predicate<Pickle> filter, RunnerSupplier runners,
+            JUnitOptions options
     ) {
         try {
-            return new FeatureRunner(feature, filter, runners, options);
+            return new FeatureRunner(feature, uniqueSuffix, filter, runners, options);
         } catch (InitializationError e) {
             throw new CucumberException("Failed to create scenario runner", e);
         }
@@ -89,7 +106,7 @@ final class FeatureRunner extends ParentRunner<PickleRunner> {
     @Override
     protected String getName() {
         String name = feature.getName().orElse("EMPTY_NAME");
-        return createName(name, options.filenameCompatibleNames());
+        return createName(name, uniqueSuffix, options.filenameCompatibleNames());
     }
 
     @Override

--- a/junit/src/main/java/io/cucumber/junit/FeatureRunner.java
+++ b/junit/src/main/java/io/cucumber/junit/FeatureRunner.java
@@ -43,10 +43,10 @@ final class FeatureRunner extends ParentRunner<PickleRunner> {
         this.options = options;
 
         Map<String, List<Pickle>> groupedByName = feature.getPickles().stream()
-                .filter(filter)
                 .collect(groupingBy(Pickle::getName));
         this.children = feature.getPickles()
                 .stream()
+                .filter(filter)
                 .map(pickle -> {
                     String featureName = getName();
                     Integer exampleId = uniqueSuffix(groupedByName, pickle, Pickle::getName);

--- a/junit/src/main/java/io/cucumber/junit/FileNameCompatibleNames.java
+++ b/junit/src/main/java/io/cucumber/junit/FileNameCompatibleNames.java
@@ -1,17 +1,33 @@
 package io.cucumber.junit;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
 final class FileNameCompatibleNames {
+
+    static String createName(String name, Integer uniqueSuffix, boolean useFilenameCompatibleNames) {
+        if (uniqueSuffix == null) {
+            return createName(name, useFilenameCompatibleNames);
+        }
+        return createName(name + " #" + uniqueSuffix + "", useFilenameCompatibleNames);
+    }
 
     static String createName(final String name, boolean useFilenameCompatibleNames) {
         if (useFilenameCompatibleNames) {
             return makeNameFilenameCompatible(name);
         }
-
         return name;
     }
 
     private static String makeNameFilenameCompatible(String name) {
         return name.replaceAll("[^A-Za-z0-9_]", "_");
+    }
+
+    static <V, K> Integer uniqueSuffix(Map<K, List<V>> groupedByName, V pickle, Function<V, K> nameOf) {
+        List<V> withSameName = groupedByName.get(nameOf.apply(pickle));
+        boolean makeNameUnique = withSameName.size() > 1;
+        return makeNameUnique ? withSameName.indexOf(pickle) + 1 : null;
     }
 
 }

--- a/junit/src/test/java/io/cucumber/junit/CucumberTest.java
+++ b/junit/src/test/java/io/cucumber/junit/CucumberTest.java
@@ -53,14 +53,14 @@ class CucumberTest {
     @Test
     void finds_features_based_on_implicit_package() throws InitializationError {
         Cucumber cucumber = new Cucumber(ImplicitFeatureAndGluePath.class);
-        assertThat(cucumber.getChildren().size(), is(equalTo(6)));
+        assertThat(cucumber.getChildren().size(), is(equalTo(7)));
         assertThat(cucumber.getChildren().get(1).getDescription().getDisplayName(), is(equalTo("Feature A")));
     }
 
     @Test
     void finds_features_based_on_explicit_root_package() throws InitializationError {
         Cucumber cucumber = new Cucumber(ExplicitFeaturePath.class);
-        assertThat(cucumber.getChildren().size(), is(equalTo(6)));
+        assertThat(cucumber.getChildren().size(), is(equalTo(7)));
         assertThat(cucumber.getChildren().get(1).getDescription().getDisplayName(), is(equalTo("Feature A")));
     }
 
@@ -104,15 +104,19 @@ class CucumberTest {
         Request.classes(computer, ValidEmpty.class).getRunner().run(notifier);
         {
             InOrder order = Mockito.inOrder(listener);
-            order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
+
             order.verify(listener)
-                    .testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
-            order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
+                    .testStarted(argThat(new DescriptionMatcher("Followed by some examples #1(Feature A)")));
             order.verify(listener)
-                    .testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
-            order.verify(listener).testStarted(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
+                    .testFinished(argThat(new DescriptionMatcher("Followed by some examples #1(Feature A)")));
             order.verify(listener)
-                    .testFinished(argThat(new DescriptionMatcher("Followed by some examples(Feature A)")));
+                    .testStarted(argThat(new DescriptionMatcher("Followed by some examples #2(Feature A)")));
+            order.verify(listener)
+                    .testFinished(argThat(new DescriptionMatcher("Followed by some examples #2(Feature A)")));
+            order.verify(listener)
+                    .testStarted(argThat(new DescriptionMatcher("Followed by some examples #3(Feature A)")));
+            order.verify(listener)
+                    .testFinished(argThat(new DescriptionMatcher("Followed by some examples #3(Feature A)")));
         }
         {
             InOrder order = Mockito.inOrder(listener);
@@ -120,12 +124,38 @@ class CucumberTest {
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("A(Feature B)")));
             order.verify(listener).testStarted(argThat(new DescriptionMatcher("B(Feature B)")));
             order.verify(listener).testFinished(argThat(new DescriptionMatcher("B(Feature B)")));
-            order.verify(listener).testStarted(argThat(new DescriptionMatcher("C(Feature B)")));
-            order.verify(listener).testFinished(argThat(new DescriptionMatcher("C(Feature B)")));
-            order.verify(listener).testStarted(argThat(new DescriptionMatcher("C(Feature B)")));
-            order.verify(listener).testFinished(argThat(new DescriptionMatcher("C(Feature B)")));
-            order.verify(listener).testStarted(argThat(new DescriptionMatcher("C(Feature B)")));
-            order.verify(listener).testFinished(argThat(new DescriptionMatcher("C(Feature B)")));
+            order.verify(listener).testStarted(argThat(new DescriptionMatcher("C #1(Feature B)")));
+            order.verify(listener).testFinished(argThat(new DescriptionMatcher("C #1(Feature B)")));
+            order.verify(listener).testStarted(argThat(new DescriptionMatcher("C #2(Feature B)")));
+            order.verify(listener).testFinished(argThat(new DescriptionMatcher("C #2(Feature B)")));
+            order.verify(listener).testStarted(argThat(new DescriptionMatcher("C #3(Feature B)")));
+            order.verify(listener).testFinished(argThat(new DescriptionMatcher("C #3(Feature B)")));
+        }
+    }
+
+    @Test
+    void cucumber_distinguishes_between_identical_features() throws Exception {
+        RunNotifier notifier = new RunNotifier();
+        RunListener listener = Mockito.mock(RunListener.class);
+        notifier.addListener(listener);
+        Request.classes(ValidEmpty.class).getRunner().run(notifier);
+        {
+            InOrder order = Mockito.inOrder(listener);
+
+            order.verify(listener)
+                    .testStarted(
+                        argThat(new DescriptionMatcher("A single scenario(A feature with a single scenario #1)")));
+            order.verify(listener)
+                    .testFinished(
+                        argThat(new DescriptionMatcher("A single scenario(A feature with a single scenario #1)")));
+
+            order.verify(listener)
+                    .testStarted(
+                        argThat(new DescriptionMatcher("A single scenario(A feature with a single scenario #2)")));
+            order.verify(listener)
+                    .testFinished(
+                        argThat(new DescriptionMatcher("A single scenario(A feature with a single scenario #2)")));
+
         }
     }
 

--- a/junit/src/test/java/io/cucumber/junit/FeatureRunnerTest.java
+++ b/junit/src/test/java/io/cucumber/junit/FeatureRunnerTest.java
@@ -121,7 +121,7 @@ class FeatureRunnerTest {
             classLoader, runtimeOptions);
         ThreadLocalRunnerSupplier runnerSupplier = new ThreadLocalRunnerSupplier(runtimeOptions, bus, backendSupplier,
             objectFactory, typeRegistrySupplier);
-        return FeatureRunner.create(feature, filters, runnerSupplier, junitOption);
+        return FeatureRunner.create(feature, null, filters, runnerSupplier, junitOption);
     }
 
     @Test
@@ -365,7 +365,7 @@ class FeatureRunnerTest {
             throw illegalStateException;
         };
 
-        FeatureRunner featureRunner = FeatureRunner.create(feature, filters, runnerSupplier, new JUnitOptions());
+        FeatureRunner featureRunner = FeatureRunner.create(feature, null, filters, runnerSupplier, new JUnitOptions());
 
         RunNotifier notifier = mock(RunNotifier.class);
         PickleRunners.PickleRunner pickleRunner = featureRunner.getChildren().get(0);

--- a/junit/src/test/java/io/cucumber/junit/PickleRunnerWithNoStepDescriptionsTest.java
+++ b/junit/src/test/java/io/cucumber/junit/PickleRunnerWithNoStepDescriptionsTest.java
@@ -25,6 +25,7 @@ class PickleRunnerWithNoStepDescriptionsTest {
             "feature name",
             mock(RunnerSupplier.class),
             pickles.get(0),
+            null,
             createJunitOptions());
 
         assertThat(runner.getDescription().getDisplayName(), is(equalTo("scenario name(feature name)")));
@@ -45,6 +46,7 @@ class PickleRunnerWithNoStepDescriptionsTest {
             "feature name",
             mock(RunnerSupplier.class),
             pickles.get(0),
+            null,
             createFileNameCompatibleJUnitOptions());
 
         assertThat(runner.getDescription().getDisplayName(), is(equalTo("scenario_name(feature_name)")));
@@ -66,6 +68,7 @@ class PickleRunnerWithNoStepDescriptionsTest {
             "имя функции",
             mock(RunnerSupplier.class),
             pickles.get(0),
+            null,
             createFileNameCompatibleJUnitOptions());
 
         assertThat(runner.getDescription().getDisplayName(), is(equalTo("____________(___________)")));

--- a/junit/src/test/java/io/cucumber/junit/PickleRunnerWithStepDescriptionsTest.java
+++ b/junit/src/test/java/io/cucumber/junit/PickleRunnerWithStepDescriptionsTest.java
@@ -34,6 +34,7 @@ class PickleRunnerWithStepDescriptionsTest {
         WithStepDescriptions runner = (WithStepDescriptions) PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             pickles.get(0),
+            null,
             createJunitOptions());
 
         // fish out the two occurrences of the same step and check whether we
@@ -69,6 +70,7 @@ class PickleRunnerWithStepDescriptionsTest {
         WithStepDescriptions runner = (WithStepDescriptions) PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             features.getPickles().get(0),
+            null,
             createJunitOptions());
 
         Description runnerDescription = runner.getDescription();
@@ -93,6 +95,7 @@ class PickleRunnerWithStepDescriptionsTest {
         PickleRunner runner = PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             features.getPickles().get(0),
+            null,
             createJunitOptions());
 
         // fish out the data from runner
@@ -115,6 +118,7 @@ class PickleRunnerWithStepDescriptionsTest {
         PickleRunner runner = PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             pickles.get(0),
+            null,
             createJunitOptions());
 
         assertEquals("scenario name", runner.getDescription().getDisplayName());
@@ -130,6 +134,7 @@ class PickleRunnerWithStepDescriptionsTest {
         PickleRunner runner = PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             pickles.get(0),
+            null,
             createJunitOptions());
 
         assertEquals("it works", runner.getDescription().getChildren().get(0).getMethodName());
@@ -145,6 +150,7 @@ class PickleRunnerWithStepDescriptionsTest {
         PickleRunner runner = PickleRunners.withStepDescriptions(
             mock(RunnerSupplier.class),
             pickles.get(0),
+            null,
             createFileNameCompatibleJunitOptions());
 
         assertEquals("scenario_name", runner.getDescription().getDisplayName());

--- a/junit/src/test/resources/io/cucumber/junit/single-duplicate.feature
+++ b/junit/src/test/resources/io/cucumber/junit/single-duplicate.feature
@@ -1,0 +1,6 @@
+Feature: A feature with a single scenario
+
+  Scenario: A single scenario
+    Given a single scenario
+    When it is executed
+    Then nothing else happens

--- a/testng/src/test/java/io/cucumber/testng/StubBackendProviderService.java
+++ b/testng/src/test/java/io/cucumber/testng/StubBackendProviderService.java
@@ -35,6 +35,14 @@ public class StubBackendProviderService implements BackendProviderService {
 
         @Override
         public void loadGlue(Glue glue, List<URI> gluePaths) {
+            glue.addStepDefinition(createStepDefinition("a scenario"));
+            glue.addStepDefinition(createStepDefinition("a scenario outline"));
+            glue.addStepDefinition(createStepDefinition("it is executed"));
+            glue.addStepDefinition(createStepDefinition("is only runs once"));
+            glue.addStepDefinition(createStepDefinition("A is used"));
+            glue.addStepDefinition(createStepDefinition("B is used"));
+            glue.addStepDefinition(createStepDefinition("C is used"));
+            glue.addStepDefinition(createStepDefinition("D is used"));
             glue.addStepDefinition(createStepDefinition("step"));
             glue.addStepDefinition(createStepDefinition("another step"));
             glue.addStepDefinition(createStepDefinition("foo"));

--- a/testng/src/test/resources/io/cucumber/testng/feature-with-outline.feature
+++ b/testng/src/test/resources/io/cucumber/testng/feature-with-outline.feature
@@ -1,0 +1,38 @@
+@FeatureTag
+Feature: A feature with scenario outlines
+
+  @ScenarioTag @ResourceA  @ResourceAReadOnly
+  Scenario: A scenario
+    Given a scenario
+    When it is executed
+    Then is only runs once
+
+  @ScenarioOutlineTag
+  Scenario Outline: A scenario outline
+    Given a scenario outline
+    When it is executed
+    Then <example> is used
+
+    @Example1Tag
+    Examples: With some text
+      | example |
+      | A       |
+      | B       |
+
+    @Example2Tag
+    Examples: With some other text
+      | example |
+      | C       |
+      | D       |
+
+  @ScenarioOutlineTag
+  Scenario Outline: A scenario outline with one example
+    Given a scenario outline
+    When it is executed
+    Then <example> is used
+
+    @Example1Tag
+    Examples:
+      | example |
+      | A       |
+      | B       |


### PR DESCRIPTION
Individual examples do not have a unique name. And while a unique name is not
required by Junit, various integrations such as sbt-junit assume this the case.

By appending ` [#n]` to a scenario name it becomes unique again. So JUnit 4s
output becomes:

```
A feature with scenario outlines
  A scenario outline #1
  A scenario outline #2
  A scenario outline #3
  A scenario outline #4
```

The `#n` was taken from JUnit 5 which renders examples as:

```
A feature with scenario outlines
  A scenario outline
    With some other text
      Example #1
      Example #2
    With some text
     Example #1
     Example #2
```

Fixes: https://github.com/cucumber/cucumber-jvm-scala/issues/102