### PR TITLE
[Core] Support proxy for publish plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - When transforming doc strings in addition to the content type Cucumber will
     also look at the type used in the step definition to disambiguate between
     doc string types.    
-* [Guice] Automatically detect `InjectorSource` ([#2432 ](https://github.com/cucumber/cucumber-jvm/pull/2432) Postelnicu George)
+* [Guice] Automatically detect `InjectorSource` ([#2432](https://github.com/cucumber/cucumber-jvm/pull/2432) Postelnicu George)
+* [Core] Support proxy for publish plugin ([#2452](https://github.com/cucumber/cucumber-jvm/pull/2452) M.P. Korstanje)
+    ```
+    cucumber.publish.proxy=https://proxy.example.com:3129
+    ```
+    Note: The publish-plugin only reads properties from the `cucumber.properties`, the environment, system properties. And
+    not `junit-platform.properties`. 
 
 ### Changed
 * [Core] Replaced `create-meta` dependency with `ci-environment` ([#2438](https://github.com/cucumber/cucumber-jvm/pull/2438) M.P. Korstanje)

--- a/core/src/main/java/io/cucumber/core/options/Constants.java
+++ b/core/src/main/java/io/cucumber/core/options/Constants.java
@@ -143,7 +143,7 @@ public final class Constants {
     public static final String PLUGIN_PROPERTY_NAME = "cucumber.plugin";
 
     /**
-     * Property name to enable publishing: {@value}
+     * Property name to enable publishing cucumber reports: {@value}
      * <p>
      * Enabling this will publish test results online.
      * <p>
@@ -152,7 +152,7 @@ public final class Constants {
     public static final String PLUGIN_PUBLISH_ENABLED_PROPERTY_NAME = "cucumber.publish.enabled";
 
     /**
-     * Property name to publish with bearer token: {@value}
+     * Property name to publish cucumber reports with bearer token: {@value}
      * <p>
      * Enabling this will publish authenticated test results online.
      * <p>
@@ -160,10 +160,18 @@ public final class Constants {
     public static final String PLUGIN_PUBLISH_TOKEN_PROPERTY_NAME = "cucumber.publish.token";
 
     /**
-     * Property name to override the publish URL: {@value} Note it is not
-     * sufficient to activate publishing.
+     * Property name to override the cucumber reports publish uri: {@value}
+     * <p>
+     * Note that setting this property is not sufficient to activate publishing.
      */
     public static final String PLUGIN_PUBLISH_URL_PROPERTY_NAME = "cucumber.publish.url";
+
+    /**
+     * Property name to set the proxy used to publish cucumber reports .
+     * <p>
+     * Note that setting this property is not sufficient to activate publishing.
+     */
+    public static final String PLUGIN_PUBLISH_PROXY_PROPERTY_NAME = "cucumber.publish.proxy";
 
     /**
      * Property name to suppress publishing advertising banner: {@value}

--- a/core/src/main/java/io/cucumber/core/plugin/PublishFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/PublishFormatter.java
@@ -9,6 +9,7 @@ import io.cucumber.plugin.event.EventPublisher;
 import java.io.IOException;
 import java.util.Map;
 
+import static io.cucumber.core.options.Constants.PLUGIN_PUBLISH_PROXY_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.PLUGIN_PUBLISH_URL_PROPERTY_NAME;
 
 public final class PublishFormatter implements ConcurrentEventListener, ColorAware {
@@ -45,10 +46,17 @@ public final class PublishFormatter implements ConcurrentEventListener, ColorAwa
     }
 
     private static CurlOption createCurlOption(String token) {
+        // Note: This only includes properties from the environment and
+        // cucumber.properties. It does not include junit-platform.properties
+        // Fixing this requires an overhaul of the plugin system.
         Map<String, String> properties = CucumberProperties.create();
         String url = properties.getOrDefault(PLUGIN_PUBLISH_URL_PROPERTY_NAME, DEFAULT_CUCUMBER_MESSAGE_STORE_URL);
         if (token != null) {
-            url = url + String.format(" -H 'Authorization: Bearer %s'", token);
+            url += String.format(" -H 'Authorization: Bearer %s'", token);
+        }
+        String proxy = properties.get(PLUGIN_PUBLISH_PROXY_PROPERTY_NAME);
+        if (proxy != null) {
+            url += String.format(" -x '%s'", proxy);
         }
         return CurlOption.parse(url);
     }


### PR DESCRIPTION
Users looking to publish cucumber reports behind a proxy can add to
`cucumber.properties`:

```
cucumber.publish.proxy=https://proxy.example.com:3129
```

Note: The publish-plugin only reads properties from the `cucumber.properties`,
the environment, system properties. And not `junit-platform.properties`. 

Fixes: #2285