### PR TITLE
[Core] Don't swallow parse errors on the CLI

### DIFF
--- a/cucumber-core/src/main/java/io/cucumber/core/runtime/Runtime.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runtime/Runtime.java
@@ -76,10 +76,12 @@ public final class Runtime {
     }
 
     public void run() {
+        // Parse the features early. Don't proceed when there are lexer errors
+        List<Feature> features = featureSupplier.get();
         context.startTestRun();
         execute(() -> {
             context.runBeforeAllHooks();
-            runFeatures();
+            runFeatures(features);
         });
         execute(context::runAfterAllHooks);
         execute(context::finishTestRun);
@@ -98,8 +100,7 @@ public final class Runtime {
         }
     }
 
-    private void runFeatures() {
-        List<Feature> features = featureSupplier.get();
+    private void runFeatures(List<Feature> features) {
         features.forEach(context::beforeFeature);
         List<Future<?>> executingPickles = features.stream()
                 .flatMap(feature -> feature.getPickles().stream())

--- a/cucumber-core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
@@ -10,6 +10,7 @@ import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.exception.CompositeCucumberException;
 import io.cucumber.core.feature.TestFeatureParser;
 import io.cucumber.core.gherkin.Feature;
+import io.cucumber.core.gherkin.FeatureParserException;
 import io.cucumber.core.options.RuntimeOptionsBuilder;
 import io.cucumber.core.runner.StepDurationTimeService;
 import io.cucumber.core.runner.TestBackendSupplier;
@@ -125,6 +126,17 @@ class RuntimeTest {
         bus.send(testCaseFinishedWithStatus(Status.AMBIGUOUS));
 
         assertThat(runtime.exitStatus(), is(equalTo((byte) 0x1)));
+    }
+
+    @Test
+    void with_parse_error() {
+        Runtime runtime = Runtime.builder()
+                .withFeatureSupplier(() -> {
+                    throw new FeatureParserException("oops");
+                })
+                .build();
+
+        assertThrows(FeatureParserException.class, runtime::run);
     }
 
     @Test


### PR DESCRIPTION
### 🤔 What's changed?

With v7.6.0 in 3bc80b964971f9a61f6d22d6fe772499edbb8933 before all and after
all hooks were introduced. This moved parsing of features into the execution
context. This resulted in any parse errors being swallowed with the assumption
that they would have been captured by the execution context already.

Fixes: #2631

