### PR TITLE
[Compatibility] Fix platform dependent tests

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dfile.encoding=UTF-8

--- a/compatibility/src/test/resources/.gitattributes
+++ b/compatibility/src/test/resources/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure that LF line endings are kept on checkout (even on windows). Tests will fail otherwise
+*.ndjson    text    eol=lf
+*.feature   text    eol=lf

--- a/core/src/test/java/io/cucumber/core/resource/ResourceScannerTest.java
+++ b/core/src/test/java/io/cucumber/core/resource/ResourceScannerTest.java
@@ -106,7 +106,7 @@ class ResourceScannerTest {
 
     @Test
     @DisabledOnOs(value = OS.WINDOWS,
-            disabledReason = "Only works if repository is explictly cloned activated symlinks and " +
+            disabledReason = "Only works if repository is explicitly cloned activated symlinks and " +
                     "developer mode in windows is activated")
     void scanForResourcesPathSymlink() {
         File file = new File("src/test/resource-symlink/test/resource.txt");
@@ -125,6 +125,9 @@ class ResourceScannerTest {
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS,
+            disabledReason = "Only works if repository is explicitly cloned activated symlinks and " +
+                    "developer mode in windows is activated")
     void scanForResourcesDirectorySymlink() {
         File file = new File("src/test/resource-symlink");
         List<URI> resources = resourceScanner.scanForResourcesPath(file.toPath());


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

This should fix all remaining problems with building under windows #2104

**Describe the solution you have implemented**

- Disabled scanForResourcesDirectorySymlink test on windows, because it suffers from the same problem as the already disabled scanForResourcesPathSymlink test

To make build work out of the box on windows the following two changes were done:
- Set maven configuration, such that maven is always called with the file encoding set to UTF-8. This is needed, because in the generated I18N sourcefiles use UTF-8 based filenames, which are otherwise not correctly passed to the compiler. 
- Ensure, that git does not do end-of-line conversion on the resource files in the compatibility module. If it does, the feature file gets converted and comparing it bytewise to the provided expected values fails. 


