### PR TITLE
[Build] Explicit docker pull before docker run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ release:
 	[ -d '../secrets' ]  || git clone keybase://team/cucumberbdd/secrets ../secrets
 	git -C ../secrets pull
 	../secrets/update_permissions
+	docker pull cucumber/cucumber-build:latest
 	docker run \
 	  --volume "${shell pwd}":/app \
 	  --volume "${shell pwd}/../secrets/import-gpg-key.sh":/home/cukebot/import-gpg-key.sh \


### PR DESCRIPTION
Although `docker run` should also pull automatically, we have had several people mentioning the fact they had to pull by themselves, otherwise the release script was failing.

This PR adds an explicit `docker pull` command before the `docker run`.

This was tested succesfully when releasing Cucumber-Scala.