### PR TITLE
[Core] Fix platform dependent unit tests

### DIFF
--- a/core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
@@ -38,7 +38,6 @@ import java.util.regex.Pattern;
 
 import static io.cucumber.core.options.Constants.FILTER_TAGS_PROPERTY_NAME;
 import static io.cucumber.core.resource.ClasspathSupport.rootPackageUri;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
@@ -77,12 +76,12 @@ class CommandlineOptionsParserTest {
     @Test
     void has_version_from_properties_file() {
         parser.parse("--version");
-        assertThat(output(), matchesPattern("\\d+\\.\\d+\\.\\d+(-RC\\d+)?(-SNAPSHOT)?\n"));
+        assertThat(output(), matchesPattern("\\d+\\.\\d+\\.\\d+(-RC\\d+)?(-SNAPSHOT)?\r?\n"));
         assertThat(parser.exitStatus(), is(Optional.of((byte) 0x0)));
     }
 
     private String output() {
-        return new String(out.toByteArray(), UTF_8);
+        return new String(out.toByteArray());
     }
 
     @Test
@@ -361,7 +360,7 @@ class CommandlineOptionsParserTest {
         parser
                 .parse("--threads", "0")
                 .build();
-        assertThat(output(), is("--threads must be > 0\n"));
+        assertThat(output(), startsWith("--threads must be > 0"));
         assertThat(parser.exitStatus(), is(Optional.of((byte) 0x1)));
     }
 
@@ -468,7 +467,7 @@ class CommandlineOptionsParserTest {
         parser
                 .parse("--count", "0")
                 .build();
-        assertThat(output(), is("--count must be > 0\n"));
+        assertThat(output(), startsWith("--count must be > 0"));
         assertThat(parser.exitStatus(), is(Optional.of((byte) 0x1)));
     }
 

--- a/core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
@@ -15,6 +15,7 @@ import io.cucumber.plugin.StrictAware;
 import io.cucumber.plugin.event.EventPublisher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -360,7 +362,7 @@ class CommandlineOptionsParserTest {
         parser
                 .parse("--threads", "0")
                 .build();
-        assertThat(output(), startsWith("--threads must be > 0"));
+        assertThat(output(), equalToCompressingWhiteSpace("--threads must be > 0"));
         assertThat(parser.exitStatus(), is(Optional.of((byte) 0x1)));
     }
 
@@ -467,7 +469,7 @@ class CommandlineOptionsParserTest {
         parser
                 .parse("--count", "0")
                 .build();
-        assertThat(output(), startsWith("--count must be > 0"));
+        assertThat(output(), equalToCompressingWhiteSpace("--count must be > 0"));
         assertThat(parser.exitStatus(), is(Optional.of((byte) 0x1)));
     }
 

--- a/core/src/test/java/io/cucumber/core/plugin/BannerTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/BannerTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import static io.cucumber.core.plugin.BytesEqualTo.isBytesEqualTo;
 import static java.util.Arrays.asList;
@@ -13,9 +15,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class BannerTest {
 
     @Test
-    void printsAnsiBanner() {
+    void printsAnsiBanner() throws UnsupportedEncodingException {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        Banner banner = new Banner(new PrintStream(bytes), false);
+        Banner banner = new Banner(new PrintStream(bytes, false, StandardCharsets.UTF_8.name()), false);
 
         banner.print(asList(
             new Banner.Line("Bla"),
@@ -37,7 +39,7 @@ class BannerTest {
     @Test
     void printsMonochromeBanner() throws Exception {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        Banner banner = new Banner(new PrintStream(bytes), true);
+        Banner banner = new Banner(new PrintStream(bytes, false, StandardCharsets.UTF_8.name()), true);
 
         banner.print(asList(
             new Banner.Line("Bla"),

--- a/core/src/test/java/io/cucumber/core/plugin/NoPublishFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/NoPublishFormatterTest.java
@@ -4,15 +4,17 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import static io.cucumber.core.plugin.BytesEqualTo.isBytesEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class NoPublishFormatterTest {
     @Test
-    public void should_print_banner() {
+    public void should_print_banner() throws UnsupportedEncodingException {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        PrintStream out = new PrintStream(bytes);
+        PrintStream out = new PrintStream(bytes, false, StandardCharsets.UTF_8.name());
         NoPublishFormatter noPublishFormatter = new NoPublishFormatter(out);
         noPublishFormatter.setMonochrome(true);
         noPublishFormatter.printBanner();

--- a/core/src/test/java/io/cucumber/core/plugin/UrlReporterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/UrlReporterTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import static io.cucumber.core.plugin.BytesEqualTo.isBytesEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,17 +24,17 @@ class UrlReporterTest {
             "\u001B[32m\u001B[1m└──────────────────────────────────────────────────────────────────────────┘\u001B[0m\n";
 
     @Test
-    void printsTheCorrespondingReportsCucumberIoUrl() {
+    void printsTheCorrespondingReportsCucumberIoUrl() throws UnsupportedEncodingException {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        UrlReporter urlReporter = new UrlReporter(new PrintStream(bytes));
+        UrlReporter urlReporter = new UrlReporter(new PrintStream(bytes, false, StandardCharsets.UTF_8.name()));
         urlReporter.report(message);
         assertThat(bytes, isBytesEqualTo(message));
     }
 
     @Test
-    void printsTheCorrespondingReportsCucumberIoUrlInMonoChrome() {
+    void printsTheCorrespondingReportsCucumberIoUrlInMonoChrome() throws UnsupportedEncodingException {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        UrlReporter urlReporter = new UrlReporter(new PrintStream(bytes));
+        UrlReporter urlReporter = new UrlReporter(new PrintStream(bytes, false, StandardCharsets.UTF_8.name()));
         urlReporter.setMonochrome(true);
 
         urlReporter.report(message);


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

Fixing the encoding related problems in tests of #2104 

**Describe the solution you have implemented**

BannerTest, NoPublishFormatterTest, UrlReporterTest:
Using UTF-8 encoding in tests instead of relying on default encoding of the system, because otherwise the non-ascii characters are destroyed. 

CommandLineOptionsParserTest:
Removed the line endings from the comparision, so moving to the same behaviour as other non-failing tests of the same class.

**Additional context**

