### PR TITLE
[Core] Use canonical file name to create FileOutputStream for plugins

### DIFF
--- a/core/src/main/java/io/cucumber/core/plugin/PluginFactory.java
+++ b/core/src/main/java/io/cucumber/core/plugin/PluginFactory.java
@@ -234,7 +234,7 @@ public final class PluginFactory {
         }
 
         try {
-            return new FileOutputStream(file);
+            return new FileOutputStream(canonicalFile);
         } catch (FileNotFoundException e) {
             // See: https://github.com/cucumber/cucumber-jvm/issues/2108
             throw new IllegalArgumentException(String.format("" +


### PR DESCRIPTION
https://github.com/cucumber/cucumber-jvm/issues/2108

**Describe the solution you have implemented**
Variables file and canonicalFile should be the file on the file system. Native code throws Exception when opening file.
canonicalFile is possible.