### PR TITLE
[Spring] Inject CucumberContextConfiguration constructor dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Fixed
+- [Spring] Inject CucumberContextConfiguration constructor dependencies ([#2664](https://github.com/cucumber/cucumber-jvm/pull/2664) M.P. Korstanje)
+ 
 ## [7.10.0] - 2022-12-11
 ### Added
 - Enabled reproducible builds ([#2641](https://github.com/cucumber/cucumber-jvm/issues/2641) Hervé Boutemy )

--- a/cucumber-spring/src/test/java/io/cucumber/spring/TestTestContextAdaptorTest.java
+++ b/cucumber-spring/src/test/java/io/cucumber/spring/TestTestContextAdaptorTest.java
@@ -1,18 +1,30 @@
 package io.cucumber.spring;
 
 import io.cucumber.core.backend.CucumberBackendException;
+import io.cucumber.spring.beans.BellyBean;
+import io.cucumber.spring.beans.DummyComponent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.NonNull;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestContextManager;
 import org.springframework.test.context.TestExecutionListener;
 
 import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -182,10 +194,125 @@ public class TestTestContextAdaptorTest {
         inOrder.verify(listener).afterTestClass(any());
     }
 
+    @ParameterizedTest
+    @ValueSource(classes = { WithAutowiredDependency.class, WithConstructorDependency.class })
+    void autowireAndPostProcessesOnlyOnce(Class<? extends Spy> testClass) {
+        TestContextManager manager = new TestContextManager(testClass);
+        TestContextAdaptor adaptor = new TestContextAdaptor(manager, singletonList(testClass));
+
+        assertAll(
+            () -> assertDoesNotThrow(adaptor::start),
+            () -> assertNotNull(manager.getTestContext().getTestInstance()),
+            () -> assertSame(manager.getTestContext().getTestInstance(), adaptor.getInstance(testClass)),
+            () -> assertEquals(1, adaptor.getInstance(testClass).autowiredCount()),
+            () -> assertEquals(1, adaptor.getInstance(testClass).postProcessedCount()),
+            () -> assertNotNull(adaptor.getInstance(testClass).getBelly()),
+            () -> assertNotNull(adaptor.getInstance(testClass).getDummyComponent()),
+            () -> assertDoesNotThrow(adaptor::stop));
+    }
+
     @CucumberContextConfiguration
     @ContextConfiguration("classpath:cucumber.xml")
     public static class SomeContextConfiguration {
 
+    }
+
+    private interface Spy {
+
+        int postProcessedCount();
+
+        int autowiredCount();
+
+        BellyBean getBelly();
+
+        DummyComponent getDummyComponent();
+
+    }
+
+    @CucumberContextConfiguration
+    @ContextConfiguration("classpath:cucumber.xml")
+    public static class WithAutowiredDependency implements BeanNameAware, Spy {
+
+        @Autowired
+        BellyBean belly;
+
+        int postProcessedCount = 0;
+        int autowiredCount = 0;
+
+        private DummyComponent dummyComponent;
+
+        @Autowired
+        public void setDummyComponent(DummyComponent dummyComponent) {
+            this.dummyComponent = dummyComponent;
+            this.autowiredCount++;
+        }
+
+        @Override
+        public void setBeanName(@NonNull String ignored) {
+            postProcessedCount++;
+        }
+
+        @Override
+        public int postProcessedCount() {
+            return postProcessedCount;
+        }
+
+        @Override
+        public int autowiredCount() {
+            return autowiredCount;
+        }
+
+        @Override
+        public BellyBean getBelly() {
+            return belly;
+        }
+
+        @Override
+        public DummyComponent getDummyComponent() {
+            return dummyComponent;
+        }
+    }
+
+    @CucumberContextConfiguration
+    @ContextConfiguration("classpath:cucumber.xml")
+    public static class WithConstructorDependency implements BeanNameAware, Spy {
+
+        final BellyBean belly;
+        final DummyComponent dummyComponent;
+
+        int postProcessedCount = 0;
+        int autowiredCount = 0;
+
+        public WithConstructorDependency(BellyBean belly, DummyComponent dummyComponent) {
+            this.belly = belly;
+            this.dummyComponent = dummyComponent;
+            this.autowiredCount++;
+        }
+
+        @Override
+        public void setBeanName(@NonNull String ignored) {
+            postProcessedCount++;
+        }
+
+        @Override
+        public int postProcessedCount() {
+            return postProcessedCount;
+        }
+
+        @Override
+        public int autowiredCount() {
+            return autowiredCount;
+        }
+
+        @Override
+        public BellyBean getBelly() {
+            return belly;
+        }
+
+        @Override
+        public DummyComponent getDummyComponent() {
+            return dummyComponent;
+        }
     }
 
 }


### PR DESCRIPTION
### 🤔 What's changed?

In #2661 classes annotated with `@CucumberContextConfiguration` were created as beans directly from the bean factory. This allowed them to be prepared as test instances by JUnit. However, we did not tell the factory that it should autowire constructor dependencies resulting in #2663.

Additionally, because beans were created directly from the bean factory, they were not added to the application context. This meant that while dependencies could be injected into them, they could not be injected into other objects.

Fixes: #2663

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
