### PR TITLE
[Java8] Allow test execution context to be garbage collected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
- *  [Core] Improve error message when an unknown plugin is used ([#2053](https://github.com/cucumber/cucumber-jvm/issues/2053) M.P. Korstanje)
+ * [Core] Improve error message when an unknown plugin is used ([#2053](https://github.com/cucumber/cucumber-jvm/issues/2053) M.P. Korstanje)
+ * [Java8] Allow test execution context to be garbage collected ([#2067](https://github.com/cucumber/cucumber-jvm/issues/2067) M.P. Korstanje)
 
 ## [6.2.2] (2020-07-09)
 

--- a/core/src/main/java/io/cucumber/core/backend/ScenarioScoped.java
+++ b/core/src/main/java/io/cucumber/core/backend/ScenarioScoped.java
@@ -9,4 +9,16 @@ package io.cucumber.core.backend;
  */
 public interface ScenarioScoped {
 
+    /**
+     * Disposes of the test execution context.
+     * <p>
+     * Scenario scoped step definition may be used in events. Thus retaining a
+     * potential reference to the test execution context. When many tests are
+     * used this may result in an over consumption of memory. Disposing of the
+     * execution context resolves this problem.
+     */
+    default void dispose() {
+
+    }
+
 }

--- a/core/src/main/java/io/cucumber/core/runner/CachingGlue.java
+++ b/core/src/main/java/io/cucumber/core/runner/CachingGlue.java
@@ -371,6 +371,8 @@ final class CachingGlue implements Glue {
         while (glueIterator.hasNext()) {
             Object glue = glueIterator.next();
             if (glue instanceof ScenarioScoped) {
+                ScenarioScoped scenarioScoped = (ScenarioScoped) glue;
+                scenarioScoped.dispose();
                 glueIterator.remove();
             }
         }

--- a/core/src/main/java/io/cucumber/core/runner/CoreDefaultDataTableEntryTransformerDefinition.java
+++ b/core/src/main/java/io/cucumber/core/runner/CoreDefaultDataTableEntryTransformerDefinition.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 class CoreDefaultDataTableEntryTransformerDefinition implements DefaultDataTableEntryTransformerDefinition {
 
-    private final DefaultDataTableEntryTransformerDefinition delegate;
+    protected final DefaultDataTableEntryTransformerDefinition delegate;
     private final TableEntryByTypeTransformer transformer;
 
     private CoreDefaultDataTableEntryTransformerDefinition(DefaultDataTableEntryTransformerDefinition delegate) {
@@ -58,6 +58,13 @@ class CoreDefaultDataTableEntryTransformerDefinition implements DefaultDataTable
             super(delegate);
         }
 
+        @Override
+        public void dispose() {
+            if (delegate instanceof ScenarioScoped) {
+                ScenarioScoped scenarioScoped = (ScenarioScoped) delegate;
+                scenarioScoped.dispose();
+            }
+        }
     }
 
     private static class ConvertingTransformer implements TableEntryByTypeTransformer {

--- a/core/src/main/java/io/cucumber/core/runner/CoreHookDefinition.java
+++ b/core/src/main/java/io/cucumber/core/runner/CoreHookDefinition.java
@@ -15,7 +15,7 @@ import static java.util.Objects.requireNonNull;
 class CoreHookDefinition {
 
     private final UUID id;
-    private final HookDefinition delegate;
+    protected final HookDefinition delegate;
     private final Expression tagExpression;
 
     private CoreHookDefinition(UUID id, HookDefinition delegate) {
@@ -72,6 +72,14 @@ class CoreHookDefinition {
 
         private ScenarioScopedCoreHookDefinition(HookDefinition delegate) {
             super(UUID.randomUUID(), delegate);
+        }
+
+        @Override
+        public void dispose() {
+            if (delegate instanceof ScenarioScoped) {
+                ScenarioScoped scenarioScoped = (ScenarioScoped) delegate;
+                scenarioScoped.dispose();
+            }
         }
 
     }

--- a/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -314,6 +314,48 @@ class CachingGlueTest {
     }
 
     @Test
+    void disposes_of_scenario_scoped_beans() {
+        MockedScenarioScopedStepDefinition stepDefinition = new MockedScenarioScopedStepDefinition("^pattern1");
+        glue.addStepDefinition(stepDefinition);
+        MockedScenarioScopedHookDefinition hookDefinition1 = new MockedScenarioScopedHookDefinition();
+        glue.addBeforeHook(hookDefinition1);
+        MockedScenarioScopedHookDefinition hookDefinition2 = new MockedScenarioScopedHookDefinition();
+        glue.addAfterHook(hookDefinition2);
+        MockedScenarioScopedHookDefinition hookDefinition3 = new MockedScenarioScopedHookDefinition();
+        glue.addBeforeStepHook(hookDefinition3);
+        MockedScenarioScopedHookDefinition hookDefinition4 = new MockedScenarioScopedHookDefinition();
+        glue.addAfterStepHook(hookDefinition4);
+
+        MockedDocStringTypeDefinition docStringType = new MockedDocStringTypeDefinition();
+        glue.addDocStringType(docStringType);
+        MockedDefaultDataTableEntryTransformer defaultDataTableEntryTransformer = new MockedDefaultDataTableEntryTransformer();
+        glue.addDefaultDataTableEntryTransformer(defaultDataTableEntryTransformer);
+        MockedDefaultDataTableCellTransformer defaultDataTableCellTransformer = new MockedDefaultDataTableCellTransformer();
+        glue.addDefaultDataTableCellTransformer(defaultDataTableCellTransformer);
+        MockedParameterTypeDefinition parameterType = new MockedParameterTypeDefinition();
+        glue.addParameterType(parameterType);
+        MockedDataTableTypeDefinition dataTableType = new MockedDataTableTypeDefinition();
+        glue.addDataTableType(dataTableType);
+        MockedDefaultParameterTransformer defaultParameterTransformer = new MockedDefaultParameterTransformer();
+        glue.addDefaultParameterTransformer(defaultParameterTransformer);
+
+        glue.prepareGlue(stepTypeRegistry);
+        glue.removeScenarioScopedGlue();
+
+        assertThat(stepDefinition.isDisposed(), is(true));
+        assertThat(hookDefinition1.isDisposed(), is(true));
+        assertThat(hookDefinition2.isDisposed(), is(true));
+        assertThat(hookDefinition3.isDisposed(), is(true));
+        assertThat(hookDefinition4.isDisposed(), is(true));
+        assertThat(docStringType.isDisposed(), is(true));
+        assertThat(defaultDataTableEntryTransformer.isDisposed(), is(true));
+        assertThat(defaultDataTableCellTransformer.isDisposed(), is(true));
+        assertThat(defaultParameterTransformer.isDisposed(), is(true));
+        assertThat(parameterType.isDisposed(), is(true));
+        assertThat(dataTableType.isDisposed(), is(true));
+    }
+
+    @Test
     void returns_no_match_after_evicting_scenario_scoped() throws AmbiguousStepDefinitionsException {
         URI uri = URI.create("file:path/to.feature");
         String stepText = "pattern1";
@@ -424,6 +466,16 @@ class CachingGlueTest {
         MockedScenarioScopedStepDefinition(String pattern, boolean transposed, Type... types) {
             super(pattern, transposed, types);
         }
+        private boolean disposed;
+
+        @Override
+        public void dispose() {
+            disposed = true;
+        }
+
+        public boolean isDisposed() {
+            return disposed;
+        }
 
     }
 
@@ -442,6 +494,17 @@ class CachingGlueTest {
         @Override
         public String getLocation() {
             return "mocked data table type definition";
+        }
+
+        private boolean disposed;
+
+        @Override
+        public void dispose() {
+            disposed = true;
+        }
+
+        public boolean isDisposed() {
+            return disposed;
         }
 
     }
@@ -463,12 +526,22 @@ class CachingGlueTest {
             return "mocked parameter type location";
         }
 
+        private boolean disposed;
+
+        @Override
+        public void dispose() {
+            disposed = true;
+        }
+
+        public boolean isDisposed() {
+            return disposed;
+        }
+
     }
 
     private static class MockedHookDefinition implements HookDefinition {
 
         private final int order;
-        boolean disposed;
 
         MockedHookDefinition() {
             this(0);
@@ -542,6 +615,17 @@ class CachingGlueTest {
             return order;
         }
 
+        private boolean disposed;
+
+        @Override
+        public void dispose() {
+            disposed = true;
+        }
+
+        public boolean isDisposed() {
+            return disposed;
+        }
+
     }
 
     private static class MockedStepDefinition extends StubStepDefinition {
@@ -570,6 +654,17 @@ class CachingGlueTest {
             return "mocked default parameter transformer";
         }
 
+        private boolean disposed;
+
+        @Override
+        public void dispose() {
+            disposed = true;
+        }
+
+        public boolean isDisposed() {
+            return disposed;
+        }
+
     }
 
     private static class MockedDefaultDataTableCellTransformer
@@ -588,6 +683,17 @@ class CachingGlueTest {
         @Override
         public String getLocation() {
             return "mocked default data table cell transformer";
+        }
+
+        private boolean disposed;
+
+        @Override
+        public void dispose() {
+            disposed = true;
+        }
+
+        public boolean isDisposed() {
+            return disposed;
         }
 
     }
@@ -615,6 +721,17 @@ class CachingGlueTest {
             return "mocked default data table entry transformer";
         }
 
+        private boolean disposed;
+
+        @Override
+        public void dispose() {
+            disposed = true;
+        }
+
+        public boolean isDisposed() {
+            return disposed;
+        }
+
     }
 
     private static class MockedDocStringTypeDefinition implements DocStringTypeDefinition, ScenarioScoped {
@@ -632,6 +749,17 @@ class CachingGlueTest {
         @Override
         public String getLocation() {
             return "mocked default data table entry transformer";
+        }
+
+        private boolean disposed;
+
+        @Override
+        public void dispose() {
+            disposed = true;
+        }
+
+        public boolean isDisposed() {
+            return disposed;
         }
 
     }

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableCellDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableCellDefinition.java
@@ -13,11 +13,7 @@ final class Java8DataTableCellDefinition extends AbstractDatatableElementTransfo
         Class<?> returnType = resolveRawArguments(DataTableCellDefinitionBody.class, body.getClass())[0];
         this.dataTableType = new DataTableType(
             returnType,
-            (String cell) -> execute(replaceEmptyPatternsWithEmptyString(cell)));
-    }
-
-    private Object execute(Object cell) {
-        return Invoker.invoke(this, body, method, cell);
+            (String cell) -> invokeMethod(replaceEmptyPatternsWithEmptyString(cell)));
     }
 
     @Override

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableDefinition.java
@@ -14,11 +14,7 @@ final class Java8DataTableDefinition extends AbstractDatatableElementTransformer
         Class<?> returnType = resolveRawArguments(DataTableDefinitionBody.class, body.getClass())[0];
         this.dataTableType = new DataTableType(
             returnType,
-            (DataTable table) -> execute(replaceEmptyPatternsWithEmptyString(table)));
-    }
-
-    private Object execute(DataTable table) {
-        return Invoker.invoke(this, body, method, table);
+            (DataTable table) -> invokeMethod(replaceEmptyPatternsWithEmptyString(table)));
     }
 
     @Override

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableEntryDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableEntryDefinition.java
@@ -15,11 +15,7 @@ final class Java8DataTableEntryDefinition extends AbstractDatatableElementTransf
         Class<?> returnType = resolveRawArguments(DataTableEntryDefinitionBody.class, body.getClass())[0];
         this.dataTableType = new DataTableType(
             returnType,
-            (Map<String, String> entry) -> execute(replaceEmptyPatternsWithEmptyString(entry)));
-    }
-
-    private Object execute(Map<String, String> entry) {
-        return Invoker.invoke(this, body, method, entry);
+            (Map<String, String> entry) -> invokeMethod(replaceEmptyPatternsWithEmptyString(entry)));
     }
 
     @Override

--- a/java8/src/main/java/io/cucumber/java8/Java8DataTableRowDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DataTableRowDefinition.java
@@ -15,11 +15,7 @@ final class Java8DataTableRowDefinition extends AbstractDatatableElementTransfor
         Class<?> returnType = resolveRawArguments(DataTableRowDefinitionBody.class, body.getClass())[0];
         this.dataTableType = new DataTableType(
             returnType,
-            (List<String> row) -> execute(replaceEmptyPatternsWithEmptyString(row)));
-    }
-
-    private Object execute(List<String> row) {
-        return Invoker.invoke(this, body, method, row);
+            (List<String> row) -> invokeMethod(replaceEmptyPatternsWithEmptyString(row)));
     }
 
     @Override

--- a/java8/src/main/java/io/cucumber/java8/Java8DefaultDataTableCellTransformerDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DefaultDataTableCellTransformerDefinition.java
@@ -3,8 +3,6 @@ package io.cucumber.java8;
 import io.cucumber.core.backend.DefaultDataTableCellTransformerDefinition;
 import io.cucumber.datatable.TableCellByTypeTransformer;
 
-import java.lang.reflect.Type;
-
 class Java8DefaultDataTableCellTransformerDefinition extends AbstractDatatableElementTransformerDefinition
         implements DefaultDataTableCellTransformerDefinition {
 
@@ -14,13 +12,9 @@ class Java8DefaultDataTableCellTransformerDefinition extends AbstractDatatableEl
 
     @Override
     public TableCellByTypeTransformer tableCellByTypeTransformer() {
-        return (fromValue, toValueType) -> execute(
+        return (fromValue, toValueType) -> invokeMethod(
             replaceEmptyPatternsWithEmptyString(fromValue),
             toValueType);
-    }
-
-    private Object execute(String fromValue, Type toValueType) {
-        return Invoker.invoke(this, body, method, fromValue, toValueType);
     }
 
 }

--- a/java8/src/main/java/io/cucumber/java8/Java8DefaultDataTableEntryTransformerDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DefaultDataTableEntryTransformerDefinition.java
@@ -3,9 +3,6 @@ package io.cucumber.java8;
 import io.cucumber.core.backend.DefaultDataTableEntryTransformerDefinition;
 import io.cucumber.datatable.TableEntryByTypeTransformer;
 
-import java.lang.reflect.Type;
-import java.util.Map;
-
 class Java8DefaultDataTableEntryTransformerDefinition extends AbstractDatatableElementTransformerDefinition
         implements DefaultDataTableEntryTransformerDefinition {
 
@@ -20,13 +17,8 @@ class Java8DefaultDataTableEntryTransformerDefinition extends AbstractDatatableE
 
     @Override
     public TableEntryByTypeTransformer tableEntryByTypeTransformer() {
-        return (fromValue, toValueType, tableCellByTypeTransformer) -> execute(
+        return (fromValue, toValueType, tableCellByTypeTransformer) -> invokeMethod(
             replaceEmptyPatternsWithEmptyString(fromValue),
             toValueType);
     }
-
-    private Object execute(Map<String, String> fromValue, Type toValueType) {
-        return Invoker.invoke(this, body, method, fromValue, toValueType);
-    }
-
 }

--- a/java8/src/main/java/io/cucumber/java8/Java8DefaultParameterTypeDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DefaultParameterTypeDefinition.java
@@ -3,8 +3,6 @@ package io.cucumber.java8;
 import io.cucumber.core.backend.DefaultParameterTransformerDefinition;
 import io.cucumber.cucumberexpressions.ParameterByTypeTransformer;
 
-import java.lang.reflect.Type;
-
 class Java8DefaultParameterTypeDefinition extends AbstractGlueDefinition
         implements DefaultParameterTransformerDefinition {
 
@@ -14,11 +12,7 @@ class Java8DefaultParameterTypeDefinition extends AbstractGlueDefinition
 
     @Override
     public ParameterByTypeTransformer parameterByTypeTransformer() {
-        return this::execute;
-    }
-
-    private Object execute(String fromValue, Type toValue) {
-        return Invoker.invoke(this, body, method, fromValue, toValue);
+        return (fromValue, toValue) -> invokeMethod(fromValue, toValue);
     }
 
 }

--- a/java8/src/main/java/io/cucumber/java8/Java8DocStringTypeDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8DocStringTypeDefinition.java
@@ -20,11 +20,7 @@ final class Java8DocStringTypeDefinition extends AbstractGlueDefinition implemen
         this.docStringType = new DocStringType(
             returnType,
             contentType,
-            this::execute);
-    }
-
-    private Object execute(String content) {
-        return Invoker.invoke(this, body, method, content);
+            this::invokeMethod);
     }
 
     @Override

--- a/java8/src/main/java/io/cucumber/java8/Java8HookDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8HookDefinition.java
@@ -32,7 +32,7 @@ final class Java8HookDefinition extends AbstractGlueDefinition implements HookDe
         } else {
             args = new Object[] { new io.cucumber.java8.Scenario(state) };
         }
-        Invoker.invoke(this, body, method, args);
+        invokeMethod(args);
     }
 
     @Override

--- a/java8/src/main/java/io/cucumber/java8/Java8ParameterTypeDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8ParameterTypeDefinition.java
@@ -1,6 +1,7 @@
 package io.cucumber.java8;
 
 import io.cucumber.core.backend.ParameterTypeDefinition;
+import io.cucumber.cucumberexpressions.CaptureGroupTransformer;
 import io.cucumber.cucumberexpressions.ParameterType;
 
 import java.util.Collections;
@@ -15,11 +16,8 @@ class Java8ParameterTypeDefinition extends AbstractGlueDefinition implements Par
     ) {
         super(body, new Exception().getStackTrace()[3]);
         Class<?> returnType = resolveRawArguments(bodyClass, body.getClass())[0];
-        this.parameterType = new ParameterType(name, Collections.singletonList(regex), returnType, this::execute);
-    }
-
-    private Object execute(String[] parameterContent) {
-        return Invoker.invoke(this, body, method, parameterContent);
+        this.parameterType = new ParameterType(name, Collections.singletonList(regex), returnType,
+            (CaptureGroupTransformer) this::invokeMethod);
     }
 
     @Override

--- a/java8/src/main/java/io/cucumber/java8/Java8StepDefinition.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8StepDefinition.java
@@ -41,8 +41,8 @@ final class Java8StepDefinition extends AbstractGlueDefinition implements StepDe
     }
 
     @Override
-    public void execute(final Object[] args) {
-        Invoker.invoke(this, body, method, args);
+    public void execute(Object[] args) {
+        invokeMethod(args);
     }
 
     @Override


### PR DESCRIPTION
Glue definitions in Java8 retain a reference to the test execution context.
Glue definitions in turn are used in events. Events in turn may be stored for
the entire duration of Cucumbers execution. So when many scenarios are executed
this may results in significant memory usage.

By removing the reference to the test execution context after the scenario is
executed we can still use step definitions in events without the associated
memory consumption.

Fixes: #2066