### PR TITLE
[Build] Build with with Maven wrapper in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: install wrapper
         run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: install dependencies
-        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml -X
+        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
       - name: test
         run: ./mvnw verify -P-spotless-apply --toolchains .github/workflows/.toolchains.xml
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: 'Build'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository
@@ -27,18 +27,18 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
-      - name: debug
-        run: mvn --version
+      - name: install wrapper
+        run: ./mvnw -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: install dependencies
-        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml -X
+        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml -X
       - name: test
-        run: mvn verify -P-spotless-apply --toolchains .github/workflows/.toolchains.xml
+        run: ./mvnw verify -P-spotless-apply --toolchains .github/workflows/.toolchains.xml
         env:
           CUCUMBER_PUBLISH_TOKEN: ${{ secrets.CUCUMBER_PUBLISH_TOKEN }}
 
   javadoc:
     name: 'Javadoc'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository
@@ -52,14 +52,16 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
+      - name: install wrapper
+        run: ./mvnw -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: install dependencies
-        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
+        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
       - name: javadoc
-        run: mvn javadoc:jar --toolchains .github/workflows/.toolchains.xml
+        run: ./mvnw javadoc:jar --toolchains .github/workflows/.toolchains.xml
 
   coverage:
     name: 'Coverage'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository
@@ -73,10 +75,12 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
+      - name: install wrapper
+        run: ./mvnw -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: install dependencies
-        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
+        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
       - name: test (coverage)
-        run: mvn jacoco:prepare-agent verify jacoco:report --toolchains .github/workflows/.toolchains.xml
+        run: ./mvnw jacoco:prepare-agent verify jacoco:report --toolchains .github/workflows/.toolchains.xml
       - uses: codecov/codecov-action@v1
         with:
           file: ./**/target/site/jacoco/jacoco.xml
@@ -84,7 +88,7 @@ jobs:
 
   semver:
     name: 'Semver'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository
@@ -98,7 +102,9 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
+      - name: install wrapper
+        run: ./mvnw -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: install dependencies
-        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
+        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
       - name: test (Semver check)
-        run: mvn verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true -Darchetype.test.skip=true --toolchains .github/workflows/.toolchains.xml
+        run: ./mvnw verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true -Darchetype.test.skip=true --toolchains .github/workflows/.toolchains.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: debug
         run: pwd && tree
       - name: install dependencies
-        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
+        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml -X
       - name: test
         run: mvn verify -P-spotless-apply --toolchains .github/workflows/.toolchains.xml
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Maven Wrapper
         run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: Install dependencies
-        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
+        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B --show-version --toolchains .github/workflows/.toolchains.xml
       - name: Test
         run: ./mvnw verify -P-spotless-apply --toolchains .github/workflows/.toolchains.xml
         env:
@@ -55,7 +55,7 @@ jobs:
       - name: Install Maven Wrapper
         run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: Install dependencies
-        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
+        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version --toolchains .github/workflows/.toolchains.xml
       - name: Javadoc
         run: ./mvnw javadoc:jar --toolchains .github/workflows/.toolchains.xml
 
@@ -78,7 +78,7 @@ jobs:
       - name: Install Maven Wrapper
         run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: Install dependencies
-        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
+        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version --toolchains .github/workflows/.toolchains.xml
       - name: Test (Coverage)
         run: ./mvnw jacoco:prepare-agent verify jacoco:report --toolchains .github/workflows/.toolchains.xml
       - uses: codecov/codecov-action@v1
@@ -105,6 +105,6 @@ jobs:
       - name: Install Maven Wrapper
         run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: Install dependencies
-        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
+        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version --toolchains .github/workflows/.toolchains.xml
       - name: Test (Semver check)
         run: ./mvnw verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true -Darchetype.test.skip=true --toolchains .github/workflows/.toolchains.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           version: '11'
       - name: install wrapper
-        run: ./mvnw -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: install dependencies
         run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml -X
       - name: test
@@ -53,7 +53,7 @@ jobs:
         with:
           version: '11'
       - name: install wrapper
-        run: ./mvnw -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: install dependencies
         run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
       - name: javadoc
@@ -76,7 +76,7 @@ jobs:
         with:
           version: '11'
       - name: install wrapper
-        run: ./mvnw -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: install dependencies
         run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
       - name: test (coverage)
@@ -103,7 +103,7 @@ jobs:
         with:
           version: '11'
       - name: install wrapper
-        run: ./mvnw -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
+        run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: install dependencies
         run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
       - name: test (Semver check)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           version: '11'
       - name: debug
-        run: tree
+        run: pwd && tree
       - name: install dependencies
         run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
       - name: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
+      - name: debug
+        run: tree
       - name: install dependencies
         run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
       - name: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: 'Build'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository
@@ -28,7 +28,7 @@ jobs:
         with:
           version: '11'
       - name: debug
-        run: pwd && tree
+        run: mvn --version
       - name: install dependencies
         run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml -X
       - name: test
@@ -38,7 +38,7 @@ jobs:
 
   javadoc:
     name: 'Javadoc'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository
@@ -59,7 +59,7 @@ jobs:
 
   coverage:
     name: 'Coverage'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository
@@ -84,7 +84,7 @@ jobs:
 
   semver:
     name: 'Semver'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,11 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
-      - name: install wrapper
+      - name: Install Maven Wrapper
         run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
-      - name: install dependencies
+      - name: Install dependencies
         run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
-      - name: test
+      - name: Test
         run: ./mvnw verify -P-spotless-apply --toolchains .github/workflows/.toolchains.xml
         env:
           CUCUMBER_PUBLISH_TOKEN: ${{ secrets.CUCUMBER_PUBLISH_TOKEN }}
@@ -52,11 +52,11 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
-      - name: install wrapper
+      - name: Install Maven Wrapper
         run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
-      - name: install dependencies
+      - name: Install dependencies
         run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
-      - name: javadoc
+      - name: Javadoc
         run: ./mvnw javadoc:jar --toolchains .github/workflows/.toolchains.xml
 
   coverage:
@@ -75,11 +75,11 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
-      - name: install wrapper
+      - name: Install Maven Wrapper
         run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
-      - name: install dependencies
+      - name: Install dependencies
         run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
-      - name: test (coverage)
+      - name: Test (Coverage)
         run: ./mvnw jacoco:prepare-agent verify jacoco:report --toolchains .github/workflows/.toolchains.xml
       - uses: codecov/codecov-action@v1
         with:
@@ -102,9 +102,9 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
-      - name: install wrapper
+      - name: Install Maven Wrapper
         run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
-      - name: install dependencies
+      - name: Install dependencies
         run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B -V --toolchains .github/workflows/.toolchains.xml
-      - name: test (Semver check)
+      - name: Test (Semver check)
         run: ./mvnw verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true -Darchetype.test.skip=true --toolchains .github/workflows/.toolchains.xml

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -40,14 +40,6 @@
     </dependencyManagement>
 
     <dependencies>
-
-        <dependency>
-            <groupId>org.commonjava.maven.plugins</groupId>
-            <artifactId>directory-maven-plugin</artifactId>
-            <version>0.3.1</version>
-        </dependency>
-
-
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-core</artifactId>

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -40,6 +40,14 @@
     </dependencyManagement>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.commonjava.maven.plugins</groupId>
+            <artifactId>directory-maven-plugin</artifactId>
+            <version>0.3.1</version>
+        </dependency>
+
+
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-core</artifactId>


### PR DESCRIPTION
Because of https://github.com/jdcasey/directory-maven-plugin/issues/16 Cucumber JVM can not be build with Maven > 3.8. However Ubuntu Latest used by Github actions now includes Maven 3.8.2. This is a temporary fix until we can build with the provided Maven version again.