### PR TITLE
Add Step information in @BeforeStep and @AfterStep hook #1805

### DIFF
--- a/core/src/main/java/io/cucumber/core/backend/HookStep.java
+++ b/core/src/main/java/io/cucumber/core/backend/HookStep.java
@@ -1,0 +1,10 @@
+package io.cucumber.core.backend;
+
+import org.apiguardian.api.API;
+
+@API(status = API.Status.EXPERIMENTAL)
+public interface HookStep extends Step {
+
+    PickleStep getRelatedStep();
+
+}

--- a/core/src/main/java/io/cucumber/core/backend/PickleStep.java
+++ b/core/src/main/java/io/cucumber/core/backend/PickleStep.java
@@ -1,0 +1,24 @@
+package io.cucumber.core.backend;
+
+import org.apiguardian.api.API;
+
+@API(status = API.Status.EXPERIMENTAL)
+public interface PickleStep extends Step {
+
+    enum Keyword {
+        GIVEN,
+        WHEN,
+        THEN
+    }
+
+    /**
+     * @return the {@link Keyword} for this step
+     */
+    Keyword getKeyword();
+
+    /**
+     * @return the arguments passed into this step
+     */
+    Object[] getArguments();
+
+}

--- a/core/src/main/java/io/cucumber/core/backend/Step.java
+++ b/core/src/main/java/io/cucumber/core/backend/Step.java
@@ -1,0 +1,8 @@
+package io.cucumber.core.backend;
+
+import org.apiguardian.api.API;
+
+@API(status = API.Status.EXPERIMENTAL)
+public interface Step {
+
+}

--- a/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
@@ -1,9 +1,11 @@
 package io.cucumber.core.backend;
 
+import io.cucumber.plugin.event.TestStep;
 import org.apiguardian.api.API;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.Optional;
 
 @API(status = API.Status.STABLE)
 public interface TestCaseState {
@@ -91,4 +93,8 @@ public interface TestCaseState {
      */
     Integer getLine();
 
+    /**
+     * @return the current TestStep being executed in the Scenario.
+     */
+    Optional<TestStep> getCurrentTestStep();
 }

--- a/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/backend/TestCaseState.java
@@ -1,6 +1,5 @@
 package io.cucumber.core.backend;
 
-import io.cucumber.plugin.event.TestStep;
 import org.apiguardian.api.API;
 
 import java.net.URI;
@@ -96,5 +95,5 @@ public interface TestCaseState {
     /**
      * @return the current TestStep being executed in the Scenario.
      */
-    Optional<TestStep> getCurrentTestStep();
+    Optional<Step> getCurrentTestStep();
 }

--- a/core/src/main/java/io/cucumber/core/runner/HookStep.java
+++ b/core/src/main/java/io/cucumber/core/runner/HookStep.java
@@ -1,0 +1,14 @@
+package io.cucumber.core.runner;
+
+class HookStep implements io.cucumber.core.backend.HookStep {
+
+    final PickleStep relatedStep;
+
+    public HookStep(HookTestStep testStep) {
+        relatedStep = new PickleStep(testStep.getRelatedTestStep());
+    }
+
+    public PickleStep getRelatedStep() {
+        return relatedStep;
+    }
+}

--- a/core/src/main/java/io/cucumber/core/runner/HookTestStep.java
+++ b/core/src/main/java/io/cucumber/core/runner/HookTestStep.java
@@ -8,7 +8,7 @@ final class HookTestStep extends TestStep implements io.cucumber.plugin.event.Ho
 
     private final HookType hookType;
     private final HookDefinitionMatch definitionMatch;
-    private io.cucumber.plugin.event.TestStep relatedTestStep;
+    private PickleStepTestStep relatedTestStep;
 
     HookTestStep(UUID id, HookType hookType, HookDefinitionMatch definitionMatch) {
         super(id, definitionMatch);
@@ -21,12 +21,12 @@ final class HookTestStep extends TestStep implements io.cucumber.plugin.event.Ho
         return hookType;
     }
 
-    public void setRelatedTestStep(io.cucumber.plugin.event.TestStep step) {
+    public void setRelatedTestStep(PickleStepTestStep step) {
         this.relatedTestStep = step;
     }
 
     @Override
-    public io.cucumber.plugin.event.TestStep getRelatedTestStep() {
+    public PickleStepTestStep getRelatedTestStep() {
         return relatedTestStep;
     }
 

--- a/core/src/main/java/io/cucumber/core/runner/HookTestStep.java
+++ b/core/src/main/java/io/cucumber/core/runner/HookTestStep.java
@@ -8,6 +8,7 @@ final class HookTestStep extends TestStep implements io.cucumber.plugin.event.Ho
 
     private final HookType hookType;
     private final HookDefinitionMatch definitionMatch;
+    private io.cucumber.plugin.event.TestStep relatedTestStep;
 
     HookTestStep(UUID id, HookType hookType, HookDefinitionMatch definitionMatch) {
         super(id, definitionMatch);
@@ -18,6 +19,15 @@ final class HookTestStep extends TestStep implements io.cucumber.plugin.event.Ho
     @Override
     public HookType getHookType() {
         return hookType;
+    }
+
+    public void setRelatedTestStep(io.cucumber.plugin.event.TestStep step) {
+        this.relatedTestStep = step;
+    }
+
+    @Override
+    public io.cucumber.plugin.event.TestStep getRelatedTestStep() {
+        return relatedTestStep;
     }
 
     HookDefinitionMatch getDefinitionMatch() {

--- a/core/src/main/java/io/cucumber/core/runner/PickleStep.java
+++ b/core/src/main/java/io/cucumber/core/runner/PickleStep.java
@@ -1,0 +1,25 @@
+package io.cucumber.core.runner;
+
+import io.cucumber.plugin.event.Argument;
+
+class PickleStep implements io.cucumber.core.backend.PickleStep {
+
+    private final Keyword keyword;
+
+    private final Object[] arguments;
+
+    public PickleStep(PickleStepTestStep pickleStepTestStep) {
+        this.keyword = Keyword.valueOf(pickleStepTestStep.getStep().getType().name());
+        this.arguments = pickleStepTestStep.getDefinitionArgument().stream().map(Argument::getValue).toArray();
+    }
+
+    @Override
+    public Keyword getKeyword() {
+        return keyword;
+    }
+
+    @Override
+    public Object[] getArguments() {
+        return arguments;
+    }
+}

--- a/core/src/main/java/io/cucumber/core/runner/PickleStep.java
+++ b/core/src/main/java/io/cucumber/core/runner/PickleStep.java
@@ -9,7 +9,7 @@ class PickleStep implements io.cucumber.core.backend.PickleStep {
     private final Object[] arguments;
 
     public PickleStep(PickleStepTestStep pickleStepTestStep) {
-        this.keyword = Keyword.valueOf(pickleStepTestStep.getStep().getType().name());
+        this.keyword = Keyword.valueOf(pickleStepTestStep.getStep().getGwtType().name());
         this.arguments = pickleStepTestStep.getDefinitionArgument().stream().map(Argument::getValue).toArray();
     }
 

--- a/core/src/main/java/io/cucumber/core/runner/TestCase.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCase.java
@@ -156,9 +156,15 @@ final class TestCase implements io.cucumber.plugin.event.TestCase {
     public List<TestStep> getTestSteps() {
         List<TestStep> testSteps = new ArrayList<>(beforeHooks);
         for (PickleStepTestStep step : this.testSteps) {
-            testSteps.addAll(step.getBeforeStepHookSteps());
+            step.getBeforeStepHookSteps().forEach(hookTestStep -> {
+                hookTestStep.setRelatedTestStep(step);
+                testSteps.add(hookTestStep);
+            });
             testSteps.add(step);
-            testSteps.addAll(step.getAfterStepHookSteps());
+            step.getAfterStepHookSteps().forEach(hookTestStep -> {
+                hookTestStep.setRelatedTestStep(step);
+                testSteps.add(hookTestStep);
+            });
         }
         testSteps.addAll(afterHooks);
         return testSteps;

--- a/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
@@ -1,6 +1,7 @@
 package io.cucumber.core.runner;
 
 import io.cucumber.core.backend.Status;
+import io.cucumber.core.backend.Step;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.messages.Messages;
 import io.cucumber.messages.Messages.Attachment;
@@ -145,8 +146,19 @@ class TestCaseState implements io.cucumber.core.backend.TestCaseState {
     }
 
     @Override
-    public Optional<TestStep> getCurrentTestStep() {
-        return testCase.getTestSteps().stream().filter(t -> t.getId().equals(currentTestStepId)).findFirst();
+    public Optional<Step> getCurrentTestStep() {
+        return testCase.getTestSteps().stream()
+                .filter(t -> t.getId().equals(currentTestStepId))
+                .findFirst()
+                .map(step -> {
+                    if (testStep instanceof HookTestStep) {
+                        return new HookStep((HookTestStep) testStep);
+                    }
+                    if (testStep instanceof PickleStepTestStep) {
+                        return new PickleStep((PickleStepTestStep) testStep);
+                    }
+                    return null;
+                });
     }
 
     Throwable getError() {

--- a/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
@@ -8,6 +8,7 @@ import io.cucumber.messages.Messages.Attachment.ContentEncoding;
 import io.cucumber.plugin.event.EmbedEvent;
 import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.TestCase;
+import io.cucumber.plugin.event.TestStep;
 import io.cucumber.plugin.event.WriteEvent;
 
 import java.net.URI;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -140,6 +142,11 @@ class TestCaseState implements io.cucumber.core.backend.TestCaseState {
     @Override
     public Integer getLine() {
         return testCase.getLocation().getLine();
+    }
+
+    @Override
+    public Optional<TestStep> getCurrentTestStep() {
+        return testCase.getTestSteps().stream().filter(t -> t.getId().equals(currentTestStepId)).findFirst();
     }
 
     Throwable getError() {

--- a/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
@@ -9,7 +9,6 @@ import io.cucumber.messages.Messages.Attachment.ContentEncoding;
 import io.cucumber.plugin.event.EmbedEvent;
 import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.TestCase;
-import io.cucumber.plugin.event.TestStep;
 import io.cucumber.plugin.event.WriteEvent;
 
 import java.net.URI;
@@ -151,11 +150,11 @@ class TestCaseState implements io.cucumber.core.backend.TestCaseState {
                 .filter(t -> t.getId().equals(currentTestStepId))
                 .findFirst()
                 .map(step -> {
-                    if (testStep instanceof HookTestStep) {
-                        return new HookStep((HookTestStep) testStep);
+                    if (step instanceof HookTestStep) {
+                        return new HookStep((HookTestStep) step);
                     }
-                    if (testStep instanceof PickleStepTestStep) {
-                        return new PickleStep((PickleStepTestStep) testStep);
+                    if (step instanceof PickleStepTestStep) {
+                        return new PickleStep((PickleStepTestStep) step);
                     }
                     return null;
                 });

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesStep.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesStep.java
@@ -1,6 +1,7 @@
 package io.cucumber.core.gherkin.messages;
 
 import io.cucumber.core.gherkin.Argument;
+import io.cucumber.core.gherkin.GwtStepType;
 import io.cucumber.core.gherkin.Step;
 import io.cucumber.core.gherkin.StepType;
 import io.cucumber.gherkin.GherkinDialect;
@@ -18,6 +19,7 @@ final class GherkinMessagesStep implements Step {
     private final String keyWord;
     private final StepType stepType;
     private final String previousGwtKeyWord;
+    private final GwtStepType gwtStepType;
     private final Messages.Location location;
 
     GherkinMessagesStep(
@@ -32,6 +34,11 @@ final class GherkinMessagesStep implements Step {
         this.keyWord = keyword;
         this.stepType = extractKeyWordType(keyWord, dialect);
         this.previousGwtKeyWord = previousGwtKeyWord;
+        if (stepType.isGivenWhenThen()) {
+            this.gwtStepType = GwtStepType.valueOf(stepType.name());
+        } else {
+            this.gwtStepType = extractGwtStepType(previousGwtKeyWord, dialect);
+        }
         this.location = location;
     }
 
@@ -71,6 +78,19 @@ final class GherkinMessagesStep implements Step {
         throw new IllegalStateException("Keyword " + keyWord + " was neither given, when, then, and, but nor *");
     }
 
+    private static GwtStepType extractGwtStepType(String keyWord, GherkinDialect dialect) {
+        if (dialect.getGivenKeywords().contains(keyWord)) {
+            return GwtStepType.GIVEN;
+        }
+        if (dialect.getWhenKeywords().contains(keyWord)) {
+            return GwtStepType.WHEN;
+        }
+        if (dialect.getThenKeywords().contains(keyWord)) {
+            return GwtStepType.THEN;
+        }
+        throw new IllegalStateException("Keyword " + keyWord + " was neither given, when nor then");
+    }
+
     @Override
     public String getKeyword() {
         return keyWord;
@@ -89,6 +109,11 @@ final class GherkinMessagesStep implements Step {
     @Override
     public StepType getType() {
         return stepType;
+    }
+
+    @Override
+    public GwtStepType getGwtType() {
+        return gwtStepType;
     }
 
     @Override

--- a/gherkin-messages/src/test/java/io/cucumber/core/gherkin/messages/FeatureParserTest.java
+++ b/gherkin-messages/src/test/java/io/cucumber/core/gherkin/messages/FeatureParserTest.java
@@ -4,6 +4,7 @@ import io.cucumber.core.gherkin.DataTableArgument;
 import io.cucumber.core.gherkin.DocStringArgument;
 import io.cucumber.core.gherkin.Feature;
 import io.cucumber.core.gherkin.FeatureParserException;
+import io.cucumber.core.gherkin.GwtStepType;
 import io.cucumber.core.gherkin.Pickle;
 import io.cucumber.core.gherkin.Step;
 import io.cucumber.plugin.event.Node;
@@ -21,6 +22,7 @@ import static java.nio.file.Files.readAllBytes;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -128,6 +130,27 @@ class FeatureParserTest {
                 "(5:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'When GA'\n" +
                 "(6:5): expected: #EOF, #Language, #TagLine, #FeatureLine, #Comment, #Empty, got 'Then TA'",
             exception.getMessage());
+    }
+
+    @Test
+    void gherkin_messages_step_gwt_type_should_be_determined_correclty() throws IOException {
+        URI uri = URI.create("classpath:com/example.feature");
+        String source = new String(
+                readAllBytes(Paths.get("src/test/resources/io/cucumber/core/gherkin/messages/given-when-then.feature")));
+        Feature feature = parser.parse(uri, source, UUID::randomUUID).get();
+        assertNotNull(feature.getPickles());
+        assertEquals(1, feature.getPickles().size());
+        List<Step> steps = feature.getPickles().get(0).getSteps();
+        assertEquals(9, steps.size());
+        assertEquals(GwtStepType.GIVEN, steps.get(0).getGwtType());
+        assertEquals(GwtStepType.GIVEN, steps.get(1).getGwtType());
+        assertEquals(GwtStepType.GIVEN, steps.get(2).getGwtType());
+        assertEquals(GwtStepType.WHEN, steps.get(3).getGwtType());
+        assertEquals(GwtStepType.WHEN, steps.get(4).getGwtType());
+        assertEquals(GwtStepType.WHEN, steps.get(5).getGwtType());
+        assertEquals(GwtStepType.THEN, steps.get(6).getGwtType());
+        assertEquals(GwtStepType.THEN, steps.get(7).getGwtType());
+        assertEquals(GwtStepType.THEN, steps.get(8).getGwtType());
     }
 
 }

--- a/gherkin-messages/src/test/resources/io/cucumber/core/gherkin/messages/given-when-then.feature
+++ b/gherkin-messages/src/test/resources/io/cucumber/core/gherkin/messages/given-when-then.feature
@@ -1,0 +1,12 @@
+Feature: Given-When-Then-And-But
+
+  Scenario: Check GherkinMessageStep parsing
+    Given first given
+    And second given
+    But third given
+    When first when
+    And second when
+    But third then
+    Then first then
+    And second then
+    But third then

--- a/gherkin/src/main/java/io/cucumber/core/gherkin/GwtStepType.java
+++ b/gherkin/src/main/java/io/cucumber/core/gherkin/GwtStepType.java
@@ -1,0 +1,7 @@
+package io.cucumber.core.gherkin;
+
+public enum GwtStepType {
+    GIVEN,
+    WHEN,
+    THEN
+}

--- a/gherkin/src/main/java/io/cucumber/core/gherkin/Step.java
+++ b/gherkin/src/main/java/io/cucumber/core/gherkin/Step.java
@@ -6,6 +6,8 @@ public interface Step extends io.cucumber.plugin.event.Step {
 
     String getPreviousGivenWhenThenKeyword();
 
+    GwtStepType getGwtType();
+
     String getId();
 
     @Override

--- a/java/README.md
+++ b/java/README.md
@@ -128,6 +128,11 @@ annotating a method. The method may declare an argument of type
  * `@BeforeStep`
  * `@AfterStep`
  
+Optionally, the following hooks can also declare an argument of type
+`io.cucumber.java.Step`.
+ * `@BeforeStep`
+ * `@AfterStep`
+ 
 ## Transformers 
 
 Cucumber expression parameters, data tables and docs strings can be transformed

--- a/java/src/main/java/io/cucumber/java/GlueAdaptor.java
+++ b/java/src/main/java/io/cucumber/java/GlueAdaptor.java
@@ -32,11 +32,11 @@ final class GlueAdaptor {
         } else if (annotationType.equals(BeforeStep.class)) {
             BeforeStep beforeStep = (BeforeStep) annotation;
             String tagExpression = beforeStep.value();
-            glue.addBeforeStepHook(new JavaHookDefinition(method, tagExpression, beforeStep.order(), lookup));
+            glue.addBeforeStepHook(new JavaStepHookDefinition(method, tagExpression, beforeStep.order(), lookup));
         } else if (annotationType.equals(AfterStep.class)) {
             AfterStep afterStep = (AfterStep) annotation;
             String tagExpression = afterStep.value();
-            glue.addAfterStepHook(new JavaHookDefinition(method, tagExpression, afterStep.order(), lookup));
+            glue.addAfterStepHook(new JavaStepHookDefinition(method, tagExpression, afterStep.order(), lookup));
         } else if (annotationType.equals(ParameterType.class)) {
             ParameterType parameterType = (ParameterType) annotation;
             String pattern = parameterType.value();

--- a/java/src/main/java/io/cucumber/java/InvalidMethodSignatureException.java
+++ b/java/src/main/java/io/cucumber/java/InvalidMethodSignatureException.java
@@ -34,6 +34,13 @@ final class InvalidMethodSignatureException extends CucumberBackendException {
             return this;
         }
 
+        InvalidMethodSignatureExceptionBuilder addAnnotations(Class<?>[] annotations) {
+            for (Class annotation : annotations) {
+                addAnnotation(annotation);
+            }
+            return this;
+        }
+
         InvalidMethodSignatureExceptionBuilder addSignature(String signature) {
             signatures.add(signature);
             return this;

--- a/java/src/main/java/io/cucumber/java/JavaHookDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaHookDefinition.java
@@ -1,20 +1,10 @@
 package io.cucumber.java;
 
 import io.cucumber.core.backend.HookDefinition;
-import io.cucumber.core.backend.HookStep;
 import io.cucumber.core.backend.Lookup;
-import io.cucumber.core.backend.PickleStep;
 import io.cucumber.core.backend.TestCaseState;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 import static io.cucumber.java.InvalidMethodSignatureException.builder;
 import static java.util.Objects.requireNonNull;
@@ -32,100 +22,36 @@ final class JavaHookDefinition extends AbstractGlueDefinition implements HookDef
 
     private static Method requireValidMethod(Method method) {
         Class<?>[] parameterTypes = method.getParameterTypes();
-        if (parameterTypes.length > 0) {
-            Class<?>[] annotationTypes = getRelevantMethodAnnotations(method.getAnnotations());
-            for (Class<?> parameterType : parameterTypes) {
-                checkParameter(method, parameterType, annotationTypes);
+        if (parameterTypes.length > 1) {
+            throw createInvalidSignatureException(method);
+        }
+        if (parameterTypes.length == 1) {
+            Class<?> parameterType = parameterTypes[0];
+            if (!(Object.class.equals(parameterType) || io.cucumber.java.Scenario.class.equals(parameterType))) {
+                throw createInvalidSignatureException(method);
             }
         }
         return method;
     }
 
-    private static Class<?>[] getRelevantMethodAnnotations(Annotation[] annotations) {
-        if (null == annotations || annotations.length == 0) {
-            return new Class<?>[0];
-        }
-        Class<?>[] relevant = null;
-        for (Annotation annotation : annotations) {
-            Class<? extends Annotation> annotationType = annotation.annotationType();
-            if (Before.class.equals(annotationType) || After.class.equals(annotationType)) {
-                return new Class<?>[] { Before.class, After.class };
-            }
-            if (BeforeStep.class.equals(annotationType) || AfterStep.class.equals(annotationType)) {
-                relevant = new Class<?>[] { BeforeStep.class, AfterStep.class };
-            }
-        }
-        return relevant;
-    }
-
-    private static Set<Class<?>> getAcceptedTypes(Class<?> annotationType) {
-        if (null == annotationType) {
-            return Collections.emptySet();
-        }
-        Set<Class<?>> accepted = new HashSet<>();
-        if (Before.class.equals(annotationType) || After.class.equals(annotationType)) {
-            accepted.add(Scenario.class);
-        }
-        if (BeforeStep.class.equals(annotationType) || AfterStep.class.equals(annotationType)) {
-            accepted.addAll(Arrays.asList(Scenario.class, Step.class));
-        }
-        return accepted;
-    }
-
-    private static void checkParameter(Method method, Class<?> parameterType, Class<?>[] annotationTypes) {
-        for (Class<?> annotationType : annotationTypes) {
-            Set<Class<?>> acceptedTypes = getAcceptedTypes(annotationType);
-            if (!(Object.class.equals(parameterType) || acceptedTypes.contains(parameterType))) {
-                throw createInvalidSignatureException(method, annotationTypes, acceptedTypes);
-            }
-        }
-    }
-
-    private static InvalidMethodSignatureException createInvalidSignatureException(
-            Method method,
-            Class<?>[] methodAnnotations,
-            Set<Class<?>> acceptedTypes
-    ) {
-        InvalidMethodSignatureException.InvalidMethodSignatureExceptionBuilder builder = builder(method);
-        builder.addAnnotations(methodAnnotations);
-        String methodName = "public void before_or_after";
-        if (acceptedTypes.contains(Step.class)) {
-            methodName += "_step";
-            builder.addSignature(methodName + "(io.cucumber.java.Scenario scenario, io.cucumber.java.Step step)");
-            builder.addSignature(methodName + "(io.cucumber.java.Step step, io.cucumber.java.Scenario scenario)");
-            builder.addSignature(methodName + "(io.cucumber.java.Step step)");
-        }
-        builder.addSignature(methodName + "(io.cucumber.java.Scenario scenario)");
-        builder.addSignature(methodName + "()");
-        return builder.build();
+    private static InvalidMethodSignatureException createInvalidSignatureException(Method method) {
+        return builder(method)
+                .addAnnotation(Before.class)
+                .addAnnotation(After.class)
+                .addSignature("public void before_or_after(io.cucumber.java.Scenario scenario)")
+                .addSignature("public void before_or_after()")
+                .build();
     }
 
     @Override
     public void execute(TestCaseState state) {
-        List<Object> parameters = new ArrayList<>();
-        for (Class<?> parameterType : method.getParameterTypes()) {
-            if (parameterType.equals(Scenario.class)) {
-                parameters.add(new Scenario(state));
-            }
-            if (parameterType.equals(Step.class)) {
-                PickleStep pickleStep = getCurrentPickleStep(state);
-                parameters.add(new Step(pickleStep));
-            }
+        Object[] args;
+        if (method.getParameterTypes().length == 1) {
+            args = new Object[] { new io.cucumber.java.Scenario(state) };
+        } else {
+            args = new Object[0];
         }
-        invokeMethod(parameters.toArray());
-    }
-
-    private PickleStep getCurrentPickleStep(TestCaseState state) {
-        io.cucumber.core.backend.Step step = state.getCurrentTestStep()
-                .orElseThrow(() -> new IllegalStateException("No current TestStep was found in TestCaseState"));
-        HookStep hookStep = (HookStep) Optional.of(step)
-                .filter(HookStep.class::isInstance)
-                .orElseThrow(() -> new IllegalArgumentException(String.format("Current TestStep should be a %s instead of a %s",
-                        HookStep.class.getSimpleName(), step.getClass().getSimpleName())));
-        return Optional.of(hookStep)
-                .map(HookStep::getRelatedStep)
-                .orElseThrow(() -> new IllegalStateException("Current HookStep has no related PickleStep"));
-
+        invokeMethod(args);
     }
 
     @Override

--- a/java/src/main/java/io/cucumber/java/JavaHookDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaHookDefinition.java
@@ -87,10 +87,6 @@ final class JavaHookDefinition extends AbstractGlueDefinition implements HookDef
             Set<Class<?>> acceptedTypes
     ) {
         InvalidMethodSignatureException.InvalidMethodSignatureExceptionBuilder builder = builder(method);
-        if (methodAnnotations.length == 0) {
-            throw new IllegalArgumentException(
-                "Method should be annotated with one of: @Before, @After, @BeforeStep, @AfterStep");
-        }
         builder.addAnnotations(methodAnnotations);
         String methodName = "public void before_or_after";
         if (acceptedTypes.contains(Step.class)) {
@@ -122,12 +118,10 @@ final class JavaHookDefinition extends AbstractGlueDefinition implements HookDef
     private PickleStep getCurrentPickleStep(TestCaseState state) {
         io.cucumber.core.backend.Step step = state.getCurrentTestStep()
                 .orElseThrow(() -> new IllegalStateException("No current TestStep was found in TestCaseState"));
-
-        HookStep hookStep = Optional.of(step)
+        HookStep hookStep = (HookStep) Optional.of(step)
                 .filter(HookStep.class::isInstance)
                 .orElseThrow(() -> new IllegalArgumentException(String.format("Current TestStep should be a %s instead of a %s",
-                        HookStep.class.getSimpleName(), currentTestStep.get().getClass().getSimpleName())));
-                                
+                        HookStep.class.getSimpleName(), step.getClass().getSimpleName())));
         return Optional.of(hookStep)
                 .map(HookStep::getRelatedStep)
                 .orElseThrow(() -> new IllegalStateException("Current HookStep has no related PickleStep"));

--- a/java/src/main/java/io/cucumber/java/JavaStepHookDefinition.java
+++ b/java/src/main/java/io/cucumber/java/JavaStepHookDefinition.java
@@ -1,0 +1,106 @@
+package io.cucumber.java;
+
+import io.cucumber.core.backend.HookDefinition;
+import io.cucumber.core.backend.HookStep;
+import io.cucumber.core.backend.Lookup;
+import io.cucumber.core.backend.PickleStep;
+import io.cucumber.core.backend.TestCaseState;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.cucumber.java.InvalidMethodSignatureException.builder;
+import static java.util.Objects.requireNonNull;
+
+final class JavaStepHookDefinition extends AbstractGlueDefinition implements HookDefinition {
+
+    private final String tagExpression;
+    private final int order;
+
+    JavaStepHookDefinition(Method method, String tagExpression, int order, Lookup lookup) {
+        super(requireValidMethod(method), lookup);
+        this.tagExpression = requireNonNull(tagExpression, "tag-expression may not be null");
+        this.order = order;
+    }
+
+    private static Method requireValidMethod(Method method) {
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        if (parameterTypes.length > 2) {
+            throw createInvalidSignatureException(method);
+        }
+        if (parameterTypes.length == 2) {
+            Class<?> parameterType1 = parameterTypes[0];
+            Class<?> parameterType2 = parameterTypes[1];
+            if (!(isObjectOrClass(parameterType1, Scenario.class) && isObjectOrClass(parameterType2, Step.class) ||
+                    isObjectOrClass(parameterType1, Step.class) && isObjectOrClass(parameterType2, Scenario.class))) {
+                throw createInvalidSignatureException(method);
+            }
+        }
+        if (parameterTypes.length == 1) {
+            Class<?> parameterType1 = parameterTypes[0];
+            if (!(isObjectOrClass(parameterType1, Scenario.class) || isObjectOrClass(parameterType1, Step.class))) {
+                throw createInvalidSignatureException(method);
+            }
+        }
+        return method;
+    }
+
+    private static InvalidMethodSignatureException createInvalidSignatureException(Method method) {
+        return builder(method)
+                .addAnnotation(BeforeStep.class)
+                .addAnnotation(AfterStep.class)
+                .addSignature(
+                    "public void before_or_after_step(io.cucumber.java.Scenario scenario, io.cucumber.java.Step step)")
+                .addSignature(
+                    "public void before_or_after_step(io.cucumber.java.Step step, io.cucumber.java.Scenario scenario)")
+                .addSignature("public void before_or_after_step(io.cucumber.java.Scenario scenario)")
+                .addSignature("public void before_or_after_step(io.cucumber.java.Step step)")
+                .addSignature("public void before_or_after_step()")
+                .build();
+    }
+
+    private static boolean isObjectOrClass(Object type, Class<?> clazz) {
+        return null != type && (Object.class.equals(type) || clazz.equals(type));
+    }
+
+    @Override
+    public void execute(TestCaseState state) {
+        List<Object> parameters = new ArrayList<>();
+        for (Class<?> parameterType : method.getParameterTypes()) {
+            if (parameterType.equals(Scenario.class)) {
+                parameters.add(new Scenario(state));
+            }
+            if (parameterType.equals(Step.class)) {
+                PickleStep pickleStep = getCurrentPickleStep(state);
+                parameters.add(new Step(pickleStep));
+            }
+        }
+        invokeMethod(parameters.toArray());
+    }
+
+    private PickleStep getCurrentPickleStep(TestCaseState state) {
+        io.cucumber.core.backend.Step step = state.getCurrentTestStep()
+                .orElseThrow(() -> new IllegalStateException("No current TestStep was found in TestCaseState"));
+        HookStep hookStep = (HookStep) Optional.of(step)
+                .filter(HookStep.class::isInstance)
+                .orElseThrow(
+                    () -> new IllegalArgumentException(String.format("Current TestStep should be a %s instead of a %s",
+                        HookStep.class.getSimpleName(), step.getClass().getSimpleName())));
+        return Optional.of(hookStep)
+                .map(HookStep::getRelatedStep)
+                .orElseThrow(() -> new IllegalStateException("Current HookStep has no related PickleStep"));
+    }
+
+    @Override
+    public String getTagExpression() {
+        return tagExpression;
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
+    }
+
+}

--- a/java/src/main/java/io/cucumber/java/Step.java
+++ b/java/src/main/java/io/cucumber/java/Step.java
@@ -1,0 +1,68 @@
+package io.cucumber.java;
+
+import io.cucumber.core.backend.TestCaseState;
+import io.cucumber.plugin.event.HookTestStep;
+import io.cucumber.plugin.event.Location;
+import io.cucumber.plugin.event.PickleStepTestStep;
+import io.cucumber.plugin.event.StepArgument;
+import io.cucumber.plugin.event.TestStep;
+import org.apiguardian.api.API;
+
+import java.util.Optional;
+
+/**
+ * BeforeStep or AfterStep Hooks that declare a parameter of this type will
+ * receive an instance of this class.
+ */
+@API(status = API.Status.EXPERIMENTAL)
+public class Step implements io.cucumber.plugin.event.Step {
+
+    final TestCaseState testCaseState;
+
+    final io.cucumber.plugin.event.Step delegate;
+
+    public Step(TestCaseState state) {
+        this.testCaseState = state;
+        Optional<TestStep> currentTestStep = state.getCurrentTestStep();
+        if (!currentTestStep.isPresent()) {
+            throw new IllegalStateException("No current TestStep was found in TestCaseState");
+        }
+        if (!(currentTestStep.get() instanceof HookTestStep)) {
+            throw new IllegalStateException("Current TestStep is not a HookTestStep");
+        }
+        TestStep relatedTestStep = ((HookTestStep) currentTestStep.get()).getRelatedTestStep();
+        if (null == relatedTestStep) {
+            throw new IllegalStateException("No related TestStep for current HookTestStep was found");
+        }
+        if (!(relatedTestStep instanceof PickleStepTestStep)) {
+            throw new IllegalStateException("Related TestStep is not a PickleStepTestStep");
+        }
+        delegate = ((PickleStepTestStep) relatedTestStep).getStep();
+    }
+
+    @Override
+    public StepArgument getArgument() {
+        return delegate.getArgument();
+    }
+
+    @Override
+    public String getKeyword() {
+        return delegate.getKeyword();
+    }
+
+    @Override
+    public String getText() {
+        return delegate.getText();
+    }
+
+    @Override
+    public int getLine() {
+        return delegate.getLine();
+    }
+
+    @Override
+    public Location getLocation() {
+        return delegate.getLocation();
+    }
+
+}

--- a/java/src/main/java/io/cucumber/java/Step.java
+++ b/java/src/main/java/io/cucumber/java/Step.java
@@ -1,68 +1,29 @@
 package io.cucumber.java;
 
-import io.cucumber.core.backend.TestCaseState;
-import io.cucumber.plugin.event.HookTestStep;
-import io.cucumber.plugin.event.Location;
-import io.cucumber.plugin.event.PickleStepTestStep;
-import io.cucumber.plugin.event.StepArgument;
-import io.cucumber.plugin.event.TestStep;
+import io.cucumber.core.backend.PickleStep;
 import org.apiguardian.api.API;
-
-import java.util.Optional;
 
 /**
  * BeforeStep or AfterStep Hooks that declare a parameter of this type will
  * receive an instance of this class.
  */
 @API(status = API.Status.EXPERIMENTAL)
-public class Step implements io.cucumber.plugin.event.Step {
+public final class Step implements PickleStep {
 
-    final TestCaseState testCaseState;
+    final io.cucumber.core.backend.PickleStep delegate;
 
-    final io.cucumber.plugin.event.Step delegate;
-
-    public Step(TestCaseState state) {
-        this.testCaseState = state;
-        Optional<TestStep> currentTestStep = state.getCurrentTestStep();
-        if (!currentTestStep.isPresent()) {
-            throw new IllegalStateException("No current TestStep was found in TestCaseState");
-        }
-        if (!(currentTestStep.get() instanceof HookTestStep)) {
-            throw new IllegalStateException("Current TestStep is not a HookTestStep");
-        }
-        TestStep relatedTestStep = ((HookTestStep) currentTestStep.get()).getRelatedTestStep();
-        if (null == relatedTestStep) {
-            throw new IllegalStateException("No related TestStep for current HookTestStep was found");
-        }
-        if (!(relatedTestStep instanceof PickleStepTestStep)) {
-            throw new IllegalStateException("Related TestStep is not a PickleStepTestStep");
-        }
-        delegate = ((PickleStepTestStep) relatedTestStep).getStep();
+    public Step(final PickleStep delegate) {
+        this.delegate = delegate;
     }
 
     @Override
-    public StepArgument getArgument() {
-        return delegate.getArgument();
-    }
-
-    @Override
-    public String getKeyword() {
+    public PickleStep.Keyword getKeyword() {
         return delegate.getKeyword();
     }
 
     @Override
-    public String getText() {
-        return delegate.getText();
-    }
-
-    @Override
-    public int getLine() {
-        return delegate.getLine();
-    }
-
-    @Override
-    public Location getLocation() {
-        return delegate.getLocation();
+    public Object[] getArguments() {
+        return delegate.getArguments();
     }
 
 }

--- a/java/src/test/java/io/cucumber/java/JavaHookDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaHookDefinitionTest.java
@@ -1,8 +1,6 @@
 package io.cucumber.java;
 
-import io.cucumber.core.backend.HookStep;
 import io.cucumber.core.backend.Lookup;
-import io.cucumber.core.backend.PickleStep;
 import io.cucumber.core.backend.TestCaseState;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,14 +11,11 @@ import org.mockito.quality.Strictness;
 
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @SuppressWarnings({ "WeakerAccess" })
 @ExtendWith({ MockitoExtension.class })
@@ -38,12 +33,6 @@ public class JavaHookDefinitionTest {
 
     @Mock
     private TestCaseState state;
-
-    @Mock
-    private PickleStep pickleStepTestStep;
-
-    @Mock
-    private HookStep hookTestStep;
 
     private boolean invoked = false;
 
@@ -74,61 +63,6 @@ public class JavaHookDefinitionTest {
     }
 
     @Test
-    void can_create_with_scenario_and_step_arguments() throws Throwable {
-        mockValidStep();
-        Method method = JavaHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class, Step.class);
-        JavaHookDefinition definition = new JavaHookDefinition(method, "", 0, lookup);
-        definition.execute(state);
-        assertTrue(invoked);
-    }
-
-    @BeforeStep
-    public void scenario_step_arguments(Scenario scenario, Step step) {
-        invoked = true;
-    }
-
-    @Test
-    void can_create_with_step_and_scenario_arguments() throws Throwable {
-        mockValidStep();
-        Method method = JavaHookDefinitionTest.class.getMethod("step_scenario_arguments", Step.class, Scenario.class);
-        JavaHookDefinition definition = new JavaHookDefinition(method, "", 0, lookup);
-        definition.execute(state);
-        assertTrue(invoked);
-    }
-
-    @BeforeStep
-    public void step_scenario_arguments(Step step, Scenario scenario) {
-        invoked = true;
-    }
-
-    @Test
-    void can_create_with_only_step_argument() throws Throwable {
-        mockValidStep();
-        Method method = JavaHookDefinitionTest.class.getMethod("beforestep_step_argument", Step.class);
-        JavaHookDefinition definition = new JavaHookDefinition(method, "", 0, lookup);
-        definition.execute(state);
-        assertTrue(invoked);
-    }
-
-    @BeforeStep
-    public void beforestep_step_argument(Step step) {
-        invoked = true;
-    }
-
-    @Test
-    void can_create_with_only_scenario_argument() throws Throwable {
-        Method method = JavaHookDefinitionTest.class.getMethod("beforestep_scenario_argument", Scenario.class);
-        JavaHookDefinition definition = new JavaHookDefinition(method, "", 0, lookup);
-        definition.execute(state);
-        assertTrue(invoked);
-    }
-
-    @BeforeStep
-    public void beforestep_scenario_argument(Scenario scenario) {
-        invoked = true;
-    }
-
-    @Test
     void fails_if_hook_argument_is_not_scenario_result() throws NoSuchMethodException {
         Method method = JavaHookDefinitionTest.class.getMethod("invalid_parameter", String.class);
         InvalidMethodSignatureException exception = assertThrows(
@@ -143,28 +77,6 @@ public class JavaHookDefinitionTest {
 
     @Before
     public void invalid_parameter(String badType) {
-
-    }
-
-    @Test
-    void fails_if_hook_argument_is_not_scenario_step_result() throws NoSuchMethodException {
-        Method method = JavaHookDefinitionTest.class.getMethod("invalid_parameter_step", String.class);
-        InvalidMethodSignatureException exception = assertThrows(
-            InvalidMethodSignatureException.class,
-            () -> new JavaHookDefinition(method, "", 0, lookup));
-        assertThat(exception.getMessage(), startsWith("" +
-                "A method annotated with BeforeStep or AfterStep must have one of these signatures:\n" +
-                " * public void before_or_after_step(io.cucumber.java.Scenario scenario, io.cucumber.java.Step step)\n" +
-                " * public void before_or_after_step(io.cucumber.java.Step step, io.cucumber.java.Scenario scenario)\n" +
-                " * public void before_or_after_step(io.cucumber.java.Step step)\n" +
-                " * public void before_or_after_step(io.cucumber.java.Scenario scenario)\n" +
-                " * public void before_or_after_step()\n" +
-                "at io.cucumber.java.JavaHookDefinitionTest.invalid_parameter_step(java.lang.String"));
-    }
-
-    @BeforeStep
-    @AfterStep
-    public void invalid_parameter_step(String badType) {
 
     }
 
@@ -192,73 +104,6 @@ public class JavaHookDefinitionTest {
     @Before
     public void too_many_parameters(Scenario arg1, String arg2) {
 
-    }
-
-    @Test
-    void fails_if_step_hook_argument_for_non_step_hook() throws NoSuchMethodException {
-        Method method = JavaHookDefinitionTest.class.getMethod("invalid_step_parameter", Step.class);
-        assertThrows(
-            InvalidMethodSignatureException.class,
-            () -> new JavaHookDefinition(method, "", 0, lookup));
-    }
-
-    @Before
-    public void invalid_step_parameter(Step step) {
-
-    }
-
-    @Test
-    void fails_if_step_hook_argument_and_both_beforestep_and_before_annotations() throws NoSuchMethodException {
-        Method method = JavaHookDefinitionTest.class.getMethod("double_annotated_invalid_step_parameter", Step.class);
-        assertThrows(
-            InvalidMethodSignatureException.class,
-            () -> new JavaHookDefinition(method, "", 0, lookup));
-    }
-
-    @Before
-    @BeforeStep
-    public void double_annotated_invalid_step_parameter(Step step) {
-        // Invalid because @Before cannot set Step
-    }
-
-    private void mockValidStep() {
-        when(state.getCurrentTestStep()).thenReturn(Optional.of(hookTestStep));
-        when(hookTestStep.getRelatedStep()).thenReturn(pickleStepTestStep);
-    }
-
-    @Test
-    void fails_if_testcasestate_has_no_current_teststep() throws NoSuchMethodException {
-        when(state.getCurrentTestStep()).thenReturn(Optional.empty());
-        Method method = JavaHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class, Step.class);
-        JavaHookDefinition javaHookDefinition = new JavaHookDefinition(method, "", 0, lookup);
-        IllegalStateException exception = assertThrows(
-            IllegalStateException.class,
-            () -> javaHookDefinition.execute(state));
-        assertThat(exception.getMessage(), startsWith("No current TestStep was found in TestCaseState"));
-    }
-
-    @Test
-    void fails_if_testcase_has_no_hookstep_as_current_teststep() throws NoSuchMethodException {
-        when(state.getCurrentTestStep()).thenReturn(Optional.of(mock(PickleStep.class)));
-        Method method = JavaHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class, Step.class);
-        JavaHookDefinition javaHookDefinition = new JavaHookDefinition(method, "", 0, lookup);
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> {
-                javaHookDefinition.execute(state);
-            });
-        assertThat(exception.getMessage(), startsWith("Current TestStep should be a HookStep instead of"));
-    }
-
-    @Test
-    void fails_if_testcase_current_hookstep_has_no_related_step() throws NoSuchMethodException {
-        when(state.getCurrentTestStep()).thenReturn(Optional.of(mock(HookStep.class)));
-        Method method = JavaHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class, Step.class);
-        JavaHookDefinition javaHookDefinition = new JavaHookDefinition(method, "", 0, lookup);
-        IllegalStateException exception = assertThrows(
-            IllegalStateException.class,
-            () -> javaHookDefinition.execute(state));
-        assertThat(exception.getMessage(), startsWith("Current HookStep has no related PickleStep"));
     }
 
 }

--- a/java/src/test/java/io/cucumber/java/JavaHookDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaHookDefinitionTest.java
@@ -209,7 +209,7 @@ public class JavaHookDefinitionTest {
 
     @Test
     void fails_if_step_hook_argument_and_both_beforestep_and_before_annotations() throws NoSuchMethodException {
-        Method method = JavaHookDefinitionTest.class.getMethod("double_annotated_with_invalid_step_parameter", Step.class);
+        Method method = JavaHookDefinitionTest.class.getMethod("double_annotated_invalid_step_parameter", Step.class);
         assertThrows(
             InvalidMethodSignatureException.class,
             () -> new JavaHookDefinition(method, "", 0, lookup));
@@ -217,7 +217,7 @@ public class JavaHookDefinitionTest {
 
     @Before
     @BeforeStep
-    public void double_annotated_with_invalid_step_parameter(Step step) {
+    public void double_annotated_invalid_step_parameter(Step step) {
         // Invalid because @Before cannot set Step
     }
 
@@ -232,8 +232,8 @@ public class JavaHookDefinitionTest {
         Method method = JavaHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class, Step.class);
         JavaHookDefinition javaHookDefinition = new JavaHookDefinition(method, "", 0, lookup);
         IllegalStateException exception = assertThrows(
-                IllegalStateException.class,
-                () -> javaHookDefinition.execute(state));
+            IllegalStateException.class,
+            () -> javaHookDefinition.execute(state));
         assertThat(exception.getMessage(), startsWith("No current TestStep was found in TestCaseState"));
     }
 
@@ -243,10 +243,10 @@ public class JavaHookDefinitionTest {
         Method method = JavaHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class, Step.class);
         JavaHookDefinition javaHookDefinition = new JavaHookDefinition(method, "", 0, lookup);
         IllegalArgumentException exception = assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                    javaHookDefinition.execute(state);
-                });
+            IllegalArgumentException.class,
+            () -> {
+                javaHookDefinition.execute(state);
+            });
         assertThat(exception.getMessage(), startsWith("Current TestStep should be a HookStep instead of"));
     }
 
@@ -256,8 +256,8 @@ public class JavaHookDefinitionTest {
         Method method = JavaHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class, Step.class);
         JavaHookDefinition javaHookDefinition = new JavaHookDefinition(method, "", 0, lookup);
         IllegalStateException exception = assertThrows(
-                IllegalStateException.class,
-                () -> javaHookDefinition.execute(state));
+            IllegalStateException.class,
+            () -> javaHookDefinition.execute(state));
         assertThat(exception.getMessage(), startsWith("Current HookStep has no related PickleStep"));
     }
 

--- a/java/src/test/java/io/cucumber/java/JavaHookDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaHookDefinitionTest.java
@@ -2,6 +2,8 @@ package io.cucumber.java;
 
 import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.TestCaseState;
+import io.cucumber.plugin.event.HookTestStep;
+import io.cucumber.plugin.event.PickleStepTestStep;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -11,11 +13,13 @@ import org.mockito.quality.Strictness;
 
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings({ "WeakerAccess" })
 @ExtendWith({ MockitoExtension.class })
@@ -34,6 +38,12 @@ public class JavaHookDefinitionTest {
     @Mock
     private TestCaseState state;
 
+    @Mock
+    private PickleStepTestStep pickleStepTestStep;
+
+    @Mock
+    private HookTestStep hookTestStep;
+
     private boolean invoked = false;
 
     @Test
@@ -51,14 +61,69 @@ public class JavaHookDefinitionTest {
 
     @Test
     void can_create_with_single_scenario_argument() throws Throwable {
-        Method method = JavaHookDefinitionTest.class.getMethod("single_argument", Scenario.class);
+        Method method = JavaHookDefinitionTest.class.getMethod("scenario_argument", Scenario.class);
         JavaHookDefinition definition = new JavaHookDefinition(method, "", 0, lookup);
         definition.execute(state);
         assertTrue(invoked);
     }
 
     @Before
-    public void single_argument(Scenario scenario) {
+    public void scenario_argument(Scenario scenario) {
+        invoked = true;
+    }
+
+    @Test
+    void can_create_with_scenario_and_step_arguments() throws Throwable {
+        mockValidStep();
+        Method method = JavaHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class, Step.class);
+        JavaHookDefinition definition = new JavaHookDefinition(method, "", 0, lookup);
+        definition.execute(state);
+        assertTrue(invoked);
+    }
+
+    @BeforeStep
+    public void scenario_step_arguments(Scenario scenario, Step step) {
+        invoked = true;
+    }
+
+    @Test
+    void can_create_with_step_and_scenario_arguments() throws Throwable {
+        mockValidStep();
+        Method method = JavaHookDefinitionTest.class.getMethod("step_scenario_arguments", Step.class, Scenario.class);
+        JavaHookDefinition definition = new JavaHookDefinition(method, "", 0, lookup);
+        definition.execute(state);
+        assertTrue(invoked);
+    }
+
+    @BeforeStep
+    public void step_scenario_arguments(Step step, Scenario scenario) {
+        invoked = true;
+    }
+
+    @Test
+    void can_create_with_only_step_argument() throws Throwable {
+        mockValidStep();
+        Method method = JavaHookDefinitionTest.class.getMethod("beforestep_step_argument", Step.class);
+        JavaHookDefinition definition = new JavaHookDefinition(method, "", 0, lookup);
+        definition.execute(state);
+        assertTrue(invoked);
+    }
+
+    @BeforeStep
+    public void beforestep_step_argument(Step step) {
+        invoked = true;
+    }
+
+    @Test
+    void can_create_with_only_scenario_argument() throws Throwable {
+        Method method = JavaHookDefinitionTest.class.getMethod("beforestep_scenario_argument", Scenario.class);
+        JavaHookDefinition definition = new JavaHookDefinition(method, "", 0, lookup);
+        definition.execute(state);
+        assertTrue(invoked);
+    }
+
+    @BeforeStep
+    public void beforestep_scenario_argument(Scenario scenario) {
         invoked = true;
     }
 
@@ -69,13 +134,36 @@ public class JavaHookDefinitionTest {
             InvalidMethodSignatureException.class,
             () -> new JavaHookDefinition(method, "", 0, lookup));
         assertThat(exception.getMessage(), startsWith("" +
-                "A method annotated with Before, After, BeforeStep or AfterStep must have one of these signatures:\n" +
+                "A method annotated with Before or After must have one of these signatures:\n" +
                 " * public void before_or_after(io.cucumber.java.Scenario scenario)\n" +
                 " * public void before_or_after()\n" +
                 "at io.cucumber.java.JavaHookDefinitionTest.invalid_parameter(java.lang.String"));
     }
 
+    @Before
     public void invalid_parameter(String badType) {
+
+    }
+
+    @Test
+    void fails_if_hook_argument_is_not_scenario_step_result() throws NoSuchMethodException {
+        Method method = JavaHookDefinitionTest.class.getMethod("invalid_parameter_step", String.class);
+        InvalidMethodSignatureException exception = assertThrows(
+                InvalidMethodSignatureException.class,
+                () -> new JavaHookDefinition(method, "", 0, lookup));
+        assertThat(exception.getMessage(), startsWith("" +
+                "A method annotated with BeforeStep or AfterStep must have one of these signatures:\n" +
+                " * public void before_or_after_step(io.cucumber.java.Scenario scenario, io.cucumber.java.Step step)\n" +
+                " * public void before_or_after_step(io.cucumber.java.Step step, io.cucumber.java.Scenario scenario)\n" +
+                " * public void before_or_after_step(io.cucumber.java.Step step)\n" +
+                " * public void before_or_after_step(io.cucumber.java.Scenario scenario)\n" +
+                " * public void before_or_after_step()\n" +
+                "at io.cucumber.java.JavaHookDefinitionTest.invalid_parameter_step(java.lang.String"));
+    }
+
+    @BeforeStep
+    @AfterStep
+    public void invalid_parameter_step(String badType) {
 
     }
 
@@ -87,6 +175,7 @@ public class JavaHookDefinitionTest {
             () -> new JavaHookDefinition(method, "", 0, lookup));
     }
 
+    @Before
     public void invalid_generic_parameter(List<String> badType) {
 
     }
@@ -99,8 +188,41 @@ public class JavaHookDefinitionTest {
             () -> new JavaHookDefinition(method, "", 0, lookup));
     }
 
+    @Before
     public void too_many_parameters(Scenario arg1, String arg2) {
 
+    }
+
+    @Test
+    void fails_if_step_hook_argument_for_non_step_hook() throws NoSuchMethodException {
+        Method method = JavaHookDefinitionTest.class.getMethod("invalid_step_parameter", Step.class);
+        assertThrows(
+                InvalidMethodSignatureException.class,
+                () -> new JavaHookDefinition(method, "", 0, lookup));
+    }
+
+    @Before
+    public void invalid_step_parameter(Step step) {
+
+    }
+
+    @Test
+    void fails_if_step_hook_argument_and_both_beforestep_and_before_annotations() throws NoSuchMethodException {
+        Method method = JavaHookDefinitionTest.class.getMethod("double_annotated_with_invalid_step_parameter", Step.class);
+        assertThrows(
+                InvalidMethodSignatureException.class,
+                () -> new JavaHookDefinition(method, "", 0, lookup));
+    }
+
+    @Before
+    @BeforeStep
+    public void double_annotated_with_invalid_step_parameter(Step step) {
+        // Invalid because @Before cannot set Step
+    }
+
+    private void mockValidStep() {
+        when(state.getCurrentTestStep()).thenReturn(Optional.of(hookTestStep));
+        when(hookTestStep.getRelatedTestStep()).thenReturn(pickleStepTestStep);
     }
 
 }

--- a/java/src/test/java/io/cucumber/java/JavaStepHookDefinitionTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaStepHookDefinitionTest.java
@@ -1,0 +1,245 @@
+package io.cucumber.java;
+
+import io.cucumber.core.backend.HookStep;
+import io.cucumber.core.backend.Lookup;
+import io.cucumber.core.backend.PickleStep;
+import io.cucumber.core.backend.TestCaseState;
+import org.junit.Ignore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings({ "WeakerAccess" })
+@ExtendWith({ MockitoExtension.class })
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+@Ignore
+public class JavaStepHookDefinitionTest {
+
+    private final Lookup lookup = new Lookup() {
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getInstance(Class<T> glueClass) {
+            return (T) JavaStepHookDefinitionTest.this;
+        }
+    };
+
+    @Mock
+    private TestCaseState state;
+
+    @Mock
+    private PickleStep pickleStepTestStep;
+
+    @Mock
+    private HookStep hookTestStep;
+
+    private boolean invoked = false;
+
+    @Test
+    void can_create_with_no_argument() throws Throwable {
+        Method method = JavaStepHookDefinitionTest.class.getMethod("no_arguments");
+        JavaStepHookDefinition definition = new JavaStepHookDefinition(method, "", 0, lookup);
+        definition.execute(state);
+        assertTrue(invoked);
+    }
+
+    @BeforeStep
+    public void no_arguments() {
+        invoked = true;
+    }
+
+    @Test
+    void can_create_with_single_scenario_argument() throws Throwable {
+        Method method = JavaStepHookDefinitionTest.class.getMethod("scenario_argument", Scenario.class);
+        JavaStepHookDefinition definition = new JavaStepHookDefinition(method, "", 0, lookup);
+        definition.execute(state);
+        assertTrue(invoked);
+    }
+
+    @BeforeStep
+    public void scenario_argument(Scenario scenario) {
+        invoked = true;
+    }
+
+    @Test
+    void can_create_with_scenario_and_step_arguments() throws Throwable {
+        mockValidStep();
+        Method method = JavaStepHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class,
+            Step.class);
+        JavaStepHookDefinition definition = new JavaStepHookDefinition(method, "", 0, lookup);
+        definition.execute(state);
+        assertTrue(invoked);
+    }
+
+    @BeforeStep
+    public void scenario_step_arguments(Scenario scenario, Step step) {
+        invoked = true;
+    }
+
+    @Test
+    void can_create_with_step_and_scenario_arguments() throws Throwable {
+        mockValidStep();
+        Method method = JavaStepHookDefinitionTest.class.getMethod("step_scenario_arguments", Step.class,
+            Scenario.class);
+        JavaStepHookDefinition definition = new JavaStepHookDefinition(method, "", 0, lookup);
+        definition.execute(state);
+        assertTrue(invoked);
+    }
+
+    @BeforeStep
+    public void step_scenario_arguments(Step step, Scenario scenario) {
+        invoked = true;
+    }
+
+    @Test
+    void can_create_with_only_step_argument() throws Throwable {
+        mockValidStep();
+        Method method = JavaStepHookDefinitionTest.class.getMethod("beforestep_step_argument", Step.class);
+        JavaStepHookDefinition definition = new JavaStepHookDefinition(method, "", 0, lookup);
+        definition.execute(state);
+        assertTrue(invoked);
+    }
+
+    @BeforeStep
+    public void beforestep_step_argument(Step step) {
+        invoked = true;
+    }
+
+    @Test
+    void can_create_with_only_scenario_argument() throws Throwable {
+        Method method = JavaStepHookDefinitionTest.class.getMethod("beforestep_scenario_argument", Scenario.class);
+        JavaStepHookDefinition definition = new JavaStepHookDefinition(method, "", 0, lookup);
+        definition.execute(state);
+        assertTrue(invoked);
+    }
+
+    @BeforeStep
+    public void beforestep_scenario_argument(Scenario scenario) {
+        invoked = true;
+    }
+
+    @Test
+    void fails_if_hook_argument_is_not_scenario_result() throws NoSuchMethodException {
+        Method method = JavaStepHookDefinitionTest.class.getMethod("invalid_parameter", String.class);
+        InvalidMethodSignatureException exception = assertThrows(
+            InvalidMethodSignatureException.class,
+            () -> new JavaStepHookDefinition(method, "", 0, lookup));
+        assertThat(exception.getMessage(), startsWith("" +
+                "A method annotated with BeforeStep or AfterStep must have one of these signatures:\n" +
+                " * public void before_or_after_step(io.cucumber.java.Scenario scenario, io.cucumber.java.Step step)\n" +
+                " * public void before_or_after_step(io.cucumber.java.Step step, io.cucumber.java.Scenario scenario)\n" +
+                " * public void before_or_after_step(io.cucumber.java.Scenario scenario)\n" +
+                " * public void before_or_after_step(io.cucumber.java.Step step)\n" +
+                " * public void before_or_after_step()"));
+    }
+
+    @BeforeStep
+    public void invalid_parameter(String badType) {
+
+    }
+
+    @Test
+    void fails_if_hook_argument_is_not_scenario_step_result() throws NoSuchMethodException {
+        Method method = JavaStepHookDefinitionTest.class.getMethod("invalid_parameter_step", String.class);
+        InvalidMethodSignatureException exception = assertThrows(
+            InvalidMethodSignatureException.class,
+            () -> new JavaStepHookDefinition(method, "", 0, lookup));
+        assertThat(exception.getMessage(), startsWith("" +
+                "A method annotated with BeforeStep or AfterStep must have one of these signatures:\n" +
+                " * public void before_or_after_step(io.cucumber.java.Scenario scenario, io.cucumber.java.Step step)\n" +
+                " * public void before_or_after_step(io.cucumber.java.Step step, io.cucumber.java.Scenario scenario)\n" +
+                " * public void before_or_after_step(io.cucumber.java.Scenario scenario)\n" +
+                " * public void before_or_after_step(io.cucumber.java.Step step)\n" +
+                " * public void before_or_after_step()"));
+    }
+
+    @BeforeStep
+    @AfterStep
+    public void invalid_parameter_step(String badType) {
+
+    }
+
+    @Test
+    void fails_if_generic_hook_argument_is_not_scenario_result() throws NoSuchMethodException {
+        Method method = JavaStepHookDefinitionTest.class.getMethod("invalid_generic_parameter", List.class);
+        assertThrows(
+            InvalidMethodSignatureException.class,
+            () -> new JavaStepHookDefinition(method, "", 0, lookup));
+    }
+
+    @Before
+    public void invalid_generic_parameter(List<String> badType) {
+
+    }
+
+    @Test
+    void fails_if_too_many_arguments() throws NoSuchMethodException {
+        Method method = JavaStepHookDefinitionTest.class.getMethod("too_many_parameters", Scenario.class, String.class);
+        assertThrows(
+            InvalidMethodSignatureException.class,
+            () -> new JavaStepHookDefinition(method, "", 0, lookup));
+    }
+
+    @Before
+    public void too_many_parameters(Scenario arg1, String arg2) {
+
+    }
+
+    private void mockValidStep() {
+        when(state.getCurrentTestStep()).thenReturn(Optional.of(hookTestStep));
+        when(hookTestStep.getRelatedStep()).thenReturn(pickleStepTestStep);
+    }
+
+    @Test
+    void fails_if_testcasestate_has_no_current_teststep() throws NoSuchMethodException {
+        when(state.getCurrentTestStep()).thenReturn(Optional.empty());
+        Method method = JavaStepHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class,
+            Step.class);
+        JavaStepHookDefinition javaStepHookDefinition = new JavaStepHookDefinition(method, "", 0, lookup);
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> javaStepHookDefinition.execute(state));
+        assertThat(exception.getMessage(), startsWith("No current TestStep was found in TestCaseState"));
+    }
+
+    @Test
+    void fails_if_testcase_has_no_hookstep_as_current_teststep() throws NoSuchMethodException {
+        when(state.getCurrentTestStep()).thenReturn(Optional.of(mock(PickleStep.class)));
+        Method method = JavaStepHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class,
+            Step.class);
+        JavaStepHookDefinition javaStepHookDefinition = new JavaStepHookDefinition(method, "", 0, lookup);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+                javaStepHookDefinition.execute(state);
+            });
+        assertThat(exception.getMessage(), startsWith("Current TestStep should be a HookStep instead of"));
+    }
+
+    @Test
+    void fails_if_testcase_current_hookstep_has_no_related_step() throws NoSuchMethodException {
+        when(state.getCurrentTestStep()).thenReturn(Optional.of(mock(HookStep.class)));
+        Method method = JavaStepHookDefinitionTest.class.getMethod("scenario_step_arguments", Scenario.class,
+            Step.class);
+        JavaStepHookDefinition javaStepHookDefinition = new JavaStepHookDefinition(method, "", 0, lookup);
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> javaStepHookDefinition.execute(state));
+        assertThat(exception.getMessage(), startsWith("Current HookStep has no related PickleStep"));
+    }
+
+}

--- a/java/src/test/java/io/cucumber/java/StepTest.java
+++ b/java/src/test/java/io/cucumber/java/StepTest.java
@@ -1,91 +1,31 @@
 package io.cucumber.java;
 
-import io.cucumber.core.backend.TestCaseState;
-import io.cucumber.plugin.event.HookTestStep;
-import io.cucumber.plugin.event.Location;
-import io.cucumber.plugin.event.PickleStepTestStep;
-import io.cucumber.plugin.event.StepArgument;
+import io.cucumber.core.backend.PickleStep;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class StepTest {
 
     @Mock
-    TestCaseState testCaseState;
-
-    @Mock
-    HookTestStep hookTestStep;
-
-    @Mock
-    PickleStepTestStep pickleStepTestStep;
+    PickleStep pickleStep;
 
     @Test
     void createTestCaseStateSuccess() {
-        when(testCaseState.getCurrentTestStep()).thenReturn(Optional.of(hookTestStep));
-        when(hookTestStep.getRelatedTestStep()).thenReturn(pickleStepTestStep);
-        io.cucumber.plugin.event.Step mockStepDelegate = mock(io.cucumber.plugin.event.Step.class);
-        when(pickleStepTestStep.getStep()).thenReturn(mockStepDelegate);
-        when(mockStepDelegate.getArgument()).thenReturn(mock(StepArgument.class));
-        when(mockStepDelegate.getKeyword()).thenReturn("Given");
-        when(mockStepDelegate.getText()).thenReturn("text");
-        when(mockStepDelegate.getLine()).thenReturn(1);
-        when(mockStepDelegate.getLocation()).thenReturn(new Location(1, 2));
-        Step step = new Step(testCaseState);
+        when(pickleStep.getArguments()).thenReturn(new Object[] { "test" });
+        when(pickleStep.getKeyword()).thenReturn(PickleStep.Keyword.GIVEN);
+        Step step = new Step(pickleStep);
         assertThat(step.delegate, is(notNullValue()));
-        assertThat(step.getArgument(), is(equalTo(mockStepDelegate.getArgument())));
-        assertThat(step.getKeyword(), is(equalTo(mockStepDelegate.getKeyword())));
-        assertThat(step.getText(), is(equalTo(mockStepDelegate.getText())));
-        assertThat(step.getLine(), is(equalTo(mockStepDelegate.getLine())));
-        assertThat(step.getLocation(), is(equalTo(mockStepDelegate.getLocation())));
+        assertThat(step.getArguments(), is(equalTo(new Object[] { "test" })));
+        assertThat(step.getKeyword(), is(equalTo(PickleStep.Keyword.GIVEN)));
     }
 
-    @Test
-    void testCaseStateShouldHaveCurrentTestStep() {
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> new Step(testCaseState));
-        assertThat(exception.getMessage(), startsWith("No current TestStep was found in TestCaseState"));
-    }
-
-    @Test
-    void testCaseStateShouldHaveCurrentStepEmpty() {
-        when(testCaseState.getCurrentTestStep()).thenReturn(Optional.empty());
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> new Step(testCaseState));
-        assertThat(exception.getMessage(), startsWith("No current TestStep was found in TestCaseState"));
-    }
-
-    @Test
-    void testCaseStateShouldHaveCurrentHookTestStep() {
-        when(testCaseState.getCurrentTestStep()).thenReturn(Optional.of(pickleStepTestStep));
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> new Step(testCaseState));
-        assertThat(exception.getMessage(), startsWith("Current TestStep is not a HookTestStep"));
-    }
-
-    @Test
-    void testCaseStateShouldHaveRelatedTestStep() {
-        when(testCaseState.getCurrentTestStep()).thenReturn(Optional.of(hookTestStep));
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> new Step(testCaseState));
-        assertThat(exception.getMessage(), startsWith("No related TestStep for current HookTestStep was found"));
-    }
-
-    @Test
-    void testCaseStateShouldHavePickleStepTestStep() {
-        when(testCaseState.getCurrentTestStep()).thenReturn(Optional.of(hookTestStep));
-        when(hookTestStep.getRelatedTestStep()).thenReturn(hookTestStep);
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> new Step(testCaseState));
-        assertThat(exception.getMessage(), startsWith("Related TestStep is not a PickleStepTestStep"));
-    }
 }

--- a/java/src/test/java/io/cucumber/java/StepTest.java
+++ b/java/src/test/java/io/cucumber/java/StepTest.java
@@ -1,0 +1,91 @@
+package io.cucumber.java;
+
+import io.cucumber.core.backend.TestCaseState;
+import io.cucumber.plugin.event.HookTestStep;
+import io.cucumber.plugin.event.Location;
+import io.cucumber.plugin.event.PickleStepTestStep;
+import io.cucumber.plugin.event.StepArgument;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StepTest {
+
+    @Mock
+    TestCaseState testCaseState;
+
+    @Mock
+    HookTestStep hookTestStep;
+
+    @Mock
+    PickleStepTestStep pickleStepTestStep;
+
+    @Test
+    void createTestCaseStateSuccess() {
+        when(testCaseState.getCurrentTestStep()).thenReturn(Optional.of(hookTestStep));
+        when(hookTestStep.getRelatedTestStep()).thenReturn(pickleStepTestStep);
+        io.cucumber.plugin.event.Step mockStepDelegate = mock(io.cucumber.plugin.event.Step.class);
+        when(pickleStepTestStep.getStep()).thenReturn(mockStepDelegate);
+        when(mockStepDelegate.getArgument()).thenReturn(mock(StepArgument.class));
+        when(mockStepDelegate.getKeyword()).thenReturn("Given");
+        when(mockStepDelegate.getText()).thenReturn("text");
+        when(mockStepDelegate.getLine()).thenReturn(1);
+        when(mockStepDelegate.getLocation()).thenReturn(new Location(1, 2));
+        Step step = new Step(testCaseState);
+        assertThat(step.delegate, is(notNullValue()));
+        assertThat(step.getArgument(), is(equalTo(mockStepDelegate.getArgument())));
+        assertThat(step.getKeyword(), is(equalTo(mockStepDelegate.getKeyword())));
+        assertThat(step.getText(), is(equalTo(mockStepDelegate.getText())));
+        assertThat(step.getLine(), is(equalTo(mockStepDelegate.getLine())));
+        assertThat(step.getLocation(), is(equalTo(mockStepDelegate.getLocation())));
+    }
+
+    @Test
+    void testCaseStateShouldHaveCurrentTestStep() {
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> new Step(testCaseState));
+        assertThat(exception.getMessage(), startsWith("No current TestStep was found in TestCaseState"));
+    }
+
+    @Test
+    void testCaseStateShouldHaveCurrentStepEmpty() {
+        when(testCaseState.getCurrentTestStep()).thenReturn(Optional.empty());
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> new Step(testCaseState));
+        assertThat(exception.getMessage(), startsWith("No current TestStep was found in TestCaseState"));
+    }
+
+    @Test
+    void testCaseStateShouldHaveCurrentHookTestStep() {
+        when(testCaseState.getCurrentTestStep()).thenReturn(Optional.of(pickleStepTestStep));
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> new Step(testCaseState));
+        assertThat(exception.getMessage(), startsWith("Current TestStep is not a HookTestStep"));
+    }
+
+    @Test
+    void testCaseStateShouldHaveRelatedTestStep() {
+        when(testCaseState.getCurrentTestStep()).thenReturn(Optional.of(hookTestStep));
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> new Step(testCaseState));
+        assertThat(exception.getMessage(), startsWith("No related TestStep for current HookTestStep was found"));
+    }
+
+    @Test
+    void testCaseStateShouldHavePickleStepTestStep() {
+        when(testCaseState.getCurrentTestStep()).thenReturn(Optional.of(hookTestStep));
+        when(hookTestStep.getRelatedTestStep()).thenReturn(hookTestStep);
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> new Step(testCaseState));
+        assertThat(exception.getMessage(), startsWith("Related TestStep is not a PickleStepTestStep"));
+    }
+}

--- a/plugin/src/main/java/io/cucumber/plugin/event/HookTestStep.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/HookTestStep.java
@@ -19,6 +19,6 @@ public interface HookTestStep extends TestStep {
      */
     HookType getHookType();
 
-    TestStep getRelatedTestStep();
+    PickleStepTestStep getRelatedTestStep();
 
 }

--- a/plugin/src/main/java/io/cucumber/plugin/event/HookTestStep.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/HookTestStep.java
@@ -19,4 +19,6 @@ public interface HookTestStep extends TestStep {
      */
     HookType getHookType();
 
+    TestStep getRelatedTestStep();
+
 }


### PR DESCRIPTION
Related to https://github.com/cucumber/cucumber-jvm/issues/1805 

Added "related step" to HookTestStep, referring to the (PickleStep)TestStep the BeforeStep/AfterStep annotated HookTestStep relates to. This way the actual PickleStepTestStep can be added to the signature of the BeforeStep/AfterStep annotated method.
