### PR TITLE
[Core] Mark Allure 5 and 6 plugins as incompatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Enabled reproducible builds ([2641](https://github.com/cucumber/cucumber-jvm/issues/2641) Hervé Boutemy )
+- [Core] Mark Allure 5 and 6 plugins as incompatible ([2652](https://github.com/cucumber/cucumber-jvm/issues/2652) M.P. Korstanje)
+
 
 ## [7.9.0] - 2022-11-01
 ### Changed

--- a/cucumber-core/src/main/java/io/cucumber/core/options/PluginOption.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/options/PluginOption.java
@@ -79,6 +79,8 @@ public class PluginOption implements Options.Plugin {
         incompatible.add("io.qameta.allure.cucumber2jvm.AllureCucumber2Jvm");
         incompatible.add("io.qameta.allure.cucumber3jvm.AllureCucumber3Jvm");
         incompatible.add("io.qameta.allure.cucumber4jvm.AllureCucumber4Jvm");
+        incompatible.add("io.qameta.allure.cucumber5jvm.AllureCucumber5Jvm");
+        incompatible.add("io.qameta.allure.cucumber6jvm.AllureCucumber6Jvm");
         INCOMPATIBLE_PLUGIN_CLASSES = unmodifiableSet(incompatible);
     }
 


### PR DESCRIPTION
### 🤔 What's changed?

This bans the use of the incompatible plugins 

```
io.qameta.allure.cucumber5jvm.AllureCucumber5Jvm
io.qameta.allure.cucumber6jvm.AllureCucumber6Jvm
```

This will prevent users from making the mistake of using the wrong plugin
version with Cucumber. This avoids questions and noise all around.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
