### PR TITLE
[JUnit Platform] Discourage use of Cucumber filters

### DIFF
--- a/examples/calculator-java-junit5/pom.xml
+++ b/examples/calculator-java-junit5/pom.xml
@@ -93,8 +93,8 @@
                     <execution>
                         <!-- Work around. Surefire does not use JUnits Test Engine discovery functionality.
 
-                             Alternatively annotate a class with `io.cucumber.junit.platform.engine.Cucumber`
-                             to mark its package for the discovery of feature files.  -->
+                             Alternatively use the JUnit Platform Suite Engine.
+                         -->
                         <id>cli-test</id>
                         <phase>test</phase>
                         <goals>

--- a/junit-platform-engine/README.md
+++ b/junit-platform-engine/README.md
@@ -278,60 +278,70 @@ documentation
 documentation on Cucumber properties see [Constants](src/main/java/io/cucumber/junit/platform/engine/Constants.java).
 
 ```
-cucumber.ansi-colors.disabled=                                # true or false. default: false                     
+cucumber.ansi-colors.disabled=                                # true or false. 
+                                                              # default: false                     
       
-cucumber.filter.name=                                         # a regular expression
-                                                              # only scenarios with matching names are executed. 
-                                                              # example: ^Hello (World|Cucumber)$     
+cucumber.filter.name=                                         # a regular expression.
+                                                              # only scenarios with matching names are executed.
+                                                              # example: ^Hello (World|Cucumber)$
+                                                              # note: To ensure consistent reports between Cucumber and
+                                                              # JUnit 5 prefer using JUnit 5s discovery request filters
+                                                              # or JUnit 5 tag expressions instead.
 
-cucumber.filter.tags=                                         # a cucumber tag expression. 
-                                                              # only scenarios with matching tags are executed. 
+cucumber.filter.tags=                                         # a cucumber tag expression.
+                                                              # only scenarios with matching tags are executed.
                                                               # example: @Cucumber and not (@Gherkin or @Zucchini)
+                                                              # note: To ensure consistent reports between Cucumber and
+                                                              # JUnit 5 prefer using JUnit 5s discovery request filters
+                                                              # or JUnit 5 tag expressions instead.
 
-cucumber.glue=                                                # comma separated package names. 
+cucumber.glue=                                                # comma separated package names.
                                                               # example: com.example.glue  
 
-cucumber.junit-platform.naming-strategy=                      # long or short. default: short
-                                                              # include parent descriptor name in test descriptor.                   
+cucumber.junit-platform.naming-strategy=                      # long or short.
+                                                              # default: short
+                                                              # include parent descriptor name in test descriptor.
 
-cucumber.plugin=                                              # comma separated plugin strings. 
+cucumber.plugin=                                              # comma separated plugin strings.
                                                               # example: pretty, json:path/to/report.json
 
 cucumber.object-factory=                                      # object factory class name.
                                                               # example: com.example.MyObjectFactory
 
-cucumber.publish.enabled                                      # true or false. default: false
-                                                              # enable publishing of test results 
+cucumber.publish.enabled                                      # true or false. 
+                                                              # default: false
+                                                              # enable publishing of test results
 
-cucumber.publish.quiet                                        # true or false. default: false
-                                                              # suppress publish banner after test execution  
+cucumber.publish.quiet                                        # true or false. 
+                                                              # default: false
+                                                              # suppress publish banner after test execution.
 
 cucumber.publish.token                                        # any string value.
-                                                              # publish authenticated test results    
+                                                              # publish authenticated test results.
 
-cucumber.snippet-type=                                        # underscore or camelcase. 
+cucumber.snippet-type=                                        # underscore or camelcase.
                                                               # default: underscore
 
-cucumber.execution.dry-run=                                   # true or false. 
+cucumber.execution.dry-run=                                   # true or false.
                                                               # default: false
 
-cucumber.execution.parallel.enabled=                          # true or false. 
+cucumber.execution.parallel.enabled=                          # true or false.
                                                               # default: false
 
-cucumber.execution.parallel.config.strategy=                  # dynamic, fixed or custom. 
+cucumber.execution.parallel.config.strategy=                  # dynamic, fixed or custom.
                                                               # default: dynamic
 
-cucumber.execution.parallel.config.fixed.parallelism=         # positive integer. 
-                                                              # example: 4 
+cucumber.execution.parallel.config.fixed.parallelism=         # positive integer.
+                                                              # example: 4
 
 cucumber.execution.parallel.config.dynamic.factor=            # positive double.
                                                               # default: 1.0
 
-cucumber.execution.parallel.config.custom.class=              # class name. 
+cucumber.execution.parallel.config.custom.class=              # class name.
                                                               # example: com.example.MyCustomParallelStrategy
 
 cucumber.execution.exclusive-resources.<tag-name>.read-write= # a comma separated list of strings
-                                                              # example: resource-a, resource-b 
+                                                              # example: resource-a, resource-b.
 
 cucumber.execution.exclusive-resources.<tag-name>.read=       # a comma separated list of strings
                                                               # example: resource-a, resource-b

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -44,22 +44,34 @@ public final class Constants {
     /**
      * Property name used to set name filter: {@value}
      * <p>
-     * Filters features by name based on the provided regex pattern e.g:
+     * Filter scenarios by name based on the provided regex pattern e.g:
      * {@code ^Hello (World|Cucumber)$}. Scenarios that do not match the
      * expression are not executed.
      * <p>
-     * By default all scenarios are executed
+     * By default, all scenarios are executed
+     * <p>
+     * Note: To ensure consistent reports between Cucumber and JUnit 5 prefer
+     * using JUnit 5 discovery request filters,
+     * {@link org.junit.platform.suite.api.IncludeTags} or <a
+     * href=https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions>JUnit
+     * 5 tag expressions</a> instead.
      */
     public static final String FILTER_NAME_PROPERTY_NAME = io.cucumber.core.options.Constants.FILTER_NAME_PROPERTY_NAME;
 
     /**
      * Property name used to set tag filter: {@value}
      * <p>
-     * Filters scenarios by tag based on the provided tag expression e.g:
+     * Filter scenarios by tag based on the provided tag expression e.g:
      * {@code @Cucumber and not (@Gherkin or @Zucchini)}. Scenarios that do not
      * match the expression are not executed.
      * <p>
-     * By default all scenarios are executed
+     * By default, all scenarios are executed
+     * <p>
+     * Note: To ensure consistent reports between Cucumber and JUnit 5 prefer
+     * using JUnit 5 discovery request filters,
+     * {@link org.junit.platform.suite.api.IncludeTags} or <a
+     * href=https://junit.org/junit5/docs/current/user-guide/#running-tests-tag-expressions>JUnit
+     * 5 tag expressions</a> instead.
      */
     public static final String FILTER_TAGS_PROPERTY_NAME = io.cucumber.core.options.Constants.FILTER_TAGS_PROPERTY_NAME;
 


### PR DESCRIPTION
JUnit 5 can filter test cases by name or tag as part of its
discover/select/execute model. Cucumber can also filter scenarios based on
their name or tags. To ensure this functionality does not interfere with
JUnit 5s model by hiding scenarios from discovery this is implemented through
`Node.shouldBeSkipped`.

As a result when using `cucumber.filter.*` for each skipped scenario JUnit 5
will explicitly report that:

```
'cucumber.filter.tags=@foo' did not match this scenario
```

while Cucumber will quietly skip the scenario in the reports.

