### PR TITLE
Advanced boolean parsing. Fixes #2095

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* `cucumber.*` JVM system properties and `CUCUMBER_*` environment variables that represent booleans
+  will now resolve to `true` except for the following values, which will resolve to `false`:
+  * `[empty string]`
+  * `0`
+  * `false`
+  * `no`
+
 ## [6.5.0] (2020-08-17)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   * `0`
   * `false`
   * `no`
+  
+  ([#2095](https://github.com/cucumber/cucumber-jvm/pull/2097)
+   [#2097](https://github.com/cucumber/cucumber-jvm/pull/2097)
+   Aslak Hellesøy)
 
 ## [6.5.0] (2020-08-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] (In Git)
 
 ### Added
-
+* Boolean system properties and environment variables (`cucumber.*` and `CUCUMBER_*`)
+  are strictly parsed. The values `0`, `false`, `no` are interpreted as `false`.
+  The values `1`, `true`, `yes` are interpreted as `true`. All other values will
+  throw an exception.
+  ([#2095](https://github.com/cucumber/cucumber-jvm/pull/2097)
+   [#2097](https://github.com/cucumber/cucumber-jvm/pull/2097)
+   Aslak Hellesøy)
+   
 ### Changed
 
 ### Deprecated
@@ -16,21 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
-
 * Publish instructions now recommend using `src/test/resources/cucumber.properties`.
  ([#2096](https://github.com/cucumber/cucumber-jvm/pull/2096)
   Aslak Hellesøy)
-* `cucumber.*` JVM system properties and `CUCUMBER_*` environment variables that represent booleans
-  will now resolve to `true` except for the following values, which will resolve to `false`:
-  * `[empty string]`
-  * `0`
-  * `false`
-  * `no`
   
-  ([#2095](https://github.com/cucumber/cucumber-jvm/pull/2097)
-   [#2097](https://github.com/cucumber/cucumber-jvm/pull/2097)
-   Aslak Hellesøy)
-
 ## [6.5.0] (2020-08-17)
 
 ### Added

--- a/core/src/main/java/io/cucumber/core/options/BooleanString.java
+++ b/core/src/main/java/io/cucumber/core/options/BooleanString.java
@@ -1,0 +1,14 @@
+package io.cucumber.core.options;
+
+public class BooleanString {
+    /**
+     * Parses a string into a boolean
+     * 
+     * @param  s the string to parse
+     * @return   true unless s is null, "", "false", "no" or "0".
+     */
+    public static boolean parseBoolean(String s) {
+        return !(s == null || "".equalsIgnoreCase(s) || "false".equalsIgnoreCase(s) || "no".equalsIgnoreCase(s)
+                || "0".equalsIgnoreCase(s));
+    }
+}

--- a/core/src/main/java/io/cucumber/core/options/BooleanString.java
+++ b/core/src/main/java/io/cucumber/core/options/BooleanString.java
@@ -1,14 +1,29 @@
 package io.cucumber.core.options;
 
-public class BooleanString {
-    /**
-     * Parses a string into a boolean
-     * 
-     * @param  s the string to parse
-     * @return   true unless s is null, "", "false", "no" or "0".
-     */
-    public static boolean parseBoolean(String s) {
-        return !(s == null || "".equalsIgnoreCase(s) || "false".equalsIgnoreCase(s) || "no".equalsIgnoreCase(s)
-                || "0".equalsIgnoreCase(s));
+final class BooleanString {
+
+    static boolean parseBoolean(String s) {
+        if (s == null) {
+            return false;
+        }
+
+        if ("false".equalsIgnoreCase(s)) {
+            return false;
+        } else if ("no".equalsIgnoreCase(s)) {
+            return false;
+        } else if ("0".equalsIgnoreCase(s)) {
+            return false;
+        }
+
+        if ("true".equalsIgnoreCase(s)) {
+            return true;
+        } else if ("yes".equalsIgnoreCase(s)) {
+            return true;
+        } else if ("1".equalsIgnoreCase(s)) {
+            return true;
+        }
+
+        throw new IllegalArgumentException(
+            String.format("'%s' Was not a valid boolean value. Please use either 'true' or 'false'.", s));
     }
 }

--- a/core/src/main/java/io/cucumber/core/options/BooleanString.java
+++ b/core/src/main/java/io/cucumber/core/options/BooleanString.java
@@ -7,20 +7,22 @@ final class BooleanString {
             return false;
         }
 
-        if ("false".equalsIgnoreCase(s)) {
+        if ("true".equalsIgnoreCase(s)) {
+            return true;
+        } else if ("false".equalsIgnoreCase(s)) {
             return false;
-        } else if ("no".equalsIgnoreCase(s)) {
-            return false;
+        }
+
+        if ("1".equalsIgnoreCase(s)) {
+            return true;
         } else if ("0".equalsIgnoreCase(s)) {
             return false;
         }
 
-        if ("true".equalsIgnoreCase(s)) {
+        if ("yes".equalsIgnoreCase(s)) {
             return true;
-        } else if ("yes".equalsIgnoreCase(s)) {
-            return true;
-        } else if ("1".equalsIgnoreCase(s)) {
-            return true;
+        } else if ("no".equalsIgnoreCase(s)) {
+            return false;
         }
 
         throw new IllegalArgumentException(

--- a/core/src/main/java/io/cucumber/core/options/CucumberPropertiesParser.java
+++ b/core/src/main/java/io/cucumber/core/options/CucumberPropertiesParser.java
@@ -42,12 +42,12 @@ public final class CucumberPropertiesParser {
 
         parse(properties,
             ANSI_COLORS_DISABLED_PROPERTY_NAME,
-            Boolean::parseBoolean,
+            BooleanString::parseBoolean,
             builder::setMonochrome);
 
         parse(properties,
             EXECUTION_DRY_RUN_PROPERTY_NAME,
-            Boolean::parseBoolean,
+            BooleanString::parseBoolean,
             builder::setDryRun);
 
         parse(properties,
@@ -62,7 +62,7 @@ public final class CucumberPropertiesParser {
 
         parse(properties,
             EXECUTION_STRICT_PROPERTY_NAME,
-            Boolean::parseBoolean,
+            BooleanString::parseBoolean,
             CucumberPropertiesParser::errorOnNonStrict);
 
         parseAll(properties,
@@ -107,12 +107,12 @@ public final class CucumberPropertiesParser {
 
         parse(properties,
             PLUGIN_PUBLISH_ENABLED_PROPERTY_NAME,
-            Boolean::parseBoolean,
+            BooleanString::parseBoolean,
             builder::setPublish);
 
         parse(properties,
             PLUGIN_PUBLISH_QUIET_PROPERTY_NAME,
-            Boolean::parseBoolean,
+            BooleanString::parseBoolean,
             builder::setPublishQuiet);
 
         parse(properties,
@@ -122,7 +122,7 @@ public final class CucumberPropertiesParser {
 
         parse(properties,
             WIP_PROPERTY_NAME,
-            Boolean::parseBoolean,
+            BooleanString::parseBoolean,
             builder::setWip);
 
         return builder;

--- a/core/src/test/java/io/cucumber/core/options/BooleanStringTest.java
+++ b/core/src/test/java/io/cucumber/core/options/BooleanStringTest.java
@@ -1,48 +1,36 @@
 package io.cucumber.core.options;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class BooleanStringTest {
-    @Test
-    public void no_is_false() {
-        assertThat(BooleanString.parseBoolean("no"), is(false));
-    }
-
-    @Test
-    public void _0_is_false() {
-        assertThat(BooleanString.parseBoolean("0"), is(false));
-    }
-
-    @Test
-    public void false_is_false() {
-        assertThat(BooleanString.parseBoolean("false"), is(false));
-    }
-
-    @Test
-    public void empty_is_false() {
-        assertThat(BooleanString.parseBoolean(""), is(false));
-    }
 
     @Test
     public void null_is_false() {
         assertThat(BooleanString.parseBoolean(null), is(false));
     }
 
-    @Test
-    public void yes_is_true() {
-        assertThat(BooleanString.parseBoolean("yes"), is(true));
+    @ParameterizedTest
+    @ValueSource(strings = { "false", "no", "0"})
+    public void falsy_values_are_false(String value) {
+        assertThat(BooleanString.parseBoolean(value), is(false));
     }
 
-    @Test
-    public void _1_is_true() {
-        assertThat(BooleanString.parseBoolean("1"), is(true));
+    @ParameterizedTest
+    @ValueSource(strings = { "true", "yes", "1" })
+    public void truthy_values_are_true(String value) {
+        assertThat(BooleanString.parseBoolean(value), is(true));
     }
 
-    @Test
-    public void true_is_true() {
-        assertThat(BooleanString.parseBoolean("true"), is(true));
+    @ParameterizedTest
+    @ValueSource(strings = { "y", "n", "-1", " ", "" })
+    public void unknown_values_throw_illegal_argument_exception(String value) {
+        assertThrows(IllegalArgumentException.class, () -> BooleanString.parseBoolean(value));
     }
+
 }

--- a/core/src/test/java/io/cucumber/core/options/BooleanStringTest.java
+++ b/core/src/test/java/io/cucumber/core/options/BooleanStringTest.java
@@ -1,0 +1,48 @@
+package io.cucumber.core.options;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class BooleanStringTest {
+    @Test
+    public void no_is_false() {
+        assertThat(BooleanString.parseBoolean("no"), is(false));
+    }
+
+    @Test
+    public void _0_is_false() {
+        assertThat(BooleanString.parseBoolean("0"), is(false));
+    }
+
+    @Test
+    public void false_is_false() {
+        assertThat(BooleanString.parseBoolean("false"), is(false));
+    }
+
+    @Test
+    public void empty_is_false() {
+        assertThat(BooleanString.parseBoolean(""), is(false));
+    }
+
+    @Test
+    public void null_is_false() {
+        assertThat(BooleanString.parseBoolean(null), is(false));
+    }
+
+    @Test
+    public void yes_is_true() {
+        assertThat(BooleanString.parseBoolean("yes"), is(true));
+    }
+
+    @Test
+    public void _1_is_true() {
+        assertThat(BooleanString.parseBoolean("1"), is(true));
+    }
+
+    @Test
+    public void true_is_true() {
+        assertThat(BooleanString.parseBoolean("true"), is(true));
+    }
+}

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
@@ -2,6 +2,7 @@ package io.cucumber.junit.platform.engine;
 
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.feature.GluePath;
+import io.cucumber.core.options.BooleanString;
 import io.cucumber.core.options.ObjectFactoryParser;
 import io.cucumber.core.options.PluginOption;
 import io.cucumber.core.options.PublishTokenParser;
@@ -156,7 +157,7 @@ class CucumberEngineOptions implements
 
     boolean isParallelExecutionEnabled() {
         return configurationParameters
-                .get(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, Boolean::parseBoolean)
+                .get(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, BooleanString::parseBoolean)
                 .orElse(false);
     }
 

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
@@ -2,7 +2,6 @@ package io.cucumber.junit.platform.engine;
 
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.feature.GluePath;
-import io.cucumber.core.options.BooleanString;
 import io.cucumber.core.options.ObjectFactoryParser;
 import io.cucumber.core.options.PluginOption;
 import io.cucumber.core.options.PublishTokenParser;
@@ -157,7 +156,7 @@ class CucumberEngineOptions implements
 
     boolean isParallelExecutionEnabled() {
         return configurationParameters
-                .get(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, BooleanString::parseBoolean)
+                .getBoolean(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME)
                 .orElse(false);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -574,6 +574,11 @@
                                     <new>method boolean io.cucumber.core.options.CucumberOptionsAnnotationParser.CucumberOptions::publish()</new>
                                     <justification>Internal API</justification>
                                 </item>
+                                <item>
+                                    <code>java.class.added</code>
+                                    <new>class io.cucumber.core.options.BooleanString</new>
+                                    <justification>Internal API</justification>
+                                </item>
                                 <!-- Gherkin parser related -->
                                 <item>
                                     <code>java.class.nonPublicPartOfAPI</code>

--- a/pom.xml
+++ b/pom.xml
@@ -574,11 +574,6 @@
                                     <new>method boolean io.cucumber.core.options.CucumberOptionsAnnotationParser.CucumberOptions::publish()</new>
                                     <justification>Internal API</justification>
                                 </item>
-                                <item>
-                                    <code>java.class.added</code>
-                                    <new>class io.cucumber.core.options.BooleanString</new>
-                                    <justification>Internal API</justification>
-                                </item>
                                 <!-- Gherkin parser related -->
                                 <item>
                                     <code>java.class.nonPublicPartOfAPI</code>


### PR DESCRIPTION
This fixes #2095

The value of a system property/enviromnent variable will resolve to `true` unless it's empty, `false`, `no` or `0`.