### PR TITLE
Add section on possible Cucumber-Java8 deprecation

### DIFF
--- a/release-notes/v7.0.0.md
+++ b/release-notes/v7.0.0.md
@@ -225,3 +225,13 @@ should fail a test run.
 To make migration graceful the `--strict` and `--non-strict` CLI arguments and
 `cucumber.execution.strict` property were left in place. These have now been
 removed.
+
+
+Cucumber-Java8 currently under consideration for deprecation
+------------------------------------------------------------
+
+Due to technical difficulties, the `cucumber-java8` module is currently
+[under consideration for removal](https://github.com/cucumber/cucumber-jvm/issues/2174).
+While [alternatives are explored](https://github.com/cucumber/cucumber-jvm/issues/2279),
+you can already [migrate to `cucumber-java` annotation based step definitions automatically](https://github.com/timtebeek/cucumber-jvm-upgrades).
+For now [Cucumber-Java8 is removed as recommendation](https://github.com/cucumber/docs/pull/783).


### PR DESCRIPTION
As well as how to migrate automatically. 

As [discussed via Slack](https://cucumberbdd.slack.com/archives/C6RLMP3C4/p1664789917517839)