### PR TITLE
[JUnit Platform] Support cucumber.features property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] (In Git)
 
 ### Added
+*  [JUnit Platform] Support `cucumber.features` property ([#2498](https://github.com/cucumber/cucumber-jvm/pull/2498) M.P. Korstanje)
 
 ### Changed
 * Update dependency io.cucumber:ci-environment to v9 ([#2475](https://github.com/cucumber/cucumber-jvm/pull/2475) M.P. Korstanje)

--- a/core/README.md
+++ b/core/README.md
@@ -32,7 +32,7 @@ cucumber.execution.wip=         # true or false. default: false.
                                 # Fails if there any passing scenarios
                                 # CLI only.   
 
-cucumber.features=              # command separated paths to feature files. 
+cucumber.features=              # comma separated paths to feature files. 
                                 # example: path/to/example.feature, path/to/other.feature
   
 cucumber.filter.name=           # a regular expression

--- a/core/src/main/resources/io/cucumber/core/options/USAGE.txt
+++ b/core/src/main/resources/io/cucumber/core/options/USAGE.txt
@@ -121,7 +121,7 @@ cucumber.execution.wip=         # true or false. default: false.
                                 # Fails if there any passing scenarios
                                 # CLI only.
 
-cucumber.features=              # command separated paths to feature files.
+cucumber.features=              # comma separated paths to feature files.
                                 # example: path/to/example.feature, path/to/other.feature
 
 cucumber.filter.name=           # a regular expression

--- a/junit-platform-engine/README.md
+++ b/junit-platform-engine/README.md
@@ -288,6 +288,11 @@ cucumber.filter.name=                                         # a regular expres
                                                               # JUnit 5 prefer using JUnit 5s discovery request filters
                                                               # or JUnit 5 tag expressions instead.
 
+cucumber.features=                                            # comma separated paths to feature files. 
+                                                              # example: path/to/example.feature, path/to/other.feature
+                                                              # note: When used any discovery selectors from the JUnit
+                                                              # Platform will be ignored. Use with caution and care.
+
 cucumber.filter.tags=                                         # a cucumber tag expression.
                                                               # only scenarios with matching tags are executed.
                                                               # example: @Cucumber and not (@Gherkin or @Zucchini)

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -42,6 +42,28 @@ public final class Constants {
     public static final String EXECUTION_EXCLUSIVE_RESOURCES_TAG_TEMPLATE_VARIABLE = "<tag-name>";
 
     /**
+     * Property name used to set feature location: {@value}
+     * <p>
+     * A comma separated list of:
+     * <ul>
+     * <li>{@code path/to/dir} - Load the files with the extension ".feature"
+     * for the directory {@code path} and its sub directories.
+     * <li>{@code path/name.feature} - Load the feature file
+     * {@code path/name.feature} from the file system.</li>
+     * <li>{@code classpath:path/name.feature} - Load the feature file
+     * {@code path/name.feature} from the classpath.</li>
+     * <li>{@code path/name.feature:3:9} - Load the scenarios on line 3 and line
+     * 9 in the file {@code path/name.feature}.</li>
+     * </ul>
+     * <p>
+     * NOTE: When used any discovery selectors from the JUnit Platform will be
+     * ignored. Use with caution and care.
+     *
+     * @see io.cucumber.core.feature.FeatureWithLines
+     */
+    public static final String FEATURES_PROPERTY_NAME = io.cucumber.core.options.Constants.FEATURES_PROPERTY_NAME;
+
+    /**
      * Property name used to set name filter: {@value}
      * <p>
      * Filter scenarios by name based on the provided regex pattern e.g:

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
@@ -1,6 +1,7 @@
 package io.cucumber.junit.platform.engine;
 
 import io.cucumber.core.backend.ObjectFactory;
+import io.cucumber.core.feature.FeatureWithLines;
 import io.cucumber.core.feature.GluePath;
 import io.cucumber.core.options.ObjectFactoryParser;
 import io.cucumber.core.options.PluginOption;
@@ -16,6 +17,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -25,6 +27,7 @@ import java.util.stream.Stream;
 import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME_PREFIX;
 import static io.cucumber.junit.platform.engine.Constants.ANSI_COLORS_DISABLED_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.EXECUTION_DRY_RUN_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.FEATURES_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.FILTER_NAME_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.FILTER_TAGS_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
@@ -165,4 +168,14 @@ class CucumberEngineOptions implements
                 .orElse(DefaultNamingStrategy.SHORT);
     }
 
+    List<FeatureWithLines> featuresWithLines() {
+        return configurationParameters.get(FEATURES_PROPERTY_NAME,
+            s -> Arrays.stream(s.split(","))
+                    .map(String::trim)
+                    .map(FeatureWithLines::parse)
+                    .sorted(Comparator.comparing(FeatureWithLines::uri))
+                    .distinct()
+                    .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
+    }
 }

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
@@ -2,6 +2,7 @@ package io.cucumber.junit.platform.engine;
 
 import io.cucumber.core.feature.FeatureIdentifier;
 import io.cucumber.core.feature.FeatureParser;
+import io.cucumber.core.feature.FeatureWithLines;
 import io.cucumber.core.gherkin.Feature;
 import io.cucumber.core.gherkin.Pickle;
 import io.cucumber.core.logging.Logger;
@@ -54,7 +55,7 @@ final class FeatureResolver {
         this.namingStrategy = new CucumberEngineOptions(parameters).namingStrategy();
     }
 
-    static FeatureResolver createFeatureResolver(
+    static FeatureResolver create(
             ConfigurationParameters parameters, CucumberEngineDescriptor engineDescriptor,
             Predicate<String> packageFilter
     ) {
@@ -228,6 +229,14 @@ final class FeatureResolver {
 
     void resolveUri(UriSelector selector) {
         resolveUri(stripQuery(selector.getUri()))
+                .forEach(featureDescriptor -> {
+                    featureDescriptor.prune(TestDescriptorOnLine.from(selector));
+                    engineDescriptor.mergeFeature(featureDescriptor);
+                });
+    }
+
+    void resolveFeatureWithLines(FeatureWithLines selector) {
+        resolveUri(selector.uri())
                 .forEach(featureDescriptor -> {
                     featureDescriptor.prune(TestDescriptorOnLine.from(selector));
                     engineDescriptor.mergeFeature(featureDescriptor);

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/TestDescriptorOnLine.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/TestDescriptorOnLine.java
@@ -1,5 +1,6 @@
 package io.cucumber.junit.platform.engine;
 
+import io.cucumber.core.feature.FeatureWithLines;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.discovery.ClasspathResourceSelector;
 import org.junit.platform.engine.discovery.FileSelector;
@@ -35,6 +36,19 @@ class TestDescriptorOnLine {
 
     private static boolean anyTestDescriptor(TestDescriptor testDescriptor) {
         return true;
+    }
+
+    private static Predicate<TestDescriptor> eitherTestDescriptor(
+            Predicate<TestDescriptor> a, Predicate<TestDescriptor> b
+    ) {
+        return a.or(b);
+    }
+
+    static Predicate<TestDescriptor> from(FeatureWithLines selector) {
+        return selector.lines().stream()
+                .map(TestDescriptorOnLine::testDescriptorOnLine)
+                .reduce(TestDescriptorOnLine::eitherTestDescriptor)
+                .orElse(TestDescriptorOnLine::anyTestDescriptor);
     }
 
     static Predicate<TestDescriptor> from(UriSelector selector) {

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
@@ -18,7 +18,6 @@ import static io.cucumber.junit.platform.engine.Constants.EXECUTION_EXCLUSIVE_RE
 import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.READ_SUFFIX;
 import static io.cucumber.junit.platform.engine.Constants.READ_WRITE_SUFFIX;
-import static io.cucumber.junit.platform.engine.FeatureResolver.createFeatureResolver;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Optional.of;
@@ -51,7 +50,7 @@ class FeatureResolverTest {
     }
 
     private TestDescriptor getFeature() {
-        FeatureResolver featureResolver = createFeatureResolver(configurationParameters, engineDescriptor,
+        FeatureResolver featureResolver = FeatureResolver.create(configurationParameters, engineDescriptor,
             aPackage -> true);
         featureResolver.resolveClasspathResource(selectClasspathResource(featurePath));
         Set<? extends TestDescriptor> features = engineDescriptor.getChildren();


### PR DESCRIPTION
_Usually it not necessary to use the `cucumber.features` property. See the notes section below._

JUnit 5 support is still anything but first class https://github.com/junit-team/junit5/issues/2849. As such users
do need a quick and easy way to select feature files from the
commandline i.e:

```
mvn test -Dcucumber.features=path/to/example.feature
```

When enabled, other discovery selectors will be ignored. As such it would be prudent to select only the cucumber engine for execution with `-Dsurefire.includeJUnit5Engines=cucumber` and enabling pretty printing with `-Dcucumber.plugin=pretty`. I.e:

```
mvn test -Dsurefire.includeJUnit5Engines=cucumber -Dcucumber.plugin=pretty -Dcucumber.features=path/to/example.feature 
```


Of all possible options is the least-worst solution. Additionally a warning is logged prompting users to request better support. The relevant  issues to request/support/sponsor are:

 - IDEA 
   - https://youtrack.jetbrains.com/issue/IDEA-227508
   - https://youtrack.jetbrains.com/issue/IDEA-276463
   - https://youtrack.jetbrains.com/issue/IDEA-276477

 - Eclipse
   -  No issue exists (yet).

 - Maven Surefire
   -  https://issues.apache.org/jira/browse/SUREFIRE-1724

 - Gradle
   - https://github.com/gradle/gradle/issues/4773

---

Note:  Usually it not necessary to use the `cucumber.features` property. 

* When using the `@Suite` annotation use the [JUnit 5 Suite annotations](https://junit.org/junit5/docs/current/api/org.junit.platform.suite.api/org/junit/platform/suite/api/package-summary.html) dedicated to selecting tests. I.e: `@SelectClasspathResource` or `@SelectFile`.

* When using the JUnit Platform Launcher API, use `DiscoverySelectors.selectClasspathResource` or `DiscoverySelectors.selectFile`. 

* When using the JUnit ConsoleLauncher use the `--select-file` or `--select-classpath-resource` CLI options.

Note: Rerun files are not (yet?) supported with JUnit 5. See: https://github.com/cucumber/cucumber-jvm/issues/2805.
