### PR TITLE
[Core] Remove --add-plugin alternate name from USAGE.txt

### DIFF
--- a/core/src/main/resources/io/cucumber/core/options/USAGE.txt
+++ b/core/src/main/resources/io/cucumber/core/options/USAGE.txt
@@ -11,7 +11,7 @@ Options:
                                            provided Cucumber will search the
                                            classpath.
 
-  -p, --[add-]plugin PLUGIN[:[PATH|[URI [OPTIONS]]]
+  -p, --plugin PLUGIN[:[PATH|[URI [OPTIONS]]]
                                            Register a plugin.
                                            Built-in formatter PLUGIN types:
                                            html, json, junit, message, pretty,


### PR DESCRIPTION
--add-plugin is no longer a valid synonym for --plugin; it was removed in https://github.com/cucumber/cucumber-jvm/commit/839dba7ccc734428d95a628c3886356ed9ed1677 .  But the USAGE still listed it as a synonym.
