### PR TITLE
[Java] Process glue classes distinctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+ - [Java] Process glue classes distinctly ([#2582](https://github.com/cucumber/cucumber-jvm/pull/2582) M.P. Korstanje)
 
 ## [7.4.1] (2022-06-23)
 

--- a/guice/src/main/java/io/cucumber/guice/GuiceBackend.java
+++ b/guice/src/main/java/io/cucumber/guice/GuiceBackend.java
@@ -32,6 +32,7 @@ final class GuiceBackend implements Backend {
                 .map(classFinder::scanForClassesInPackage)
                 .flatMap(Collection::stream)
                 .filter(InjectorSource.class::isAssignableFrom)
+                .distinct()
                 .forEach(container::addClass);
     }
 

--- a/guice/src/test/java/io/cucumber/guice/GuiceBackendTest.java
+++ b/guice/src/test/java/io/cucumber/guice/GuiceBackendTest.java
@@ -13,12 +13,14 @@ import java.net.URI;
 import java.util.function.Supplier;
 
 import static java.lang.Thread.currentThread;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith({ MockitoExtension.class })
@@ -37,6 +39,14 @@ class GuiceBackendTest {
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
         backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/guice/integration")));
         verify(factory).addClass(YourInjectorSource.class);
+    }
+
+    @Test
+    void finds_injector_source_impls_once_by_classpath_url() {
+        GuiceBackend backend = new GuiceBackend(factory, classLoader);
+        backend.loadGlue(glue, asList(URI.create("classpath:io/cucumber/guice/integration"),
+            URI.create("classpath:io/cucumber/guice/integration")));
+        verify(factory, times(1)).addClass(YourInjectorSource.class);
     }
 
     @Test

--- a/java/src/main/java/io/cucumber/java/JavaBackend.java
+++ b/java/src/main/java/io/cucumber/java/JavaBackend.java
@@ -37,6 +37,7 @@ final class JavaBackend implements Backend {
                 .map(ClasspathSupport::packageName)
                 .map(classFinder::scanForClassesInPackage)
                 .flatMap(Collection::stream)
+                .distinct()
                 .forEach(aGlueClass -> scan(aGlueClass, (method, annotation) -> {
                     container.addClass(method.getDeclaringClass());
                     glueAdaptor.addDefinition(method, annotation);

--- a/java/src/test/java/io/cucumber/java/JavaBackendTest.java
+++ b/java/src/test/java/io/cucumber/java/JavaBackendTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
 
 import static java.lang.Thread.currentThread;
@@ -27,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({ MockitoExtension.class })
+@ExtendWith(MockitoExtension.class)
 class JavaBackendTest {
 
     @Captor
@@ -51,6 +52,14 @@ class JavaBackendTest {
         backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/java/steps")));
         backend.buildWorld();
         verify(factory).addClass(Steps.class);
+    }
+
+    @Test
+    void finds_step_definitions_once_by_classpath_url() {
+        backend.loadGlue(glue,
+            asList(URI.create("classpath:io/cucumber/java/steps"), URI.create("classpath:io/cucumber/java/steps")));
+        backend.buildWorld();
+        verify(factory, times(1)).addClass(Steps.class);
     }
 
     @Test

--- a/java8/src/main/java/io/cucumber/java8/Java8Backend.java
+++ b/java8/src/main/java/io/cucumber/java8/Java8Backend.java
@@ -48,6 +48,7 @@ final class Java8Backend implements Backend {
                 .flatMap(Collection::stream)
                 .filter(glueClass -> !glueClass.isInterface())
                 .filter(glueClass -> glueClass.getConstructors().length > 0)
+                .distinct()
                 .forEach(glueClass -> {
                     container.addClass(glueClass);
                     lambdaGlueClasses.add(glueClass);

--- a/java8/src/test/java/io/cucumber/java8/Java8BackendTest.java
+++ b/java8/src/test/java/io/cucumber/java8/Java8BackendTest.java
@@ -10,12 +10,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URI;
+import java.util.Arrays;
 
 import static java.lang.Thread.currentThread;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-@ExtendWith({ MockitoExtension.class })
+@ExtendWith(MockitoExtension.class)
 class Java8BackendTest {
 
     @Mock
@@ -36,6 +39,14 @@ class Java8BackendTest {
         backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/java8/steps")));
         backend.buildWorld();
         verify(factory).addClass(Steps.class);
+    }
+
+    @Test
+    void finds_step_definitions_once_by_classpath_url() {
+        backend.loadGlue(glue,
+            asList(URI.create("classpath:io/cucumber/java8/steps"), URI.create("classpath:io/cucumber/java8/steps")));
+        backend.buildWorld();
+        verify(factory, times(1)).addClass(Steps.class);
     }
 
 }

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -18,6 +18,7 @@
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <spring.version>5.3.21</spring.version>
         <project.Automatic-Module-Name>io.cucumber.spring</project.Automatic-Module-Name>
+        <mockito.version>4.6.1</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -107,6 +108,12 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring/src/main/java/io/cucumber/spring/SpringBackend.java
+++ b/spring/src/main/java/io/cucumber/spring/SpringBackend.java
@@ -31,7 +31,8 @@ final class SpringBackend implements Backend {
                 .map(ClasspathSupport::packageName)
                 .map(classFinder::scanForClassesInPackage)
                 .flatMap(Collection::stream)
-                .filter((Class clazz) -> clazz.getAnnotation(CucumberContextConfiguration.class) != null)
+                .filter((Class<?> clazz) -> clazz.getAnnotation(CucumberContextConfiguration.class) != null)
+                .distinct()
                 .forEach(container::addClass);
     }
 

--- a/spring/src/test/java/io/cucumber/spring/SpringBackendTest.java
+++ b/spring/src/test/java/io/cucumber/spring/SpringBackendTest.java
@@ -1,0 +1,55 @@
+package io.cucumber.spring;
+
+import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.ObjectFactory;
+import io.cucumber.core.backend.StepDefinition;
+import io.cucumber.spring.annotationconfig.AnnotationContextConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.URI;
+
+import static java.lang.Thread.currentThread;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SpringBackendTest {
+
+    @Mock
+    private Glue glue;
+
+    @Mock
+    private ObjectFactory factory;
+
+    private SpringBackend backend;
+
+    @BeforeEach
+    void createBackend() {
+        this.backend = new SpringBackend(factory, currentThread()::getContextClassLoader);
+    }
+
+    @Test
+    void finds_annotation_context_configuration_by_classpath_url() {
+        backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/spring/annotationconfig")));
+        backend.buildWorld();
+        verify(factory).addClass(AnnotationContextConfiguration.class);
+    }
+
+    @Test
+    void finds_annotaiton_context_configuration_once_by_classpath_url() {
+        backend.loadGlue(glue, asList(
+            URI.create("classpath:io/cucumber/spring/annotationconfig"),
+            URI.create("classpath:io/cucumber/spring/annotationconfig")));
+        backend.buildWorld();
+        verify(factory, times(1)).addClass(AnnotationContextConfiguration.class);
+    }
+
+}


### PR DESCRIPTION
Users may provide glue paths where one is a strict subset of hte other.
For example:

```
com.example
com.example.app
```

Cucumber would scan both packages (and sub packages), and for each process the
classes it discovered. This would result in the classes from the `app` package
being processed twice.

Fixes: #2581

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
