### PR TITLE
[DeltaSpike] Un-deprecate Deltaspike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [Core] Use a [message based JUnit XML Formatter](https://github.com/cucumber/cucumber-junit-xml-formatter) ([#2638](https://github.com/cucumber/cucumber-jvm/pull/2638) M.P. Korstanje)
 - [Core] Throw an exception when tag expressions are incorrectly escaped ([tag-expressions/#17](https://github.com/cucumber/tag-expressions/pull/17) Aslak Hellesøy)
+- [DeltaSpike] Un-Deprecated deltaspike - can be made to work on Java 17.
 
 ### Fixed
 - [Core] Improve test step creation performance ([#2666](https://github.com/cucumber/cucumber-jvm/issues/2666), Julien Kronegg)
+
 
 ## [7.10.1] - 2022-12-16
 ### Fixed

--- a/cucumber-deltaspike/pom.xml
+++ b/cucumber-deltaspike/pom.xml
@@ -10,11 +10,11 @@
 
     <artifactId>cucumber-deltaspike</artifactId>
     <packaging>jar</packaging>
-    <name>Cucumber-JVM: DeltaSpike - Deprecated</name>
+    <name>Cucumber-JVM: DeltaSpike</name>
 
     <properties>
         <apiguardian-api.version>1.1.2</apiguardian-api.version>
-        <cdi-api.version>1.2</cdi-api.version>
+        <cdi-api.version>2.0.SP1</cdi-api.version>
         <deltaspike.version>1.9.6</deltaspike.version>
         <junit-jupiter.version>5.9.1</junit-jupiter.version>
         <project.Automatic-Module-Name>io.cucumber.deltaspike</project.Automatic-Module-Name>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se-core</artifactId>
-            <version>1.1.34.Final</version>
+            <version>3.1.9.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cucumber-deltaspike/src/test/java/io/cucumber/deltaspike/Belly.java
+++ b/cucumber-deltaspike/src/test/java/io/cucumber/deltaspike/Belly.java
@@ -1,5 +1,8 @@
 package io.cucumber.deltaspike;
 
+import javax.inject.Singleton;
+
+@Singleton
 public class Belly {
 
     private int cukes;

--- a/cucumber-deltaspike/src/test/resources/META-INF/beans.xml
+++ b/cucumber-deltaspike/src/test/resources/META-INF/beans.xml
@@ -1,7 +1,4 @@
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns="http://java.sun.com/xml/ns/javaee"
-       xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       bean-discovery-mode="all" version="2.0">
 </beans>


### PR DESCRIPTION
It appeared that DeltaSpike wouldn't work on Java 17. This could be resolved by upgrading to CDI 2.0.

Closes #2650.