### PR TITLE
Issue a PUT request after a GET request responding with 202 and a Location header

### DIFF
--- a/core/src/main/java/io/cucumber/core/plugin/PublishFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/PublishFormatter.java
@@ -7,19 +7,16 @@ import io.cucumber.plugin.ConcurrentEventListener;
 import io.cucumber.plugin.event.EventPublisher;
 
 import java.io.IOException;
-import java.net.URI;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.Map;
 
 import static io.cucumber.core.options.Constants.PLUGIN_PUBLISH_URL_PROPERTY_NAME;
-import static io.cucumber.core.options.CurlOption.HttpMethod.PUT;
 
 public final class PublishFormatter implements ConcurrentEventListener, ColorAware {
 
     /**
      * Where to publishes messages by default
      */
-    public static final String DEFAULT_CUCUMBER_MESSAGE_STORE_URL = "https://messages.cucumber.io/api/reports";
+    public static final String DEFAULT_CUCUMBER_MESSAGE_STORE_URL = "https://messages.cucumber.io/api/reports -X GET";
 
     private final UrlReporter urlReporter = new UrlReporter(System.err);
     private final MessageFormatter delegate;
@@ -50,10 +47,10 @@ public final class PublishFormatter implements ConcurrentEventListener, ColorAwa
     private static CurlOption createCurlOption(String token) {
         Map<String, String> properties = CucumberProperties.create();
         String url = properties.getOrDefault(PLUGIN_PUBLISH_URL_PROPERTY_NAME, DEFAULT_CUCUMBER_MESSAGE_STORE_URL);
-        if (token == null) {
-            return CurlOption.create(PUT, URI.create(url));
+        if (token != null) {
+            url = url + String.format(" -H 'Authorization: Bearer %s'", token);
         }
-        return CurlOption.create(PUT, URI.create(url), new SimpleEntry<>("Authorization", "Bearer " + token));
+        return CurlOption.parse(url);
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/plugin/UrlOutputStream.java
+++ b/core/src/main/java/io/cucumber/core/plugin/UrlOutputStream.java
@@ -58,36 +58,48 @@ class UrlOutputStream extends OutputStream {
     @Override
     public void close() throws IOException {
         tempOutputStream.close();
+        sendRequest(option.getUri().toURL(), option.getMethod());
+    }
 
-        URL url = option.getUri().toURL();
+    private void sendRequest(URL url, CurlOption.HttpMethod method) throws IOException {
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
         for (Entry<String, String> header : option.getHeaders()) {
             urlConnection.setRequestProperty(header.getKey(), header.getValue());
         }
         urlConnection.setInstanceFollowRedirects(true);
-        urlConnection.setRequestMethod(option.getMethod().name());
-        urlConnection.setDoOutput(true);
+        urlConnection.setRequestMethod(method.name());
+        if (method != CurlOption.HttpMethod.GET) {
+            urlConnection.setDoOutput(true);
+        }
         Map<String, List<String>> requestHeaders = urlConnection.getRequestProperties();
-        try (OutputStream outputStream = urlConnection.getOutputStream()) {
-            Files.copy(temp, outputStream);
-            handleResponse(urlConnection, requestHeaders);
+        if (urlConnection.getDoOutput()) {
+            try (OutputStream outputStream = urlConnection.getOutputStream()) {
+                Files.copy(temp, outputStream);
+                throwExceptionIfUnsuccessful(urlConnection, requestHeaders);
+            }
+        } else {
+            throwExceptionIfUnsuccessful(urlConnection, requestHeaders);
+            String location = urlConnection.getHeaderField("Location");
+            if(urlConnection.getResponseCode() == 202 && location != null) {
+                sendRequest(new URL(location), CurlOption.HttpMethod.PUT);
+            }
         }
         if (urlReporter != null) {
             urlReporter.report(urlConnection.getURL());
         }
     }
 
-    private static void handleResponse(HttpURLConnection urlConnection, Map<String, List<String>> requestHeaders)
+    private static void throwExceptionIfUnsuccessful(HttpURLConnection urlConnection, Map<String, List<String>> requestHeaders)
             throws IOException {
         Map<String, List<String>> responseHeaders = urlConnection.getHeaderFields();
         int responseCode = urlConnection.getResponseCode();
-        boolean success = 200 <= responseCode && responseCode < 300;
+        boolean unsuccessful = responseCode >= 400;
 
         InputStream inputStream = urlConnection.getErrorStream() != null ? urlConnection.getErrorStream()
                 : urlConnection.getInputStream();
         try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStream, UTF_8))) {
             String responseBody = br.lines().collect(Collectors.joining(System.lineSeparator()));
-            if (!success) {
+            if (unsuccessful) {
                 String method = urlConnection.getRequestMethod();
                 URL url = urlConnection.getURL();
                 throw createCurlLikeException(method, url, requestHeaders, responseHeaders, responseBody);
@@ -103,13 +115,13 @@ class UrlOutputStream extends OutputStream {
             String responseBody
     ) {
         return new IOException(String.format(
-            "%s:\n> %s %s%s%s%s",
-            "HTTP request failed",
-            method,
-            url,
-            headersToString("> ", requestHeaders),
-            headersToString("< ", responseHeaders),
-            responseBody));
+                "%s:\n> %s %s%s%s%s",
+                "HTTP request failed",
+                method,
+                url,
+                headersToString("> ", requestHeaders),
+                headersToString("< ", responseHeaders),
+                responseBody));
     }
 
     private static String headersToString(String prefix, Map<String, List<String>> headers) {

--- a/core/src/main/java/io/cucumber/core/plugin/UrlOutputStream.java
+++ b/core/src/main/java/io/cucumber/core/plugin/UrlOutputStream.java
@@ -72,7 +72,7 @@ class UrlOutputStream extends OutputStream {
         if (method == CurlOption.HttpMethod.GET) {
             throwExceptionIfUnsuccessful(urlConnection, requestHeaders);
             String location = urlConnection.getHeaderField("Location");
-            if(urlConnection.getResponseCode() == 202 && location != null) {
+            if (urlConnection.getResponseCode() == 202 && location != null) {
                 sendRequest(new URL(location), CurlOption.HttpMethod.PUT);
             }
         } else {
@@ -87,7 +87,9 @@ class UrlOutputStream extends OutputStream {
         }
     }
 
-    private static void throwExceptionIfUnsuccessful(HttpURLConnection urlConnection, Map<String, List<String>> requestHeaders)
+    private static void throwExceptionIfUnsuccessful(
+            HttpURLConnection urlConnection, Map<String, List<String>> requestHeaders
+    )
             throws IOException {
         Map<String, List<String>> responseHeaders = urlConnection.getHeaderFields();
         int responseCode = urlConnection.getResponseCode();
@@ -113,13 +115,13 @@ class UrlOutputStream extends OutputStream {
             String responseBody
     ) {
         return new IOException(String.format(
-                "%s:\n> %s %s%s%s%s",
-                "HTTP request failed",
-                method,
-                url,
-                headersToString("> ", requestHeaders),
-                headersToString("< ", responseHeaders),
-                responseBody));
+            "%s:\n> %s %s%s%s%s",
+            "HTTP request failed",
+            method,
+            url,
+            headersToString("> ", requestHeaders),
+            headersToString("< ", responseHeaders),
+            responseBody));
     }
 
     private static String headersToString(String prefix, Map<String, List<String>> headers) {

--- a/core/src/test/java/io/cucumber/core/plugin/UrlOutputStreamTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/UrlOutputStreamTest.java
@@ -78,7 +78,8 @@ public class UrlOutputStreamTest {
     @Test
     void it_sends_the_body_twice_for_307_redirect_with_put(Vertx vertx, VertxTestContext testContext) throws Exception {
         String requestBody = "hello";
-        TestServer testServer = new TestServer(port, testContext, requestBody + requestBody, HttpMethod.PUT, null, null, 200, "");
+        TestServer testServer = new TestServer(port, testContext, requestBody + requestBody, HttpMethod.PUT, null, null,
+            200, "");
         CurlOption url = CurlOption.parse(format("http://localhost:%d/redirect", port));
         verifyRequest(url, testServer, vertx, testContext, requestBody);
 
@@ -86,14 +87,15 @@ public class UrlOutputStreamTest {
     }
 
     @Test
-    void it_sends_the_body_once_for_202_and_location_with_get(Vertx vertx, VertxTestContext testContext) throws Exception {
+    void it_sends_the_body_once_for_202_and_location_with_get(Vertx vertx, VertxTestContext testContext)
+            throws Exception {
         String requestBody = "hello";
         TestServer testServer = new TestServer(port, testContext, requestBody, HttpMethod.PUT, null, null, 200, "");
         CurlOption url = CurlOption.parse(format("http://localhost:%d/accept -X GET", port));
         verifyRequest(url, testServer, vertx, testContext, requestBody);
 
         assertThat(testContext.awaitCompletion(TIMEOUT_SECONDS, TimeUnit.SECONDS), is(true));
-        if(exception != null) {
+        if (exception != null) {
             throw exception;
         }
         assertThat(testServer.receivedBody.toString("utf-8"), is(equalTo(requestBody)));

--- a/core/src/test/java/io/cucumber/core/plugin/UrlOutputStreamTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/UrlOutputStreamTest.java
@@ -45,12 +45,12 @@ public class UrlOutputStreamTest {
         String requestBody = "hello";
         TestServer testServer = new TestServer(port, testContext, requestBody, HttpMethod.PUT, null, null, 500,
             "Oh noes");
-        CurlOption option = CurlOption.parse(format("http://localhost:%d", port));
+        CurlOption option = CurlOption.parse(format("http://localhost:%d/s3", port));
 
         verifyRequest(option, testServer, vertx, testContext, requestBody);
         assertThat(testContext.awaitCompletion(TIMEOUT_SECONDS, TimeUnit.SECONDS), is(true));
         assertThat(exception.getMessage(), equalTo("HTTP request failed:\n" +
-                "> PUT http://localhost:" + port + "\n" +
+                "> PUT http://localhost:" + port + "/s3\n" +
                 "< HTTP/1.1 500 Internal Server Error\n" +
                 "< transfer-encoding: chunked\n" +
                 "Oh noes"));
@@ -75,9 +75,9 @@ public class UrlOutputStreamTest {
     }
 
     @Test
-    void follows_307_temporary_redirects(Vertx vertx, VertxTestContext testContext) throws InterruptedException {
+    void it_sends_the_body_twice_for_307_redirect_with_put(Vertx vertx, VertxTestContext testContext) throws InterruptedException {
         String requestBody = "hello";
-        TestServer testServer = new TestServer(port, testContext, requestBody, HttpMethod.PUT, null, null, 200, "");
+        TestServer testServer = new TestServer(port, testContext, requestBody + requestBody, HttpMethod.PUT, null, null, 200, "");
         CurlOption url = CurlOption.parse(format("http://localhost:%d/redirect", port));
         verifyRequest(url, testServer, vertx, testContext, requestBody);
 
@@ -144,6 +144,7 @@ public class UrlOutputStreamTest {
         private final String expectedContentType;
         private final int statusCode;
         private final String responseBody;
+        private final Buffer receivedBody = Buffer.buffer(0);
 
         public TestServer(
                 int port,
@@ -168,30 +169,31 @@ public class UrlOutputStreamTest {
         public void start(Promise<Void> startPromise) {
             Router router = Router.router(vertx);
             router.route("/redirect").handler(ctx -> {
+                ctx.request().handler(receivedBody::appendBuffer);
                 ctx.response().setStatusCode(307);
-                ctx.response().headers().add("Location", "http://localhost:" + port);
+                ctx.response().headers().add("Location", "http://localhost:" + port + "/s3");
                 ctx.response().end();
             });
             router.route("/redirect-no-location").handler(ctx -> {
+                ctx.request().handler(receivedBody::appendBuffer);
                 ctx.response().setStatusCode(307);
                 ctx.response().end();
             });
 
-            router.route().handler(ctx -> {
+            router.route("/s3").handler(ctx -> {
                 ctx.response().setStatusCode(statusCode);
                 testContext.verify(() -> {
                     assertThat(ctx.request().method(), is(equalTo(expectedMethod)));
                     assertThat(ctx.request().query(), is(equalTo(expectedQuery)));
                     assertThat(ctx.request().getHeader("Content-Type"), is(equalTo(expectedContentType)));
 
-                    Buffer body = Buffer.buffer(0);
-                    ctx.request().handler(body::appendBuffer);
+                    ctx.request().handler(receivedBody::appendBuffer);
                     ctx.request().endHandler(e -> {
-                        String receivedBody = body.toString("utf-8");
+                        String receivedBodyString = receivedBody.toString("utf-8");
                         ctx.response().setChunked(true);
                         ctx.response().write(responseBody);
                         ctx.response().end();
-                        testContext.verify(() -> assertThat(receivedBody, is(equalTo(expectedBody))));
+                        testContext.verify(() -> assertThat(receivedBodyString, is(equalTo(expectedBody))));
                     });
                 });
             });

--- a/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -24,9 +24,9 @@ import io.cucumber.datatable.DataTableType;
 import io.cucumber.datatable.TableCellByTypeTransformer;
 import io.cucumber.datatable.TableEntryByTypeTransformer;
 import io.cucumber.docstring.DocStringType;
-import org.junit.jupiter.api.Test;
 import io.cucumber.messages.Messages;
 import io.cucumber.plugin.event.EventHandler;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
 import java.net.URI;
@@ -462,24 +462,24 @@ class CachingGlueTest {
 
         assertThat(hooks, contains(hookDefinition2, hookDefinition1, hookDefinition3));
     }
-    
-	@Test
-	public void emits_hook_messages_to_bus() {
-		
-		List<Messages.Envelope> events = new ArrayList<>();		
-		EventHandler<Messages.Envelope> messageEventHandler = e -> events.add(e);
-		
-		EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
-		bus.registerHandlerFor(Messages.Envelope.class, messageEventHandler);
-		CachingGlue glue = new CachingGlue(bus);
-		
-		glue.addBeforeHook(new MockedScenarioScopedHookDefinition());
-		glue.addAfterHook(new MockedScenarioScopedHookDefinition());
-		glue.addBeforeStepHook(new MockedScenarioScopedHookDefinition());
-		glue.addAfterStepHook(new MockedScenarioScopedHookDefinition());
 
-		glue.prepareGlue(stepTypeRegistry);
-		assertThat(events.size(), is(4));
+    @Test
+    public void emits_hook_messages_to_bus() {
+
+        List<Messages.Envelope> events = new ArrayList<>();
+        EventHandler<Messages.Envelope> messageEventHandler = e -> events.add(e);
+
+        EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
+        bus.registerHandlerFor(Messages.Envelope.class, messageEventHandler);
+        CachingGlue glue = new CachingGlue(bus);
+
+        glue.addBeforeHook(new MockedScenarioScopedHookDefinition());
+        glue.addAfterHook(new MockedScenarioScopedHookDefinition());
+        glue.addBeforeStepHook(new MockedScenarioScopedHookDefinition());
+        glue.addAfterStepHook(new MockedScenarioScopedHookDefinition());
+
+        glue.prepareGlue(stepTypeRegistry);
+        assertThat(events.size(), is(4));
     }
 
     private static class MockedScenarioScopedStepDefinition extends StubStepDefinition implements ScenarioScoped {

--- a/pom.xml
+++ b/pom.xml
@@ -649,6 +649,12 @@
                                     <new>.*SipozeKe.*</new>
                                     <justification>Restore uppercase Creole keyword in Gherkin 15.0.2</justification>
                                 </item>
+                                <item>
+                                    <code>java.field.constantValueChanged</code>
+                                    <old>field io.cucumber.core.plugin.PublishFormatter.DEFAULT_CUCUMBER_MESSAGE_STORE_URL</old>
+                                    <justification>https://github.com/cucumber/cucumber-jvm/pull/2099</justification>
+                                    <newValue>https://messages.cucumber.io/api/reports -X GET</newValue>
+                                </item>
                             </revapi.ignore>
                         </analysisConfiguration>
                     </configuration>


### PR DESCRIPTION
The `https://messages.cucumber.io` service responds with [413 Payload Too Large](https://httpstatuses.com/413) for message files larger than [6 Mb](https://jun711.github.io/aws/handling-aws-api-gateway-and-lambda-413-error/). This was discovered during a [chat with one of our users](https://cucumberbdd.slack.com/archives/C60TKS3SL/p1597955993030800).

We've adopted the solution outlined in [Option 2 in this blog post](https://theburningmonk.com/2020/04/hit-the-6mb-lambda-payload-limit-heres-what-you-can-do/). A `GET https://messages.cucumber.io/api/reports` request will now respond with `202 Accepted` and a `Location` header pointing to S3.

This is not a proper redirect, so we're handling this in the code by issuing a new `PUT` request if the status is `202` and the `Location` header is present.

This change preserves backwards compatibility for all HTTP verbs except `GET`. However, this change in behaviour will only manifest itself for users issuing `GET` request to servers expecting a body in the request, which is [legal, but not useful](https://stackoverflow.com/questions/978061/http-get-with-request-body). We don't expect anyone to be affected.

For this reason we consider this change to be an addition, which should trigger a minor release.

The same change has been [applied to Ruby](https://github.com/cucumber/cucumber-ruby/pull/1464).