### PR TITLE
[Spring] Invoke all TestContextManager methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,25 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Enabled reproducible builds ([2641](https://github.com/cucumber/cucumber-jvm/issues/2641) Hervé Boutemy )
-- [Core] Mark Allure 5 and 6 plugins as incompatible ([2652](https://github.com/cucumber/cucumber-jvm/issues/2652) M.P. Korstanje)
+- Enabled reproducible builds ([#2641](https://github.com/cucumber/cucumber-jvm/issues/2641) Hervé Boutemy )
+- [Core] Mark Allure 5 and 6 plugins as incompatible ([#2652](https://github.com/cucumber/cucumber-jvm/issues/2652) M.P. Korstanje)
+- [Spring] Invoke all `TestContextManager` methods ([#2661](https://github.com/cucumber/cucumber-jvm/pull/2661) M.P. Korstanje)
 
 ## Fixed
--  [Core] Emit exceptions on failure to handle test run finished events ([2651](https://github.com/cucumber/cucumber-jvm/issues/2651) M.P. Korstanje)
+- [Core] Emit exceptions on failure to handle test run finished events ([#2651](https://github.com/cucumber/cucumber-jvm/issues/2651) M.P. Korstanje)
+- [Spring] @MockBean annotation not working with JUnit5 ([#2654](https://github.com/cucumber/cucumber-jvm/pull/2654) Alexander Kirilov, M.P. Korstanje)
 
 ## [7.9.0] - 2022-11-01
 ### Changed
 - [Core] Update dependency io.cucumber:gherkin to v25.0.2. Japanese Rule translation changed from Rule to ルール.
 
 ### Added
-- [Spring] Support @CucumberContextConfiguration as a meta-annotation ([2491](https://github.com/cucumber/cucumber-jvm/issues/2491) Michael Schlatt)
+- [Spring] Support @CucumberContextConfiguration as a meta-annotation ([#2491](https://github.com/cucumber/cucumber-jvm/issues/2491) Michael Schlatt)
 
 ### Changed
 - [Core] Update dependency io.cucumber:gherkin to v24.1
-- [Core] Delegate encoding and BOM handling to gherkin ([2624](https://github.com/cucumber/cucumber-jvm/issues/2624) M.P. Korstanje)
+- [Core] Delegate encoding and BOM handling to gherkin ([#2624](https://github.com/cucumber/cucumber-jvm/issues/2624) M.P. Korstanje)
 
 ### Fixed
-- [Core] Don't swallow parse errors on the CLI ([2632](https://github.com/cucumber/cucumber-jvm/issues/2632) M.P. Korstanje)
+- [Core] Don't swallow parse errors on the CLI ([#2632](https://github.com/cucumber/cucumber-jvm/issues/2632) M.P. Korstanje)
 
 ### Security
 - [Core] Update dependency com.fasterxml.jackson to v2.13.4.20221012

--- a/cucumber-spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
+++ b/cucumber-spring/src/test/java/io/cucumber/spring/SpringFactoryTest.java
@@ -347,15 +347,10 @@ class SpringFactoryTest {
         assertDoesNotThrow(factory::stop);
     }
 
-    @ParameterizedTest
-    @ValueSource(classes = {
-            FailedBeforeTestClassContextConfiguration.class,
-            FailedBeforeTestMethodContextConfiguration.class,
-            FailedTestInstanceContextConfiguration.class
-    })
-    void shouldBeStoppableWhenFacedWithFailedApplicationContext(Class<?> contextConfiguration) {
+    @Test
+    void shouldBeStoppableWhenFacedWithFailedApplicationContext() {
         final ObjectFactory factory = new SpringFactory();
-        factory.addClass(contextConfiguration);
+        factory.addClass(FailedTestInstanceCreation.class);
 
         assertThrows(CucumberBackendException.class, factory::start);
         assertDoesNotThrow(factory::stop);
@@ -414,40 +409,9 @@ class SpringFactoryTest {
 
     @CucumberContextConfiguration
     @ContextConfiguration("classpath:cucumber.xml")
-    @TestExecutionListeners(FailedBeforeTestClassContextConfiguration.FailingListener.class)
-    public static class FailedBeforeTestClassContextConfiguration {
+    public static class FailedTestInstanceCreation {
 
-        public static class FailingListener implements TestExecutionListener {
-
-            @Override
-            public void beforeTestClass(TestContext testContext) throws Exception {
-                throw new StubException();
-            }
-
-        }
-
-    }
-
-    @CucumberContextConfiguration
-    @ContextConfiguration("classpath:cucumber.xml")
-    @TestExecutionListeners(FailedBeforeTestMethodContextConfiguration.FailingListener.class)
-    public static class FailedBeforeTestMethodContextConfiguration {
-
-        public static class FailingListener implements TestExecutionListener {
-
-            @Override
-            public void beforeTestMethod(TestContext testContext) throws Exception {
-                throw new StubException();
-            }
-
-        }
-
-    }
-    @CucumberContextConfiguration
-    @ContextConfiguration("classpath:cucumber.xml")
-    public static class FailedTestInstanceContextConfiguration {
-
-        public FailedTestInstanceContextConfiguration() {
+        public FailedTestInstanceCreation() {
             throw new RuntimeException();
         }
     }

--- a/cucumber-spring/src/test/java/io/cucumber/spring/TestTestContextAdaptorTest.java
+++ b/cucumber-spring/src/test/java/io/cucumber/spring/TestTestContextAdaptorTest.java
@@ -1,0 +1,191 @@
+package io.cucumber.spring;
+
+import io.cucumber.core.backend.CucumberBackendException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestContextManager;
+import org.springframework.test.context.TestExecutionListener;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+
+@ExtendWith(MockitoExtension.class)
+public class TestTestContextAdaptorTest {
+
+    @Mock
+    TestExecutionListener listener;
+
+    @AfterEach
+    void verifyNoMoroInteractions() {
+        Mockito.verifyNoMoreInteractions(listener);
+    }
+
+    @Test
+    void invokesAllLiveCycleHooks() throws Exception {
+        TestContextManager manager = new TestContextManager(SomeContextConfiguration.class);
+        TestContextAdaptor adaptor = new TestContextAdaptor(manager, singletonList(SomeContextConfiguration.class));
+        manager.registerTestExecutionListeners(listener);
+        InOrder inOrder = inOrder(listener);
+
+        adaptor.start();
+        inOrder.verify(listener).beforeTestClass(any());
+        inOrder.verify(listener).prepareTestInstance(any());
+        inOrder.verify(listener).beforeTestMethod(any());
+        inOrder.verify(listener).beforeTestExecution(any());
+
+        adaptor.stop();
+        inOrder.verify(listener).afterTestExecution(any());
+        inOrder.verify(listener).afterTestMethod(any());
+        inOrder.verify(listener).afterTestClass(any());
+    }
+
+    @Test
+    void invokesAfterClassIfBeforeClassFailed() throws Exception {
+        TestContextManager manager = new TestContextManager(SomeContextConfiguration.class);
+        TestContextAdaptor adaptor = new TestContextAdaptor(manager, singletonList(SomeContextConfiguration.class));
+        manager.registerTestExecutionListeners(listener);
+        InOrder inOrder = inOrder(listener);
+
+        doThrow(new RuntimeException()).when(listener).beforeTestClass(any());
+
+        assertThrows(CucumberBackendException.class, adaptor::start);
+        inOrder.verify(listener).beforeTestClass(any());
+
+        adaptor.stop();
+        inOrder.verify(listener).afterTestClass(any());
+    }
+
+    @Test
+    void invokesAfterClassIfPrepareTestInstanceFailed() throws Exception {
+        TestContextManager manager = new TestContextManager(SomeContextConfiguration.class);
+        TestContextAdaptor adaptor = new TestContextAdaptor(manager, singletonList(SomeContextConfiguration.class));
+        manager.registerTestExecutionListeners(listener);
+        InOrder inOrder = inOrder(listener);
+
+        doThrow(new RuntimeException()).when(listener).prepareTestInstance(any());
+
+        assertThrows(CucumberBackendException.class, adaptor::start);
+        inOrder.verify(listener).beforeTestClass(any());
+
+        adaptor.stop();
+        inOrder.verify(listener).afterTestClass(any());
+    }
+
+    @Test
+    void invokesAfterMethodIfBeforeMethodThrows() throws Exception {
+        TestContextManager manager = new TestContextManager(SomeContextConfiguration.class);
+        TestContextAdaptor adaptor = new TestContextAdaptor(manager, singletonList(SomeContextConfiguration.class));
+        manager.registerTestExecutionListeners(listener);
+        InOrder inOrder = inOrder(listener);
+
+        doThrow(new RuntimeException()).when(listener).beforeTestMethod(any());
+
+        assertThrows(CucumberBackendException.class, adaptor::start);
+        inOrder.verify(listener).beforeTestClass(any());
+        inOrder.verify(listener).prepareTestInstance(any());
+        inOrder.verify(listener).beforeTestMethod(any());
+
+        adaptor.stop();
+        inOrder.verify(listener).afterTestMethod(any());
+        inOrder.verify(listener).afterTestClass(any());
+    }
+
+    @Test
+    void invokesAfterTestExecutionIfBeforeTestExecutionThrows() throws Exception {
+        TestContextManager manager = new TestContextManager(SomeContextConfiguration.class);
+        TestContextAdaptor adaptor = new TestContextAdaptor(manager, singletonList(SomeContextConfiguration.class));
+        manager.registerTestExecutionListeners(listener);
+        InOrder inOrder = inOrder(listener);
+
+        doThrow(new RuntimeException()).when(listener).beforeTestExecution(any());
+
+        assertThrows(CucumberBackendException.class, adaptor::start);
+        inOrder.verify(listener).beforeTestClass(any());
+        inOrder.verify(listener).prepareTestInstance(any());
+        inOrder.verify(listener).beforeTestMethod(any());
+
+        adaptor.stop();
+        inOrder.verify(listener).afterTestExecution(any());
+        inOrder.verify(listener).afterTestMethod(any());
+        inOrder.verify(listener).afterTestClass(any());
+    }
+
+    @Test
+    void invokesAfterTestMethodIfAfterTestExecutionThrows() throws Exception {
+        TestContextManager manager = new TestContextManager(SomeContextConfiguration.class);
+        TestContextAdaptor adaptor = new TestContextAdaptor(manager, singletonList(SomeContextConfiguration.class));
+        manager.registerTestExecutionListeners(listener);
+        InOrder inOrder = inOrder(listener);
+
+        doThrow(new RuntimeException()).when(listener).afterTestExecution(any());
+
+        adaptor.start();
+        inOrder.verify(listener).beforeTestClass(any());
+        inOrder.verify(listener).prepareTestInstance(any());
+        inOrder.verify(listener).beforeTestMethod(any());
+        inOrder.verify(listener).beforeTestExecution(any());
+
+        assertThrows(CucumberBackendException.class, adaptor::stop);
+        inOrder.verify(listener).afterTestExecution(any());
+        inOrder.verify(listener).afterTestMethod(any());
+        inOrder.verify(listener).afterTestClass(any());
+    }
+
+    @Test
+    void invokesAfterTesClassIfAfterTestMethodThrows() throws Exception {
+        TestContextManager manager = new TestContextManager(SomeContextConfiguration.class);
+        TestContextAdaptor adaptor = new TestContextAdaptor(manager, singletonList(SomeContextConfiguration.class));
+        manager.registerTestExecutionListeners(listener);
+        InOrder inOrder = inOrder(listener);
+
+        doThrow(new RuntimeException()).when(listener).afterTestMethod(any());
+
+        adaptor.start();
+        inOrder.verify(listener).beforeTestClass(any());
+        inOrder.verify(listener).prepareTestInstance(any());
+        inOrder.verify(listener).beforeTestMethod(any());
+        inOrder.verify(listener).beforeTestExecution(any());
+
+        assertThrows(CucumberBackendException.class, adaptor::stop);
+        inOrder.verify(listener).afterTestExecution(any());
+        inOrder.verify(listener).afterTestMethod(any());
+        inOrder.verify(listener).afterTestClass(any());
+    }
+
+    @Test
+    void invokesAllMethodsPriorIfAfterTestClassThrows() throws Exception {
+        TestContextManager manager = new TestContextManager(SomeContextConfiguration.class);
+        TestContextAdaptor adaptor = new TestContextAdaptor(manager, singletonList(SomeContextConfiguration.class));
+        manager.registerTestExecutionListeners(listener);
+        InOrder inOrder = inOrder(listener);
+
+        doThrow(new RuntimeException()).when(listener).afterTestExecution(any());
+
+        adaptor.start();
+        inOrder.verify(listener).beforeTestClass(any());
+        inOrder.verify(listener).prepareTestInstance(any());
+        inOrder.verify(listener).beforeTestMethod(any());
+        inOrder.verify(listener).beforeTestExecution(any());
+
+        assertThrows(CucumberBackendException.class, adaptor::stop);
+        inOrder.verify(listener).afterTestExecution(any());
+        inOrder.verify(listener).afterTestMethod(any());
+        inOrder.verify(listener).afterTestClass(any());
+    }
+
+    @CucumberContextConfiguration
+    @ContextConfiguration("classpath:cucumber.xml")
+    public static class SomeContextConfiguration {
+
+    }
+
+}


### PR DESCRIPTION
### ⚡️ What's your motivation? 

To make writing tests with Spring easier Spring provides a
`TestContextManager`. This classes provides call backs for various
`TestExecutionListeners`.

These are then used by various extensions such as
the `MockitoTestExecutionListener` which injects `@MockBeans` into test
instances. When all methods are not invoked this leads to problems such as
(#2654,#2655,#2656)

While this was initially (#1470) not a problem, it appears that various
listener implementations have started to assume that all methods would be
invoked.

Closes: #2655
Fixes: #2654, #2572

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)
- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
