### PR TITLE
Improve publish instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Publish instructions now recommend using `src/test/resources/cucumber.properties`.
+ ([#2096](https://github.com/cucumber/cucumber-jvm/pull/2096)
+  Aslak Hellesøy)
+
 ## [6.5.0] (2020-08-17)
 
 ### Added

--- a/core/src/main/java/io/cucumber/core/plugin/NoPublishFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/NoPublishFormatter.java
@@ -48,24 +48,25 @@ public final class NoPublishFormatter implements ConcurrentEventListener, ColorA
                     new Banner.Span("Share your Cucumber Report with your team at "),
                     new Banner.Span("https://reports.cucumber.io", AnsiEscapes.CYAN, AnsiEscapes.INTENSITY_BOLD,
                         AnsiEscapes.UNDERLINE)),
+                new Banner.Line("Activate publishing with one of the following:"),
                 new Banner.Line(""),
                 new Banner.Line(
-                    new Banner.Span("Code:                   "),
-                    new Banner.Span("@CucumberOptions", AnsiEscapes.CYAN),
-                    new Banner.Span("(publish = "),
-                    new Banner.Span("true", AnsiEscapes.CYAN),
-                    new Banner.Span(")")),
+                    new Banner.Span("src/test/resources/cucumber.properties:    "),
+                    new Banner.Span("cucumber.publish.enabled", AnsiEscapes.CYAN),
+                    new Banner.Span("="),
+                    new Banner.Span("true", AnsiEscapes.CYAN)),
                 new Banner.Line(
-                    new Banner.Span("Environment variable:   "),
+                    new Banner.Span("Environment variable:                      "),
                     new Banner.Span(PLUGIN_PUBLISH_ENABLED_PROPERTY_NAME.toUpperCase().replace('.', '_'),
                         AnsiEscapes.CYAN),
                     new Banner.Span("="),
                     new Banner.Span("true", AnsiEscapes.CYAN)),
                 new Banner.Line(
-                    new Banner.Span("System property:        "),
-                    new Banner.Span("-D" + PLUGIN_PUBLISH_ENABLED_PROPERTY_NAME, AnsiEscapes.CYAN),
-                    new Banner.Span("="),
-                    new Banner.Span("true", AnsiEscapes.CYAN)),
+                    new Banner.Span("JUnit:                                     "),
+                    new Banner.Span("@CucumberOptions", AnsiEscapes.CYAN),
+                    new Banner.Span("(publish = "),
+                    new Banner.Span("true", AnsiEscapes.CYAN),
+                    new Banner.Span(")")),
                 new Banner.Line(""),
                 new Banner.Line(
                     new Banner.Span("More information at "),
@@ -78,11 +79,7 @@ public final class NoPublishFormatter implements ConcurrentEventListener, ColorA
                     new Banner.Span("true", AnsiEscapes.INTENSITY_BOLD),
                     new Banner.Span(" to")),
                 new Banner.Line(
-                    new Banner.Span("src/test/resources/cucumber.properties", AnsiEscapes.INTENSITY_BOLD),
-                    new Banner.Span(" or")),
-                new Banner.Line(
-                    new Banner.Span("src/test/resources/junit-platform.properties", AnsiEscapes.INTENSITY_BOLD),
-                    new Banner.Span(" (cucumber-junit-platform-engine)"))),
+                    new Banner.Span("src/test/resources/cucumber.properties", AnsiEscapes.INTENSITY_BOLD))),
             AnsiEscapes.GREEN, AnsiEscapes.INTENSITY_BOLD);
     }
 }

--- a/core/src/test/java/io/cucumber/core/plugin/NoPublishFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/NoPublishFormatterTest.java
@@ -18,19 +18,19 @@ class NoPublishFormatterTest {
         noPublishFormatter.setMonochrome(true);
         noPublishFormatter.printBanner();
         assertThat(bytes.toString("UTF-8"), is("" +
-                "┌───────────────────────────────────────────────────────────────────────────────┐\n" +
-                "│ Share your Cucumber Report with your team at https://reports.cucumber.io      │\n" +
-                "│                                                                               │\n" +
-                "│ Code:                   @CucumberOptions(publish = true)                      │\n" +
-                "│ Environment variable:   CUCUMBER_PUBLISH_ENABLED=true                         │\n" +
-                "│ System property:        -Dcucumber.publish.enabled=true                       │\n" +
-                "│                                                                               │\n" +
-                "│ More information at https://reports.cucumber.io/docs/cucumber-jvm             │\n" +
-                "│                                                                               │\n" +
-                "│ To disable this message, add cucumber.publish.quiet=true to                   │\n" +
-                "│ src/test/resources/cucumber.properties or                                     │\n" +
-                "│ src/test/resources/junit-platform.properties (cucumber-junit-platform-engine) │\n" +
-                "└───────────────────────────────────────────────────────────────────────────────┘\n"));
+                "┌─────────────────────────────────────────────────────────────────────────────┐\n" +
+                "│ Share your Cucumber Report with your team at https://reports.cucumber.io    │\n" +
+                "│ Activate publishing with one of the following:                              │\n" +
+                "│                                                                             │\n" +
+                "│ src/test/resources/cucumber.properties:    cucumber.publish.enabled=true    │\n" +
+                "│ Environment variable:                      CUCUMBER_PUBLISH_ENABLED=true    │\n" +
+                "│ JUnit:                                     @CucumberOptions(publish = true) │\n" +
+                "│                                                                             │\n" +
+                "│ More information at https://reports.cucumber.io/docs/cucumber-jvm           │\n" +
+                "│                                                                             │\n" +
+                "│ To disable this message, add cucumber.publish.quiet=true to                 │\n" +
+                "│ src/test/resources/cucumber.properties                                      │\n" +
+                "└─────────────────────────────────────────────────────────────────────────────┘\n"));
     }
 
 }


### PR DESCRIPTION
The old instructions for activating publishing allowed too many things to go wrong:

* Many users don't know how to set environment variables. They'll set them in Windows system settings not realising a reboot is required to make it take effect
* Adding `publish = true` to `@CucumberOptions` will have no effect if Cucumber is run from IDEA's native runner (green triangles in the gutter)

For this reason the top recommendation is now to set `cucumber.publish.enabled=true` in `src/test/resources/cucumber.properties`. This should be picked up regardless of how people run Cucumber.

I've also removed the recommendation to use `src/test/resources/junit-platform.properties` since it will be ignored when using the IDEA runner.