### PR TITLE
[Core] Fix platform dependent unit tests

### DIFF
--- a/core/src/test/java/io/cucumber/core/resource/ResourceScannerTest.java
+++ b/core/src/test/java/io/cucumber/core/resource/ResourceScannerTest.java
@@ -2,6 +2,8 @@ package io.cucumber.core.resource;
 
 import io.cucumber.core.exception.CucumberException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.net.URI;
@@ -103,6 +105,9 @@ class ResourceScannerTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS,
+            disabledReason = "Only works if repository is explictly cloned activated symlinks and " +
+                    "developer mode in windows is activated")
     void scanForResourcesPathSymlink() {
         File file = new File("src/test/resource-symlink/test/resource.txt");
         List<URI> resources = resourceScanner.scanForResourcesPath(file.toPath());


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

Fixing the last test of #2104 and the PluginFactoryTest, which also fails on windows.

**Describe the solution you have implemented**
Ignore ResourceScannerTest#scanForResourcesPathSymlink on windows, because to make it run windows needs to be in developer mode, and the repo has to be cloned with actived symlinks.
The PluginFactory Test fails on windows, because the plugins (the real ones, not the test plugins) which get a file paramter, open the file directly during instantiation. On windows the test failed, because junit cannot delete the tmpDir due to open files. The change uses the EventPublisher to send events to the plugin, especially the TestRunFinished Event. During handling of TestRunFinished the plugins close the file and junit can successfully clean up afterwards.

**Additional context**
Add any other context or screenshots about the pull request here.
