### PR TITLE
The project should be possible to build without prior knowledge ..

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-s .mvn/settings-cucumber-jvm.xml

--- a/.mvn/settings-cucumber-jvm.xml
+++ b/.mvn/settings-cucumber-jvm.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <localRepository>${user.home}/.m2/repository-cucumber-jvm</localRepository>
+    <interactiveMode>true</interactiveMode>
+    <offline>false</offline>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -151,32 +151,32 @@
     </profiles>
 
     <build>
-    	
-    	<!-- You may run a build without any goal .. just type 'mvn' -->
-    	<defaultGoal>clean install</defaultGoal>
-    	
-    	<plugins>
-    		<plugin>
+
+        <!-- You may run a build without any goal .. just type 'mvn' -->
+        <defaultGoal>clean install</defaultGoal>
+
+        <plugins>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
-					<execution>
-						<id>enforce-maven-3-3-1-plus</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<fail>true</fail>
-							<rules>
-								<requireMavenVersion>
-									<version>${maven.version.min}</version>
-								</requireMavenVersion>                
-							</rules>
-						</configuration>
-					</execution>
-				</executions>
-    		</plugin>
-    		
+                    <execution>
+                        <id>enforce-maven-3-3-1-plus</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <fail>true</fail>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>${maven.version.min}</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,11 @@
 
         <!--Maven plugins-->
         <groovy.version>2.5.15</groovy.version>
+        
+        <!--Minimum required maven version - 3.5.4 was released 2018-06-21 --> 
+        <maven.version.min>3.5.4</maven.version.min>
     </properties>
+    
     <scm>
         <connection>scm:git:git://github.com/cucumber/cucumber-jvm.git</connection>
         <developerConnection>scm:git:git@github.com:cucumber/cucumber-jvm.git</developerConnection>
@@ -114,6 +118,11 @@
                             <artifactId>maven-failsafe-plugin</artifactId>
                             <version>3.0.0-M6</version>
                         </plugin>
+                        <plugin>
+			                <groupId>org.apache.maven.plugins</groupId>
+			                <artifactId>maven-enforcer-plugin</artifactId>
+                            <version>3.0.0</version>
+                        </plugin>
                     </plugins>
                 </pluginManagement>
             </build>
@@ -138,10 +147,36 @@
                 </plugins>
             </build>
         </profile>
+        
     </profiles>
 
     <build>
-        <plugins>
+    	
+    	<!-- You may run a build without any goal .. just type 'mvn' -->
+    	<defaultGoal>clean install</defaultGoal>
+    	
+    	<plugins>
+    		<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+					<execution>
+						<id>enforce-maven-3-3-1-plus</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<fail>true</fail>
+							<rules>
+								<requireMavenVersion>
+									<version>${maven.version.min}</version>
+								</requireMavenVersion>                
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+    		</plugin>
+    		
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -193,7 +228,6 @@
             <plugin>
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
-                <version>1.0</version>
                 <executions>
                     <execution>
                         <id>directories</id>


### PR DESCRIPTION
The project should be possible to build without prior knowledge about necessary maven goals. 
In a Java developers environment conflicts with dependencies on other Java/Maven projects should be avoided.

- Introduce a variable to specify the required minimum maven version .. The variable is configured to a version which is assumed to be neither too old nor too new and is preferably API compatible to "modern maven-plugins".
- Configure an isolated local Maven repository cache using the maven -s option in .mvn/maven.config (Since maven 3.3.1+) - see https://maven.apache.org/configure.html
- Configure a project-specific settings(...).xml with minimum requirements - this is where the localRepository element points to an isolated local repository. There is no need to create the repository path manually ( this is done by maven).
- .... After cloning the project entering 'mvn' should build it without any further arguments.

### 🤔 What's changed?

- Add .mvn/maven.config ... points to the next file:
- Add .mvn/settings-cucumber-jvm.xml
- Change root pom.xml .. manage version of the enforcer plugin (3.0.0) and enforce mimimum maven version 3.5.4 (from 2018) it should work with 3.3.1 too

### ⚡️ What's your motivation? 

When I first started working on the project there were conflicts with the state of my local repository as the cucumber project did not have any minimum requirements. The unmanaged enforcer plugin was not API compatible with my newer maven version. It should be as easy as possible for newcomers to the project to build the project even without prior knowledge. 
