### PR TITLE
[JUnit Platform] Support discovery selectors with FilePosition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] (In Git)
 
 ### Added
+ * [JUnit Platform] Support discovery selectors with FilePosition ([2121](https://github.com/cucumber/cucumber-jvm/pull/2121) M.P. Korstanje) 
 
 ### Changed
+ * [JUnit Platform] Update dependency org.junit.platform:junit-platform-engine to v1.7.0
 
 ### Deprecated
 

--- a/junit-platform-engine/README.md
+++ b/junit-platform-engine/README.md
@@ -237,12 +237,20 @@ Supported `DiscoverySelector`s are:
 The only supported `DiscoveryFilter` is the `PackageNameFilter` and only when
 features are selected from the classpath.
 
+### Selecting individual scenarios, rules and examples 
+
+The `FileSelector` and `ClasspathResourceSelector` support a `FilePosition`.
+
+ * `DiscoverySelectors.selectClasspathResource("rule.feature", FilePosition.from(5))`
+ * `DiscoverySelectors.selectFile("rule.feature", FilePosition.from(5))`
+
 The `UriSelector` supports URI's with a `line` query parameter:
   - `classpath:/com/example/example.feature?line=20`
   - `file:/path/to/com/example/example.feature?line=20`
- 
+
 Any `TestDescriptor` that matches the line *and* its descendants will be
-included in the discovery result.
+included in the discovery result. So for example selecting a `Rule` will 
+execute all scenarios contained within.
 
 ## Tags ##
 

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/TestDescriptorOnLine.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/TestDescriptorOnLine.java
@@ -1,0 +1,62 @@
+package io.cucumber.junit.platform.engine;
+
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.discovery.ClasspathResourceSelector;
+import org.junit.platform.engine.discovery.FileSelector;
+import org.junit.platform.engine.discovery.UriSelector;
+import org.junit.platform.engine.support.descriptor.ClasspathResourceSource;
+import org.junit.platform.engine.support.descriptor.FileSource;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static org.junit.platform.engine.support.descriptor.FilePosition.fromQuery;
+
+@SuppressWarnings("Convert2MethodRef")
+class TestDescriptorOnLine {
+
+    static Predicate<TestDescriptor> testDescriptorOnLine(int line) {
+        return descriptor -> descriptor.getSource()
+                .flatMap(testSource -> {
+                    if (testSource instanceof FileSource) {
+                        FileSource fileSystemSource = (FileSource) testSource;
+                        return fileSystemSource.getPosition();
+                    }
+                    if (testSource instanceof ClasspathResourceSource) {
+                        ClasspathResourceSource classpathResourceSource = (ClasspathResourceSource) testSource;
+                        return classpathResourceSource.getPosition();
+                    }
+                    return Optional.empty();
+                })
+                .map(filePosition -> filePosition.getLine())
+                .map(testSourceLine -> line == testSourceLine)
+                .orElse(false);
+    }
+
+    private static boolean anyTestDescriptor(TestDescriptor testDescriptor) {
+        return true;
+    }
+
+    static Predicate<TestDescriptor> from(UriSelector selector) {
+        String query = selector.getUri().getQuery();
+        return fromQuery(query)
+                .map(filePosition -> filePosition.getLine())
+                .map(TestDescriptorOnLine::testDescriptorOnLine)
+                .orElse(TestDescriptorOnLine::anyTestDescriptor);
+    }
+
+    static Predicate<TestDescriptor> from(ClasspathResourceSelector selector) {
+        return selector.getPosition()
+                .map(filePosition -> filePosition.getLine())
+                .map(TestDescriptorOnLine::testDescriptorOnLine)
+                .orElse(TestDescriptorOnLine::anyTestDescriptor);
+    }
+
+    static Predicate<TestDescriptor> from(FileSelector selector) {
+        return selector.getPosition()
+                .map(filePosition -> filePosition.getLine())
+                .map(TestDescriptorOnLine::testDescriptorOnLine)
+                .orElse(TestDescriptorOnLine::anyTestDescriptor);
+    }
+
+}

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
@@ -11,6 +11,7 @@ import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.engine.discovery.FilePosition;
 import org.junit.platform.engine.discovery.UniqueIdSelector;
 
 import java.io.File;
@@ -60,6 +61,32 @@ class DiscoverySelectorResolverTest {
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
         assertEquals(1, testDescriptor.getChildren().size());
+    }
+
+    @Test
+    void resolveRequestWithClasspathResourceSelectorAndFilePosition() {
+        String feature = "io/cucumber/junit/platform/engine/rule.feature";
+        FilePosition line = FilePosition.from(5);
+        DiscoverySelector resource = selectClasspathResource(feature, line);
+        EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
+        resolver.resolveSelectors(discoveryRequest, testDescriptor);
+        assertEquals(1L, testDescriptor.getDescendants()
+                .stream()
+                .filter(TestDescriptor::isTest)
+                .count());
+    }
+
+    @Test
+    void resolveRequestWithClasspathResourceSelectorAndFilePositionOfContainer() {
+        String feature = "io/cucumber/junit/platform/engine/rule.feature";
+        FilePosition line = FilePosition.from(3);
+        DiscoverySelector resource = selectClasspathResource(feature, line);
+        EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
+        resolver.resolveSelectors(discoveryRequest, testDescriptor);
+        assertEquals(2L, testDescriptor.getDescendants()
+                .stream()
+                .filter(TestDescriptor::isTest)
+                .count());
     }
 
     @Test
@@ -153,6 +180,32 @@ class DiscoverySelectorResolverTest {
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
         assertEquals(1, testDescriptor.getChildren().size());
+    }
+
+    @Test
+    void resolveRequestWithFileSelectorAndPosition() {
+        String feature = "src/test/resources/io/cucumber/junit/platform/engine/rule.feature";
+        FilePosition line = FilePosition.from(5);
+        DiscoverySelector resource = selectFile(feature, line);
+        EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
+        resolver.resolveSelectors(discoveryRequest, testDescriptor);
+        assertEquals(1L, testDescriptor.getDescendants()
+                .stream()
+                .filter(TestDescriptor::isTest)
+                .count());
+    }
+
+    @Test
+    void resolveRequestWithFileSelectorAndPositionOfContainer() {
+        String feature = "src/test/resources/io/cucumber/junit/platform/engine/rule.feature";
+        FilePosition line = FilePosition.from(3);
+        DiscoverySelector resource = selectFile(feature, line);
+        EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
+        resolver.resolveSelectors(discoveryRequest, testDescriptor);
+        assertEquals(2L, testDescriptor.getDescendants()
+                .stream()
+                .filter(TestDescriptor::isTest)
+                .count());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
 
         <!--Test Dependencies-->
         <junit.version>4.13</junit.version>
-        <junit-jupiter.version>5.6.2</junit-jupiter.version>
-        <junit-platform.version>1.6.2</junit-platform.version>
+        <junit-jupiter.version>5.7.0</junit-jupiter.version>
+        <junit-platform.version>1.7.0</junit-platform.version>
         <hamcrest.version>2.2</hamcrest.version>
         <mockito.version>3.5.10</mockito.version>
         <!--Maven plugins-->


### PR DESCRIPTION
There was no good way to discover and execute a single test when using a file
based test system like Cucumber. Recently JUnit added support for file position
in the `FileSelector` and `ClasspathResourceSelector`.

See: https://github.com/junit-team/junit5/issues/2146

This implements a filter that prunes all scenarios that do not match the
`FilePosition` from the discovery selector. This feature itself is not new. It
was already implemented for the `UriSelector`.

This feature will benefit the implementation of [IDEA-227508](https://youtrack.jetbrains.com/issue/IDEA-227508). If you would like to use this feature in the future please up up-vote it.

TODO:
 - [ ] Create demo project for the benefit of the IDEA/Eclipse people.
 - [ ] Create issue to track feature request with IDEA/Eclipse/VsCode/Gradle/Maven ect