### PR TITLE
[Core] Add space between scenario url and name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+* [Core] SummaryPrinter outputs clickable links ([#2184](https://github.com/cucumber/cucumber-jvm/issues/2184) M.P. Korstanje)
 
 ## [6.9.0] (2020-11-12)
 

--- a/core/src/test/java/io/cucumber/core/plugin/StatsTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/StatsTest.java
@@ -1,12 +1,19 @@
 package io.cucumber.core.plugin;
 
+import io.cucumber.plugin.event.Location;
 import io.cucumber.plugin.event.Status;
+import io.cucumber.plugin.event.TestCase;
+import io.cucumber.plugin.event.TestStep;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.net.URI;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 
 import static java.time.Duration.ofHours;
 import static java.time.Duration.ofMillis;
@@ -46,7 +53,7 @@ class StatsTest {
         counter.addStep(Status.PASSED);
         counter.addStep(Status.PASSED);
         counter.addStep(Status.PASSED);
-        counter.addScenario(Status.PASSED, "scenario designation");
+        counter.addScenario(Status.PASSED, createTestCase("classpath:com/example", 42,  "scenario designation"));
         counter.printStats(new PrintStream(baos));
 
         assertThat(baos.toString(), startsWith(String.format(
@@ -74,7 +81,7 @@ class StatsTest {
 
     private void addOneStepScenario(Stats counter, Status status) {
         counter.addStep(status);
-        counter.addScenario(status, "scenario designation");
+        counter.addScenario(status, createTestCase("classpath:com/example", 14, "scenario designation"));
     }
 
     @Test
@@ -174,13 +181,13 @@ class StatsTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         counter.addStep(Status.FAILED);
-        counter.addScenario(Status.FAILED, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addScenario(Status.FAILED, createTestCase("path/file.feature", 3, "Scenario: scenario_name"));
         counter.addStep(Status.AMBIGUOUS);
-        counter.addScenario(Status.AMBIGUOUS, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addScenario(Status.AMBIGUOUS, createTestCase("path/file.feature", 3, "Scenario: scenario_name"));
         counter.addStep(Status.UNDEFINED);
-        counter.addScenario(Status.UNDEFINED, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addScenario(Status.UNDEFINED, createTestCase("path/file.feature", 3, "Scenario: scenario_name"));
         counter.addStep(Status.PENDING);
-        counter.addScenario(Status.PENDING, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addScenario(Status.PENDING, createTestCase("path/file.feature", 3,  "Scenario: scenario_name"));
         counter.printStats(new PrintStream(baos));
 
         assertThat(baos.toString(), startsWith(String.format("" +
@@ -205,13 +212,13 @@ class StatsTest {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         counter.addStep(Status.FAILED);
-        counter.addScenario(Status.FAILED, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addScenario(Status.FAILED, createTestCase("path/file.feature", 3, "Scenario: scenario_name"));
         counter.addStep(Status.AMBIGUOUS);
-        counter.addScenario(Status.AMBIGUOUS, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addScenario(Status.AMBIGUOUS, createTestCase("path/file.feature", 3, "Scenario: scenario_name"));
         counter.addStep(Status.UNDEFINED);
-        counter.addScenario(Status.UNDEFINED, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addScenario(Status.UNDEFINED, createTestCase("path/file.feature", 3, "Scenario: scenario_name"));
         counter.addStep(Status.PENDING);
-        counter.addScenario(Status.PENDING, "path/file.feature:3 # Scenario: scenario_name");
+        counter.addScenario(Status.PENDING, createTestCase("path/file.feature", 3, "Scenario: scenario_name"));
         counter.printStats(new PrintStream(baos));
 
         assertThat(baos.toString(), startsWith(String.format("" +
@@ -228,6 +235,55 @@ class StatsTest {
                 "path/file.feature:3 # Scenario: scenario_name%n" +
                 "%n" +
                 "4 Scenarios")));
+    }
+
+    private static TestCase createTestCase(String uri, int line, String name) {
+        return new TestCase() {
+            @Override
+            public Integer getLine() {
+                return getLocation().getLine();
+            }
+
+            @Override
+            public Location getLocation() {
+                return new Location(line, -1);
+            }
+
+            @Override
+            public String getKeyword() {
+                return "Scenario";
+            }
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public String getScenarioDesignation() {
+                return null;
+            }
+
+            @Override
+            public List<String> getTags() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<TestStep> getTestSteps() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public URI getUri() {
+                return URI.create(uri);
+            }
+
+            @Override
+            public UUID getId() {
+                return UUID.randomUUID();
+            }
+        };
     }
 
 }


### PR DESCRIPTION
The summary printer concatenated the url and scenario name without an
additional space. This made it impossible to click the urls.

Fixes: https://github.com/cucumber/cucumber-jvm/issues/2184