### PR TITLE
[JUnit Platform] Support feature files with space in filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [TestNG] Remove spurious Optional\[<Feature Name>] from test name ([#2488](https://github.com/cucumber/cucumber-jvm/pull/2488) M.P. Korstanje)
 * [BOM] Add missing dependencies to bill of materials ([#2496](https://github.com/cucumber/cucumber-jvm/pull/2496) M.P. Korstanje)
 * [Spring] Start and stop test context once per scenario ([#2517](https://github.com/cucumber/cucumber-jvm/pull/2517) M.P. Korstanje)
+* [JUnit Platform] Feature files with space in filename generate Illegal Character ([#2521](https://github.com/cucumber/cucumber-jvm/pull/2521) G. Fernandez)
 
 ## [7.2.3] (2022-01-13)
 

--- a/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureOrigin.java
+++ b/junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureOrigin.java
@@ -31,7 +31,7 @@ abstract class FeatureOrigin {
             if (!uri.getSchemeSpecificPart().startsWith("/")) {
                 // ClasspathResourceSource.from expects all resources to start
                 // with a forward slash
-                uri = URI.create(CLASSPATH_SCHEME_PREFIX + "/" + uri.getSchemeSpecificPart());
+                uri = URI.create(CLASSPATH_SCHEME_PREFIX + "/" + uri.getRawSchemeSpecificPart());
             }
             ClasspathResourceSource source = ClasspathResourceSource.from(uri);
             return new ClasspathFeatureOrigin(source);

--- a/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
+++ b/junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolverTest.java
@@ -79,6 +79,14 @@ class DiscoverySelectorResolverTest {
     }
 
     @Test
+    void resolveRequestWithClasspathResourceSelectorAndWithSpaceInFilename() {
+        DiscoverySelector resource = selectClasspathResource("io/cucumber/junit/platform/engine/with space.feature");
+        EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
+        resolver.resolveSelectors(discoveryRequest, testDescriptor);
+        assertEquals(1, testDescriptor.getChildren().size());
+    }
+
+    @Test
     void resolveRequestWithClasspathResourceSelectorAndFilePosition() {
         String feature = "io/cucumber/junit/platform/engine/rule.feature";
         FilePosition line = FilePosition.from(5);
@@ -120,7 +128,7 @@ class DiscoverySelectorResolverTest {
         DiscoverySelector resource = selectClasspathRoots(singleton(classpathRoot)).get(0);
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
-        assertEquals(6, testDescriptor.getChildren().size());
+        assertEquals(7, testDescriptor.getChildren().size());
     }
 
     @Test
@@ -256,7 +264,7 @@ class DiscoverySelectorResolverTest {
         DiscoverySelector resource = selectDirectory("src/test/resources/io/cucumber/junit/platform/engine");
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
-        assertEquals(5, testDescriptor.getChildren().size());
+        assertEquals(6, testDescriptor.getChildren().size());
     }
 
     @Test
@@ -264,7 +272,7 @@ class DiscoverySelectorResolverTest {
         DiscoverySelector resource = selectPackage("io.cucumber.junit.platform.engine");
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
-        assertEquals(5, testDescriptor.getChildren().size());
+        assertEquals(6, testDescriptor.getChildren().size());
     }
 
     @Test
@@ -397,7 +405,7 @@ class DiscoverySelectorResolverTest {
         DiscoverySelector resource = selectClass(RunCucumberTest.class);
         EngineDiscoveryRequest discoveryRequest = new SelectorRequest(resource);
         resolver.resolveSelectors(discoveryRequest, testDescriptor);
-        assertEquals(5, testDescriptor.getChildren().size());
+        assertEquals(6, testDescriptor.getChildren().size());
     }
 
     @Test

--- a/junit-platform-engine/src/test/resources/io/cucumber/junit/platform/engine/with space.feature
+++ b/junit-platform-engine/src/test/resources/io/cucumber/junit/platform/engine/with space.feature
@@ -1,0 +1,1 @@
+Feature: A feature without any scenarios

--- a/junit-platform-engine/src/test/resources/io/cucumber/junit/platform/engine/with space.feature
+++ b/junit-platform-engine/src/test/resources/io/cucumber/junit/platform/engine/with space.feature
@@ -1,1 +1,6 @@
-Feature: A feature without any scenarios
+Feature: A feature with a single scenario inside a file with space in filename
+
+  Scenario: A single scenario
+    Given a single scenario
+    When it is executed
+    Then nothing else happens


### PR DESCRIPTION

### 🤔 What's changed?

* Add a file with a space in test cases.
* Replace URI.getSchemeSpecificPart by URI.getRawSchemeSpecificPart to
  keep space encoded.

### ⚡️ What's your motivation? 

Fixes #2520 

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
