### PR TITLE
[Core] Emit exceptions on failure to handle test run finished events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enabled reproducible builds ([2641](https://github.com/cucumber/cucumber-jvm/issues/2641) Hervé Boutemy )
 - [Core] Mark Allure 5 and 6 plugins as incompatible ([2652](https://github.com/cucumber/cucumber-jvm/issues/2652) M.P. Korstanje)
 
+## Fixed
+-  [Core] Emit exceptions on failure to handle test run finished events ([2651](https://github.com/cucumber/cucumber-jvm/issues/2651) M.P. Korstanje)
 
 ## [7.9.0] - 2022-11-01
 ### Changed

--- a/cucumber-core/src/main/java/io/cucumber/core/runtime/Runtime.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runtime/Runtime.java
@@ -83,8 +83,11 @@ public final class Runtime {
             context.runBeforeAllHooks();
             runFeatures(features);
         });
-        execute(context::runAfterAllHooks);
-        execute(context::finishTestRun);
+        try {
+            execute(context::runAfterAllHooks);
+        } finally {
+            context.finishTestRun();
+        }
         Throwable exception = context.getThrowable();
         if (exception != null) {
             throwAsUncheckedException(exception);

--- a/cucumber-core/src/test/java/io/cucumber/core/backend/StubPendingException.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/backend/StubPendingException.java
@@ -2,6 +2,9 @@ package io.cucumber.core.backend;
 
 import io.cucumber.core.backend.Pending;
 
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
 @Pending
 public final class StubPendingException extends RuntimeException {
 
@@ -11,6 +14,16 @@ public final class StubPendingException extends RuntimeException {
 
     public StubPendingException(String message) {
         super(message);
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter printWriter) {
+        printWriter.print(getMessage());
+    }
+
+    @Override
+    public void printStackTrace(PrintStream printStream) {
+        printStream.print(getMessage());
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-parent</artifactId>
         <version>4.1.1</version>
+        <relativePath/>
     </parent>
     <artifactId>cucumber-jvm</artifactId>
     <version>7.10.0-SNAPSHOT</version>


### PR DESCRIPTION
### 🤔 What's changed?

The runtime would collect exceptions thrown upon emitting the TestRunFinished
event. The assumption was that these were collected in the test context.
Though this is impossible. The test context is collecting exceptions to include
in the report. So it sits inside the test run started and finished events.


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.