### PR TITLE
[Core] Warn when cucumber.options is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [Core] Warn when `cucumber.options` is used ([#2685](https://github.com/cucumber/cucumber-jvm/pull/2685) M.P. Korstanje)
 
 ## [7.11.0] - 2023-01-12
 ### Added

--- a/cucumber-core/src/main/java/io/cucumber/core/options/Constants.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/options/Constants.java
@@ -119,6 +119,13 @@ public final class Constants {
     public static final String OBJECT_FACTORY_PROPERTY_NAME = "cucumber.object-factory";
 
     /**
+     * Property name formerly used to pass command line options to Cucumber:
+     * {@value} This property is no longer read by Cucumber. Please use any of
+     * the
+     */
+    static final String OPTIONS_PROPERTY_NAME = "cucumber.options";
+
+    /**
      * Property name to enable plugins: {@value}
      * <p>
      * A comma separated list of {@code [PLUGIN[:PATH_OR_URL]]} e.g:

--- a/cucumber-core/src/main/java/io/cucumber/core/options/CucumberPropertiesParser.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/options/CucumberPropertiesParser.java
@@ -3,6 +3,8 @@ package io.cucumber.core.options;
 import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.feature.FeatureWithLines;
 import io.cucumber.core.feature.GluePath;
+import io.cucumber.core.logging.Logger;
+import io.cucumber.core.logging.LoggerFactory;
 import io.cucumber.tagexpressions.TagExpressionParser;
 
 import java.nio.file.Path;
@@ -24,6 +26,7 @@ import static io.cucumber.core.options.Constants.FILTER_NAME_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.FILTER_TAGS_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.GLUE_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.OBJECT_FACTORY_PROPERTY_NAME;
+import static io.cucumber.core.options.Constants.OPTIONS_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.PLUGIN_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.PLUGIN_PUBLISH_ENABLED_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.PLUGIN_PUBLISH_QUIET_PROPERTY_NAME;
@@ -32,9 +35,12 @@ import static io.cucumber.core.options.Constants.SNIPPET_TYPE_PROPERTY_NAME;
 import static io.cucumber.core.options.Constants.WIP_PROPERTY_NAME;
 import static io.cucumber.core.options.OptionsFileParser.parseFeatureWithLinesFile;
 import static java.util.Arrays.stream;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 
 public final class CucumberPropertiesParser {
+
+    private static final Logger log = LoggerFactory.getLogger(CucumberPropertiesParser.class);
 
     public RuntimeOptionsBuilder parse(Map<String, String> properties) {
         return parse(properties::get);
@@ -96,14 +102,19 @@ public final class CucumberPropertiesParser {
             ObjectFactoryParser::parseObjectFactory,
             builder::setObjectFactoryClass);
 
+        parse(properties,
+            OPTIONS_PROPERTY_NAME,
+            identity(),
+            warnWhenCucumberOptionsIsUsed());
+
         parseAll(properties,
             PLUGIN_PROPERTY_NAME,
-            splitAndMap(Function.identity()),
+            splitAndMap(identity()),
             builder::addPluginName);
 
         parse(properties,
             PLUGIN_PUBLISH_TOKEN_PROPERTY_NAME,
-            s -> s, // No validation - validated on server
+            identity(), // No validation - validated on server
             builder::setPublishToken);
 
         parse(properties,
@@ -127,6 +138,16 @@ public final class CucumberPropertiesParser {
             builder::setWip);
 
         return builder;
+    }
+
+    private static Consumer<String> warnWhenCucumberOptionsIsUsed() {
+        // Quite a few old blogs still recommend the use of cucumber.options
+        // This should take care of recurring question involving this property.
+        return commandLineOptions -> log.warn(() -> String.format("" +
+                "Passing commandline options via the property '%s' is no longer supported. " +
+                "Please use individual properties instead. " +
+                "See the java doc on %s for details.",
+            OPTIONS_PROPERTY_NAME, Constants.class.getName()));
     }
 
     private <T> void parse(

--- a/cucumber-core/src/test/java/io/cucumber/core/options/CucumberPropertiesParserTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/options/CucumberPropertiesParserTest.java
@@ -2,6 +2,8 @@ package io.cucumber.core.options;
 
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.exception.CucumberException;
+import io.cucumber.core.logging.LogRecordListener;
+import io.cucumber.core.logging.WithLogRecordListener;
 import io.cucumber.core.order.StandardPickleOrders;
 import io.cucumber.core.snippets.SnippetType;
 import io.cucumber.tagexpressions.TagExpressionParser;
@@ -30,6 +32,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@WithLogRecordListener
 class CucumberPropertiesParserTest {
 
     private final CucumberPropertiesParser cucumberPropertiesParser = new CucumberPropertiesParser();
@@ -136,6 +139,16 @@ class CucumberPropertiesParserTest {
         properties.put(Constants.OBJECT_FACTORY_PROPERTY_NAME, CustomObjectFactory.class.getName());
         RuntimeOptions options = cucumberPropertiesParser.parse(properties).build();
         assertThat(options.getObjectFactoryClass(), equalTo(CustomObjectFactory.class));
+    }
+
+    @Test
+    void should_warn_about_cucumber_options(LogRecordListener logRecordListener) {
+        properties.put(Constants.OPTIONS_PROPERTY_NAME, "--help");
+        cucumberPropertiesParser.parse(properties).build();
+        assertThat(logRecordListener.getLogRecords().get(0).getMessage(), equalTo("" +
+                "Passing commandline options via the property 'cucumber.options' is no longer supported. " +
+                "Please use individual properties instead. " +
+                "See the java doc on io.cucumber.core.options.Constants for details."));
     }
 
     @Test


### PR DESCRIPTION
### 🤔 What's changed?

In #1779 we deprecated and removed cucumber.options. Unfortunately there are a slew of outdated tutorials still in existence. And this outdated knowledge creates a slow trickle of questions on StackOverflow. It would be nice if we can stop this waste of everyone's time.

Fixes: #2673

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)
### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
