### PR TITLE
Fixed mock beans not injected with @MockBean in JUnit 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 -  [Core] Emit exceptions on failure to handle test run finished events ([2651](https://github.com/cucumber/cucumber-jvm/issues/2651) M.P. Korstanje)
+- [Spring] @MockBean annotation not working with JUnit5 ([2654](https://github.com/cucumber/cucumber-jvm/pull/2655) Alexander Kirilov, M.P. Korstanje)
 
 ## [7.9.0] - 2022-11-01
 ### Changed

--- a/cucumber-spring/src/main/java/io/cucumber/spring/TestContextAdaptor.java
+++ b/cucumber-spring/src/main/java/io/cucumber/spring/TestContextAdaptor.java
@@ -53,6 +53,7 @@ class TestContextAdaptor {
         try {
             Class<?> delegateTestClass = delegate.getTestContext().getTestClass();
             delegateTestInstance = applicationContext.getBean(delegateTestClass);
+            delegate.prepareTestInstance(delegateTestInstance);
             Method dummyMethod = TestContextAdaptor.class.getMethod("cucumberDoesNotHaveASingleTestMethod");
             delegate.beforeTestMethod(delegateTestInstance, dummyMethod);
         } catch (Exception e) {


### PR DESCRIPTION
Fix suggested by https://github.com/mpkorstanje in https://github.com/cucumber/cucumber-jvm/issues/2654

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

As suggested by @mpkorstanje I have added a call to prepareTestInstance which properly injects the mocked beans from the spring context. 

### ⚡️ What's your motivation? 

Fixing #2654 

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
