### PR TITLE
[Archetype] Fix dependency resolution in InteliJ IDEA

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -46,6 +46,7 @@
             <groupId>org.junit</groupId>
             <artifactId>junit-bom</artifactId>
             <version>${junit-jupiter.version}</version>
+            <type>pom</type>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
When a type is not explicitly provided, the bundled Maven version used by
InteliJ IDEA explicitly looks for a jar type dependency. Making this explicit
allows the dependency to be resolved correctly.