### PR TITLE
[JUnit Platform] Use Kotlin dsl in Gradle scripts

### DIFF
--- a/junit-platform-engine/README.md
+++ b/junit-platform-engine/README.md
@@ -57,10 +57,10 @@ parameter. This will include the feature name as part of the tests name.
 
 #### Gradle
 
-```groovy
-test {
+```kotlin
+tasks.test {
     useJUnitPlatform()
-    systemProperty 'cucumber.junit-platform.naming-strategy', 'long'
+    systemProperty("cucumber.junit-platform.naming-strategy", "long")
 }
 ```
 
@@ -121,9 +121,9 @@ Add the following to your `pom.xml`:
 ```
 #### Use the Gradle JavaExec task  ####
 
-Add the following to your `build.gradle`:
+Add the following to your `build.gradle.kts`:
 
-```groovy
+```kotlin
 tasks {
 
 	val consoleLauncherTest by registering(JavaExec::class) {

--- a/release-notes/v7.0.0.md
+++ b/release-notes/v7.0.0.md
@@ -122,10 +122,10 @@ e.g for Maven:
 ```            
 or for Gradle:
 
-```build.gradle
-test {
+```build.gradle.kts
+tasks.test {
     useJUnitPlatform()
-    systemProperty 'cucumber.junit-platform.naming-strategy', 'long'
+    systemProperty("cucumber.junit-platform.naming-strategy", "long")
 }
 ```
 


### PR DESCRIPTION

As per comment from M.P. Korstanje, we should align our examples for
Gradle documentation as just Kotlin, as the Gradle team are recommending
Kotlin going forward.

