### PR TITLE
Add Step information in @BeforeStep and @AfterStep hook #1805

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-archetype</artifactId>

--- a/cdi2/pom.xml
+++ b/cdi2/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-cdi2</artifactId>

--- a/compatibility/pom.xml
+++ b/compatibility/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cucumber-jvm</artifactId>
         <groupId>io.cucumber</groupId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-core</artifactId>

--- a/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
@@ -1,9 +1,11 @@
 package io.cucumber.core.backend;
 
+import io.cucumber.plugin.event.TestStep;
 import org.apiguardian.api.API;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.Optional;
 
 @API(status = API.Status.STABLE)
 public interface TestCaseState {
@@ -91,4 +93,5 @@ public interface TestCaseState {
      */
     Integer getLine();
 
+    Optional<TestStep> getCurrentTestStep();
 }

--- a/core/src/main/java/io/cucumber/core/runner/HookTestStep.java
+++ b/core/src/main/java/io/cucumber/core/runner/HookTestStep.java
@@ -8,6 +8,7 @@ final class HookTestStep extends TestStep implements io.cucumber.plugin.event.Ho
 
     private final HookType hookType;
     private final HookDefinitionMatch definitionMatch;
+    private io.cucumber.plugin.event.TestStep relatedTestStep;
 
     HookTestStep(UUID id, HookType hookType, HookDefinitionMatch definitionMatch) {
         super(id, definitionMatch);
@@ -18,6 +19,16 @@ final class HookTestStep extends TestStep implements io.cucumber.plugin.event.Ho
     @Override
     public HookType getHookType() {
         return hookType;
+    }
+
+    @Override
+    public void setRelatedTestStep(io.cucumber.plugin.event.TestStep step) {
+        this.relatedTestStep = step;
+    }
+
+    @Override
+    public io.cucumber.plugin.event.TestStep getRelatedTestStep() {
+        return relatedTestStep;
     }
 
     HookDefinitionMatch getDefinitionMatch() {

--- a/core/src/main/java/io/cucumber/core/runner/TestCase.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCase.java
@@ -156,9 +156,15 @@ final class TestCase implements io.cucumber.plugin.event.TestCase {
     public List<TestStep> getTestSteps() {
         List<TestStep> testSteps = new ArrayList<>(beforeHooks);
         for (PickleStepTestStep step : this.testSteps) {
-            testSteps.addAll(step.getBeforeStepHookSteps());
+            step.getBeforeStepHookSteps().forEach(hookTestStep -> {
+                hookTestStep.setRelatedTestStep(step);
+                testSteps.add(hookTestStep);
+            });
             testSteps.add(step);
-            testSteps.addAll(step.getAfterStepHookSteps());
+            step.getAfterStepHookSteps().forEach(hookTestStep -> {
+                hookTestStep.setRelatedTestStep(step);
+                testSteps.add(hookTestStep);
+            });
         }
         testSteps.addAll(afterHooks);
         return testSteps;

--- a/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
@@ -8,6 +8,7 @@ import io.cucumber.messages.Messages.Attachment.ContentEncoding;
 import io.cucumber.plugin.event.EmbedEvent;
 import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.TestCase;
+import io.cucumber.plugin.event.TestStep;
 import io.cucumber.plugin.event.WriteEvent;
 
 import java.net.URI;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -140,6 +142,11 @@ class TestCaseState implements io.cucumber.core.backend.TestCaseState {
     @Override
     public Integer getLine() {
         return testCase.getLocation().getLine();
+    }
+
+    @Override
+    public Optional<TestStep> getCurrentTestStep() {
+        return testCase.getTestSteps().stream().filter(t -> t.getId().equals(currentTestStepId)).findFirst();
     }
 
     Throwable getError() {

--- a/deltaspike/pom.xml
+++ b/deltaspike/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-deltaspike</artifactId>

--- a/docstring/pom.xml
+++ b/docstring/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cucumber-jvm</artifactId>
         <groupId>io.cucumber</groupId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/java-calculator-junit5/pom.xml
+++ b/examples/java-calculator-junit5/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-calculator-junit5</artifactId>

--- a/examples/java-calculator-testng/pom.xml
+++ b/examples/java-calculator-testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-calculator-testng</artifactId>

--- a/examples/java-calculator/pom.xml
+++ b/examples/java-calculator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-calculator</artifactId>

--- a/examples/java-wicket/java-wicket-main/pom.xml
+++ b/examples/java-wicket/java-wicket-main/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>java-wicket</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket-main</artifactId>
     <name>Examples: Wicket application</name>

--- a/examples/java-wicket/java-wicket-test/pom.xml
+++ b/examples/java-wicket/java-wicket-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>java-wicket</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket-test</artifactId>
     <name>Examples: Wicket application tested with Selenium</name>

--- a/examples/java-wicket/pom.xml
+++ b/examples/java-wicket/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket</artifactId>
     <packaging>pom</packaging>

--- a/examples/java8-calculator/pom.xml
+++ b/examples/java8-calculator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java8-calculator</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-examples</artifactId>

--- a/examples/spring-txn/pom.xml
+++ b/examples/spring-txn/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-txn</artifactId>

--- a/gherkin-messages/pom.xml
+++ b/gherkin-messages/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/gherkin/pom.xml
+++ b/gherkin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-guice</artifactId>

--- a/jakarta-cdi/pom.xml
+++ b/jakarta-cdi/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-jakarta-cdi</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-java</artifactId>

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-java8</artifactId>

--- a/junit-platform-engine/pom.xml
+++ b/junit-platform-engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-junit-platform-engine</artifactId>

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-junit</artifactId>

--- a/kotlin-java8/pom.xml
+++ b/kotlin-java8/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-kotlin-java8</artifactId>

--- a/needle/pom.xml
+++ b/needle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-needle</artifactId>

--- a/openejb/pom.xml
+++ b/openejb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-openejb</artifactId>

--- a/picocontainer/pom.xml
+++ b/picocontainer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-picocontainer</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-plugin</artifactId>

--- a/plugin/src/main/java/io/cucumber/plugin/event/HookTestStep.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/HookTestStep.java
@@ -19,4 +19,8 @@ public interface HookTestStep extends TestStep {
      */
     HookType getHookType();
 
+    void setRelatedTestStep(TestStep step);
+
+    TestStep getRelatedTestStep();
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <version>2.1.1</version>
     </parent>
     <artifactId>cucumber-jvm</artifactId>
-    <version>6.8.1-SNAPSHOT</version>
+    <version>6.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Cucumber-JVM</name>
     <description>Cucumber for the JVM</description>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-spring</artifactId>

--- a/testng/pom.xml
+++ b/testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-testng</artifactId>

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.1-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-weld</artifactId>


### PR DESCRIPTION
Related to [https://github.com/cucumber/cucumber-jvm/issues/1805]. 

Added "related step" to HookTestStep, referring to the (PickleStep)TestStep the BeforeStep/AfterStep annotated HookTestStep relates to. This way the actual PickleStepTestStep can be added to the signature of the BeforeStep/AfterStep annotated method.
