### PR TITLE
[Core] Add ParameterType message source reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [JUnit Platform Engine] Add constant for fixed.max-pool-size property ([#2713](https://github.com/cucumber/cucumber-jvm/pull/2713) M.P. Korstanje)
 - [Core] Support directories containing exclusively rerun files using the `@path/to/rerun` syntax ([#2710](https://github.com/cucumber/cucumber-jvm/pull/2710) Daniel Whitney, M.P. Korstanje)
 - [Core] Improved event bus performance using UUID generator selectable through SPI ([#2703](https://github.com/cucumber/cucumber-jvm/pull/2703) Julien Kronegg)
+- [Core] Added source reference in parameter type messages ([#2719](https://github.com/cucumber/cucumber-jvm/issues/2719) Julien Kronegg) 
 
 ### Fixed
 - [Pico] Improve performance ([#2724](https://github.com/cucumber/cucumber-jvm/issues/2724) Julien Kronegg)

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/CachingGlue.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/CachingGlue.java
@@ -235,7 +235,7 @@ final class CachingGlue implements Glue {
         parameterTypeDefinitions.forEach(ptd -> {
             ParameterType<?> parameterType = ptd.parameterType();
             stepTypeRegistry.defineParameterType(parameterType);
-            emitParameterTypeDefined(parameterType);
+            emitParameterTypeDefined(ptd);
         });
         dataTableTypeDefinitions.forEach(dtd -> stepTypeRegistry.defineDataTableType(dtd.dataTableType()));
         docStringTypeDefinitions.forEach(dtd -> stepTypeRegistry.defineDocStringType(dtd.docStringType()));
@@ -285,14 +285,17 @@ final class CachingGlue implements Glue {
         afterHooks.forEach(this::emitHook);
     }
 
-    private void emitParameterTypeDefined(ParameterType<?> parameterType) {
+    private void emitParameterTypeDefined(ParameterTypeDefinition parameterTypeDefinition) {
+        ParameterType<?> parameterType = parameterTypeDefinition.parameterType();
         io.cucumber.messages.types.ParameterType messagesParameterType = new io.cucumber.messages.types.ParameterType(
             parameterType.getName(),
             parameterType.getRegexps(),
             parameterType.preferForRegexpMatch(),
             parameterType.useForSnippets(),
             bus.generateId().toString(),
-            null);
+            parameterTypeDefinition.getSourceReference()
+                    .map(this::createSourceReference)
+                    .orElseGet(this::emptySourceReference));
         bus.send(Envelope.of(messagesParameterType));
     }
 


### PR DESCRIPTION
### 🤔 What's changed?

The `ParameterType` emited on the event bus contains now the `SourceReference`.

### ⚡️ What's your motivation? 

Fixes #2719

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

N/A

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
