### PR TITLE
[JUnit Platform] Warn if feature files could not be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] (In Git)
 
 ### Added
+ * [JUnit Platform] Warn if feature files could not be found ([#2179](https://github.com/cucumber/cucumber-jvm/issues/2179) M.P. Korstanje)
 
 ### Changed
 

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineExecutionContext.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineExecutionContext.java
@@ -3,6 +3,8 @@ package io.cucumber.junit.platform.engine;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.gherkin.Feature;
 import io.cucumber.core.gherkin.Pickle;
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
 import io.cucumber.core.plugin.PluginFactory;
 import io.cucumber.core.plugin.Plugins;
 import io.cucumber.core.runtime.BackendServiceLoader;
@@ -20,8 +22,6 @@ import io.cucumber.core.runtime.ThreadLocalRunnerSupplier;
 import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.core.runtime.TypeRegistryConfigurerSupplier;
 import org.apiguardian.api.API;
-import org.junit.platform.commons.logging.Logger;
-import org.junit.platform.commons.logging.LoggerFactory;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
 

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/nofeatures/NoFeatures.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/nofeatures/NoFeatures.java
@@ -1,0 +1,8 @@
+package io.cucumber.junit.platform.engine.nofeatures;
+
+import io.cucumber.junit.platform.engine.Cucumber;
+
+@Cucumber
+public class NoFeatures {
+
+}


### PR DESCRIPTION
Both Surefire and Gradle assume that tests are contained within a class and
use `ClassSelector` to discover tests in these classes. Cucumber uses plain
text files. By using a class annotated with `@Cucumber` we work around this
behaviour. Cucumber will then scan the package and sub-packages of the
annotated class for feature files.

When using this system, in case of misconfiguration it is not immediately clear
if the test engine is not picked up or if the location of the feature files and
annotated class do not line up.

While we can not generically log a warning in case a discovery selector did not
find any features, we can log a warning in this special case. It is clear that
the intend was to put feature files in the package. Otherwise the annotated
class could/should be removed to suppress this warning.

Fixes: https://github.com/cucumber/cucumber-jvm/issues/2179