### PR TITLE
[Core] CucumberOptions default snippet type should not override properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+* [Core] CucumberOptions default snippet type should not override properties ([2107](https://github.com/cucumber/cucumber-jvm/pull/2107) M.P. Korstanje)
 
 ## [6.6.0] (2020-08-26)
 

--- a/core/README.md
+++ b/core/README.md
@@ -9,10 +9,8 @@ sub modules together e.g. `cucumber-junit` and `cucumber-java`.
 ## Properties, Environment variables, System Options ##
 
 Cucumber will in order of precedence parse properties from system properties,
-environment variables and the `cucumber.properties` file.
-
-Note that options provided by `@CucumberOptions` take precedence over the
-properties file and CLI arguments take precedence over all.
+environment variables, `@CucumberOptions` and the `cucumber.properties` file.
+Note that the CLI arguments take precedence over all.
 
 Note that the `cucumber-junit-platform-engine` is provided with properties
 by the Junit Platform rather than Cucumber. See

--- a/core/src/main/java/io/cucumber/core/options/CucumberOptionsAnnotationParser.java
+++ b/core/src/main/java/io/cucumber/core/options/CucumberOptionsAnnotationParser.java
@@ -109,7 +109,9 @@ public final class CucumberOptionsAnnotationParser {
     }
 
     private void addSnippets(CucumberOptions options, RuntimeOptionsBuilder args) {
-        args.setSnippetType(options.snippets());
+        if (options.snippets() != SnippetType.UNDERSCORE) {
+            args.setSnippetType(options.snippets());
+        }
     }
 
     private void addGlue(CucumberOptions options, RuntimeOptionsBuilder args) {

--- a/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
@@ -192,6 +192,13 @@ class CucumberOptionsAnnotationParserTest {
     }
 
     @Test
+    void default_snippet_type_should_not_override_existing_snippet_type() {
+        RuntimeOptions options = new RuntimeOptionsBuilder().setSnippetType(SnippetType.CAMELCASE).build();
+        RuntimeOptions runtimeOptions = parser().parse(WithDefaultOptions.class).build(options);
+        assertThat(runtimeOptions.getSnippetType(), is(equalTo(SnippetType.CAMELCASE)));
+    }
+
+    @Test
     void create_default_summary_printer_when_no_summary_printer_plugin_is_defined() {
         RuntimeOptions runtimeOptions = parser()
                 .parse(ClassWithNoSummaryPrinterPlugin.class)
@@ -305,6 +312,11 @@ class CucumberOptionsAnnotationParserTest {
     }
 
     private static class WithoutOptions {
+        // empty
+    }
+
+    @CucumberOptions
+    private static class WithDefaultOptions {
         // empty
     }
 


### PR DESCRIPTION
When using `cucumber.properties`

```
cucumber.snippet-type=camelcase
```

In combination with:

```
@RunWith(Cucumber.class)
@CucumberOptions
public class RunCucumberTest {

}
```

The default snippet type from `@CucumberOptions` would override the value set
by `cucumber.properties`.