### PR TITLE
[JUnit Platform Engine] Cache parsed features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [JUnit Platform Engine] Corrupted junit-xml report when using `surefire.rerunFailingTestsCount` parameter ([#2709](https://github.com/cucumber/cucumber-jvm/pull/2709) M.P. Korstanje)
 
 ## [7.11.1] - 2023-01-27
 ### Added

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CachingFeatureParser.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CachingFeatureParser.java
@@ -1,0 +1,24 @@
+package io.cucumber.junit.platform.engine;
+
+import io.cucumber.core.feature.FeatureParser;
+import io.cucumber.core.gherkin.Feature;
+import io.cucumber.core.resource.Resource;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+class CachingFeatureParser {
+
+    private final Map<URI, Optional<Feature>> cache = new HashMap<>();
+    private final FeatureParser delegate;
+
+    CachingFeatureParser(FeatureParser delegate) {
+        this.delegate = delegate;
+    }
+
+    Optional<Feature> parseResource(Resource resource) {
+        return cache.computeIfAbsent(resource.getUri(), uri -> delegate.parseResource(resource));
+    }
+}

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DiscoverySelectorResolver.java
@@ -27,7 +27,7 @@ import static org.junit.platform.engine.Filter.composeFilters;
 
 class DiscoverySelectorResolver {
 
-    private static final Logger log = LoggerFactory.getLogger(FeatureResolver.class);
+    private static final Logger log = LoggerFactory.getLogger(DiscoverySelectorResolver.class);
 
     private static boolean warnedWhenCucumberFeaturesPropertyIsUsed = false;
 

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureDescriptor.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureDescriptor.java
@@ -20,6 +20,10 @@ class FeatureDescriptor extends AbstractTestDescriptor implements Node<CucumberE
         this.feature = feature;
     }
 
+    Feature getFeature() {
+        return feature;
+    }
+
     private static void pruneRecursively(TestDescriptor descriptor, Predicate<TestDescriptor> toKeep) {
         if (!toKeep.test(descriptor)) {
             if (descriptor.isTest()) {

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureResolver.java
@@ -38,7 +38,7 @@ final class FeatureResolver {
 
     private static final Logger log = LoggerFactory.getLogger(FeatureResolver.class);
 
-    private final FeatureParser featureParser = new FeatureParser(UUID::randomUUID);
+    private final CachingFeatureParser featureParser = new CachingFeatureParser(new FeatureParser(UUID::randomUUID));
     private final ResourceScanner<Feature> featureScanner = new ResourceScanner<>(
         ClassLoaders::getDefaultClassLoader,
         FeatureIdentifier::isFeature,

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/NodeDescriptor.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/NodeDescriptor.java
@@ -89,17 +89,17 @@ abstract class NodeDescriptor extends AbstractTestDescriptor implements Node<Cuc
 
     static final class PickleDescriptor extends NodeDescriptor {
 
-        private final Pickle pickleEvent;
+        private final Pickle pickle;
         private final Set<TestTag> tags;
         private final Set<ExclusiveResource> exclusiveResources = new LinkedHashSet<>(0);
 
         PickleDescriptor(
                 ConfigurationParameters parameters, UniqueId uniqueId, String name, TestSource source,
-                Pickle pickleEvent
+                Pickle pickle
         ) {
             super(parameters, uniqueId, name, source);
-            this.pickleEvent = pickleEvent;
-            this.tags = getTags(pickleEvent);
+            this.pickle = pickle;
+            this.tags = getTags(pickle);
             this.tags.forEach(tag -> {
                 ExclusiveResourceOptions exclusiveResourceOptions = new ExclusiveResourceOptions(parameters, tag);
                 exclusiveResourceOptions.exclusiveReadWriteResource()
@@ -109,6 +109,10 @@ abstract class NodeDescriptor extends AbstractTestDescriptor implements Node<Cuc
                         .map(resource -> new ExclusiveResource(resource, LockMode.READ))
                         .forEach(exclusiveResources::add);
             });
+        }
+
+        Pickle getPickle() {
+            return pickle;
         }
 
         private Set<TestTag> getTags(Pickle pickleEvent) {
@@ -136,7 +140,7 @@ abstract class NodeDescriptor extends AbstractTestDescriptor implements Node<Cuc
 
         private Optional<SkipResult> shouldBeSkippedByTagFilter(CucumberEngineExecutionContext context) {
             return context.getOptions().tagFilter().map(expression -> {
-                if (expression.evaluate(pickleEvent.getTags())) {
+                if (expression.evaluate(pickle.getTags())) {
                     return SkipResult.doNotSkip();
                 }
                 return SkipResult
@@ -148,7 +152,7 @@ abstract class NodeDescriptor extends AbstractTestDescriptor implements Node<Cuc
 
         private Optional<SkipResult> shouldBeSkippedByNameFilter(CucumberEngineExecutionContext context) {
             return context.getOptions().nameFilter().map(pattern -> {
-                if (pattern.matcher(pickleEvent.getName()).matches()) {
+                if (pattern.matcher(pickle.getName()).matches()) {
                     return SkipResult.doNotSkip();
                 }
                 return SkipResult
@@ -161,7 +165,7 @@ abstract class NodeDescriptor extends AbstractTestDescriptor implements Node<Cuc
         public CucumberEngineExecutionContext execute(
                 CucumberEngineExecutionContext context, DynamicTestExecutor dynamicTestExecutor
         ) {
-            context.runTestCase(pickleEvent);
+            context.runTestCase(pickle);
             return context;
         }
 


### PR DESCRIPTION
### 🤔 What's changed?

The JUnit Platform allows Scenarios and Examples to be selected by their
unique id. This id is stable between test executions and can be used to rerun
failing Scenarios and Examples.

For practical reasons each unique id is processed individually[+] and results
in a feature file being parsed. The parsed feature is then compiled into
pickles. Both are mapped to a hierarchy of JUnit 5 test descriptors. These are
then merged. The merge process will discard any duplicate nodes.

Each time a feature file is parsed the parser will assign unique identifiers
to all ast nodes and pickles. As a result the merged hierarchy of junit test
descriptors contained pickles that belonged to a different feature file.

This poses a problem for tools such as the junit-xml-formatter that depend on
the identifiers in pickles and features to stitch everything back together. By
caching the parsed feature files we ensure that within a single execution the
internal identifiers do not change.

 + : It would actually matter little if we did process all unique ids at once,
     the problem would persist when uri selectors are used, either alone or in
     combination with unique id selectors.

Fixes: #2709

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

