### PR TITLE
[Spring] Start and stop test context once per scenario 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - `org.glassfish.jaxb:jaxb-runtime`
 - [TestNG] Remove spurious Optional\[<Feature Name>] from test name ([#2488](https://github.com/cucumber/cucumber-jvm/pull/2488) M.P. Korstanje)
 * [BOM] Add missing dependencies to bill of materials ([#2496](https://github.com/cucumber/cucumber-jvm/pull/2496) M.P. Korstanje)
+* [Spring] Start and stop test context once per scenario ([#2517](https://github.com/cucumber/cucumber-jvm/pull/2517) M.P. Korstanje)
 
 ## [7.2.3] (2022-01-13)
 

--- a/spring/src/main/java/io/cucumber/spring/CucumberScenarioScope.java
+++ b/spring/src/main/java/io/cucumber/spring/CucumberScenarioScope.java
@@ -37,7 +37,9 @@ class CucumberScenarioScope implements Scope {
     @Override
     public String getConversationId() {
         CucumberTestContext context = CucumberTestContext.getInstance();
-        return context.getId();
+        return context.getId()
+                .map(id -> "cucumber_test_context_" + id)
+                .orElse(null);
     }
 
 }

--- a/spring/src/main/java/io/cucumber/spring/CucumberTestContext.java
+++ b/spring/src/main/java/io/cucumber/spring/CucumberTestContext.java
@@ -4,6 +4,7 @@ import org.apiguardian.api.API;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @API(status = API.Status.STABLE)
@@ -31,8 +32,8 @@ public final class CucumberTestContext {
         sessionId = sessionCounter.incrementAndGet();
     }
 
-    String getId() {
-        return "cucumber_test_context_" + sessionId;
+    Optional<Integer> getId() {
+        return Optional.ofNullable(sessionId);
     }
 
     void stop() {

--- a/spring/src/main/java/io/cucumber/spring/SpringFactory.java
+++ b/spring/src/main/java/io/cucumber/spring/SpringFactory.java
@@ -21,8 +21,6 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.Set;
 
-import static io.cucumber.spring.TestContextAdaptor.createTestContextManagerAdaptor;
-
 /**
  * Spring based implementation of ObjectFactory.
  * <p>
@@ -151,7 +149,7 @@ public final class SpringFactory implements ObjectFactory {
         // a singleton and reused between scenarios and shared between
         // threads.
         TestContextManager testContextManager = new TestContextManager(withCucumberContextConfiguration);
-        testContextAdaptor = createTestContextManagerAdaptor(testContextManager, stepClasses);
+        testContextAdaptor = new TestContextAdaptor(testContextManager, stepClasses);
         testContextAdaptor.start();
     }
 

--- a/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
+++ b/spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
@@ -23,6 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.util.Optional;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,6 +34,8 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -57,6 +61,27 @@ class SpringFactoryTest {
             () -> assertThat(o2, is(notNullValue())),
             () -> assertThat(o1, is(not(equalTo(o2)))),
             () -> assertThat(o2, is(not(equalTo(o1)))));
+    }
+
+    @Test
+    void shouldStartOneCucumberContextForEachScenario() {
+        final ObjectFactory factory = new SpringFactory();
+        factory.addClass(BellyStepDefinitions.class);
+
+        // Scenario 1
+        assertTrue(CucumberTestContext.getInstance().getId().isEmpty());
+        factory.start();
+        Optional<Integer> testContextId1 = CucumberTestContext.getInstance().getId();
+        factory.stop();
+
+        // Scenario 2
+        assertTrue(CucumberTestContext.getInstance().getId().isEmpty());
+        factory.start();
+        Optional<Integer> testContextId2 = CucumberTestContext.getInstance().getId();
+        factory.stop();
+        assertTrue(CucumberTestContext.getInstance().getId().isEmpty());
+
+        assertEquals(testContextId1.get() + 1, testContextId2.get());
     }
 
     @Test


### PR DESCRIPTION
The `TestContextAdaptor` would start the scenario scope once at the start of
each test, then another one to run the after test method hooks. Refactored
code to make the order of operations more obvious.

Also prevented scenario scopes from being registered more then once. Though
because `CucumberScenarioScope` delegates everything to `CucumberTestContext`
this effectively only reduces the log spam a bit at debug level.

Fixes: #2516