### PR TITLE
[Build] Do not download Maven Wrapper in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,10 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
-      - name: Install Maven Wrapper
-        run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: Install dependencies
-        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B --show-version --toolchains .github/workflows/.toolchains.xml
+        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B --show-version --toolchains .github/workflows/.toolchains.xml
       - name: Test
-        run: ./mvnw verify -P-spotless-apply --toolchains .github/workflows/.toolchains.xml
+        run: mvn verify -P-spotless-apply --toolchains .github/workflows/.toolchains.xml
         env:
           CUCUMBER_PUBLISH_TOKEN: ${{ secrets.CUCUMBER_PUBLISH_TOKEN }}
 
@@ -52,12 +50,10 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
-      - name: Install Maven Wrapper
-        run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: Install dependencies
-        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version --toolchains .github/workflows/.toolchains.xml
+        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version --toolchains .github/workflows/.toolchains.xml
       - name: Javadoc
-        run: ./mvnw javadoc:jar --toolchains .github/workflows/.toolchains.xml
+        run: mvn javadoc:jar --toolchains .github/workflows/.toolchains.xml
 
   coverage:
     name: 'Coverage'
@@ -75,12 +71,10 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
-      - name: Install Maven Wrapper
-        run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: Install dependencies
-        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version --toolchains .github/workflows/.toolchains.xml
+        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version --toolchains .github/workflows/.toolchains.xml
       - name: Test (Coverage)
-        run: ./mvnw jacoco:prepare-agent verify jacoco:report --toolchains .github/workflows/.toolchains.xml
+        run: mvn jacoco:prepare-agent verify jacoco:report --toolchains .github/workflows/.toolchains.xml
       - uses: codecov/codecov-action@v1
         with:
           file: ./**/target/site/jacoco/jacoco.xml
@@ -102,9 +96,7 @@ jobs:
           AdoptOpenJDK/install-jdk@v1
         with:
           version: '11'
-      - name: Install Maven Wrapper
-        run: mvn --non-recursive io.takari:maven:0.7.7:wrapper -Dmaven=3.6.3
       - name: Install dependencies
-        run: ./mvnw install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version --toolchains .github/workflows/.toolchains.xml
+        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version --toolchains .github/workflows/.toolchains.xml
       - name: Test (Semver check)
-        run: ./mvnw verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true -Darchetype.test.skip=true --toolchains .github/workflows/.toolchains.xml
+        run: mvn verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true -Darchetype.test.skip=true --toolchains .github/workflows/.toolchains.xml


### PR DESCRIPTION
As a workaround for https://github.com/jdcasey/directory-maven-plugin/issues/16
the build in CI was done with the Maven wrapper. With the release of v1.0 of
the `directory-maven-plugin` this work around is no longer needed
