### PR TITLE
[Core] Significantly reduce the size of the html report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
- *  [Core] Improve error message when plugin paths collide ([#2168](https://github.com/cucumber/cucumber-jvm/pull/2168) M.P. Korstanje)
+ * [Core] Significantly reduce the size of the html report ([cucumber/#1232](https://github.com/cucumber/cucumber/issues/1232) M.P. Korstanje)
+ * [Core] Improve error message when plugin paths collide ([#2168](https://github.com/cucumber/cucumber-jvm/pull/2168) M.P. Korstanje)
 
 ## [6.8.2] (2020-10-29)
 

--- a/core/src/main/java/io/cucumber/core/plugin/HtmlFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/HtmlFormatter.java
@@ -23,6 +23,12 @@ public final class HtmlFormatter implements ConcurrentEventListener {
     }
 
     private void write(Envelope event) {
+        // Workaround to reduce the size of the report
+        // See: https://github.com/cucumber/cucumber/issues/1232
+        if (event.hasStepDefinition() || event.hasHook() || event.hasParameterType()) {
+            return;
+        }
+
         try {
             writer.write(event);
         } catch (IOException e) {

--- a/core/src/test/java/io/cucumber/core/plugin/CanonicalEventOrderTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/CanonicalEventOrderTest.java
@@ -164,8 +164,7 @@ class CanonicalEventOrderTest {
                 () -> assertThat(comparator.compare(e, feature1Case1Started), greaterThan(EQUAL_TO)),
                 () -> assertThat(comparator.compare(e, feature1Case2Started), greaterThan(EQUAL_TO)),
                 () -> assertThat(comparator.compare(e, feature1Case3Started), greaterThan(EQUAL_TO)),
-                () -> assertThat(comparator.compare(e, feature2Case1Started), greaterThan(EQUAL_TO))
-            );
+                () -> assertThat(comparator.compare(e, feature2Case1Started), greaterThan(EQUAL_TO)));
         }
 
         assertAll(

--- a/core/src/test/java/io/cucumber/core/plugin/HtmlFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/HtmlFormatterTest.java
@@ -47,4 +47,51 @@ class HtmlFormatterTest {
                 "];"));
     }
 
+    @Test
+    void ignores_step_definitions() throws Throwable {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        HtmlFormatter formatter = new HtmlFormatter(bytes);
+        EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
+        formatter.setEventPublisher(bus);
+
+        bus.send(Messages.Envelope.newBuilder()
+                .setTestRunStarted(Messages.TestRunStarted.newBuilder()
+                        .setTimestamp(Messages.Timestamp.newBuilder()
+                                .setSeconds(10)
+                                .build())
+                        .build())
+                .build());
+        
+        bus.send(Messages.Envelope.newBuilder()
+                .setStepDefinition(Messages.StepDefinition.newBuilder()
+                        .build())
+                .build());
+
+        bus.send(Messages.Envelope.newBuilder()
+                .setHook(Messages.Hook.newBuilder()
+                        .build())
+                .build());
+
+        bus.send(Messages.Envelope.newBuilder()
+                .setParameterType(Messages.ParameterType.newBuilder()
+                        .build())
+                .build());
+
+        bus.send(
+            Messages.Envelope.newBuilder()
+                    .setTestRunFinished(Messages.TestRunFinished.newBuilder()
+                            .setTimestamp(Messages.Timestamp.newBuilder()
+                                    .setSeconds(15)
+                                    .build())
+                            .build())
+                    .build());
+
+        String html = new String(bytes.toByteArray(), UTF_8);
+        assertThat(html, containsString("" +
+                "window.CUCUMBER_MESSAGES = [" +
+                "{\"testRunStarted\":{\"timestamp\":{\"seconds\":\"10\"}}}," +
+                "{\"testRunFinished\":{\"timestamp\":{\"seconds\":\"15\"}}}" +
+                "];"));
+    }
+
 }


### PR DESCRIPTION
Cucumber-JVM will emit all step, hook and parameter type definition for each
scenario. This results in a deluge of messages that effectively grows with
the square of the number of scenarios (more scenarios, result in more step
definitions).

Executing some 500 scenarios can result in a html report anywhere between
150 and 300 MiB. The step, hook, and parameter type definitions are not used
by the html report and can be filtered out. This reduces the report size to
some 15 MiB. While still large this is much more manageable.

Further reductions will have to come from:

1. Improvements to `cucumber/react`
2. Fixing Cucumber JVM to only define steps, hooks and parameter types once.

See: https://github.com/cucumber/cucumber/issues/1232https://github.com/cucumber/cucumber/issues/1232