### PR TITLE
[Pico] Fixed UnsatisfiableDependencyException with Component dependencies 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Core] Fixed `cucumber.publish.enabled=false` ([#2747](https://github.com/cucumber/cucumber-jvm/pull/2747) M.P. Korstanje)
 - [JUnit Platform Engine] Fixed `cucumber.publish.enabled=false` ([#2747](https://github.com/cucumber/cucumber-jvm/pull/2747) M.P. Korstanje)
 - [Java] Fixed duplicate step definition for classes with interfaces ([#2757](https://github.com/cucumber/cucumber-jvm/issues/2757) Julien Kronegg) 
+- [Pico] Fixed unsatisfiable dependency with disposables ([#2762](https://github.com/cucumber/cucumber-jvm/issues/2762) Julien Kronegg)
 
 ## [7.12.0] - 2023-04-29
 ### Added

--- a/cucumber-picocontainer/src/main/java/io/cucumber/picocontainer/PicoFactory.java
+++ b/cucumber-picocontainer/src/main/java/io/cucumber/picocontainer/PicoFactory.java
@@ -43,8 +43,8 @@ public final class PicoFactory implements ObjectFactory {
     @Override
     public boolean addClass(Class<?> clazz) {
         if (isInstantiable(clazz) && classes.add(clazz)) {
-            pico.addComponent(clazz);
             addConstructorDependencies(clazz);
+            pico.addComponent(clazz);
         }
         return true;
     }

--- a/cucumber-picocontainer/src/test/java/io/cucumber/picocontainer/StepDefinitionsWithTransitiveDependencies.java
+++ b/cucumber-picocontainer/src/test/java/io/cucumber/picocontainer/StepDefinitionsWithTransitiveDependencies.java
@@ -1,5 +1,7 @@
 package io.cucumber.picocontainer;
 
+import org.picocontainer.Disposable;
+
 public class StepDefinitionsWithTransitiveDependencies {
 
     final FirstDependency firstDependency;
@@ -8,11 +10,15 @@ public class StepDefinitionsWithTransitiveDependencies {
         this.firstDependency = firstDependency;
     }
 
-    public static class FirstDependency {
+    public static class FirstDependency implements Disposable {
         final SecondDependency secondDependency;
 
         public FirstDependency(SecondDependency secondDependency) {
             this.secondDependency = secondDependency;
+        }
+
+        @Override
+        public void dispose() {
         }
     }
 


### PR DESCRIPTION
### 🤔 What's changed?

Classes registration in picoccontainer have changed from order top->down to bottom-up, which is required when one class in the hierarchy implements `Disposable`.

### ⚡️ What's your motivation? 

Fixes #2762

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

N/A

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
