### PR TITLE
[Build] Disable spotless apply in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Cucumber CI
 on:
   pull_request:
     branches:
-      - *
+      - '**'
   push:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,6 @@
 name: Cucumber CI
 
-on:
-  pull_request:
-    branches-ignore:
-      - main
-      - v4.x.x
-      - v5.x.x
-      - v6.x.x
-      - v7.x.x
-  push:
-    branches:
-      - main
-      - v4.x.x
-      - v5.x.x
-      - v6.x.x
-      - v7.x.x
+on: push
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Cucumber CI
 
 on:
   push:
-  pull_request:
     branches:
       - main
       - v4.x.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: Cucumber CI
 
 on:
+  pull_request:
+    branches-ignore:
+      - main
+      - v4.x.x
+      - v5.x.x
+      - v6.x.x
+      - v7.x.x
   push:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B --show-version --toolchains .github/workflows/.toolchains.xml
       - name: Test
-        run: mvn verify -P-spotless-apply --toolchains .github/workflows/.toolchains.xml
+        run: mvn verify --toolchains .github/workflows/.toolchains.xml
         env:
           CUCUMBER_PUBLISH_TOKEN: ${{ secrets.CUCUMBER_PUBLISH_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,16 @@
 name: Cucumber CI
 
-on: push
+on:
+  pull_request:
+    branches:
+      - *
+  push:
+    branches:
+      - main
+      - v4.x.x
+      - v5.x.x
+      - v6.x.x
+      - v7.x.x
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,9 @@
         <profile>
             <id>spotless-apply</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!CI</name>
+                </property>
             </activation>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
Spotless reformats the code to the default when building locally. This should
not run in CI. Then we can't check if the code was properly formatted.

Additionally CI should only run each job once rather then once for a push
or for a merge request.