### PR TITLE
[Datatable] Support boolean parsing in Datatables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [Datatable] Support parsing Booleans in Datatables ([#2614](https://github.com/cucumber/cucumber-jvm/pull/2614) G. Jourdan-Weil)
+
 ## [7.7.0] - 2022-09-08
 ### Added
 - [JUnit Platform] Enable parallel execution of features ([#2604](https://github.com/cucumber/cucumber-jvm/pull/2604) Sambathkumar Sekar)

--- a/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
+++ b/datatable/src/main/java/io/cucumber/datatable/DataTableTypeRegistry.java
@@ -62,6 +62,10 @@ public final class DataTableTypeRegistry {
         TableCellTransformer<Double> doubleTableCellTransformer = applyIfPresent(numberParser::parseDouble);
         defineDataTableType(new DataTableType(Double.class, doubleTableCellTransformer));
         defineDataTableType(new DataTableType(double.class, doubleTableCellTransformer));
+
+        TableCellTransformer<Boolean> booleanTableCellTransformer = applyIfPresent(Boolean::parseBoolean);
+        defineDataTableType(new DataTableType(Boolean.class, booleanTableCellTransformer, true));
+        defineDataTableType(new DataTableType(boolean.class, booleanTableCellTransformer, true));
     }
 
     private static <R> TableCellTransformer<R> applyIfPresent(Function<String, R> f) {

--- a/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
+++ b/datatable/src/test/java/io/cucumber/datatable/DataTableTypeRegistryTest.java
@@ -29,6 +29,7 @@ class DataTableTypeRegistryTest {
     private static final Type LIST_OF_LIST_OF_FLOAT = aListOf(aListOf(Float.class));
     private static final Type LIST_OF_LIST_OF_DOUBLE = aListOf(aListOf(Double.class));
     private static final Type LIST_OF_LIST_OF_STRING = aListOf(aListOf(String.class));
+    private static final Type LIST_OF_LIST_OF_BOOLEAN = aListOf(aListOf(Boolean.class));
     private static final Type LIST_OF_LIST_OF_OBJECT = aListOf(aListOf(Object.class));
 
     private static final TableCellByTypeTransformer PLACE_TABLE_CELL_TRANSFORMER = (value,
@@ -244,4 +245,28 @@ class DataTableTypeRegistryTest {
             singletonList(singletonList("")),
             dataTableType.transform(singletonList(singletonList("[blank]"))));
     }
+
+    @Test
+    void parse_boolean() {
+        DataTableTypeRegistry registry = new DataTableTypeRegistry(Locale.ENGLISH);
+        DataTableType dataTableType = registry.lookupTableTypeByType(LIST_OF_LIST_OF_BOOLEAN);
+        assertEquals(
+            singletonList(singletonList(Boolean.TRUE)),
+            dataTableType.transform(singletonList(singletonList("true"))));
+        assertEquals(
+            singletonList(singletonList(Boolean.FALSE)),
+            dataTableType.transform(singletonList(singletonList("false"))));
+    }
+
+    @Test
+    void boolean_transformer_is_replaceable() {
+        DataTableTypeRegistry registry = new DataTableTypeRegistry(Locale.ENGLISH);
+        registry.defineDataTableType(
+            new DataTableType(Boolean.class, (String cell) -> "yes".equals(cell)));
+        DataTableType dataTableType = registry.lookupTableTypeByType(LIST_OF_LIST_OF_BOOLEAN);
+        assertEquals(
+            singletonList(singletonList(Boolean.TRUE)),
+            dataTableType.transform(singletonList(singletonList("yes"))));
+    }
+
 }


### PR DESCRIPTION
### 🤔 What's changed?

Aims to fix https://github.com/cucumber/cucumber-jvm/issues/2611

Added a `TableCellTransformer` for `Boolean` and `boolean` which replacable.

### ⚡️ What's your motivation? 

N/A

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

N/A

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
