### PR TITLE
[JUnit Platform Engine] Check unique id prefix rather then engine id

### DIFF
--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
@@ -203,7 +203,7 @@ final class FeatureResolver {
     void resolveUniqueId(UniqueIdSelector uniqueIdSelector) {
         UniqueId uniqueId = uniqueIdSelector.getUniqueId();
         // Ignore any ids not from our own engine
-        if (!engineDescriptor.getUniqueId().getEngineId().equals(uniqueId.getEngineId())) {
+        if (!uniqueId.hasPrefix(engineDescriptor.getUniqueId())) {
             return;
         }
 

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
@@ -35,12 +35,12 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClasspathResource;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClasspathRoots;
@@ -236,6 +236,14 @@ class DiscoverySelectorResolverTest {
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
         assertEquals(5, testDescriptor.getChildren().size());
+    }
+
+    @Test
+    void ignoreRequestWithUniqueIdSelectorFromDifferentEngine() {
+        DiscoverySelector selector = selectUniqueId(UniqueId.forEngine("not-cucumber"));
+        EngineDiscoveryRequest discoveryRequest = new SelectorRequest(selector);
+        resolver.resolveSelectors(discoveryRequest, testDescriptor);
+        assertTrue(testDescriptor.getDescendants().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
`UniqueId.getEngine` is not guaranteed to return `cucumber`. Another engine may
launch a discovery request for Cucumber. The engine id in this case would be
`[engine:suite][engine:cucumber]`.