### PR TITLE
[JUnit Platform] Optionally use long names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 * [Java] Added `BeforeAll` and `AfterAll` hooks ([cucumber/#1876](https://github.com/cucumber/cucumber/pull/1876) M.P. Korstanje)
+* [JUnit Platform] Optionally use long names
+    - Adds `cucumber.junit-platform.naming-strategy=long` ([#2361](https://github.com/cucumber/cucumber-jvm/pull/2361) M.P. Korstanje)
 
 ### Changed
 * [Core] Updated Cucumber Expressions to v11 ([cucumber/#711](https://github.com/cucumber/cucumber/pull/771) M.P. Korstanje)

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesExample.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesExample.java
@@ -10,8 +10,10 @@ final class GherkinMessagesExample implements Node.Example {
 
     private final TableRow tableRow;
     private final int rowIndex;
+    private final Node parent;
 
-    GherkinMessagesExample(TableRow tableRow, int rowIndex) {
+    GherkinMessagesExample(Node parent, TableRow tableRow, int rowIndex) {
+        this.parent = parent;
         this.tableRow = tableRow;
         this.rowIndex = rowIndex;
     }
@@ -29,6 +31,11 @@ final class GherkinMessagesExample implements Node.Example {
     @Override
     public Optional<String> getName() {
         return Optional.of("Example #" + rowIndex);
+    }
+
+    @Override
+    public Optional<Node> getParent() {
+        return Optional.of(parent);
     }
 
 }

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesExamples.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesExamples.java
@@ -14,13 +14,15 @@ final class GherkinMessagesExamples implements Node.Examples {
     private final io.cucumber.messages.types.Examples examples;
     private final List<Example> children;
     private final Location location;
+    private final Node parent;
 
-    GherkinMessagesExamples(io.cucumber.messages.types.Examples examples) {
+    GherkinMessagesExamples(Node parent, io.cucumber.messages.types.Examples examples) {
+        this.parent = parent;
         this.examples = examples;
         this.location = GherkinMessagesLocation.from(examples.getLocation());
         AtomicInteger row = new AtomicInteger(1);
         this.children = examples.getTableBody().stream()
-                .map(tableRow -> new GherkinMessagesExample(tableRow, row.getAndIncrement()))
+                .map(tableRow -> new GherkinMessagesExample(this, tableRow, row.getAndIncrement()))
                 .collect(Collectors.toList());
     }
 
@@ -43,6 +45,11 @@ final class GherkinMessagesExamples implements Node.Examples {
     public Optional<String> getName() {
         String name = examples.getName();
         return name.isEmpty() ? Optional.empty() : Optional.of(name);
+    }
+
+    @Override
+    public Optional<Node> getParent() {
+        return Optional.of(parent);
     }
 
 }

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesFeature.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesFeature.java
@@ -46,14 +46,14 @@ final class GherkinMessagesFeature implements Feature {
 
     private Node mapRuleOrScenario(FeatureChild featureChild) {
         if (featureChild.getRule() != null) {
-            return new GherkinMessagesRule(featureChild.getRule());
+            return new GherkinMessagesRule(this, featureChild.getRule());
         }
 
         io.cucumber.messages.types.Scenario scenario = featureChild.getScenario();
         if (!scenario.getExamples().isEmpty()) {
-            return new GherkinMessagesScenarioOutline(scenario);
+            return new GherkinMessagesScenarioOutline(this, scenario);
         }
-        return new GherkinMessagesScenario(scenario);
+        return new GherkinMessagesScenario(this, scenario);
     }
 
     private boolean hasRuleOrScenario(FeatureChild featureChild) {
@@ -79,6 +79,11 @@ final class GherkinMessagesFeature implements Feature {
     public Optional<String> getName() {
         String name = feature.getName();
         return name.isEmpty() ? Optional.empty() : Optional.of(name);
+    }
+
+    @Override
+    public Optional<Node> getParent() {
+        return Optional.empty();
     }
 
     @Override

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesRule.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesRule.java
@@ -10,22 +10,29 @@ import java.util.stream.Collectors;
 
 final class GherkinMessagesRule implements Node.Rule {
 
+    private final Node parent;
     private final io.cucumber.messages.types.Rule rule;
     private final List<Node> children;
 
-    GherkinMessagesRule(io.cucumber.messages.types.Rule rule) {
+    GherkinMessagesRule(Node parent, io.cucumber.messages.types.Rule rule) {
+        this.parent = parent;
         this.rule = rule;
         this.children = rule.getChildren().stream()
                 .filter(ruleChild -> ruleChild.getScenario() != null)
                 .map(ruleChild -> {
                     io.cucumber.messages.types.Scenario scenario = ruleChild.getScenario();
                     if (!scenario.getExamples().isEmpty()) {
-                        return new GherkinMessagesScenarioOutline(scenario);
+                        return new GherkinMessagesScenarioOutline(this, scenario);
                     } else {
-                        return new GherkinMessagesScenario(scenario);
+                        return new GherkinMessagesScenario(this, scenario);
                     }
                 })
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Node> getParent() {
+        return Optional.of(parent);
     }
 
     @Override

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesScenario.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesScenario.java
@@ -7,10 +7,17 @@ import java.util.Optional;
 
 final class GherkinMessagesScenario implements Node.Scenario {
 
+    private final Node parent;
     private final io.cucumber.messages.types.Scenario scenario;
 
-    GherkinMessagesScenario(io.cucumber.messages.types.Scenario scenario) {
+    GherkinMessagesScenario(Node parent, io.cucumber.messages.types.Scenario scenario) {
+        this.parent = parent;
         this.scenario = scenario;
+    }
+
+    @Override
+    public Optional<Node> getParent() {
+        return Optional.of(parent);
     }
 
     @Override

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesScenarioOutline.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesScenarioOutline.java
@@ -12,12 +12,19 @@ final class GherkinMessagesScenarioOutline implements Node.ScenarioOutline {
 
     private final io.cucumber.messages.types.Scenario scenario;
     private final List<Examples> children;
+    private final Node parent;
 
-    GherkinMessagesScenarioOutline(io.cucumber.messages.types.Scenario scenario) {
+    GherkinMessagesScenarioOutline(Node parent, io.cucumber.messages.types.Scenario scenario) {
+        this.parent = parent;
         this.scenario = scenario;
         this.children = scenario.getExamples().stream()
-                .map(GherkinMessagesExamples::new)
+                .map(examples -> new GherkinMessagesExamples(this, examples))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Node> getParent() {
+        return Optional.of(parent);
     }
 
     @Override

--- a/junit-platform-engine/README.md
+++ b/junit-platform-engine/README.md
@@ -241,6 +241,9 @@ cucumber.filter.tags=                                         # a cucumber tag e
 cucumber.glue=                                                # comma separated package names. 
                                                               # example: com.example.glue  
 
+cucumber.junit-platform.naming-strategy=                      # long or short. default: short
+                                                              # include parent descriptor name in test descriptor.                   
+
 cucumber.plugin=                                              # comma separated plugin strings. 
                                                               # example: pretty, json:path/to/report.json
 

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -73,6 +73,21 @@ public final class Constants {
     public static final String GLUE_PROPERTY_NAME = io.cucumber.core.options.Constants.GLUE_PROPERTY_NAME;
 
     /**
+     * Property name used to configure the naming strategy: {@value}
+     * <p>
+     * Value must be one of {@code long} or {@code short}. By default, short
+     * names are used.
+     * <p>
+     * When long names are used the parent descriptor names are included into
+     * each test descriptor name. So for example a single example would be
+     * named:
+     * {@code Feature Name - Rule Name - Scenario Name - Examples Name - Example #N }.
+     * This is useful for tools that only report the test name such as Maven and
+     * Gradle.
+     */
+    public static final String JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME = "cucumber.junit-platform.naming-strategy";
+
+    /**
      * Property name to enable plugins: {@value}
      * <p>
      * A comma separated list of {@code [PLUGIN[:PATH_OR_URL]]} e.g:

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
@@ -28,6 +28,7 @@ import static io.cucumber.junit.platform.engine.Constants.EXECUTION_DRY_RUN_PROP
 import static io.cucumber.junit.platform.engine.Constants.FILTER_NAME_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.FILTER_TAGS_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.OBJECT_FACTORY_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
@@ -156,6 +157,12 @@ class CucumberEngineOptions implements
         return configurationParameters
                 .getBoolean(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME)
                 .orElse(false);
+    }
+
+    NamingStrategy namingStrategy() {
+        return configurationParameters
+                .get(JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME, DefaultNamingStrategy::getStrategy)
+                .orElse(DefaultNamingStrategy.SHORT);
     }
 
 }

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DefaultNamingStrategy.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DefaultNamingStrategy.java
@@ -1,0 +1,43 @@
+package io.cucumber.junit.platform.engine;
+
+import io.cucumber.plugin.event.Node;
+
+import java.util.Locale;
+import java.util.function.Supplier;
+
+enum DefaultNamingStrategy implements NamingStrategy {
+
+    LONG {
+        @Override
+        public String name(Node node) {
+            StringBuilder builder = new StringBuilder();
+            builder.append(nameOrKeyword(node));
+            node = node.getParent().orElse(null);
+
+            while (node != null) {
+                builder.insert(0, " - ");
+                builder.insert(0, nameOrKeyword(node));
+                node = node.getParent().orElse(null);
+            }
+
+            return builder.toString();
+        }
+    },
+
+    SHORT {
+        @Override
+        public String name(Node node) {
+            return nameOrKeyword(node);
+        }
+    };
+
+    static DefaultNamingStrategy getStrategy(String s) {
+        return valueOf(s.toUpperCase(Locale.ROOT));
+    }
+
+    private static String nameOrKeyword(Node node) {
+        Supplier<String> keyword = () -> node.getKeyword().orElse("Unknown");
+        return node.getName().orElseGet(keyword);
+    }
+
+}

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
@@ -35,7 +35,9 @@ class DiscoverySelectorResolver {
     private void resolve(
             EngineDiscoveryRequest request, CucumberEngineDescriptor engineDescriptor, Predicate<String> packageFilter
     ) {
-        FeatureResolver featureResolver = createFeatureResolver(request.getConfigurationParameters(), engineDescriptor,
+        FeatureResolver featureResolver = createFeatureResolver(
+            request.getConfigurationParameters(),
+            engineDescriptor,
             packageFilter);
 
         request.getSelectorsByType(ClasspathRootSelector.class).forEach(featureResolver::resolveClasspathRoot);

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/NamingStrategy.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/NamingStrategy.java
@@ -1,0 +1,9 @@
+package io.cucumber.junit.platform.engine;
+
+import io.cucumber.plugin.event.Node;
+
+interface NamingStrategy {
+
+    String name(Node node);
+
+}

--- a/plugin/src/main/java/io/cucumber/plugin/event/Node.java
+++ b/plugin/src/main/java/io/cucumber/plugin/event/Node.java
@@ -41,6 +41,8 @@ public interface Node {
 
     Optional<String> getName();
 
+    Optional<Node> getParent();
+
     /**
      * Recursively maps a node into another tree-like structure.
      *

--- a/plugin/src/test/java/io/cucumber/plugin/event/NodeTest.java
+++ b/plugin/src/test/java/io/cucumber/plugin/event/NodeTest.java
@@ -32,6 +32,11 @@ class NodeTest {
         public String toString() {
             return "Example #1";
         }
+
+        @Override
+        public Optional<Node> getParent() {
+            return Optional.empty();
+        }
     };
 
     private final Node.Example example2 = new Node.Example() {
@@ -54,6 +59,11 @@ class NodeTest {
         public String toString() {
             return "Example #2";
         }
+
+        @Override
+        public Optional<Node> getParent() {
+            return Optional.empty();
+        }
     };
     private final Node.Example example3 = new Node.Example() {
         @Override
@@ -74,6 +84,11 @@ class NodeTest {
         @Override
         public String toString() {
             return "Example #3";
+        }
+
+        @Override
+        public Optional<Node> getParent() {
+            return Optional.empty();
         }
     };
 
@@ -96,6 +111,11 @@ class NodeTest {
         @Override
         public String toString() {
             return "Example #4";
+        }
+
+        @Override
+        public Optional<Node> getParent() {
+            return Optional.empty();
         }
     };
 
@@ -125,6 +145,11 @@ class NodeTest {
         public String toString() {
             return "Examples A";
         }
+
+        @Override
+        public Optional<Node> getParent() {
+            return Optional.empty();
+        }
     };
     private final Node.Examples examplesB = new Node.Examples() {
         @Override
@@ -145,12 +170,16 @@ class NodeTest {
         @Override
         public Optional<String> getName() {
             return Optional.of(toString());
-
         }
 
         @Override
         public String toString() {
             return "Examples B";
+        }
+
+        @Override
+        public Optional<Node> getParent() {
+            return Optional.empty();
         }
     };
 
@@ -173,12 +202,16 @@ class NodeTest {
         @Override
         public Optional<String> getName() {
             return Optional.of(toString());
-
         }
 
         @Override
         public String toString() {
             return "Empty Examples A";
+        }
+
+        @Override
+        public Optional<Node> getParent() {
+            return Optional.empty();
         }
     };
 
@@ -201,12 +234,16 @@ class NodeTest {
         @Override
         public Optional<String> getName() {
             return Optional.of(toString());
-
         }
 
         @Override
         public String toString() {
             return "Empty Examples B";
+        }
+
+        @Override
+        public Optional<Node> getParent() {
+            return Optional.empty();
         }
     };
 
@@ -229,12 +266,16 @@ class NodeTest {
         @Override
         public Optional<String> getName() {
             return Optional.of(toString());
-
         }
 
         @Override
         public String toString() {
             return "Outline";
+        }
+
+        @Override
+        public Optional<Node> getParent() {
+            return Optional.empty();
         }
     };
 
@@ -257,12 +298,16 @@ class NodeTest {
         @Override
         public Optional<String> getName() {
             return Optional.of(toString());
-
         }
 
         @Override
         public String toString() {
             return "Empty Outline";
+        }
+
+        @Override
+        public Optional<Node> getParent() {
+            return Optional.empty();
         }
     };
 


### PR DESCRIPTION
When using:

```
cucumber.junit-platform.naming-strategy=long
```

Cucumber will output the node names as:

```
[root]
Basic Arithmetic
Basic Arithmetic - Addition
Basic Arithmetic - Another Addition
Basic Arithmetic - Many additions
Basic Arithmetic - Many additions - Single digits
Basic Arithmetic - Many additions - Single digits - Example #1
Basic Arithmetic - Many additions - Single digits - Example #2
Basic Arithmetic - Many additions - Double digits
Basic Arithmetic - Many additions - Double digits - Example #1
Basic Arithmetic - Many additions - Double digits - Example #2
Dates with different date formats
Dates with different date formats - Determine past date
Shopping
Shopping - Give correct change
```

Useful when dealing with tools such as Surefire and Gradle that do not include
the entire hierarchy and only use the name of the test node in their reports.