### PR TITLE
[Cdi2/Jakarta Cdi] Run tests for OpenWebBeans and Weld in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,6 @@ jobs:
         run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
       - name: test
         run: mvn verify -P-spotless-apply --toolchains .github/workflows/.toolchains.xml
-      - name: test cdi with openwebbeans
-        run: mvn verify -pl cdi2,jakarta-cdi -Pcdi2-openwebbeans,jakarta-cdi-openwebbeans --toolchains ../.github/workflows/.toolchains.xml
 
   javadoc:
     name: 'Javadoc'

--- a/cdi2/pom.xml
+++ b/cdi2/pom.xml
@@ -56,12 +56,12 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-		<dependency>
-		    <groupId>org.junit.jupiter</groupId>
-		    <artifactId>junit-jupiter-params</artifactId>
-		    <version>${junit-jupiter.version}</version>
-		    <scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
@@ -71,7 +71,7 @@
 
     <profiles>
         <profile>
-            <id>cdi2-weld</id>
+            <id>cdi2-all-implementations</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -83,6 +83,64 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
+        </profile>
+        <profile>
+            <id>cdi2-openwebbeans</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-se</artifactId>
+                    <version>${openwebbeans.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-impl</artifactId>
+                    <version>${openwebbeans.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se-core</artifactId>
+                    <version>${weld-se-core.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>org.jboss.weld.se:weld-se-core</classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>weld</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-se</classpathDependencyExclude>
+                                        <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-impl</classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>cdi2-openwebbeans</id>

--- a/cdi2/pom.xml
+++ b/cdi2/pom.xml
@@ -71,7 +71,7 @@
 
     <profiles>
         <profile>
-            <id>cdi2-all-implementations</id>
+            <id>cdi2-openwebbeans</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -86,6 +86,39 @@
         </profile>
         <profile>
             <id>cdi2-openwebbeans</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-se</artifactId>
+                    <version>${openwebbeans.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-impl</artifactId>
+                    <version>${openwebbeans.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>cdi2-weld</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se-core</artifactId>
+                    <version>${weld-se-core.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>cdi2-all-implementations</id>
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.openwebbeans</groupId>
@@ -141,23 +174,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>cdi2-openwebbeans</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.openwebbeans</groupId>
-                    <artifactId>openwebbeans-se</artifactId>
-                    <version>${openwebbeans.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.openwebbeans</groupId>
-                    <artifactId>openwebbeans-impl</artifactId>
-                    <version>${openwebbeans.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
         </profile>
     </profiles>
 

--- a/cdi2/pom.xml
+++ b/cdi2/pom.xml
@@ -71,7 +71,7 @@
 
     <profiles>
         <profile>
-            <id>cdi2-openwebbeans</id>
+            <id>cdi2-weld</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -102,17 +102,6 @@
             </dependencies>
         </profile>
         <profile>
-            <id>cdi2-weld</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.weld.se</groupId>
-                    <artifactId>weld-se-core</artifactId>
-                    <version>${weld-se-core.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
             <id>cdi2-all-implementations</id>
             <activation>
                 <property>
@@ -120,6 +109,12 @@
                 </property>
             </activation>
             <dependencies>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se-core</artifactId>
+                    <version>${weld-se-core.version}</version>
+                    <scope>test</scope>
+                </dependency>
                 <dependency>
                     <groupId>org.apache.openwebbeans</groupId>
                     <artifactId>openwebbeans-se</artifactId>
@@ -130,12 +125,6 @@
                     <groupId>org.apache.openwebbeans</groupId>
                     <artifactId>openwebbeans-impl</artifactId>
                     <version>${openwebbeans.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.weld.se</groupId>
-                    <artifactId>weld-se-core</artifactId>
-                    <version>${weld-se-core.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -153,20 +142,20 @@
                                 </goals>
                                 <configuration>
                                     <classpathDependencyExcludes>
-                                        <classpathDependencyExclude>org.jboss.weld.se:weld-se-core</classpathDependencyExclude>
+                                        <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-se</classpathDependencyExclude>
+                                        <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-impl</classpathDependencyExclude>
                                     </classpathDependencyExcludes>
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>weld</id>
+                                <id>openwebbeans</id>
                                 <phase>test</phase>
                                 <goals>
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
                                     <classpathDependencyExcludes>
-                                        <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-se</classpathDependencyExclude>
-                                        <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-impl</classpathDependencyExclude>
+                                        <classpathDependencyExclude>org.jboss.weld.se:weld-se-core</classpathDependencyExclude>
                                     </classpathDependencyExcludes>
                                 </configuration>
                             </execution>

--- a/jakarta-cdi/pom.xml
+++ b/jakarta-cdi/pom.xml
@@ -72,6 +72,17 @@
             </activation>
             <dependencies>
                 <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se-core</artifactId>
+                    <version>${weld.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jakarta-cdi-openwebbeans</id>
+            <dependencies>
+                <dependency>
                     <groupId>org.apache.openwebbeans</groupId>
                     <artifactId>openwebbeans-se</artifactId>
                     <version>${openwebbeans.version}</version>
@@ -120,17 +131,6 @@
                     <groupId>org.apache.xbean</groupId>
                     <artifactId>xbean-asm9-shaded</artifactId>
                     <version>${xbean.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>jakarta-cdi-weld</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.weld.se</groupId>
-                    <artifactId>weld-se-core</artifactId>
-                    <version>${weld.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -144,6 +144,12 @@
             </activation>
             <dependencies>
                 <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se-core</artifactId>
+                    <version>${weld.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
                     <groupId>org.apache.openwebbeans</groupId>
                     <artifactId>openwebbeans-se</artifactId>
                     <version>${openwebbeans.version}</version>
@@ -192,12 +198,6 @@
                     <groupId>org.apache.xbean</groupId>
                     <artifactId>xbean-asm9-shaded</artifactId>
                     <version>${xbean.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.weld.se</groupId>
-                    <artifactId>weld-se-core</artifactId>
-                    <version>${weld.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -215,18 +215,6 @@
                                 </goals>
                                 <configuration>
                                     <classpathDependencyExcludes>
-                                        <classpathDependencyExclude>org.jboss.weld.se:weld-se-core</classpathDependencyExclude>
-                                    </classpathDependencyExcludes>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>weld</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <configuration>
-                                    <classpathDependencyExcludes>
                                         <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-se</classpathDependencyExclude>
                                         <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-impl</classpathDependencyExclude>
                                         <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-spi</classpathDependencyExclude>
@@ -235,6 +223,18 @@
                                     </classpathDependencyExcludes>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>openwebbeans</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                            </execution>
+                                <configuration>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>org.jboss.weld.se:weld-se-core</classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
                         </executions>
                     </plugin>
                 </plugins>

--- a/jakarta-cdi/pom.xml
+++ b/jakarta-cdi/pom.xml
@@ -4,6 +4,7 @@
     <properties>
         <project.Automatic-Module-Name>io.cucumber.cdi.jakarta</project.Automatic-Module-Name>
         <openwebbeans.version>2.0.21</openwebbeans.version>
+        <xbean.version>4.18</xbean.version>
         <jakarta.enterprise.cdi-api.version>3.0.0</jakarta.enterprise.cdi-api.version>
         <jakarta.activation-api.version>2.0.0</jakarta.activation-api.version>
         <weld.version>4.0.0.Final</weld.version>
@@ -71,6 +72,62 @@
             </activation>
             <dependencies>
                 <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-se</artifactId>
+                    <version>${openwebbeans.version}</version>
+                    <classifier>jakarta</classifier>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-impl</artifactId>
+                    <version>${openwebbeans.version}</version>
+                    <scope>test</scope>
+                    <classifier>jakarta</classifier>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.openwebbeans</groupId>
+                    <artifactId>openwebbeans-spi</artifactId>
+                    <version>${openwebbeans.version}</version>
+                    <scope>test</scope>
+                    <classifier>jakarta</classifier>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.xbean</groupId>
+                    <artifactId>xbean-finder-shaded</artifactId>
+                    <version>${xbean.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.xbean</groupId>
+                    <artifactId>xbean-asm9-shaded</artifactId>
+                    <version>${xbean.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>jakarta-cdi-weld</id>
+            <dependencies>
+                <dependency>
                     <groupId>org.jboss.weld.se</groupId>
                     <artifactId>weld-se-core</artifactId>
                     <version>${weld.version}</version>
@@ -79,10 +136,12 @@
             </dependencies>
         </profile>
         <profile>
-            <id>jakarta-cdi-openwebbeans</id>
-            <properties>
-                <xbean.version>4.18</xbean.version>
-            </properties>
+            <id>jakarta-cdi-all-implementations</id>
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.openwebbeans</groupId>
@@ -135,7 +194,51 @@
                     <version>${xbean.version}</version>
                     <scope>test</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.jboss.weld.se</groupId>
+                    <artifactId>weld-se-core</artifactId>
+                    <version>${weld.version}</version>
+                    <scope>test</scope>
+                </dependency>
             </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>org.jboss.weld.se:weld-se-core</classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>weld</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-se</classpathDependencyExclude>
+                                        <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-impl</classpathDependencyExclude>
+                                        <classpathDependencyExclude>org.apache.openwebbeans:openwebbeans-spi</classpathDependencyExclude>
+                                        <classpathDependencyExclude>org.apache.xbean:xbean-finder-shaded</classpathDependencyExclude>
+                                        <classpathDependencyExclude>org.apache.xbean:xbean-asm9-shaded</classpathDependencyExclude>
+                                    </classpathDependencyExcludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION

@mpkorstanje this is an alternate maven configuration that lets you run the tests with both openwebbeans and weld.
It is also possible to enable just one implmentation with the profiles `cdi2-openwebbeans` and `cdi2-weld` like before.

The only issue is that the default profile will break the tests in the IDE.
I use eclipse and to be able to run unit tests I have to activate the `cdi2-openwebbeans` or `cdi2-weld` profile in the project configuration.

I let you judge if you like it.
