### PR TITLE
Include SourceReferences in message output

### DIFF
--- a/compatibility/src/test/java/io/cucumber/compatibility/matchers/AComparableMessage.java
+++ b/compatibility/src/test/java/io/cucumber/compatibility/matchers/AComparableMessage.java
@@ -50,10 +50,10 @@ public class AComparableMessage extends TypeSafeDiagnosingMatcher<GeneratedMessa
                     expected.add(hasEntry(is(fieldName), isA(expectedValue.getClass())));
                     break;
 
-                // exception: the CCK expects source references but java can not
-                // provide them
+                // exception: the CCK expects source references with URIs but
+                // Java can only provide method and stack trace references.
                 case "sourceReference":
-                    expected.add(not(hasKey(is(fieldName))));
+                    expected.add(hasKey(is(fieldName)));
                     break;
 
                 // exception: ids are not predictable

--- a/core/src/main/java/io/cucumber/core/backend/JavaMethodReference.java
+++ b/core/src/main/java/io/cucumber/core/backend/JavaMethodReference.java
@@ -1,0 +1,53 @@
+package io.cucumber.core.backend;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public final class JavaMethodReference implements SourceReference {
+
+    private final String className;
+    private final String methodName;
+    private final List<String> methodParameterTypes;
+
+    JavaMethodReference(Class<?> declaringClass, String methodName, Class<?>[] methodParameterTypes) {
+        this.className = requireNonNull(declaringClass).getName();
+        this.methodName = requireNonNull(methodName);
+        this.methodParameterTypes = new ArrayList<>(methodParameterTypes.length);
+        for (Class<?> parameterType : methodParameterTypes) {
+            this.methodParameterTypes.add(parameterType.getName());
+        }
+    }
+
+    public String className() {
+        return className;
+    }
+
+    public String methodName() {
+        return methodName;
+    }
+
+    public List<String> methodParameterTypes() {
+        return methodParameterTypes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        JavaMethodReference that = (JavaMethodReference) o;
+        return className.equals(that.className) &&
+                methodName.equals(that.methodName) &&
+                methodParameterTypes.equals(that.methodParameterTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(className, methodName, methodParameterTypes);
+    }
+
+}

--- a/core/src/main/java/io/cucumber/core/backend/Located.java
+++ b/core/src/main/java/io/cucumber/core/backend/Located.java
@@ -2,6 +2,8 @@ package io.cucumber.core.backend;
 
 import org.apiguardian.api.API;
 
+import java.util.Optional;
+
 @API(status = API.Status.STABLE)
 public interface Located {
 
@@ -29,4 +31,7 @@ public interface Located {
      */
     String getLocation();
 
+    default Optional<SourceReference> getSourceReference() {
+        return Optional.empty();
+    }
 }

--- a/core/src/main/java/io/cucumber/core/backend/SourceReference.java
+++ b/core/src/main/java/io/cucumber/core/backend/SourceReference.java
@@ -1,0 +1,22 @@
+package io.cucumber.core.backend;
+
+import java.lang.reflect.Method;
+
+public interface SourceReference {
+
+    static SourceReference fromMethod(Method method) {
+        return new JavaMethodReference(
+            method.getDeclaringClass(),
+            method.getName(),
+            method.getParameterTypes());
+    }
+
+    static SourceReference fromStackTraceElement(StackTraceElement stackTraceElement) {
+        return new StackTraceElementReference(
+            stackTraceElement.getClassName(),
+            stackTraceElement.getMethodName(),
+            stackTraceElement.getFileName(),
+            stackTraceElement.getLineNumber());
+    }
+
+}

--- a/core/src/main/java/io/cucumber/core/backend/StackTraceElementReference.java
+++ b/core/src/main/java/io/cucumber/core/backend/StackTraceElementReference.java
@@ -1,0 +1,56 @@
+package io.cucumber.core.backend;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class StackTraceElementReference implements SourceReference {
+
+    private final String className;
+    private final String methodName;
+    private final String fileName;
+    private final int lineNumber;
+
+    StackTraceElementReference(String className, String methodName, String fileName, int lineNumber) {
+        this.className = requireNonNull(className);
+        this.methodName = requireNonNull(methodName);
+        this.fileName = fileName;
+        this.lineNumber = lineNumber;
+    }
+
+    public String className() {
+        return className;
+    }
+
+    public String methodName() {
+        return methodName;
+    }
+
+    public Optional<String> fileName() {
+        return Optional.ofNullable(fileName);
+    }
+
+    public int lineNumber() {
+        return lineNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        StackTraceElementReference that = (StackTraceElementReference) o;
+        return lineNumber == that.lineNumber &&
+                className.equals(that.className) &&
+                methodName.equals(that.methodName) &&
+                Objects.equals(fileName, that.fileName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(className, methodName, fileName, lineNumber);
+    }
+
+}

--- a/core/src/main/java/io/cucumber/core/runner/CoreHookDefinition.java
+++ b/core/src/main/java/io/cucumber/core/runner/CoreHookDefinition.java
@@ -2,12 +2,14 @@ package io.cucumber.core.runner;
 
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.ScenarioScoped;
+import io.cucumber.core.backend.SourceReference;
 import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.tagexpressions.Expression;
 import io.cucumber.tagexpressions.TagExpressionException;
 import io.cucumber.tagexpressions.TagExpressionParser;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
@@ -84,4 +86,7 @@ class CoreHookDefinition {
 
     }
 
+    Optional<SourceReference> getDefinitionLocation() {
+        return delegate.getSourceReference();
+    }
 }

--- a/core/src/main/java/io/cucumber/core/runner/CoreStepDefinition.java
+++ b/core/src/main/java/io/cucumber/core/runner/CoreStepDefinition.java
@@ -3,6 +3,7 @@ package io.cucumber.core.runner;
 import io.cucumber.core.backend.CucumberBackendException;
 import io.cucumber.core.backend.CucumberInvocationTargetException;
 import io.cucumber.core.backend.ParameterInfo;
+import io.cucumber.core.backend.SourceReference;
 import io.cucumber.core.backend.StepDefinition;
 import io.cucumber.core.gherkin.Step;
 import io.cucumber.core.stepexpression.Argument;
@@ -11,6 +12,7 @@ import io.cucumber.core.stepexpression.StepExpression;
 
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
@@ -82,6 +84,10 @@ final class CoreStepDefinition implements StepDefinition {
     @Override
     public String getLocation() {
         return stepDefinition.getLocation();
+    }
+
+    Optional<SourceReference> getDefinitionLocation() {
+        return stepDefinition.getSourceReference();
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -8,6 +8,7 @@ import io.cucumber.core.backend.DocStringTypeDefinition;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.ParameterTypeDefinition;
 import io.cucumber.core.backend.ScenarioScoped;
+import io.cucumber.core.backend.SourceReference;
 import io.cucumber.core.backend.StepDefinition;
 import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.core.feature.TestFeatureParser;
@@ -28,6 +29,7 @@ import java.lang.reflect.Type;
 import java.net.URI;
 import java.time.Clock;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -626,6 +628,14 @@ class CachingGlueTest {
             return disposed;
         }
 
+        @Override
+        public Optional<SourceReference> getSourceReference() {
+            return Optional.of(SourceReference.fromStackTraceElement(new StackTraceElement(
+                "MockedScenarioScopedHookDefinition",
+                "getSourceReference",
+                "CachingGlueTest.java",
+                582)));
+        }
     }
 
     private static class MockedStepDefinition extends StubStepDefinition {

--- a/core/src/test/java/io/cucumber/core/runner/StubStepDefinition.java
+++ b/core/src/test/java/io/cucumber/core/runner/StubStepDefinition.java
@@ -1,12 +1,15 @@
 package io.cucumber.core.runner;
 
 import io.cucumber.core.backend.ParameterInfo;
+import io.cucumber.core.backend.SourceReference;
 import io.cucumber.core.backend.StepDefinition;
 import io.cucumber.core.backend.TypeResolver;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -83,6 +86,16 @@ class StubStepDefinition implements StepDefinition {
             return () -> type;
         }
 
+    }
+
+    @Override
+    public Optional<SourceReference> getSourceReference() {
+        try {
+            Method method = getClass().getMethod("getSourceReference");
+            return Optional.of(SourceReference.fromMethod(method));
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
 }

--- a/core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
@@ -506,7 +506,7 @@ class RuntimeTest {
                 .run();
 
         Messages.Meta meta = messages.get(0).getMeta();
-        assertThat(meta.getProtocolVersion(), matchesPattern("\\d+\\.\\d+\\.\\d+"));
+        assertThat(meta.getProtocolVersion(), matchesPattern("\\d+\\.\\d+\\.\\d+(-RC\\d+)?(-SNAPSHOT)?"));
         assertThat(meta.getImplementation().getName(), is("cucumber-jvm"));
         assertThat(meta.getImplementation().getVersion(), matchesPattern("\\d+\\.\\d+\\.\\d+(-RC\\d+)?(-SNAPSHOT)?"));
         assertThat(meta.getOs().getName(), matchesPattern(".+"));

--- a/java/src/main/java/io/cucumber/java/AbstractGlueDefinition.java
+++ b/java/src/main/java/io/cucumber/java/AbstractGlueDefinition.java
@@ -2,9 +2,11 @@ package io.cucumber.java;
 
 import io.cucumber.core.backend.Located;
 import io.cucumber.core.backend.Lookup;
+import io.cucumber.core.backend.SourceReference;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -13,6 +15,7 @@ abstract class AbstractGlueDefinition implements Located {
     protected final Method method;
     private final Lookup lookup;
     private String fullFormat;
+    private SourceReference sourceReference;
 
     AbstractGlueDefinition(Method method, Lookup lookup) {
         this.method = requireNonNull(method);
@@ -42,6 +45,14 @@ abstract class AbstractGlueDefinition implements Located {
             return Invoker.invokeStatic(this, method, args);
         }
         return Invoker.invoke(this, lookup.getInstance(method.getDeclaringClass()), method, args);
+    }
+
+    @Override
+    public Optional<SourceReference> getSourceReference() {
+        if (sourceReference == null) {
+            sourceReference = SourceReference.fromMethod(this.method);
+        }
+        return Optional.of(sourceReference);
     }
 
 }

--- a/java8/src/main/java/io/cucumber/java8/AbstractGlueDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/AbstractGlueDefinition.java
@@ -2,12 +2,15 @@ package io.cucumber.java8;
 
 import io.cucumber.core.backend.Located;
 import io.cucumber.core.backend.ScenarioScoped;
+import io.cucumber.core.backend.SourceReference;
 import net.jodah.typetools.TypeResolver;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import static io.cucumber.core.backend.SourceReference.fromStackTraceElement;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -16,6 +19,7 @@ abstract class AbstractGlueDefinition implements ScenarioScoped, Located {
     private Object body;
     final Method method;
     final StackTraceElement location;
+    SourceReference sourceReference;
 
     AbstractGlueDefinition(Object body, StackTraceElement location) {
         this.body = requireNonNull(body);
@@ -57,6 +61,14 @@ abstract class AbstractGlueDefinition implements ScenarioScoped, Located {
     @Override
     public final boolean isDefinedAt(StackTraceElement stackTraceElement) {
         return location.getFileName() != null && location.getFileName().equals(stackTraceElement.getFileName());
+    }
+
+    @Override
+    public Optional<SourceReference> getSourceReference() {
+        if (sourceReference == null) {
+            sourceReference = fromStackTraceElement(location);
+        }
+        return Optional.of(sourceReference);
     }
 
     Class<?>[] resolveRawArguments(Class<?> bodyClass, Class<?> body) {

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.cucumber</groupId>
@@ -27,7 +28,7 @@
         <datatable.version>3.3.1</datatable.version>
         <tag-expressions.version>3.0.0</tag-expressions.version>
         <!-- When ever messages is updated run `make update-compatibility` -->
-        <messages.version>12.2.0</messages.version>
+        <messages.version>12.3.2</messages.version>
         <gherkin.version>14.0.1</gherkin.version>
         <html-formatter.version>7.0.0</html-formatter.version>
 
@@ -599,7 +600,7 @@
                                 <item>
                                     <regex>true</regex>
                                     <code>java.method.addedToInterface</code>
-                                    <new>.*io.cucumber.messages.Messages.Meta.*</new>
+                                    <new>.*io.cucumber.messages.Messages..*</new>
                                     <justification>Internal API</justification>
                                 </item>
                             </revapi.ignore>
@@ -646,24 +647,24 @@
                         <failsOnError>true</failsOnError>
                         <checkstyleRules>
                             <module name="Checker">
-                                <property name="severity" value="error" />
+                                <property name="severity" value="error"/>
                                 <module name="TreeWalker">
-                                    <module name="AvoidStarImport" />
+                                    <module name="AvoidStarImport"/>
                                     <module name="JavadocMethod">
-                                        <property name="allowMissingParamTags" value="true" />
-                                        <property name="allowMissingReturnTag" value="true" />
+                                        <property name="allowMissingParamTags" value="true"/>
+                                        <property name="allowMissingReturnTag" value="true"/>
                                     </module>
-                                    <module name="NonEmptyAtclauseDescription" />
-                                    <module name="SuppressWarningsHolder" />
+                                    <module name="NonEmptyAtclauseDescription"/>
+                                    <module name="SuppressWarningsHolder"/>
                                     <module name="UnusedImports">
-                                        <property name="processJavadoc" value="true" />
+                                        <property name="processJavadoc" value="true"/>
                                     </module>
                                 </module>
-                                <module name="SuppressWarningsFilter" />
+                                <module name="SuppressWarningsFilter"/>
                                 <module name="RegexpSingleline">
-                                    <property name="format" value="@author" />
-                                    <property name="message" value="Please do not use @author tags" />
-                                    <property name="fileExtensions" value="java,groovy,kt" />
+                                    <property name="format" value="@author"/>
+                                    <property name="message" value="Please do not use @author tags"/>
+                                    <property name="fileExtensions" value="java,groovy,kt"/>
                                 </module>
                             </module>
                         </checkstyleRules>


### PR DESCRIPTION
Cucumber JVM can not reference files by URI. So it should use either java
methods or stack trace elements as a source reference instead.

For example:

```json
{
  "hook": {
    "id": "a1839ec6-f75d-4029-9b75-4b8203d8b2e8",
    "sourceReference": {
      "javaMethod": {
        "className": "io.cucumber.compatibility.attachments.Attachments",
        "methodName": "before",
        "methodParameterTypes": [
          "io.cucumber.java.Scenario"
        ]
      }
    }
  }
}
```

See: https://github.com/cucumber/cucumber/issues/1119
Fixes: https://github.com/cucumber/cucumber-jvm/issues/2058
