### PR TITLE
[Plugin] Deprecate TestRunFinished(Instant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 ### Deprecated
+ * [Plugin] Deprecate `TestRunFinished(Instant)` ([#2169](https://github.com/cucumber/cucumber-jvm/pull/2169) M.P. Korstanje)
 
 ### Removed
 

--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-archetype</artifactId>

--- a/cdi2/pom.xml
+++ b/cdi2/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-cdi2</artifactId>

--- a/compatibility/pom.xml
+++ b/compatibility/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cucumber-jvm</artifactId>
         <groupId>io.cucumber</groupId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-core</artifactId>

--- a/core/src/test/java/io/cucumber/core/plugin/CanonicalEventOrderTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/CanonicalEventOrderTest.java
@@ -2,7 +2,9 @@ package io.cucumber.core.plugin;
 
 import io.cucumber.plugin.event.Event;
 import io.cucumber.plugin.event.Location;
+import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent;
+import io.cucumber.plugin.event.Status;
 import io.cucumber.plugin.event.TestCase;
 import io.cucumber.plugin.event.TestCaseStarted;
 import io.cucumber.plugin.event.TestRunFinished;
@@ -12,6 +14,7 @@ import io.cucumber.plugin.event.TestSourceRead;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,13 +38,16 @@ class CanonicalEventOrderTest {
     private final Event testRead = new TestSourceRead(getInstant(), URI.create("file:path/to.feature"), "source");
     private final Event testParsed = new TestSourceParsed(getInstant(), URI.create("file:path/to.feature"),
         Collections.emptyList());
-    private final Event suggested = new SnippetsSuggestedEvent(getInstant(), URI.create("file:path/to/1.feature"), 0, 0,
+    private final Event suggested = new SnippetsSuggestedEvent(getInstant(),
+        URI.create("file:path/to/1.feature"),
+        new Location(0, -1),
+        new Location(0, -1),
         Collections.emptyList());
     private final Event feature1Case1Started = createTestCaseEvent(URI.create("file:path/to/1.feature"), 1);
     private final Event feature1Case2Started = createTestCaseEvent(URI.create("file:path/to/1.feature"), 9);
     private final Event feature1Case3Started = createTestCaseEvent(URI.create("file:path/to/1.feature"), 11);
     private final Event feature2Case1Started = createTestCaseEvent(URI.create("file:path/to/2.feature"), 1);
-    private final Event runFinished = new TestRunFinished(getInstant());
+    private final Event runFinished = new TestRunFinished(getInstant(), new Result(Status.PASSED, Duration.ZERO, null));
 
     private static Event createTestCaseEvent(final URI uri, final int line) {
         final TestCase testCase = mock(TestCase.class);

--- a/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
@@ -2,7 +2,10 @@ package io.cucumber.core.plugin;
 
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.runtime.TimeServiceEventBus;
+import io.cucumber.plugin.event.Location;
+import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent;
+import io.cucumber.plugin.event.Status;
 import io.cucumber.plugin.event.TestRunFinished;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.ZoneId;
 import java.util.Locale;
 import java.util.UUID;
@@ -38,19 +42,18 @@ class DefaultSummaryPrinterTest {
         bus.send(new SnippetsSuggestedEvent(
             bus.getInstant(),
             URI.create("classpath:com/example.feature"),
-            12,
-            13,
+            new Location(12, -1),
+            new Location(13, -1),
             singletonList("snippet")));
 
         bus.send(new SnippetsSuggestedEvent(
             bus.getInstant(),
             URI.create("classpath:com/example.feature"),
-            12,
-            14,
+            new Location(12, -1),
+            new Location(14, -1),
             singletonList("snippet")));
 
-        bus.send(new TestRunFinished(
-            bus.getInstant()));
+        bus.send(new TestRunFinished(bus.getInstant(), new Result(Status.PASSED, Duration.ZERO, null)));
 
         assertThat(new String(out.toByteArray(), UTF_8), equalToCompressingWhiteSpace("" +
                 "\n" +

--- a/core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
@@ -42,7 +42,7 @@ class UnusedStepsSummaryPrinterTest {
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/gut.feature:7", "even more cukes")));
         bus.send(new TestStepFinished(bus.getInstant(), mock(TestCase.class), mockTestStep("my/gut.feature:7"),
             new Result(Status.UNUSED, Duration.ZERO, null)));
-        bus.send(new TestRunFinished(bus.getInstant()));
+        bus.send(new TestRunFinished(bus.getInstant(), new Result(Status.PASSED, Duration.ZERO, null)));
 
         // Verify produced output
         assertThat(out, isBytesEqualTo("1 Unused steps:\n" + "my/tummy.feature:5 # some more cukes\n"));

--- a/deltaspike/pom.xml
+++ b/deltaspike/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-deltaspike</artifactId>

--- a/docstring/pom.xml
+++ b/docstring/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cucumber-jvm</artifactId>
         <groupId>io.cucumber</groupId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/java-calculator-junit5/pom.xml
+++ b/examples/java-calculator-junit5/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-calculator-junit5</artifactId>

--- a/examples/java-calculator-testng/pom.xml
+++ b/examples/java-calculator-testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-calculator-testng</artifactId>

--- a/examples/java-calculator/pom.xml
+++ b/examples/java-calculator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-calculator</artifactId>

--- a/examples/java-wicket/java-wicket-main/pom.xml
+++ b/examples/java-wicket/java-wicket-main/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>java-wicket</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket-main</artifactId>
     <name>Examples: Wicket application</name>

--- a/examples/java-wicket/java-wicket-test/pom.xml
+++ b/examples/java-wicket/java-wicket-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>java-wicket</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket-test</artifactId>
     <name>Examples: Wicket application tested with Selenium</name>

--- a/examples/java-wicket/pom.xml
+++ b/examples/java-wicket/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
     <artifactId>java-wicket</artifactId>
     <packaging>pom</packaging>

--- a/examples/java8-calculator/pom.xml
+++ b/examples/java8-calculator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java8-calculator</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-examples</artifactId>

--- a/examples/spring-txn/pom.xml
+++ b/examples/spring-txn/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-examples</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-txn</artifactId>

--- a/gherkin-messages/pom.xml
+++ b/gherkin-messages/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/gherkin/pom.xml
+++ b/gherkin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-guice</artifactId>

--- a/jakarta-cdi/pom.xml
+++ b/jakarta-cdi/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-jakarta-cdi</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-java</artifactId>

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-java8</artifactId>

--- a/junit-platform-engine/pom.xml
+++ b/junit-platform-engine/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-junit-platform-engine</artifactId>

--- a/junit/pom.xml
+++ b/junit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-junit</artifactId>

--- a/kotlin-java8/pom.xml
+++ b/kotlin-java8/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-kotlin-java8</artifactId>

--- a/needle/pom.xml
+++ b/needle/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-needle</artifactId>

--- a/openejb/pom.xml
+++ b/openejb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-openejb</artifactId>

--- a/picocontainer/pom.xml
+++ b/picocontainer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-picocontainer</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-plugin</artifactId>

--- a/plugin/src/main/java/io/cucumber/plugin/event/TestRunFinished.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/TestRunFinished.java
@@ -3,19 +3,22 @@ package io.cucumber.plugin.event;
 import org.apiguardian.api.API;
 
 import java.time.Instant;
+import java.util.Objects;
 
 @API(status = API.Status.STABLE)
 public final class TestRunFinished extends TimeStampedEvent {
 
     private final Result result;
 
+    @Deprecated
     public TestRunFinished(Instant timeInstant) {
-        this(timeInstant, null);
+        super(timeInstant);
+        this.result = null;
     }
 
     public TestRunFinished(Instant timeInstant, Result result) {
         super(timeInstant);
-        this.result = result;
+        this.result = Objects.requireNonNull(result);
     }
 
     public Result getResult() {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <version>2.1.1</version>
     </parent>
     <artifactId>cucumber-jvm</artifactId>
-    <version>6.8.3-SNAPSHOT</version>
+    <version>6.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Cucumber-JVM</name>
     <description>Cucumber for the JVM</description>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-spring</artifactId>

--- a/testng/pom.xml
+++ b/testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-testng</artifactId>

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-jvm</artifactId>
-        <version>6.8.3-SNAPSHOT</version>
+        <version>6.9.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cucumber-weld</artifactId>


### PR DESCRIPTION
Since v6 the `TestRunFinished` event always contains a result when emitted by
Cucumber.