### PR TITLE
Fix problem with PrettyFormatter printing URL encoded strings

### DIFF
--- a/core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
@@ -186,7 +186,9 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
         try (BufferedReader lines = new BufferedReader(new StringReader(event.getText()))) {
             String line;
             while ((line = lines.readLine()) != null) {
-                builder.append(String.format(STEP_SCENARIO_INDENT + line + "%n"));
+                builder.append(STEP_SCENARIO_INDENT)
+                	.append(line)
+                	.append(System.lineSeparator()); // Add system line separator - \n won't do it!
             }
         } catch (IOException e) {
             throw new CucumberException(e);

--- a/core/src/test/java/io/cucumber/core/plugin/PrettyFormatterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/PrettyFormatterTest.java
@@ -166,6 +166,34 @@ class PrettyFormatterTest {
     }
 
     @Test
+    void should_print_encoded_characters() {
+    	
+        Feature feature = TestFeatureParser.parse("path/test.feature", "" +
+                "Feature: Test feature\n" +
+                "  Scenario: Test Characters\n" +
+                "    Given first step\n" +
+                "      | URLEncoded | %71s%22i%22%3A%7B%22D |\n");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Runtime.builder()
+                .withFeatureSupplier(new StubFeatureSupplier(feature))
+                .withAdditionalPlugins(new PrettyFormatter(out))
+                .withRuntimeOptions(new RuntimeOptionsBuilder().setMonochrome().build())
+                .withBackendSupplier(new StubBackendSupplier(
+                    new StubStepDefinition("first step", "path/step_definitions.java:7", DataTable.class)))
+                .build()
+                .run();
+
+        assertThat(out, isBytesEqualTo("" +
+
+                "\n" +
+                "Scenario: Test Characters # path/test.feature:2\n" +
+                "  Given first step        # path/step_definitions.java:7\n" +
+        		"    | URLEncoded | %71s%22i%22%3A%7B%22D |\n"));
+   }
+    
+
+    @Test
     void should_print_tags() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
                 "@feature_tag\n" +


### PR DESCRIPTION
- Added a test case (should_print_encoded_characters) that prints URL encoded characters to the scenario in the form of a table .
- Adjusting of PrettyFormater .. instead of using String.format(..) - just appending
	1. the scenario indentation
	2. the line to be printed
	3. systems line-separator
.. to the StringBuilder.

Fixes issues 2544

