### PR TITLE
Always color Maven output in GitHub workflows with -Dstyle.color=always

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           version: '11'
       - name: Install dependencies
-        run: mvn install -Pinclude-extra-modules -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true -B --show-version
+        run: mvn install -Pinclude-extra-modules -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode -Dstyle.color=always --show-version
       - name: Test
         run: mvn verify -Pinclude-extra-modules
         env:
@@ -55,7 +55,7 @@ jobs:
         with:
           version: '11'
       - name: Install dependencies
-        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version
+        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode -Dstyle.color=always --show-version
       - name: Javadoc
         run: mvn javadoc:jar
 
@@ -76,7 +76,7 @@ jobs:
         with:
           version: '11'
       - name: Install dependencies
-        run: mvn install -Pinclude-extra-modules -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version
+        run: mvn install -Pinclude-extra-modules -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode -Dstyle.color=always --show-version
       - name: Test (Coverage)
         run: mvn jacoco:prepare-agent verify jacoco:report -Pinclude-extra-modules
       - uses: codecov/codecov-action@v3
@@ -102,6 +102,6 @@ jobs:
         with:
           version: '11'
       - name: Install dependencies
-        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode --show-version
+        run: mvn install -DskipTests=true -DskipITs=true -Darchetype.test.skip=true -Dmaven.javadoc.skip=true --batch-mode -Dstyle.color=always --show-version
       - name: Test (Semver check)
         run: mvn verify -Pcheck-semantic-version -DskipTests=true -DskipITs=true -Darchetype.test.skip=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Core] Omit filtered out pickles from html report ([react-components/#273](https://github.com/cucumber/react-components/pull/273) David J. Goss)
 
 ## [Unreleased]
-### Changed
-- Always color Maven output in GitHub workflows with -Dstyle.color=always ([#2616](https://github.com/cucumber/cucumber-jvm/pull/2616) Tim te Beek)
 
 ## [7.8.0] - 2022-09-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Core] Omit filtered out pickles from html report ([react-components/#273](https://github.com/cucumber/react-components/pull/273) David J. Goss)
 
 ## [Unreleased]
+### Changed
+- Always color Maven output in GitHub workflows with -Dstyle.color=always ([#2616](https://github.com/cucumber/cucumber-jvm/pull/2616) Tim te Beek)
 
 ## [7.8.0] - 2022-09-15
 ### Added
-- [Core] Support comparison of expected and actual values in IntelliJ IDEA ([#2607](https://github.com/cucumber/cucumber-jvm/issues/2607)
+- [Core] Support comparison of expected and actual values in IntelliJ IDEA ([#2607](https://github.com/cucumber/cucumber-jvm/issues/2607) Andrey Vokin)
 - [Datatable] Support parsing Booleans in Datatables ([#2614](https://github.com/cucumber/cucumber-jvm/pull/2614) G. Jourdan-Weil)
 - 
 


### PR DESCRIPTION
Consistently added just behind --batch-mode, as that normally disables color

### 🤔 What's changed?

Always color Maven output in GitHub workflows with -Dstyle.color=always

### ⚡️ What's your motivation? 

Makes it easier to spot any issues, even with the default imperfect red/green color scheme.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Pushed as a branch rather than through a fork; or would you have preferred me to use a fork still?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

