### PR TITLE
[Core] Pretty formatter to print step DataTables

### DIFF
--- a/compatibility/src/test/java/io/cucumber/compatibility/CompatibilityTest.java
+++ b/compatibility/src/test/java/io/cucumber/compatibility/CompatibilityTest.java
@@ -114,7 +114,8 @@ public class CompatibilityTest {
     }
 
     private void sortStepDefinitions(Map<String, List<JsonNode>> envelopes) {
-        Comparator<JsonNode> stepDefinitionPatternComparator = Comparator.comparing(a -> a.get("pattern").asText());
+        Comparator<JsonNode> stepDefinitionPatternComparator = Comparator
+                .comparing(a -> a.get("pattern").get("source").asText());
         List<JsonNode> actualStepDefinitions = envelopes.get("stepDefinition");
         if (actualStepDefinitions != null) {
             actualStepDefinitions.sort(stepDefinitionPatternComparator);

--- a/core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
@@ -1,6 +1,9 @@
 package io.cucumber.core.plugin;
 
 import io.cucumber.core.exception.CucumberException;
+import io.cucumber.core.gherkin.DataTableArgument;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.datatable.DataTableFormatter;
 import io.cucumber.plugin.ColorAware;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.cucumber.plugin.event.Argument;
@@ -8,6 +11,7 @@ import io.cucumber.plugin.event.EmbedEvent;
 import io.cucumber.plugin.event.EventPublisher;
 import io.cucumber.plugin.event.PickleStepTestStep;
 import io.cucumber.plugin.event.Result;
+import io.cucumber.plugin.event.StepArgument;
 import io.cucumber.plugin.event.TestCase;
 import io.cucumber.plugin.event.TestCaseStarted;
 import io.cucumber.plugin.event.TestRunFinished;
@@ -128,6 +132,21 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
                 formats.get(status + "_arg"), testStep.getDefinitionArgument());
             String locationIndent = calculateLocationIndent(event.getTestCase(), formatPlainStep(keyword, stepText));
             out.println(STEP_INDENT + formattedStepText + locationIndent + formatLocation(testStep.getCodeLocation()));
+
+            StepArgument stepArgument = testStep.getStep().getArgument();
+            if (DataTableArgument.class.isInstance(stepArgument)) {
+                DataTableFormatter tableFormatter = DataTableFormatter
+                        .builder()
+                        .prefixRow(STEP_SCENARIO_INDENT)
+                        .escapeDelimiters(false)
+                        .build();
+                DataTableArgument dataTableArgument = (DataTableArgument) stepArgument;
+                try {
+                    tableFormatter.formatTo(DataTable.create(dataTableArgument.cells()), out);
+                } catch (IOException e) {
+                    throw new CucumberException(e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

- relates to issue #2320 

**Describe the solution you have implemented**

- updates `PrettyFormatter.printStep` to process the `DataTable` if one is present in the step object
- uses DataTableFormatter exposed in cucumber-common v4 / [this PR](https://github.com/cucumber/common/pull/1624)

**Additional context**

- at the moment just figuring out a broken `StepExpressionFactoryTest` that's popped up elsewhere in the core module while QA testing (appears to be from bumping common to v4)
- opened up the PR as a draft in the meantime, in case of feedback/a different approach is needed