### PR TITLE
[Core] Make Scenario.getId() return the actual scenario id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,18 +31,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
         - Replace `DataTable.asMaps()` with -> `DataTable.entries()`
 * [TestNG] Automatically pick up properties from `testng.xml` ([#2354](https://github.com/cucumber/cucumber-jvm/pull/2354) M.P. Korstanje, Gayan Sandaruwan)
 * [Core] Pretty formatter to print step DataTables ([#2330](https://github.com/cucumber/cucumber-jvm/pull/2330) Arty Sidorenko)
+* [Core] `Scenario.getId()` returns the actual scenario id ([#2366](https://github.com/cucumber/cucumber-jvm/issues/2366) M.P. Korstanje)
+ - To obtain the original `<uri>:<line-number>` identifier use `scenario.getUri() + ":" + scenario.getLine()`.
 
 ### Deprecated
 
 ### Removed
 * [Core] Removed `--strict` and `--no-strict` options ([#1788](https://github.com/cucumber/cucumber-jvm/issues/1788) M.P. Korstanje)
-- Cucumber executes scenarios in strict mode by default
+ - Cucumber executes scenarios in strict mode by default
 * [Core] Removed deprecated `TypeRegistryConfigurer` ([#2356](https://github.com/cucumber/cucumber-jvm/issues/2356) M.P. Korstanje)
-- Use `@ParameterType` instead.
+ - Use `@ParameterType` instead.
 * [Weld] Removed `cucumber-weld` ([#2276](https://github.com/cucumber/cucumber-jvm/issues/2276) M.P. Korstanje)
-- Consider using `cucumber-jakarta-cdi` or `cucumber-cdi2`.
+ - Consider using `cucumber-jakarta-cdi` or `cucumber-cdi2`.
 * [Needle] Removed `cucumber-needled` ([#2276](https://github.com/cucumber/cucumber-jvm/issues/2276) M.P. Korstanje)
-- Consider using `cucumber-jakarta-cdi` or `cucumber-cdi2`.
+ - Consider using `cucumber-jakarta-cdi` or `cucumber-cdi2`.
 
 ### Fixed
 * [Core] Emit step hook messages ([#2009](https://github.com/cucumber/cucumber-jvm/issues/2093) Grasshopper)

--- a/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
+++ b/core/src/main/java/io/cucumber/core/runner/TestCaseState.java
@@ -130,7 +130,7 @@ class TestCaseState implements io.cucumber.core.backend.TestCaseState {
 
     @Override
     public String getId() {
-        return testCase.getUri() + ":" + getLine();
+        return testCase.getId().toString();
     }
 
     @Override

--- a/core/src/test/java/io/cucumber/core/runner/TestCaseStateTest.java
+++ b/core/src/test/java/io/cucumber/core/runner/TestCaseStateTest.java
@@ -7,11 +7,9 @@ import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.messages.types.Attachment.ContentEncoding;
 import io.cucumber.messages.types.Envelope;
 import io.cucumber.plugin.event.EmbedEvent;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -84,7 +82,7 @@ class TestCaseStateTest {
 
         TestCaseState state = createTestCaseState(feature);
 
-        assertThat(state.getId(), is(new File("path/file.feature:2").toURI().toString()));
+        assertThat(state.getUri() + ":" + state.getLine(), is(new File("path/file.feature:2").toURI().toString()));
     }
 
     @Test
@@ -98,7 +96,7 @@ class TestCaseStateTest {
                 "       | cuke  | \n");
         TestCaseState state = createTestCaseState(feature);
 
-        assertThat(state.getId(), is(new File("path/file.feature:6").toURI().toString()));
+        assertThat(state.getUri() + ":" + state.getLine(), is(new File("path/file.feature:6").toURI().toString()));
     }
 
     @Test

--- a/java/src/main/java/io/cucumber/java/Scenario.java
+++ b/java/src/main/java/io/cucumber/java/Scenario.java
@@ -108,6 +108,15 @@ public final class Scenario {
     }
 
     /**
+     * Returns the unique identifier for this scenario.
+     * <p>
+     * If this is a Scenario from Scenario Outlines this will return the id of
+     * the example row in the Scenario Outline.
+     * <p>
+     * The id is not stable across multiple executions of Cucumber but does
+     * correlate with ids used in messages output. Use the uri + line number to
+     * obtain a somewhat stable identifier of a scenario.
+     *
      * @return the id of the Scenario.
      */
     public String getId() {
@@ -122,9 +131,12 @@ public final class Scenario {
     }
 
     /**
-     * @return the line in the feature file of the Scenario. If this is a
-     *         Scenario from Scenario Outlines this will return the line of the
-     *         example row in the Scenario Outline.
+     * Returns the line in the feature file of the Scenario.
+     * <p>
+     * If this is a Scenario from Scenario Outlines this will return the line of
+     * the example row in the Scenario Outline.
+     *
+     * @return the line in the feature file of the Scenario
      */
     public Integer getLine() {
         return delegate.getLine();

--- a/java8/src/main/java/io/cucumber/java8/Scenario.java
+++ b/java8/src/main/java/io/cucumber/java8/Scenario.java
@@ -106,6 +106,15 @@ public final class Scenario {
     }
 
     /**
+     * Returns the unique identifier for this scenario.
+     * <p>
+     * If this is a Scenario from Scenario Outlines this will return the id of
+     * the example row in the Scenario Outline.
+     * <p>
+     * The id is not stable across multiple executions of Cucumber but does
+     * correlate with ids used in messages output. Use the uri + line number to
+     * obtain a somewhat stable identifier of a scenario.
+     *
      * @return the id of the Scenario.
      */
     public String getId() {
@@ -120,9 +129,12 @@ public final class Scenario {
     }
 
     /**
-     * @return the line in the feature file of the Scenario. If this is a
-     *         Scenario from Scenario Outlines this will return the line of the
-     *         example row in the Scenario Outline.
+     * Returns the line in the feature file of the Scenario.
+     * <p>
+     * If this is a Scenario from Scenario Outlines this will return the line of
+     * the example row in the Scenario Outline.
+     *
+     * @return the line in the feature file of the Scenario
      */
     public Integer getLine() {
         return delegate.getLine();


### PR DESCRIPTION
To obtain the original `<uri>:<line-number>` identifier use
`scenario.getUri() + ":" + scenario.getLine()`.

Closes: #2254
