### PR TITLE
Replace maven-antrun-plugin with groovy-maven-plugin

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -88,20 +88,18 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>generate-i18n-sources</id>
                         <goals>
-                            <goal>run</goal>
+                            <goal>execute</goal>
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <target>
-                                <taskdef name="groovy" classname="org.codehaus.groovy.ant.Groovy" classpathref="maven.plugin.classpath" />
-                                <groovy src="src/main/groovy/generate-annotations.groovy" />
-                            </target>
+                            <source>${basedir}/src/main/groovy/generate-annotations.groovy</source>
+                            <classpathScope>compile</classpathScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/java/src/main/groovy/generate-annotations.groovy
+++ b/java/src/main/groovy/generate-annotations.groovy
@@ -5,8 +5,8 @@ import java.nio.file.Files
 import java.text.Normalizer
 
 SimpleTemplateEngine engine = new SimpleTemplateEngine()
-def templateSource = new File(project.baseDir, "src/main/groovy/annotation.java.gsp").getText()
-def packageInfoSource = new File(project.baseDir, "src/main/groovy/package-info.java.gsp").getText()
+def templateSource = new File(project.basedir, "src/main/groovy/annotation.java.gsp").getText()
+def packageInfoSource = new File(project.basedir, "src/main/groovy/package-info.java.gsp").getText()
 
 static def normalize(s) {
     return Normalizer.normalize(s, Normalizer.Form.NFC)
@@ -23,7 +23,7 @@ dialectProvider.getLanguages().each { language ->
             def normalized_kw = normalize(kw.replaceAll("[\\s',!\u00AD]", ""))
             def binding = ["lang": normalized_language, "kw": normalized_kw]
             def template = engine.createTemplate(templateSource).make(binding)
-            def file = new File(project.baseDir, "target/generated-sources/i18n/java/io/cucumber/java/${normalized_language}/${normalized_kw}.java")
+            def file = new File(project.basedir, "target/generated-sources/i18n/java/io/cucumber/java/${normalized_language}/${normalized_kw}.java")
             if (!file.exists()) {
                 // Haitian has two translations that only differ by case - Sipozeke and SipozeKe
                 // Some file systems are unable to distiguish between them and overwrite the other one :-(
@@ -36,7 +36,7 @@ dialectProvider.getLanguages().each { language ->
         def name = dialect.name + ((dialect.name == dialect.nativeName) ? '' : ' - ' + dialect.nativeName)
         def binding = ["normalized_language": normalized_language, "language_name": name]
         def html = engine.createTemplate(packageInfoSource).make(binding).toString()
-        def file = new File(project.baseDir, "target/generated-sources/i18n/java/io/cucumber/java/${normalized_language}/package-info.java")
+        def file = new File(project.basedir, "target/generated-sources/i18n/java/io/cucumber/java/${normalized_language}/package-info.java")
         file.write(html, "UTF-8")
     }
 }

--- a/java8/pom.xml
+++ b/java8/pom.xml
@@ -89,20 +89,18 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>groovy-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>generate-i18n-sources</id>
                         <goals>
-                            <goal>run</goal>
+                            <goal>execute</goal>
                         </goals>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <target>
-                                <taskdef name="groovy" classname="org.codehaus.groovy.ant.Groovy" classpathref="maven.plugin.classpath" />
-                                <groovy src="src/main/groovy/generate-interfaces.groovy" />
-                            </target>
+                            <source>${basedir}/src/main/groovy/generate-interfaces.groovy</source>
+                            <classpathScope>compile</classpathScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/java8/src/main/groovy/generate-interfaces.groovy
+++ b/java8/src/main/groovy/generate-interfaces.groovy
@@ -12,12 +12,12 @@ dialectProvider.getLanguages().each { language ->
     def dialect = dialectProvider.getDialect(language, null)
     def normalized_language = dialect.language.replaceAll("[\\s-]", "_").toLowerCase()
     if (!unsupported.contains(normalized_language)) {
-        def templateSource = new File(project.baseDir, "src/main/groovy/lambda.java.gsp").getText()
+        def templateSource = new File(project.basedir, "src/main/groovy/lambda.java.gsp").getText()
         def className = "${normalized_language}".capitalize()
         def name = dialect.name + ((dialect.name == dialect.nativeName) ? '' : ' - ' + dialect.nativeName)
         def binding = ["i18n": dialect, "className": className, "language_name": name]
         def template = engine.createTemplate(templateSource).make(binding)
-        def file = new File(project.baseDir, "target/generated-sources/i18n/java/io/cucumber/java8/${className}.java")
+        def file = new File(project.basedir, "target/generated-sources/i18n/java/io/cucumber/java8/${className}.java")
         Files.createDirectories(file.parentFile.toPath())
         file.write(template.toString(), "UTF-8")
     }

--- a/pom.xml
+++ b/pom.xml
@@ -241,29 +241,9 @@
             <plugins>
                 <!-- Standard plugins - alphabetically -->
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.codehaus.groovy</groupId>
-                            <artifactId>groovy-ant</artifactId>
-                            <version>${groovy.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.codehaus.groovy</groupId>
-                            <artifactId>groovy-templates</artifactId>
-                            <version>${groovy.version}</version>
-                        </dependency>
-                        <!--
-                        Gherkin is used during build time to generate code. We add it to the plugin classpath to prevent polluting
-                        the compile/test classpaths.
-                        -->
-                        <dependency>
-                            <groupId>io.cucumber</groupId>
-                            <artifactId>gherkin</artifactId>
-                            <version>${gherkin.version}</version>
-                        </dependency>
-                    </dependencies>
+                    <groupId>org.codehaus.gmaven</groupId>
+                    <artifactId>groovy-maven-plugin</artifactId>
+                    <version>2.1.1</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

I've been unable to compile the project using `asdf`'s `openjdk-11`, getting "Unsupported class file major version 60" errors.

**Describe the solution you have implemented**

Switching to `groovy-maven-plugin` fixes the problem. (I discovered this when I configured code generation in https://github.com/cucumber/ci-environment/blob/main/java/pom.xml a few weeks ago).

**Additional context**

With this change, the project now builds with `openjdk-16` as well. We should update the GitHub Actions to use a matrix including more JDK versions.