### PR TITLE
[Core] Improve undefined step reporting

### DIFF
--- a/core/src/main/java/io/cucumber/core/plugin/DefaultSummaryPrinter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/DefaultSummaryPrinter.java
@@ -37,7 +37,7 @@ public final class DefaultSummaryPrinter implements SummaryPrinter, ColorAware, 
     }
 
     private void handleSnippetsSuggestedEvent(SnippetsSuggestedEvent event) {
-        this.snippets.addAll(event.getSnippets());
+        this.snippets.addAll(event.getSuggestion().getSnippets());
     }
 
     private void print() {

--- a/core/src/main/java/io/cucumber/core/runtime/TestCaseResultObserver.java
+++ b/core/src/main/java/io/cucumber/core/runtime/TestCaseResultObserver.java
@@ -2,19 +2,13 @@ package io.cucumber.core.runtime;
 
 import io.cucumber.plugin.event.EventHandler;
 import io.cucumber.plugin.event.EventPublisher;
-import io.cucumber.plugin.event.PickleStepTestStep;
 import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent;
 import io.cucumber.plugin.event.Status;
 import io.cucumber.plugin.event.TestCaseFinished;
-import io.cucumber.plugin.event.TestStep;
-import io.cucumber.plugin.event.TestStepFinished;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -22,59 +16,32 @@ import static io.cucumber.plugin.event.Status.PASSED;
 import static io.cucumber.plugin.event.Status.PENDING;
 import static io.cucumber.plugin.event.Status.SKIPPED;
 import static io.cucumber.plugin.event.Status.UNDEFINED;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 public final class TestCaseResultObserver implements AutoCloseable {
 
     private final EventPublisher bus;
-    private final Map<StepLocation, List<String>> snippetsPerStep = new TreeMap<>();
     private final List<Suggestion> suggestions = new ArrayList<>();
     private final EventHandler<SnippetsSuggestedEvent> snippetsSuggested = this::handleSnippetSuggestedEvent;
-    private final EventHandler<TestStepFinished> testStepFinished = this::handleTestStepFinished;
     private Result result;
     private final EventHandler<TestCaseFinished> testCaseFinished = this::handleTestCaseFinished;
 
     public TestCaseResultObserver(EventPublisher bus) {
         this.bus = bus;
         bus.registerHandlerFor(SnippetsSuggestedEvent.class, snippetsSuggested);
-        bus.registerHandlerFor(TestStepFinished.class, testStepFinished);
         bus.registerHandlerFor(TestCaseFinished.class, testCaseFinished);
     }
 
     @Override
     public void close() {
         bus.removeHandlerFor(SnippetsSuggestedEvent.class, snippetsSuggested);
-        bus.removeHandlerFor(TestStepFinished.class, testStepFinished);
         bus.removeHandlerFor(TestCaseFinished.class, testCaseFinished);
     }
 
     private void handleSnippetSuggestedEvent(SnippetsSuggestedEvent event) {
-        snippetsPerStep.putIfAbsent(new StepLocation(
-            event.getUri(),
-            event.getStepLine()),
-            event.getSnippets());
-    }
-
-    private void handleTestStepFinished(TestStepFinished event) {
-        Result result = event.getResult();
-        Status status = result.getStatus();
-        if (!status.is(UNDEFINED)) {
-            return;
-        }
-
-        TestStep testStep = event.getTestStep();
-        if (!(testStep instanceof PickleStepTestStep)) {
-            return;
-        }
-
-        PickleStepTestStep pickleStepTestStep = (PickleStepTestStep) testStep;
-        String stepText = pickleStepTestStep.getStepText();
-
-        List<String> snippets = snippetsPerStep.get(
-            new StepLocation(
-                pickleStepTestStep.getUri(),
-                pickleStepTestStep.getStepLine()));
-        suggestions.add(new Suggestion(stepText, snippets));
+        SnippetsSuggestedEvent.Suggestion s = event.getSuggestion();
+        suggestions.add(new Suggestion(s.getStep(), s.getSnippets()));
     }
 
     private void handleTestCaseFinished(TestCaseFinished event) {
@@ -117,32 +84,14 @@ public final class TestCaseResultObserver implements AutoCloseable {
 
     }
 
-    private static final class StepLocation implements Comparable<StepLocation> {
-
-        private final URI uri;
-        private final int line;
-
-        private StepLocation(URI uri, int line) {
-            this.uri = uri;
-            this.line = line;
-        }
-
-        @Override
-        public int compareTo(StepLocation o) {
-            int order = uri.compareTo(o.uri);
-            return order != 0 ? order : Integer.compare(line, o.line);
-        }
-
-    }
-
     public static final class Suggestion {
 
         final String step;
         final List<String> snippets;
 
         public Suggestion(String step, List<String> snippets) {
-            this.step = step;
-            this.snippets = snippets;
+            this.step = requireNonNull(step);
+            this.snippets = unmodifiableList(requireNonNull(snippets));
         }
 
         public String getStep() {

--- a/core/src/test/java/io/cucumber/core/plugin/CanonicalEventOrderTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/CanonicalEventOrderTest.java
@@ -4,6 +4,7 @@ import io.cucumber.plugin.event.Event;
 import io.cucumber.plugin.event.Location;
 import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent;
+import io.cucumber.plugin.event.SnippetsSuggestedEvent.Suggestion;
 import io.cucumber.plugin.event.Status;
 import io.cucumber.plugin.event.TestCase;
 import io.cucumber.plugin.event.TestCaseStarted;
@@ -48,13 +49,13 @@ class CanonicalEventOrderTest {
         URI.create("file:path/to/1.feature"),
         new Location(0, -1),
         new Location(0, -1),
-        Collections.emptyList());
+        new Suggestion("", Collections.emptyList()));
     private final Event suggested2 = new SnippetsSuggestedEvent(
         ofEpochMilli(5),
         URI.create("file:path/to/1.feature"),
         new Location(0, -1),
         new Location(0, -1),
-        Collections.emptyList());
+        new Suggestion("", Collections.emptyList()));
     private final Event feature1Case1Started = createTestCaseEvent(
         ofEpochMilli(5),
         URI.create("file:path/to/1.feature"),

--- a/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
@@ -5,6 +5,7 @@ import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.plugin.event.Location;
 import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent;
+import io.cucumber.plugin.event.SnippetsSuggestedEvent.Suggestion;
 import io.cucumber.plugin.event.Status;
 import io.cucumber.plugin.event.TestRunFinished;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,14 +45,14 @@ class DefaultSummaryPrinterTest {
             URI.create("classpath:com/example.feature"),
             new Location(12, -1),
             new Location(13, -1),
-            singletonList("snippet")));
+            new Suggestion("", singletonList("snippet"))));
 
         bus.send(new SnippetsSuggestedEvent(
             bus.getInstant(),
             URI.create("classpath:com/example.feature"),
             new Location(12, -1),
             new Location(14, -1),
-            singletonList("snippet")));
+            new Suggestion("", singletonList("snippet"))));
 
         bus.send(new TestRunFinished(bus.getInstant(), new Result(Status.PASSED, Duration.ZERO, null)));
 

--- a/core/src/test/java/io/cucumber/core/plugin/TeamCityPluginTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/TeamCityPluginTest.java
@@ -199,7 +199,8 @@ class TeamCityPluginTest {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
                 "Feature: feature name\n" +
                 "  Scenario: scenario name\n" +
-                "    Given first step\n");
+                "    Given first step\n" +
+                "    Given second step\n");
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         Runtime.builder()
@@ -211,7 +212,7 @@ class TeamCityPluginTest {
                 .run();
 
         assertThat(out, bytesContainsString("" +
-                "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step undefined' details = 'You can implement missing steps with the snippets below:|n|n' name = 'first step']\n"));
+                "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step undefined' details = 'You can implement this step and 1 other step(s)using the snippet(s) below:|n|ntest snippet 0|ntest snippet 1|n' name = 'first step']"));
     }
 
     @Test

--- a/core/src/test/java/io/cucumber/core/snippets/TestSnippet.java
+++ b/core/src/test/java/io/cucumber/core/snippets/TestSnippet.java
@@ -8,9 +8,11 @@ import java.util.Map;
 
 public class TestSnippet implements Snippet {
 
+    private int i;
+
     @Override
     public MessageFormat template() {
-        return new MessageFormat("");
+        return new MessageFormat("test snippet " + i++);
     }
 
     @Override

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/UndefinedStepException.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/UndefinedStepException.java
@@ -3,40 +3,41 @@ package io.cucumber.junit.platform.engine;
 import io.cucumber.core.runtime.TestCaseResultObserver.Suggestion;
 import org.opentest4j.IncompleteExecutionException;
 
-import java.util.List;
-
-import static java.util.stream.Collectors.joining;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 final class UndefinedStepException extends IncompleteExecutionException {
 
     private static final long serialVersionUID = 1L;
 
-    UndefinedStepException(List<Suggestion> suggestions) {
+    UndefinedStepException(Collection<Suggestion> suggestions) {
         super(createMessage(suggestions));
     }
 
-    private static String createMessage(List<Suggestion> suggestions) {
-        return suggestions.stream()
-                .map(suggestion -> createStepMessage(suggestion.getStep(), suggestion.getSnippets()))
-                .collect(joining("\n", createPreAmble(suggestions), ""));
-    }
-
-    private static String createStepMessage(String stepText, List<String> snippets) {
-        StringBuilder sb = new StringBuilder("The step \"" + stepText + "\" is undefined");
-        appendSnippets(snippets, sb);
+    private static String createMessage(Collection<Suggestion> suggestions) {
+        if (suggestions.isEmpty()) {
+            return "This step is undefined";
+        }
+        Suggestion first = suggestions.iterator().next();
+        StringBuilder sb = new StringBuilder("The step '" + first.getStep() + "'");
+        if (suggestions.size() == 1) {
+            sb.append(" is undefined.");
+        } else {
+            sb.append(" and ").append(suggestions.size() - 1).append(" other step(s) are undefined.");
+        }
+        sb.append("\n");
+        if (suggestions.size() == 1) {
+            sb.append("You can implement this step using the snippet(s) below:\n\n");
+        } else {
+            sb.append("You can implement these steps using the snippet(s) below:\n\n");
+        }
+        String snippets = suggestions
+                .stream()
+                .map(Suggestion::getSnippets)
+                .flatMap(Collection::stream)
+                .distinct()
+                .collect(Collectors.joining("\n", "", "\n"));
+        sb.append(snippets);
         return sb.toString();
     }
-
-    private static String createPreAmble(List<Suggestion> suggestions) {
-        return suggestions.size() < 2 ? "" : "There were " + suggestions.size() + " undefined steps\n";
-    }
-
-    private static void appendSnippets(List<String> snippets, StringBuilder sb) {
-        if (snippets.isEmpty()) {
-            return;
-        }
-        sb.append(". You can implement it using the snippet(s) below:\n\n");
-        sb.append(snippets.stream().collect(joining("\n---\n", "", "\n")));
-    }
-
 }

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/TestCaseResultObserverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/TestCaseResultObserverTest.java
@@ -7,6 +7,7 @@ import io.cucumber.plugin.event.Location;
 import io.cucumber.plugin.event.PickleStepTestStep;
 import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent;
+import io.cucumber.plugin.event.SnippetsSuggestedEvent.Suggestion;
 import io.cucumber.plugin.event.Status;
 import io.cucumber.plugin.event.Step;
 import io.cucumber.plugin.event.StepArgument;
@@ -215,10 +216,11 @@ class TestCaseResultObserverTest {
             uri,
             testCase.getLocation(),
             testStep.getStep().getLocation(),
-            asList(
-                "mocked snippet 1",
-                "mocked snippet 2",
-                "mocked snippet 3")));
+            new Suggestion(testStep.getStep().getText(),
+                asList(
+                    "mocked snippet 1",
+                    "mocked snippet 2",
+                    "mocked snippet 3"))));
         Result result = new Result(Status.UNDEFINED, Duration.ZERO, null);
         bus.send(new TestStepFinished(Instant.now(), testCase, testStep, result));
         bus.send(new TestCaseFinished(Instant.now(), testCase, result));
@@ -226,12 +228,11 @@ class TestCaseResultObserverTest {
         assertThat(exception.getCause(), instanceOf(UndefinedStepException.class));
 
         assertThat(exception.getCause().getMessage(), is("" +
-                "The step \"mocked\" is undefined. You can implement it using the snippet(s) below:\n" +
+                "The step 'mocked' is undefined.\n" +
+                "You can implement this step using the snippet(s) below:\n" +
                 "\n" +
                 "mocked snippet 1\n" +
-                "---\n" +
                 "mocked snippet 2\n" +
-                "---\n" +
                 "mocked snippet 3\n"));
     }
 

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/UndefinedStepExceptionTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/UndefinedStepExceptionTest.java
@@ -1,6 +1,6 @@
-package io.cucumber.junit;
+package io.cucumber.junit.platform.engine;
 
-import io.cucumber.plugin.event.SnippetsSuggestedEvent.Suggestion;
+import io.cucumber.core.runtime.TestCaseResultObserver.Suggestion;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;

--- a/plugin/src/main/java/io/cucumber/plugin/event/SnippetsSuggestedEvent.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/SnippetsSuggestedEvent.java
@@ -13,23 +13,30 @@ import static java.util.Objects.requireNonNull;
 public final class SnippetsSuggestedEvent extends TimeStampedEvent {
 
     private final URI uri;
-    private final Location scenarioLocation;
+    private final Location testCaseLocation;
     private final Location stepLocation;
-    private final List<String> snippets;
+    private final Suggestion suggestion;
 
     @Deprecated
     public SnippetsSuggestedEvent(Instant timeInstant, URI uri, int scenarioLine, int stepLine, List<String> snippets) {
         this(timeInstant, uri, new Location(scenarioLine, -1), new Location(stepLine, -1), snippets);
     }
 
+    @Deprecated
     public SnippetsSuggestedEvent(
-            Instant instant, URI uri, Location scenarioLocation, Location stepLocation, List<String> snippets
+            Instant instant, URI uri, Location testCaseLocation, Location stepLocation, List<String> snippets
+    ) {
+        this(instant, uri, testCaseLocation, stepLocation, new Suggestion("", snippets));
+    }
+
+    public SnippetsSuggestedEvent(
+            Instant instant, URI uri, Location testCaseLocation, Location stepLocation, Suggestion suggestion
     ) {
         super(instant);
         this.uri = requireNonNull(uri);
-        this.scenarioLocation = scenarioLocation;
-        this.stepLocation = stepLocation;
-        this.snippets = unmodifiableList(requireNonNull(snippets));
+        this.testCaseLocation = requireNonNull(testCaseLocation);
+        this.stepLocation = requireNonNull(stepLocation);
+        this.suggestion = requireNonNull(suggestion);
     }
 
     public URI getUri() {
@@ -43,19 +50,48 @@ public final class SnippetsSuggestedEvent extends TimeStampedEvent {
 
     @Deprecated
     public int getScenarioLine() {
-        return scenarioLocation.getLine();
+        return testCaseLocation.getLine();
     }
 
+    @Deprecated
     public Location getScenarioLocation() {
-        return scenarioLocation;
+        return testCaseLocation;
+    }
+
+    public Location getTestCaseLocation() {
+        return testCaseLocation;
     }
 
     public Location getStepLocation() {
         return stepLocation;
     }
 
+    @Deprecated
     public List<String> getSnippets() {
-        return snippets;
+        return suggestion.getSnippets();
     }
 
+    public Suggestion getSuggestion() {
+        return suggestion;
+    }
+
+    public static final class Suggestion {
+
+        final String step;
+        final List<String> snippets;
+
+        public Suggestion(String step, List<String> snippets) {
+            this.step = requireNonNull(step);
+            this.snippets = unmodifiableList(requireNonNull(snippets));
+        }
+
+        public String getStep() {
+            return step;
+        }
+
+        public List<String> getSnippets() {
+            return snippets;
+        }
+
+    }
 }

--- a/testng/src/main/java/io/cucumber/testng/UndefinedStepException.java
+++ b/testng/src/main/java/io/cucumber/testng/UndefinedStepException.java
@@ -3,41 +3,42 @@ package io.cucumber.testng;
 import io.cucumber.core.runtime.TestCaseResultObserver.Suggestion;
 import org.testng.SkipException;
 
-import java.util.List;
-
-import static java.util.stream.Collectors.joining;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 final class UndefinedStepException extends SkipException {
 
     private static final long serialVersionUID = 1L;
 
-    UndefinedStepException(List<Suggestion> suggestions) {
+    UndefinedStepException(Collection<Suggestion> suggestions) {
         super(createMessage(suggestions));
     }
 
-    private static String createMessage(List<Suggestion> suggestions) {
-        return suggestions.stream()
-                .map(suggestion -> createStepMessage(suggestion.getStep(), suggestion.getSnippets()))
-                .collect(joining("\n", createPreAmble(suggestions), ""));
-    }
-
-    private static String createStepMessage(String stepText, List<String> snippets) {
-        StringBuilder sb = new StringBuilder("The step \"" + stepText + "\" is undefined");
-        appendSnippets(snippets, sb);
-        return sb.toString();
-    }
-
-    private static String createPreAmble(List<Suggestion> suggestions) {
-        return suggestions.size() < 2 ? "" : "There were " + suggestions.size() + " undefined steps\n";
-    }
-
-    private static void appendSnippets(List<String> snippets, StringBuilder sb) {
-
-        if (snippets.isEmpty()) {
-            return;
+    private static String createMessage(Collection<Suggestion> suggestions) {
+        if (suggestions.isEmpty()) {
+            return "This step is undefined";
         }
-        sb.append(". You can implement it using the snippet(s) below:\n\n");
-        sb.append(snippets.stream().collect(joining("\n---\n", "", "\n")));
+        Suggestion first = suggestions.iterator().next();
+        StringBuilder sb = new StringBuilder("The step '" + first.getStep() + "'");
+        if (suggestions.size() == 1) {
+            sb.append(" is undefined.");
+        } else {
+            sb.append(" and ").append(suggestions.size() - 1).append(" other step(s) are undefined.");
+        }
+        sb.append("\n");
+        if (suggestions.size() == 1) {
+            sb.append("You can implement this step using the snippet(s) below:\n\n");
+        } else {
+            sb.append("You can implement these steps using the snippet(s) below:\n\n");
+        }
+        String snippets = suggestions
+                .stream()
+                .map(Suggestion::getSnippets)
+                .flatMap(Collection::stream)
+                .distinct()
+                .collect(Collectors.joining("\n", "", "\n"));
+        sb.append(snippets);
+        return sb.toString();
     }
 
     @Override

--- a/testng/src/test/java/io/cucumber/testng/TestCaseResultObserverTest.java
+++ b/testng/src/test/java/io/cucumber/testng/TestCaseResultObserverTest.java
@@ -2,10 +2,13 @@ package io.cucumber.testng;
 
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.runtime.TimeServiceEventBus;
+import io.cucumber.plugin.event.Location;
 import io.cucumber.plugin.event.PickleStepTestStep;
 import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent;
+import io.cucumber.plugin.event.SnippetsSuggestedEvent.Suggestion;
 import io.cucumber.plugin.event.Status;
+import io.cucumber.plugin.event.Step;
 import io.cucumber.plugin.event.TestCase;
 import io.cucumber.plugin.event.TestCaseFinished;
 import io.cucumber.plugin.event.TestStepFinished;
@@ -38,17 +41,18 @@ public class TestCaseResultObserverTest {
     private final EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
 
     private final URI uri = URI.create("file:path/to.feature");
-    private final int line = 0;
+    private final Location location = new Location(0, -1);
     private final Exception error = new Exception();
     private final TestCase testCase = mock(TestCase.class);
     private final PickleStepTestStep step = createPickleStepTestStep();
 
     private PickleStepTestStep createPickleStepTestStep() {
-        PickleStepTestStep step = mock(PickleStepTestStep.class);
-        when(step.getStepLine()).thenReturn(line);
-        when(step.getUri()).thenReturn(uri);
-        when(step.getStepText()).thenReturn("some step");
-        return step;
+        PickleStepTestStep testStep = mock(PickleStepTestStep.class);
+        Step step = mock(Step.class);
+        when(step.getLocation()).thenReturn(location);
+        when(testStep.getStep()).thenReturn(step);
+        when(testStep.getUri()).thenReturn(uri);
+        return testStep;
     }
 
     @Test
@@ -96,7 +100,8 @@ public class TestCaseResultObserverTest {
     public void should_be_failed_for_undefined_result() {
         TestCaseResultObserver resultListener = TestCaseResultObserver.observe(bus);
 
-        bus.send(new SnippetsSuggestedEvent(now(), uri, line, line, singletonList("stub snippet")));
+        bus.send(new SnippetsSuggestedEvent(now(), uri, location, location,
+            new Suggestion("some step", singletonList("stub snippet"))));
 
         Result stepResult = new Result(UNDEFINED, ZERO, error);
         bus.send(new TestStepFinished(now(), testCase, step, stepResult));
@@ -109,7 +114,8 @@ public class TestCaseResultObserverTest {
         SkipException skipException = (SkipException) exception.getCause();
         assertThat(skipException.isSkip(), is(false));
         assertThat(skipException.getMessage(), is("" +
-                "The step \"some step\" is undefined. You can implement it using the snippet(s) below:\n" +
+                "The step 'some step' is undefined.\n" +
+                "You can implement this step using the snippet(s) below:\n" +
                 "\n" +
                 "stub snippet\n"));
     }
@@ -118,7 +124,8 @@ public class TestCaseResultObserverTest {
     public void should_not_be_skipped_for_undefined_result() {
         TestCaseResultObserver resultListener = TestCaseResultObserver.observe(bus);
 
-        bus.send(new SnippetsSuggestedEvent(now(), uri, line, line, singletonList("stub snippet")));
+        bus.send(new SnippetsSuggestedEvent(now(), uri, location,
+            location, new SnippetsSuggestedEvent.Suggestion("some step", singletonList("stub snippet"))));
 
         Result stepResult = new Result(UNDEFINED, ZERO, error);
         bus.send(new TestStepFinished(now(), testCase, step, stepResult));
@@ -131,7 +138,8 @@ public class TestCaseResultObserverTest {
         SkipException skipException = (SkipException) exception.getCause();
         assertThat(skipException.isSkip(), is(false));
         assertThat(skipException.getMessage(), is("" +
-                "The step \"some step\" is undefined. You can implement it using the snippet(s) below:\n" +
+                "The step 'some step' is undefined.\n" +
+                "You can implement this step using the snippet(s) below:\n" +
                 "\n" +
                 "stub snippet\n"));
     }

--- a/testng/src/test/java/io/cucumber/testng/UndefinedStepExceptionTest.java
+++ b/testng/src/test/java/io/cucumber/testng/UndefinedStepExceptionTest.java
@@ -1,7 +1,7 @@
-package io.cucumber.junit;
+package io.cucumber.testng;
 
-import io.cucumber.plugin.event.SnippetsSuggestedEvent.Suggestion;
-import org.junit.jupiter.api.Test;
+import io.cucumber.core.runtime.TestCaseResultObserver.Suggestion;
+import org.testng.annotations.Test;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -9,16 +9,16 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-class UndefinedStepExceptionTest {
+public class UndefinedStepExceptionTest {
 
     @Test
-    void should_generate_a_message_for_no_suggestions() {
+    public void should_generate_a_message_for_no_suggestions() {
         UndefinedStepException exception = new UndefinedStepException(emptyList());
         assertThat(exception.getMessage(), is("This step is undefined"));
     }
 
     @Test
-    void should_generate_a_message_for_one_suggestions() {
+    public void should_generate_a_message_for_one_suggestions() {
         UndefinedStepException exception = new UndefinedStepException(
             singletonList(
                 new Suggestion("some step", singletonList("some snippet")))
@@ -32,7 +32,7 @@ class UndefinedStepExceptionTest {
     }
 
     @Test
-    void should_generate_a_message_for_one_suggestions_with_multiple_snippets() {
+    public void should_generate_a_message_for_one_suggestions_with_multiple_snippets() {
         UndefinedStepException exception = new UndefinedStepException(
             singletonList(
                 new Suggestion("some step", asList("some snippet", "some other snippet")))
@@ -47,7 +47,7 @@ class UndefinedStepExceptionTest {
     }
 
     @Test
-    void should_generate_a_message_for_two_suggestions() {
+    public void should_generate_a_message_for_two_suggestions() {
         UndefinedStepException exception = new UndefinedStepException(
             asList(
                 new Suggestion("some step", singletonList("some snippet")),
@@ -63,7 +63,7 @@ class UndefinedStepExceptionTest {
     }
 
     @Test
-    void should_generate_a_message_without_duplicate_suggestions() {
+    public void should_generate_a_message_without_duplicate_suggestions() {
         UndefinedStepException exception = new UndefinedStepException(
             asList(
                 new Suggestion("some step", asList("some snippet", "some snippet")),
@@ -79,7 +79,7 @@ class UndefinedStepExceptionTest {
     }
 
     @Test
-    void should_generate_a_message_for_three_suggestions() {
+    public void should_generate_a_message_for_three_suggestions() {
         UndefinedStepException exception = new UndefinedStepException(
             asList(
                 new Suggestion("some step", singletonList("some snippet")),


### PR DESCRIPTION
The various ways to execute Cucumber report undefined steps inconsistently.
Partially because different tools have different reporting needs. Nevertheless:

When reporting per step or scenario the suggestion should include snippets for all
undefined steps in that scenario. This applies to:
 - JUnit4
 - TestNG
 - JUnit5
 - Teamcity Plugin 

When reporting per test run the suggestion should include snippets for all
undefined steps in the execution. This applies to:
 - CLI

When printing snippets they should be copy-pasted into an IDE without further
editing. This means individual snippets or groups of snippets should not be
separated by spacers, text or anything else.

Fixes: #2024