### PR TITLE
[Core] pretty formatter should not print null locations

### DIFF
--- a/core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
@@ -130,9 +130,8 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
             String status = event.getResult().getStatus().name().toLowerCase(ROOT);
             String formattedStepText = formatStepText(keyword, stepText, formats.get(status),
                 formats.get(status + "_arg"), testStep.getDefinitionArgument());
-            String locationIndent = calculateLocationIndent(event.getTestCase(), formatPlainStep(keyword, stepText));
-            out.println(STEP_INDENT + formattedStepText + locationIndent + formatLocation(testStep.getCodeLocation()));
-
+            String locationComment = formatLocationComment(event, testStep, keyword, stepText);
+            out.println(STEP_INDENT + formattedStepText + locationComment);
             StepArgument stepArgument = testStep.getStep().getArgument();
             if (DataTableArgument.class.isInstance(stepArgument)) {
                 DataTableFormatter tableFormatter = DataTableFormatter
@@ -148,6 +147,17 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
                 }
             }
         }
+    }
+
+    private String formatLocationComment(
+            TestStepFinished event, PickleStepTestStep testStep, String keyword, String stepText
+    ) {
+        String codeLocation = testStep.getCodeLocation();
+        if (codeLocation == null) {
+            return "";
+        }
+        String locationIndent = calculateLocationIndent(event.getTestCase(), formatPlainStep(keyword, stepText));
+        return locationIndent + formatLocation(codeLocation);
     }
 
     private void printError(TestStepFinished event) {


### PR DESCRIPTION
When dealing with undefined steps, or steps that do not have a location the
pretty formatter prints a null value. This print should be omitted.

```
    Scenario: a few cukes               # io/cucumber/skeleton/belly.feature:3
      Given I have 42 cukes in my belly # io.cucumber.skeleton.StepDefinitions.I_have_cukes_in_my_belly(int)
      When I wait 1 hour                # null
      Then my belly should growl        # null
```
