### PR TITLE
[Core] Remove usage of Collectors.toUnmodifiableList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+ - [Core] Removed usage of since Java 10 `Collectors.toUnmodifiableList()` method ([#2531](https://github.com/cucumber/cucumber-jvm/pull/2531) M.P. Korstanje) 
 
 ## [7.3.0] (2022-04-19)
 

--- a/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesFeatureParser.java
+++ b/gherkin-messages/src/main/java/io/cucumber/core/gherkin/messages/GherkinMessagesFeatureParser.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static io.cucumber.messages.types.SourceMediaType.TEXT_X_CUCUMBER_GHERKIN_PLAIN;
 import static java.util.stream.Collectors.toList;
@@ -30,7 +29,7 @@ public final class GherkinMessagesFeatureParser implements FeatureParser {
                 .idGenerator(() -> idGenerator.get().toString())
                 .build()
                 .parse(Envelope.of(new Source(path.toString(), source, TEXT_X_CUCUMBER_GHERKIN_PLAIN)))
-                .collect(Collectors.toUnmodifiableList());
+                .collect(toList());
 
         List<String> errors = envelopes.stream()
                 .map(Envelope::getParseError)


### PR DESCRIPTION
`Collectors.toUnmodifiableList` was introduced since java 10. Which is slightly too modern for us to use.

Fixes #2530

### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
