### PR TITLE
[Core] Fix NoSuchMethodError PrintWriter(OutputStream, boolean, Charset)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+ * [Core] Fix NoSuchMethodError `PrintWriter(OutputStream, boolean, Charset)` ([#2578](https://github.com/cucumber/cucumber-jvm/pull/2578) M.P. Korstanje)
 
 ## [7.4.0] (2022-06-22)
 

--- a/core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
@@ -22,7 +22,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -52,7 +51,7 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
 
     private final Map<UUID, Integer> commentStartIndex = new HashMap<>();
 
-    private final PrintWriter out;
+    private final UTF8PrintWriter out;
     private Formats formats = ansi();
 
     public PrettyFormatter(OutputStream out) {

--- a/core/src/main/java/io/cucumber/core/plugin/ProgressFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/ProgressFormatter.java
@@ -9,7 +9,6 @@ import io.cucumber.plugin.event.TestRunFinished;
 import io.cucumber.plugin.event.TestStepFinished;
 
 import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,7 +35,7 @@ public final class ProgressFormatter implements ConcurrentEventListener, ColorAw
         }
     };
 
-    private final PrintWriter out;
+    private final UTF8PrintWriter out;
     private boolean monochrome = false;
 
     public ProgressFormatter(OutputStream out) {

--- a/core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
@@ -8,7 +8,6 @@ import io.cucumber.plugin.event.TestCaseFinished;
 import io.cucumber.plugin.event.TestRunFinished;
 
 import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,7 +23,7 @@ import static io.cucumber.core.plugin.PrettyFormatter.relativize;
  */
 public final class RerunFormatter implements ConcurrentEventListener {
 
-    private final PrintWriter out;
+    private final UTF8PrintWriter out;
     private final Map<URI, Collection<Integer>> featureAndFailedLinesMapping = new HashMap<>();
 
     public RerunFormatter(OutputStream out) {
@@ -46,7 +45,7 @@ public final class RerunFormatter implements ConcurrentEventListener {
     private void finishReport() {
         for (Map.Entry<URI, Collection<Integer>> entry : featureAndFailedLinesMapping.entrySet()) {
             FeatureWithLines featureWithLines = create(relativize(entry.getKey()), entry.getValue());
-            out.println(featureWithLines);
+            out.println(featureWithLines.toString());
         }
 
         out.close();

--- a/core/src/main/java/io/cucumber/core/plugin/UTF8PrintWriter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/UTF8PrintWriter.java
@@ -1,13 +1,82 @@
 package io.cucumber.core.plugin;
 
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
+import java.io.OutputStreamWriter;
 
-final class UTF8PrintWriter extends PrintWriter {
+/**
+ * A "good enough" PrintWriter implementation that writes UTF-8 and rethrows all
+ * exceptions as runtime exceptions.
+ */
+final class UTF8PrintWriter implements Appendable, Closeable, Flushable {
+
+    private final OutputStreamWriter out;
 
     UTF8PrintWriter(OutputStream out) {
-        super(out, false, StandardCharsets.UTF_8);
+        this.out = new UTF8OutputStreamWriter(out);
+    }
+
+    public void println() {
+        try {
+            out.write(System.lineSeparator());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void println(String s) {
+        try {
+            out.write(s);
+            out.write(System.lineSeparator());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void flush() {
+        try {
+            out.flush();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            out.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Appendable append(CharSequence csq) {
+        try {
+            return out.append(csq);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Appendable append(CharSequence csq, int start, int end) {
+        try {
+            return out.append(csq, start, end);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Appendable append(char c) {
+        try {
+            return out.append(c);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/core/src/main/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinter.java
+++ b/core/src/main/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinter.java
@@ -9,7 +9,6 @@ import io.cucumber.plugin.event.TestRunFinished;
 import io.cucumber.plugin.event.TestStepFinished;
 
 import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -24,7 +23,7 @@ public final class UnusedStepsSummaryPrinter implements ColorAware, ConcurrentEv
 
     private final Map<String, String> registeredSteps = new TreeMap<>();
     private final Set<String> usedSteps = new TreeSet<>();
-    private final PrintWriter out;
+    private final UTF8PrintWriter out;
     private Formats formats = ansi();
 
     public UnusedStepsSummaryPrinter(OutputStream out) {

--- a/core/src/test/java/io/cucumber/core/plugin/UTF8PrintWriterTest.java
+++ b/core/src/test/java/io/cucumber/core/plugin/UTF8PrintWriterTest.java
@@ -1,0 +1,48 @@
+package io.cucumber.core.plugin;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static io.cucumber.core.plugin.BytesEqualTo.isBytesEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class UTF8PrintWriterTest {
+
+    final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    final UTF8PrintWriter out = new UTF8PrintWriter(bytes);
+
+    @Test
+    void println() {
+        out.println();
+        out.println("Hello ");
+        out.close();
+        assertThat(bytes, isBytesEqualTo(
+            System.lineSeparator() + "Hello " + System.lineSeparator()));
+    }
+
+    @Test
+    void append() {
+        out.append("Hello");
+        out.append("Hello World", 5, 11);
+        out.close();
+        assertThat(bytes, isBytesEqualTo("Hello World"));
+    }
+
+    @Test
+    void flush() {
+        out.append("Hello");
+        assertThat(bytes, isBytesEqualTo(""));
+        out.flush();
+        assertThat(bytes, isBytesEqualTo("Hello"));
+    }
+
+    @Test
+    void close() {
+        out.append("Hello");
+        assertThat(bytes, isBytesEqualTo(""));
+        out.close();
+        assertThat(bytes, isBytesEqualTo("Hello"));
+    }
+
+}


### PR DESCRIPTION
The `PrintWriter(OutputStream, boolean, Charset)` method was introduced in
Java 10 and can't yet be used on Java 8. And while support for Open JDK 8 has
ended 2 months ago, Adoptium and Corretto are receiving support until 2026 and
Azul and Oracle have support until 2030.

As such we're replacing the `PrintWriter` implementation with our own
"good enough" version.

Fixes: #2575
