### PR TITLE
[Core] Remove --strict and --no-strict options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Deprecated
 
 ### Removed
+ * [Core] Removed `--strict` and `--no-strict` options ([#1788](https://github.com/cucumber/cucumber-jvm/issues/1788) M.P. Korstanje)
+  - Cucumber executes scenarios in strict mode by default
 
 ### Fixed
 

--- a/core/README.md
+++ b/core/README.md
@@ -28,8 +28,6 @@ cucumber.execution.limit=       # number of scenarios to execute (CLI only).
   
 cucumber.execution.order=       # lexical, reverse, random or random:[seed] (CLI only). default: lexical
 
-cucumber.execution.strict=      # true or false. default: false.
-
 cucumber.execution.wip=         # true or false. default: false.
                                 # Fails if there any passing scenarios
                                 # CLI only.   

--- a/core/src/main/java/io/cucumber/core/cli/CommandlineOptions.java
+++ b/core/src/main/java/io/cucumber/core/cli/CommandlineOptions.java
@@ -47,11 +47,6 @@ public final class CommandlineOptions {
     public static final String DRY_RUN = "--dry-run";
     public static final String DRY_RUN_SHORT = "-d";
 
-    public static final String NO_STRICT = "--no-strict";
-
-    public static final String STRICT = "--strict";
-    public static final String STRICT_SHORT = "-s";
-
     public static final String NO_MONOCHROME = "--no-monochrome";
 
     public static final String MONOCHROME = "--monochrome";

--- a/core/src/main/java/io/cucumber/core/options/CommandlineOptionsParser.java
+++ b/core/src/main/java/io/cucumber/core/options/CommandlineOptionsParser.java
@@ -42,7 +42,6 @@ import static io.cucumber.core.cli.CommandlineOptions.NAME;
 import static io.cucumber.core.cli.CommandlineOptions.NAME_SHORT;
 import static io.cucumber.core.cli.CommandlineOptions.NO_DRY_RUN;
 import static io.cucumber.core.cli.CommandlineOptions.NO_MONOCHROME;
-import static io.cucumber.core.cli.CommandlineOptions.NO_STRICT;
 import static io.cucumber.core.cli.CommandlineOptions.NO_SUMMARY;
 import static io.cucumber.core.cli.CommandlineOptions.OBJECT_FACTORY;
 import static io.cucumber.core.cli.CommandlineOptions.ORDER;
@@ -50,8 +49,6 @@ import static io.cucumber.core.cli.CommandlineOptions.PLUGIN;
 import static io.cucumber.core.cli.CommandlineOptions.PLUGIN_SHORT;
 import static io.cucumber.core.cli.CommandlineOptions.PUBLISH;
 import static io.cucumber.core.cli.CommandlineOptions.SNIPPETS;
-import static io.cucumber.core.cli.CommandlineOptions.STRICT;
-import static io.cucumber.core.cli.CommandlineOptions.STRICT_SHORT;
 import static io.cucumber.core.cli.CommandlineOptions.TAGS;
 import static io.cucumber.core.cli.CommandlineOptions.TAGS_SHORT;
 import static io.cucumber.core.cli.CommandlineOptions.THREADS;
@@ -141,14 +138,8 @@ public final class CommandlineOptionsParser {
                 parsedOptions.setDryRun(true);
             } else if (arg.equals(NO_DRY_RUN)) {
                 parsedOptions.setDryRun(false);
-            } else if (arg.equals(NO_STRICT)) {
-                out.println("--no-strict is no longer effective");
-                exitCode = 1;
-                return parsedOptions;
             } else if (arg.equals(NO_SUMMARY)) {
                 parsedOptions.setNoSummary();
-            } else if (arg.equals(STRICT) || arg.equals(STRICT_SHORT)) {
-                log.warn(() -> "--strict is enabled by default. This option will be removed in a future release.");
             } else if (arg.equals(MONOCHROME) || arg.equals(MONOCHROME_SHORT)) {
                 parsedOptions.setMonochrome(true);
             } else if (arg.equals(NO_MONOCHROME)) {

--- a/core/src/main/java/io/cucumber/core/options/Constants.java
+++ b/core/src/main/java/io/cucumber/core/options/Constants.java
@@ -46,16 +46,6 @@ public final class Constants {
     public static final String EXECUTION_ORDER_PROPERTY_NAME = "cucumber.execution.order";
 
     /**
-     * Property name used to disable strict execution: {@value}
-     * <p>
-     * When using strict execution Cucumber will treat undefined and pending
-     * steps as errors.
-     * <p>
-     * By default, strict execution is enabled.
-     */
-    public static final String EXECUTION_STRICT_PROPERTY_NAME = "cucumber.execution.strict";
-
-    /**
      * Property name used to enable wip execution: {@value}
      * <p>
      * When using wip execution Cucumber will fail if there are any passing

--- a/core/src/main/java/io/cucumber/core/options/CucumberOptionsAnnotationParser.java
+++ b/core/src/main/java/io/cucumber/core/options/CucumberOptionsAnnotationParser.java
@@ -40,7 +40,6 @@ public final class CucumberOptionsAnnotationParser {
                 addTags(classWithOptions, options, args);
                 addPlugins(options, args);
                 addPublish(options, args);
-                addStrict(options, args);
                 addName(options, args);
                 addSnippets(options, args);
                 addGlue(options, args);
@@ -91,13 +90,6 @@ public final class CucumberOptionsAnnotationParser {
     private void addPublish(CucumberOptions options, RuntimeOptionsBuilder args) {
         if (options.publish()) {
             args.setPublish(true);
-        }
-    }
-
-    private void addStrict(CucumberOptions options, RuntimeOptionsBuilder args) {
-        if (!options.strict()) {
-            throw new CucumberException(
-                "@CucumberOptions(strict=false) is no longer supported. Please use strict=true");
         }
     }
 
@@ -195,8 +187,6 @@ public final class CucumberOptionsAnnotationParser {
     public interface CucumberOptions {
 
         boolean dryRun();
-
-        boolean strict();
 
         String[] features();
 

--- a/core/src/main/java/io/cucumber/core/options/CucumberPropertiesParser.java
+++ b/core/src/main/java/io/cucumber/core/options/CucumberPropertiesParser.java
@@ -19,7 +19,6 @@ import static io.cucumber.core.options.Constants.ANSI_COLORS_DISABLED_PROPERTY_N
 import static io.cucumber.core.options.Constants.EXECUTION_DRY_RUN_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.EXECUTION_LIMIT_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.EXECUTION_ORDER_PROPERTY_NAME;
-import static io.cucumber.core.options.Constants.EXECUTION_STRICT_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.FEATURES_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.FILTER_NAME_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.FILTER_TAGS_PROPERTY_NAME;
@@ -59,11 +58,6 @@ public final class CucumberPropertiesParser {
             EXECUTION_ORDER_PROPERTY_NAME,
             PickleOrderParser::parse,
             builder::setPickleOrder);
-
-        parse(properties,
-            EXECUTION_STRICT_PROPERTY_NAME,
-            BooleanString::parseBoolean,
-            CucumberPropertiesParser::errorOnNonStrict);
 
         parseAll(properties,
             FEATURES_PROPERTY_NAME,
@@ -132,13 +126,6 @@ public final class CucumberPropertiesParser {
             Map<String, String> properties, String propertyName, Function<String, T> parser, Consumer<T> setter
     ) {
         parseAll(properties, propertyName, parser.andThen(Collections::singletonList), setter);
-    }
-
-    private static void errorOnNonStrict(Boolean strict) {
-        if (!strict) {
-            throw new CucumberException(EXECUTION_STRICT_PROPERTY_NAME
-                    + "=false is no longer effective. Please use =true (the default) or remove this property");
-        }
     }
 
     private <T> void parseAll(

--- a/core/src/main/resources/io/cucumber/core/options/USAGE.txt
+++ b/core/src/main/resources/io/cucumber/core/options/USAGE.txt
@@ -117,8 +117,6 @@ cucumber.execution.limit=       # number of scenarios to execute (CLI only).
 
 cucumber.execution.order=       # lexical, reverse, random or random:[seed] (CLI only). default: lexical
 
-cucumber.execution.strict=      # true or false. default: false.
-
 cucumber.execution.wip=         # true or false. default: false.
                                 # Fails if there any passing scenarios
                                 # CLI only.

--- a/core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
@@ -421,7 +421,7 @@ class CommandlineOptionsParserTest {
     @Test
     void set_strict_on_strict_aware_formatters() {
         RuntimeOptions options = parser
-                .parse("--strict", "--plugin", AwareFormatter.class.getName())
+                .parse("--plugin", AwareFormatter.class.getName())
                 .build();
         Plugins plugins = new Plugins(new PluginFactory(), options);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));

--- a/core/src/test/java/io/cucumber/core/options/CucumberOptions.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberOptions.java
@@ -13,8 +13,6 @@ public @interface CucumberOptions {
 
     boolean dryRun() default false;
 
-    boolean strict() default true;
-
     String[] features() default {};
 
     String[] glue() default {};

--- a/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
+++ b/core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
@@ -258,16 +258,6 @@ class CucumberOptionsAnnotationParserTest {
         // empty
     }
 
-    @CucumberOptions(strict = true)
-    private static class Strict {
-        // empty
-    }
-
-    @CucumberOptions
-    private static class NotStrict {
-        // empty
-    }
-
     @CucumberOptions(name = { "name1", "name2" })
     private static class MultipleNames {
         // empty
@@ -385,11 +375,6 @@ class CucumberOptionsAnnotationParserTest {
         @Override
         public boolean dryRun() {
             return annotation.dryRun();
-        }
-
-        @Override
-        public boolean strict() {
-            return annotation.strict();
         }
 
         @Override

--- a/core/src/test/java/io/cucumber/core/plugin/StatsTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/StatsTest.java
@@ -207,7 +207,7 @@ class StatsTest {
     }
 
     @Test
-    void should_print_failed_ambiguous_pending_undefined_scenarios_if_strict() {
+    void should_print_failed_ambiguous_pending_undefined_scenarios() {
         Stats counter = createMonochromeSummaryCounter();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 

--- a/core/src/test/java/io/cucumber/core/runtime/ExitStatusTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/ExitStatusTest.java
@@ -28,11 +28,11 @@ class ExitStatusTest {
 
     @Test
     void should_pass_if_no_features_are_found() {
-        createStrictRuntime();
+        createRuntime();
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
     }
 
-    private void createStrictRuntime() {
+    private void createRuntime() {
         createExitStatus(new RuntimeOptionsBuilder().build());
     }
 
@@ -44,13 +44,13 @@ class ExitStatusTest {
 
     @Test
     void wip_with_ambiguous_scenarios() {
-        createStrictWipRuntime();
+        createWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.AMBIGUOUS));
 
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
     }
 
-    private void createStrictWipRuntime() {
+    private void createWipRuntime() {
         createExitStatus(new RuntimeOptionsBuilder().setWip(true).build());
     }
 
@@ -60,7 +60,7 @@ class ExitStatusTest {
 
     @Test
     void wip_with_failed_failed_scenarios() {
-        createStrictWipRuntime();
+        createWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
@@ -69,7 +69,7 @@ class ExitStatusTest {
 
     @Test
     void wip_with_failed_passed_scenarios() {
-        createStrictWipRuntime();
+        createWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
@@ -78,7 +78,7 @@ class ExitStatusTest {
 
     @Test
     void wip_with_failed_scenarios() {
-        createStrictWipRuntime();
+        createWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
@@ -86,7 +86,7 @@ class ExitStatusTest {
 
     @Test
     void wip_with_passed_failed_scenarios() {
-        createStrictWipRuntime();
+        createWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
@@ -95,7 +95,7 @@ class ExitStatusTest {
 
     @Test
     void wip_with_passed_scenarios() {
-        createStrictWipRuntime();
+        createWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
 
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x1)));
@@ -103,7 +103,7 @@ class ExitStatusTest {
 
     @Test
     void wip_with_pending_scenarios() {
-        createStrictWipRuntime();
+        createWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PENDING));
 
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
@@ -111,26 +111,26 @@ class ExitStatusTest {
 
     @Test
     void wip_with_skipped_scenarios() {
-        createNonStrictWipExitStatus();
+        createNonWipExitStatus();
         bus.send(testCaseFinishedWithStatus(Status.SKIPPED));
 
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
     }
 
-    private void createNonStrictWipExitStatus() {
+    private void createNonWipExitStatus() {
         createExitStatus(new RuntimeOptionsBuilder().setWip(true).build());
     }
 
     @Test
     void wip_with_undefined_scenarios() {
-        createStrictWipRuntime();
+        createWipRuntime();
         bus.send(testCaseFinishedWithStatus(Status.UNDEFINED));
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
     }
 
     @Test
     void with_ambiguous_scenarios() {
-        createStrictRuntime();
+        createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.AMBIGUOUS));
 
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x1)));
@@ -138,7 +138,7 @@ class ExitStatusTest {
 
     @Test
     void with_failed_failed_scenarios() {
-        createStrictRuntime();
+        createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
@@ -147,7 +147,7 @@ class ExitStatusTest {
 
     @Test
     void with_failed_passed_scenarios() {
-        createStrictRuntime();
+        createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
 
@@ -156,7 +156,7 @@ class ExitStatusTest {
 
     @Test
     void with_failed_scenarios() {
-        createStrictRuntime();
+        createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x1)));
@@ -164,7 +164,7 @@ class ExitStatusTest {
 
     @Test
     void with_passed_failed_scenarios() {
-        createStrictRuntime();
+        createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
@@ -173,7 +173,7 @@ class ExitStatusTest {
 
     @Test
     void with_passed_passed_scenarios() {
-        createStrictRuntime();
+        createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
 
@@ -182,7 +182,7 @@ class ExitStatusTest {
 
     @Test
     void with_passed_scenarios() {
-        createStrictRuntime();
+        createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
 
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
@@ -190,7 +190,7 @@ class ExitStatusTest {
 
     @Test
     void with_pending_scenarios() {
-        createStrictRuntime();
+        createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PENDING));
 
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x1)));
@@ -198,7 +198,7 @@ class ExitStatusTest {
 
     @Test
     void with_skipped_scenarios() {
-        createStrictRuntime();
+        createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.SKIPPED));
 
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x0)));
@@ -206,7 +206,7 @@ class ExitStatusTest {
 
     @Test
     void with_undefined_scenarios() {
-        createStrictRuntime();
+        createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.UNDEFINED));
         assertThat(exitStatus.exitStatus(), is(equalTo((byte) 0x1)));
     }

--- a/core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
+++ b/core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
@@ -4,17 +4,13 @@ import io.cucumber.core.backend.Glue;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.ParameterInfo;
 import io.cucumber.core.backend.ScenarioScoped;
-import io.cucumber.core.backend.StubHookDefinition;
-import io.cucumber.core.backend.StubPendingException;
 import io.cucumber.core.backend.StubStepDefinition;
 import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.exception.CompositeCucumberException;
 import io.cucumber.core.feature.TestFeatureParser;
 import io.cucumber.core.gherkin.Feature;
-import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.options.RuntimeOptionsBuilder;
-import io.cucumber.core.plugin.JUnitFormatter;
 import io.cucumber.core.runner.StepDurationTimeService;
 import io.cucumber.core.runner.TestBackendSupplier;
 import io.cucumber.messages.Messages;
@@ -36,21 +32,17 @@ import io.cucumber.plugin.event.TestStepStarted;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.ArgumentCaptor;
-import org.opentest4j.TestAbortedException;
 
-import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
 import static java.time.Clock.fixed;
 import static java.time.Duration.ZERO;
-import static java.time.Duration.ofMillis;
 import static java.time.Instant.EPOCH;
 import static java.time.ZoneId.of;
 import static java.util.Arrays.asList;
@@ -75,13 +67,13 @@ class RuntimeTest {
 
     @Test
     void with_passed_scenarios() {
-        Runtime runtime = createStrictRuntime();
+        Runtime runtime = createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PASSED));
 
         assertThat(runtime.exitStatus(), is(equalTo((byte) 0x0)));
     }
 
-    private Runtime createStrictRuntime() {
+    private Runtime createRuntime() {
         return Runtime.builder()
                 .withRuntimeOptions(
                     new RuntimeOptionsBuilder()
@@ -96,14 +88,14 @@ class RuntimeTest {
 
     @Test
     void with_undefined_scenarios() {
-        Runtime runtime = createStrictRuntime();
+        Runtime runtime = createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.UNDEFINED));
         assertThat(runtime.exitStatus(), is(equalTo((byte) 0x1)));
     }
 
     @Test
     void with_pending_scenarios() {
-        Runtime runtime = createStrictRuntime();
+        Runtime runtime = createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.PENDING));
 
         assertThat(runtime.exitStatus(), is(equalTo((byte) 0x1)));
@@ -111,21 +103,15 @@ class RuntimeTest {
 
     @Test
     void with_skipped_scenarios() {
-        Runtime runtime = createNonStrictRuntime();
+        Runtime runtime = createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.SKIPPED));
 
         assertThat(runtime.exitStatus(), is(equalTo((byte) 0x0)));
     }
 
-    private Runtime createNonStrictRuntime() {
-        return Runtime.builder()
-                .withEventBus(bus)
-                .build();
-    }
-
     @Test
     void with_failed_scenarios() {
-        Runtime runtime = createStrictRuntime();
+        Runtime runtime = createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.FAILED));
 
         assertThat(runtime.exitStatus(), is(equalTo((byte) 0x1)));
@@ -133,7 +119,7 @@ class RuntimeTest {
 
     @Test
     void with_ambiguous_scenarios() {
-        Runtime runtime = createStrictRuntime();
+        Runtime runtime = createRuntime();
         bus.send(testCaseFinishedWithStatus(Status.AMBIGUOUS));
 
         assertThat(runtime.exitStatus(), is(equalTo((byte) 0x1)));

--- a/junit/src/main/java/io/cucumber/junit/CucumberOptions.java
+++ b/junit/src/main/java/io/cucumber/junit/CucumberOptions.java
@@ -22,14 +22,6 @@ public @interface CucumberOptions {
     boolean dryRun() default false;
 
     /**
-     * @return     true if undefined and pending steps should be treated as
-     *             errors.
-     * @deprecated will be removed and cucumber will default to strict
-     */
-    @Deprecated
-    boolean strict() default true;
-
-    /**
      * Either a URI or path to a directory of features or a URI or path to a
      * single feature optionally followed by a colon and line numbers.
      * <p>

--- a/junit/src/main/java/io/cucumber/junit/JUnitCucumberOptionsProvider.java
+++ b/junit/src/main/java/io/cucumber/junit/JUnitCucumberOptionsProvider.java
@@ -46,11 +46,6 @@ final class JUnitCucumberOptionsProvider implements CucumberOptionsAnnotationPar
         }
 
         @Override
-        public boolean strict() {
-            return annotation.strict();
-        }
-
-        @Override
         public String[] features() {
             return annotation.features();
         }

--- a/junit/src/test/java/io/cucumber/junit/JUnitReporterWithStepNotificationsTest.java
+++ b/junit/src/test/java/io/cucumber/junit/JUnitReporterWithStepNotificationsTest.java
@@ -258,44 +258,6 @@ class JUnitReporterWithStepNotificationsTest {
     }
 
     @Test
-    void test_step_undefined_fires_test_failure_and_test_finished_for_undefined_step_in_strict_mode() {
-        EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
-        JUnitReporter jUnitReporter = new JUnitReporter(bus, new JUnitOptionsBuilder()
-                .setStepNotifications(true)
-                .build());
-
-        jUnitReporter.startExecutionUnit(pickleRunner, runNotifier);
-
-        Suggestion suggestion = new Suggestion("step name", singletonList("some snippet"));
-        bus.send(new SnippetsSuggestedEvent(now(), featureUri, scenarioLine, scenarioLine, suggestion));
-        bus.send(new TestCaseStarted(now(), testCase));
-        bus.send(new TestStepStarted(now(), testCase, mockTestStep(step)));
-        Throwable exception = new CucumberException("No step definitions found");
-        Result result = new Result(Status.UNDEFINED, ZERO, exception);
-        bus.send(new TestStepFinished(now(), testCase, mockTestStep(step), result));
-
-        verify(runNotifier).fireTestFailure(failureArgumentCaptor.capture());
-        verify(runNotifier).fireTestFinished(pickleRunner.describeChild(step));
-
-        Failure stepFailure = failureArgumentCaptor.getValue();
-        assertThat(stepFailure.getDescription(), is(equalTo(pickleRunner.describeChild(step))));
-        assertThat(stepFailure.getException(), is(equalTo(exception)));
-
-        bus.send(new TestCaseFinished(now(), testCase, result));
-
-        verify(runNotifier, times(2)).fireTestFailure(failureArgumentCaptor.capture());
-        verify(runNotifier).fireTestFinished(pickleRunner.describeChild(step));
-
-        Failure pickleFailure = failureArgumentCaptor.getValue();
-        assertThat(pickleFailure.getDescription(), is(equalTo(pickleRunner.getDescription())));
-        assertThat(pickleFailure.getException().getMessage(), is("" +
-                "The step 'step name' is undefined.\n" +
-                "You can implement this step using the snippet(s) below:\n" +
-                "\n" +
-                "some snippet\n"));
-    }
-
-    @Test
     void test_step_finished_fires_test_failure_and_test_finished_for_failed_step() {
         jUnitReporter.startExecutionUnit(pickleRunner, runNotifier);
 

--- a/testng/src/main/java/io/cucumber/testng/CucumberOptions.java
+++ b/testng/src/main/java/io/cucumber/testng/CucumberOptions.java
@@ -22,14 +22,6 @@ public @interface CucumberOptions {
     boolean dryRun() default false;
 
     /**
-     * @return     true if undefined and pending steps should be treated as
-     *             errors.
-     * @deprecated will be removed and cucumber will default to strict
-     */
-    @Deprecated
-    boolean strict() default true;
-
-    /**
      * Either a URI or path to a directory of features or a URI or path to a
      * single feature optionally followed by a colon and line numbers.
      * <p>

--- a/testng/src/main/java/io/cucumber/testng/TestNGCucumberOptionsProvider.java
+++ b/testng/src/main/java/io/cucumber/testng/TestNGCucumberOptionsProvider.java
@@ -46,11 +46,6 @@ final class TestNGCucumberOptionsProvider implements CucumberOptionsAnnotationPa
         }
 
         @Override
-        public boolean strict() {
-            return annotation.strict();
-        }
-
-        @Override
         public String[] features() {
             return annotation.features();
         }

--- a/testng/src/test/java/io/cucumber/testng/TestNGCucumberRunnerTest.java
+++ b/testng/src/test/java/io/cucumber/testng/TestNGCucumberRunnerTest.java
@@ -31,8 +31,8 @@ public class TestNGCucumberRunnerTest {
     }
 
     @Test
-    public void runScenarioWithUndefinedStepsStrict() {
-        testNGCucumberRunner = new TestNGCucumberRunner(RunScenarioWithUndefinedStepsStrict.class);
+    public void runScenarioWithUndefinedSteps() {
+        testNGCucumberRunner = new TestNGCucumberRunner(RunScenarioWithUndefinedSteps.class);
         Object[][] scenarios = testNGCucumberRunner.provideScenarios();
 
         // the feature file only contains one scenario
@@ -75,7 +75,7 @@ public class TestNGCucumberRunnerTest {
 
     @CucumberOptions(
             features = "classpath:io/cucumber/undefined/undefined_steps.feature")
-    static class RunScenarioWithUndefinedStepsStrict extends AbstractTestNGCucumberTests {
+    static class RunScenarioWithUndefinedSteps extends AbstractTestNGCucumberTests {
 
     }
 


### PR DESCRIPTION
Cucumber executes scenarios in strict mode by default.

Fixes: #1788