### PR TITLE
Improve release instructions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,18 +18,49 @@ Also check if you can upgrade any dependencies:
 make update-dependency-versions
 ```
 
-## Make the release ##
+## Decide what the next version should be ##
 
-In order to make releases secrets are required. Members of the core team can
-install keybase and join the `cucumberbdd` team to access these secrets.
+This depends on what's changed (see `CHANGELOG.md`):
 
-Remove the empty sections in the changelog. Don't commit these but run: 
+* Bump `MAJOR` if:
+  * There are `Changed` or `Removed` entries
+  * A cucumber library dependency upgrade was major
+* Bump `MINOR` if:
+  * There are `Added` entries
+* Bump `PATCH` if:
+  * There are `Fixed` or `Deprecated` entries
+
+Display future version by running:
 
 ```
 make version
 ```
 
-Check if branch name and version are as expected.
+Check if branch name and version are as expected. To change version run:
+
+```
+mvn versions:set -DnewVersion=X.Y.Z-SNAPSHOT
+```
+
+## Secrets ##
+
+Secrets are required to make releases. Members of the core team can install
+keybase and join the `cucumberbdd` team to access these secrets.
+
+During the release process, secrets are fetched from keybase and used to sign
+and upload the maven artifacts.
+
+## Make the release ##
+
+Remove the empty sections in the changelog. Don't commit anything yet.
+
+Check if branch name and version are as expected:
+
+```
+make version
+```
+
+Do the release:
 
 ```
 make release
@@ -44,48 +75,3 @@ Update the cucumber-jvm version in the documentation project:
 The cucumber-jvm version for the docs is specified in the docs [versions.yaml](https://github.com/cucumber/docs.cucumber.io/blob/master/data/versions.yaml)
 
 All done! Hurray!
-
-# GPG Keys #
-
-To make a release you must have the `devs@cucumber.io` GPG private key imported in gpg2.
-
-```
-gpg --import devs-cucumber.io.key
-```
-
-Additionally upload privileges to the Sonatype repositories are required. See the 
-[OSSRH Guide](http://central.sonatype.org/pages/ossrh-guide.html) for instructions. Then an 
-administrator will have to grant you access to the cucumber repository.
-
-Finally both your OSSRH credentials and private key must be setup in your `~/.m2/settings.xml` - 
-for example:
-
-```
-<settings>
-    <servers>
-        <server>
-            <id>ossrh</id>
-            <username>sonatype-user-name</username>
-            <password>sonatype-password</password>
-        </server>
-    </servers>
-    <profiles>
-        <profile>
-            <id>ossrh</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <gpg.executable>gpg2</gpg.executable>
-                <gpg.useagent>true</gpg.useagent>
-            </properties>
-        </profile>
-        <profile>
-            <id>sign-with-cucumber-key</id>
-            <properties>
-                <gpg.keyname>dev-cucumber.io-key-id</gpg.keyname>
-            </properties>
-        </profile>
-    </profiles>
-</settings>
-```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,8 +52,6 @@ and upload the maven artifacts.
 
 ## Make the release ##
 
-Remove the empty sections in the changelog. Don't commit anything yet.
-
 Check if branch name and version are as expected:
 
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,15 +20,16 @@ make update-dependency-versions
 
 ## Decide what the next version should be ##
 
-This depends on what's changed (see `CHANGELOG.md`):
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). To sum it up, it depends on what's changed (see `CHANGELOG.md`). Given a version number MAJOR.MINOR.PATCH:
 
-* Bump `MAJOR` if:
-  * There are `Changed` or `Removed` entries
+* Bump `MAJOR` when you make incompatible API changes:
+  * There are `Removed` entries, or `Changed` entries breaking compatibility
   * A cucumber library dependency upgrade was major
-* Bump `MINOR` if:
-  * There are `Added` entries
-* Bump `PATCH` if:
-  * There are `Fixed` or `Deprecated` entries
+* Bump `MINOR` when you add functionality in a backwards compatible manner:
+  * There are `Added` entries, `Changed` entries preserving compatibility, or
+  `Deprecated` entries
+* Bump `PATCH` when you make backwards compatible bug fixes:
+  * There are `Fixed` entries
 
 Display future version by running:
 

--- a/scripts/remove-empty-sections-changelog.awk
+++ b/scripts/remove-empty-sections-changelog.awk
@@ -1,0 +1,30 @@
+function start_buffering() {
+  buf = $0
+}
+function store_line_in_buffer() {
+  buf = buf ORS $0
+}
+function clear_buffer() {
+  buf = ""
+}
+/^### (Added|Changed|Deprecated|Removed|Fixed)$/ {
+  start_buffering()
+  next
+}
+/^## / {
+  clear_buffer()
+}
+/^ *$/ {
+  if (buf != "") {
+    store_line_in_buffer()
+  } else {
+    print $0
+  }
+}
+!/^ *$/ {
+  if (buf != "") {
+    print buf
+    clear_buffer()
+  }
+  print $0
+}

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -61,7 +61,9 @@ new_release_link=$(echo "${release_link}" | \
   sed "s/${last_version}/${new_version}/g" | \
   sed "s/v[0-9]\+.[0-9]\+.[0-9]\+/v${last_version}/")
 
-changelog=$(echo "${changelog}" | sed "${insertion_line_number} i ${new_release_link}")
+changelog=$(echo "${changelog}" | sed "${insertion_line_number} i \\
+${new_release_link}
+")
 
 # Insert a new [Unreleased] header
 

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -43,7 +43,7 @@ changelog=$(echo "${changelog}" | sed "s/## \[Unreleased\] (In Git)/## \[${new_v
 # Update [Unreleased] diff link
 line_number_colon_unreleased_link=$(echo "${changelog}" | grep -n "\[Unreleased\]")
 line_number=$(echo "${line_number_colon_unreleased_link}" | cut -d: -f1)
-unreleased_link=$(echo "${line_number_colon_unreleased_link}" | cut -d' ' -f2)
+unreleased_link=$(echo "${line_number_colon_unreleased_link}" | awk '{print $2}')
 
 if [[ "${unreleased_link}" =~ \/v([0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+)?) ]]; then
   last_version="${BASH_REMATCH[1]}"

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -59,7 +59,7 @@ insertion_line_number=$((line_number + 1))
 release_link=$(echo "${changelog}" | head -n ${insertion_line_number} | tail -1)
 new_release_link=$(echo "${release_link}" | \
   sed "s/${last_version}/${new_version}/g" | \
-  sed "s/v[0-9]\+.[0-9]\+.[0-9]\+/v${last_version}/")
+  sed -E "s/v[0-9]\+.[0-9]\+.[0-9]\+/v${last_version}/")
 
 changelog=$(echo "${changelog}" | sed "${insertion_line_number} i \\
 ${new_release_link}

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -6,6 +6,7 @@ set -uf -o pipefail
 # * The [Unreleased] diff link is updated
 # * A new diff link for the new release is added
 # * The ## [Unreleased] header is changed to a version header with date
+# * The empty sections are removed
 # * A new, empty [Unreleased] paragraph is added at the top
 #
 
@@ -64,6 +65,11 @@ new_release_link=$(echo "${release_link}" | \
 changelog=$(echo "${changelog}" | sed "${insertion_line_number} i \\
 ${new_release_link}
 ")
+
+# Remove empty sections
+
+scripts_path="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+changelog=$(echo "${changelog}" | awk -f "${scripts_path}/remove-empty-sections-changelog.awk")
 
 # Insert a new [Unreleased] header
 

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -67,6 +67,8 @@ ${new_release_link}
 
 # Insert a new [Unreleased] header
 
-changelog=$(echo "${changelog}" | sed "s/----/----\n${header_escaped}\n/g")
+changelog=$(echo "${changelog}" | sed "s/----/----\\
+${header_escaped}\\
+/g")
 
 echo "${changelog}"


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

While releasing Cucumber-JVM 6.6.0, we ran into some issues:
- We (wrongly) assumed that setting the version is done by editing it in the root `pom.xml`, which made the release process because versions in root pom and submodules pom do not match
- We manually reverted some files and got issues with the `update-changelog.sh` script
- We were not sure that credentials for pushing artifacts to sonatype would automatically work

Overall the overall release process went smoothly. Anyway we think we can improve it even further.

**Describe the solution you have implemented**

- [x] Make `update-changelog.sh` more robust and runnable on osx
- [x] Add information about proper way to set version
- [x] Clarify what credentials information is needed
- [x] Remove empty sections automatically
