### PR TITLE
Remove 'plugin' from publish-related env vars/system props.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       script: mvn verify -P-spotless-apply --toolchains .travis-toolchains.xml
       env:
       - VERIFY=true
-      - CUCUMBER_PLUGIN_PUBLISH_TOKEN=trigger/build/with/publish/plugin
+      - CUCUMBER_PUBLISH_TOKEN=trigger/build/with/publish/plugin
 
       # 1.3 Coverage
     - stage: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     Aslak Hellesøy, M.P. Korstanje).
    There are several ways to enable this:
    * `@CucumberOptions(publish = true)`
-   * `CUCUMBER_PLUGIN_PUBLISH_ENABLED=true` (Environment variable)
-   * `-Dcucumber.plugin.publish.enabled=true` (System property)
+   * `CUCUMBER_PUBLISH_ENABLED=true` (Environment variable)
+   * `-Dcucumber.publish.enabled=true` (System property)
 
 ### Changed
 

--- a/cdi2/src/test/resources/cucumber.properties
+++ b/cdi2/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/core/src/main/java/io/cucumber/core/options/Constants.java
+++ b/core/src/main/java/io/cucumber/core/options/Constants.java
@@ -155,25 +155,25 @@ public final class Constants {
     /**
      * Setting this to true will enable publishing.
      */
-    public static final String PLUGIN_PUBLISH_ENABLED_PROPERTY_NAME = "cucumber.plugin.publish.enabled";
+    public static final String PLUGIN_PUBLISH_ENABLED_PROPERTY_NAME = "cucumber.publish.enabled";
 
     // TODO: Document consistently with other parameters.
     /**
      * Setting this to true will enable publishing with a Bearer token.
      */
-    public static final String PLUGIN_PUBLISH_TOKEN_PROPERTY_NAME = "cucumber.plugin.publish.token";
+    public static final String PLUGIN_PUBLISH_TOKEN_PROPERTY_NAME = "cucumber.publish.token";
 
     /**
      * Defining this will override the publishing URL (it is not sufficient to
      * activate publishing).
      */
-    public static final String PLUGIN_PUBLISH_URL_PROPERTY_NAME = "cucumber.plugin.publish.url";
+    public static final String PLUGIN_PUBLISH_URL_PROPERTY_NAME = "cucumber.publish.url";
 
     /**
      * Setting this to true will prevent the publish advertising banner from
      * being printed.
      */
-    public static final String PLUGIN_PUBLISH_QUIET_PROPERTY_NAME = "cucumber.plugin.publish.quiet";
+    public static final String PLUGIN_PUBLISH_QUIET_PROPERTY_NAME = "cucumber.publish.quiet";
 
     /**
      * Property name to control naming convention for generated snippets:

--- a/core/src/test/java/io/cucumber/core/plugin/NoPublishFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/NoPublishFormatterTest.java
@@ -22,12 +22,12 @@ class NoPublishFormatterTest {
                 "│ Share your Cucumber Report with your team at https://reports.cucumber.io      │\n" +
                 "│                                                                               │\n" +
                 "│ Code:                   @CucumberOptions(publish = true)                      │\n" +
-                "│ Environment variable:   CUCUMBER_PLUGIN_PUBLISH_ENABLED=true                  │\n" +
-                "│ System property:        -Dcucumber.plugin.publish.enabled=true                │\n" +
+                "│ Environment variable:   CUCUMBER_PUBLISH_ENABLED=true                         │\n" +
+                "│ System property:        -Dcucumber.publish.enabled=true                       │\n" +
                 "│                                                                               │\n" +
                 "│ More information at https://reports.cucumber.io/docs/cucumber-jvm             │\n" +
                 "│                                                                               │\n" +
-                "│ To disable this message, add cucumber.plugin.publish.quiet=true to            │\n" +
+                "│ To disable this message, add cucumber.publish.quiet=true to                   │\n" +
                 "│ src/test/resources/cucumber.properties or                                     │\n" +
                 "│ src/test/resources/junit-platform.properties (cucumber-junit-platform-engine) │\n" +
                 "└───────────────────────────────────────────────────────────────────────────────┘\n"));

--- a/deltaspike/src/test/resources/cucumber.properties
+++ b/deltaspike/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/guice/src/test/resources/cucumber.properties
+++ b/guice/src/test/resources/cucumber.properties
@@ -1,3 +1,3 @@
 guice.injector-source=io.cucumber.guice.integration.YourInjectorSource
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true
 

--- a/jakarta-cdi/src/test/resources/cucumber.properties
+++ b/jakarta-cdi/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/java/src/test/resources/cucumber.properties
+++ b/java/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/java8/src/test/resources/cucumber.properties
+++ b/java8/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/junit-platform-engine/src/test/resources/junit-platform.properties
+++ b/junit-platform-engine/src/test/resources/junit-platform.properties
@@ -1,3 +1,3 @@
 cucumber.glue=io.cucumber.junit.platform.engine
 cucumber.filter.tags=not @Disabled
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/junit/src/test/resources/cucumber.properties
+++ b/junit/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/kotlin-java8/src/test/resources/cucumber.properties
+++ b/kotlin-java8/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/needle/src/test/resources/cucumber.properties
+++ b/needle/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/openejb/src/test/resources/cucumber.properties
+++ b/openejb/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/picocontainer/src/test/resources/cucumber.properties
+++ b/picocontainer/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/spring/src/test/resources/cucumber.properties
+++ b/spring/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/testng/src/test/resources/cucumber.properties
+++ b/testng/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true

--- a/weld/src/test/resources/cucumber.properties
+++ b/weld/src/test/resources/cucumber.properties
@@ -1,1 +1,1 @@
-cucumber.plugin.publish.quiet=true
+cucumber.publish.quiet=true


### PR DESCRIPTION
This changes the publish-related environment variables (and corresponding JVM system properties) from:

* `CUCUMBER_PLUGIN_PUBLISH_ENABLED`
* `CUCUMBER_PLUGIN_PUBLISH_TOKEN`
* `CUCUMBER_PLUGIN_PUBLISH_URL`
* `CUCUMBER_PLUGIN_PUBLISH_QUIET`

to:

* `CUCUMBER_PUBLISH_ENABLED`
* `CUCUMBER_PUBLISH_TOKEN`
* `CUCUMBER_PUBLISH_URL`
* `CUCUMBER_PUBLISH_QUIET`

The reasons for doing this are:

* The environment variables should be identical across Cucumber implementations
* Cucumber-JVM is the only implementation that has renamed "formatter" to "plugin", and "plugin" is confusing on Cucumber.js and Cucumber-Ruby
* The names are shorter

This is related to https://github.com/cucumber/cucumber-ruby/pull/1452#discussion_r470004804