### PR TITLE
Reduced mockito usage (pass 1: simple cases)

### DIFF
--- a/cucumber-core/src/test/java/io/cucumber/core/order/PickleOrderTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/order/PickleOrderTest.java
@@ -1,11 +1,9 @@
 package io.cucumber.core.order;
 
 import io.cucumber.core.gherkin.Pickle;
+import io.cucumber.core.gherkin.Step;
 import io.cucumber.plugin.event.Location;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -13,27 +11,14 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
-import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
 class PickleOrderTest {
-
-    @Mock
-    Pickle firstPickle;
-
-    @Mock
-    Pickle secondPickle;
-
-    @Mock
-    Pickle thirdPickle;
 
     @Test
     void lexical_uri_order() {
-        when(firstPickle.getUri()).thenReturn(URI.create("file:com/example/a.feature"));
-        when(firstPickle.getLocation()).thenReturn(new Location(2, -1));
-        when(secondPickle.getUri()).thenReturn(URI.create("file:com/example/a.feature"));
-        when(secondPickle.getLocation()).thenReturn(new Location(3, -1));
-        when(thirdPickle.getUri()).thenReturn(URI.create("file:com/example/b.feature"));
+        Pickle firstPickle = new StubPickle(new Location(2, -1), URI.create("file:com/example/a.feature"));
+        Pickle secondPickle = new StubPickle(new Location(3, -1), URI.create("file:com/example/a.feature"));
+        Pickle thirdPickle = new StubPickle(null, URI.create("file:com/example/b.feature"));
 
         PickleOrder order = StandardPickleOrders.lexicalUriOrder();
         List<Pickle> pickles = order.orderPickles(Arrays.asList(thirdPickle, secondPickle, firstPickle));
@@ -42,11 +27,9 @@ class PickleOrderTest {
 
     @Test
     void reverse_lexical_uri_order() {
-        when(firstPickle.getUri()).thenReturn(URI.create("file:com/example/a.feature"));
-        when(firstPickle.getLocation()).thenReturn(new Location(2, -1));
-        when(secondPickle.getUri()).thenReturn(URI.create("file:com/example/a.feature"));
-        when(secondPickle.getLocation()).thenReturn(new Location(3, -1));
-        when(thirdPickle.getUri()).thenReturn(URI.create("file:com/example/b.feature"));
+        Pickle firstPickle = new StubPickle(new Location(2, -1), URI.create("file:com/example/a.feature"));
+        Pickle secondPickle = new StubPickle(new Location(3, -1), URI.create("file:com/example/a.feature"));
+        Pickle thirdPickle = new StubPickle(null, URI.create("file:com/example/b.feature"));
 
         PickleOrder order = StandardPickleOrders.reverseLexicalUriOrder();
         List<Pickle> pickles = order.orderPickles(Arrays.asList(secondPickle, thirdPickle, firstPickle));
@@ -55,9 +38,67 @@ class PickleOrderTest {
 
     @Test
     void random_order() {
+        Pickle firstPickle = new StubPickle(new Location(2, -1), URI.create("file:com/example/a.feature"));
+        Pickle secondPickle = new StubPickle(new Location(3, -1), URI.create("file:com/example/a.feature"));
+        Pickle thirdPickle = new StubPickle(null, URI.create("file:com/example/b.feature"));
+
         PickleOrder order = StandardPickleOrders.random(42);
         List<Pickle> pickles = order.orderPickles(Arrays.asList(firstPickle, secondPickle, thirdPickle));
         assertThat(pickles, contains(secondPickle, firstPickle, thirdPickle));
     }
 
+    private static class StubPickle implements Pickle {
+        private final Location location;
+        private final URI uri;
+
+        public StubPickle(Location location, URI uri) {
+            this.location = location;
+            this.uri = uri;
+        }
+
+        @Override
+        public String getKeyword() {
+            return null;
+        }
+
+        @Override
+        public String getLanguage() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public Location getLocation() {
+            return location;
+        }
+
+        @Override
+        public Location getScenarioLocation() {
+            return null;
+        }
+
+        @Override
+        public List<Step> getSteps() {
+            return null;
+        }
+
+        @Override
+        public List<String> getTags() {
+            return null;
+        }
+
+        @Override
+        public URI getUri() {
+            return uri;
+        }
+
+        @Override
+        public String getId() {
+            return null;
+        }
+    }
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/CanonicalEventOrderTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/CanonicalEventOrderTest.java
@@ -27,8 +27,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 class CanonicalEventOrderTest {
 
@@ -81,10 +79,7 @@ class CanonicalEventOrderTest {
         new Result(Status.PASSED, Duration.ZERO, null));
 
     private static TestCaseStarted createTestCaseEvent(Instant instant, URI uri, int line) {
-        final TestCase testCase = mock(TestCase.class);
-        given(testCase.getUri()).willReturn(uri);
-        given(testCase.getLocation()).willReturn(new Location(line, -1));
-        return new TestCaseStarted(instant, testCase);
+        return new TestCaseStarted(instant, new StubTestCase(uri, new Location(line, -1)));
     }
 
     @Test

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/PluginFactoryTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/PluginFactoryTest.java
@@ -8,15 +8,7 @@ import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.messages.types.Envelope;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.cucumber.plugin.EventListener;
-import io.cucumber.plugin.event.EventHandler;
-import io.cucumber.plugin.event.EventPublisher;
-import io.cucumber.plugin.event.PickleStepTestStep;
-import io.cucumber.plugin.event.Result;
-import io.cucumber.plugin.event.Status;
-import io.cucumber.plugin.event.TestCase;
-import io.cucumber.plugin.event.TestRunFinished;
-import io.cucumber.plugin.event.TestRunStarted;
-import io.cucumber.plugin.event.TestStepFinished;
+import io.cucumber.plugin.event.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -48,7 +40,6 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 class PluginFactoryTest {
 
@@ -196,8 +187,8 @@ class PluginFactoryTest {
             EventBus bus = new TimeServiceEventBus(new ClockStub(ZERO), UUID::randomUUID);
             plugin.setEventPublisher(bus);
             Result result = new Result(Status.PASSED, ZERO, null);
-            TestStepFinished event = new TestStepFinished(bus.getInstant(), mock(TestCase.class),
-                mock(PickleStepTestStep.class), result);
+            TestStepFinished event = new TestStepFinished(bus.getInstant(), new StubTestCase(),
+                new StubPickleStepTestStep(), result);
             bus.send(event);
 
             assertThat(mockSystemOut.toString(), is(not(equalTo(""))));

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/ProgressFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/ProgressFormatterTest.java
@@ -2,19 +2,16 @@ package io.cucumber.core.plugin;
 
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.runtime.TimeServiceEventBus;
-import io.cucumber.plugin.event.HookTestStep;
-import io.cucumber.plugin.event.PickleStepTestStep;
-import io.cucumber.plugin.event.Result;
-import io.cucumber.plugin.event.TestCase;
-import io.cucumber.plugin.event.TestRunFinished;
-import io.cucumber.plugin.event.TestStepFinished;
+import io.cucumber.plugin.event.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import static io.cucumber.core.plugin.Bytes.bytes;
@@ -24,13 +21,14 @@ import static io.cucumber.plugin.event.Status.UNDEFINED;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.IsEqualCompressingWhiteSpace.equalToCompressingWhiteSpace;
-import static org.mockito.Mockito.mock;
 
 class ProgressFormatterTest {
 
     final EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final ProgressFormatter formatter = new ProgressFormatter(out);
+    private final MockTestCase mocktestCase = new MockTestCase();
+    private final MockPickleStepTestStep mockPickleStepTestStep = new MockPickleStepTestStep();
 
     @BeforeEach
     void setup() {
@@ -47,7 +45,7 @@ class ProgressFormatterTest {
     @Test
     void prints_empty_line_and_green_dot_for_passing_test_run() {
         Result result = new Result(PASSED, Duration.ZERO, null);
-        bus.send(new TestStepFinished(Instant.now(), mock(TestCase.class), mock(PickleStepTestStep.class), result));
+        bus.send(new TestStepFinished(Instant.now(), mocktestCase, mockPickleStepTestStep, result));
         bus.send(new TestRunFinished(Instant.now(), result));
         assertThat(out, bytes(equalToCompressingWhiteSpace(AnsiEscapes.GREEN + "." + AnsiEscapes.RESET + "\n")));
     }
@@ -55,35 +53,128 @@ class ProgressFormatterTest {
     @Test
     void print_green_dot_for_passing_step() {
         Result result = new Result(PASSED, Duration.ZERO, null);
-        bus.send(new TestStepFinished(Instant.now(), mock(TestCase.class), mock(PickleStepTestStep.class), result));
+        bus.send(new TestStepFinished(Instant.now(), mocktestCase, mockPickleStepTestStep, result));
         assertThat(out, bytes(equalTo(AnsiEscapes.GREEN + "." + AnsiEscapes.RESET)));
     }
 
     @Test
     void print_yellow_U_for_undefined_step() {
         Result result = new Result(UNDEFINED, Duration.ZERO, null);
-        bus.send(new TestStepFinished(Instant.now(), mock(TestCase.class), mock(PickleStepTestStep.class), result));
+        bus.send(new TestStepFinished(Instant.now(), mocktestCase, mockPickleStepTestStep, result));
         assertThat(out, bytes(equalTo(AnsiEscapes.YELLOW + "U" + AnsiEscapes.RESET)));
     }
 
     @Test
     void print_nothing_for_passed_hook() {
         Result result = new Result(PASSED, Duration.ZERO, null);
-        bus.send(new TestStepFinished(Instant.now(), mock(TestCase.class), mock(HookTestStep.class), result));
+        bus.send(new TestStepFinished(Instant.now(), mocktestCase, mockPickleStepTestStep, result));
     }
 
     @Test
     void print_red_F_for_failed_step() {
         Result result = new Result(FAILED, Duration.ZERO, null);
-        bus.send(new TestStepFinished(Instant.now(), mock(TestCase.class), mock(PickleStepTestStep.class), result));
+        bus.send(new TestStepFinished(Instant.now(), mocktestCase, mockPickleStepTestStep, result));
         assertThat(out, bytes(equalTo(AnsiEscapes.RED + "F" + AnsiEscapes.RESET)));
     }
 
     @Test
     void print_red_F_for_failed_hook() {
         Result result = new Result(FAILED, Duration.ZERO, null);
-        bus.send(new TestStepFinished(Instant.now(), mock(TestCase.class), mock(HookTestStep.class), result));
+        bus.send(new TestStepFinished(Instant.now(), mocktestCase, mockPickleStepTestStep, result));
         assertThat(out, bytes(equalTo(AnsiEscapes.RED + "F" + AnsiEscapes.RESET)));
     }
 
+    private class MockTestCase implements TestCase {
+        @Override
+        public Integer getLine() {
+            return null;
+        }
+
+        @Override
+        public Location getLocation() {
+            return null;
+        }
+
+        @Override
+        public String getKeyword() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getScenarioDesignation() {
+            return null;
+        }
+
+        @Override
+        public List<String> getTags() {
+            return null;
+        }
+
+        @Override
+        public List<TestStep> getTestSteps() {
+            return null;
+        }
+
+        @Override
+        public URI getUri() {
+            return null;
+        }
+
+        @Override
+        public UUID getId() {
+            return null;
+        }
+    }
+
+    private class MockPickleStepTestStep implements PickleStepTestStep {
+        @Override
+        public String getPattern() {
+            return null;
+        }
+
+        @Override
+        public Step getStep() {
+            return null;
+        }
+
+        @Override
+        public List<Argument> getDefinitionArgument() {
+            return null;
+        }
+
+        @Override
+        public StepArgument getStepArgument() {
+            return null;
+        }
+
+        @Override
+        public int getStepLine() {
+            return 0;
+        }
+
+        @Override
+        public URI getUri() {
+            return null;
+        }
+
+        @Override
+        public String getStepText() {
+            return null;
+        }
+
+        @Override
+        public String getCodeLocation() {
+            return null;
+        }
+
+        @Override
+        public UUID getId() {
+            return null;
+        }
+    }
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/StubPickleStepTestStep.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/StubPickleStepTestStep.java
@@ -1,0 +1,58 @@
+package io.cucumber.core.plugin;
+
+import io.cucumber.plugin.event.Argument;
+import io.cucumber.plugin.event.PickleStepTestStep;
+import io.cucumber.plugin.event.Step;
+import io.cucumber.plugin.event.StepArgument;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+class StubPickleStepTestStep implements PickleStepTestStep {
+
+    @Override
+    public String getPattern() {
+        return null;
+    }
+
+    @Override
+    public Step getStep() {
+        return null;
+    }
+
+    @Override
+    public List<Argument> getDefinitionArgument() {
+        return null;
+    }
+
+    @Override
+    public StepArgument getStepArgument() {
+        return null;
+    }
+
+    @Override
+    public int getStepLine() {
+        return 0;
+    }
+
+    @Override
+    public URI getUri() {
+        return null;
+    }
+
+    @Override
+    public String getStepText() {
+        return null;
+    }
+
+    @Override
+    public String getCodeLocation() {
+        return null;
+    }
+
+    @Override
+    public UUID getId() {
+        return null;
+    }
+}

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/StubTestCase.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/StubTestCase.java
@@ -1,0 +1,69 @@
+package io.cucumber.core.plugin;
+
+import io.cucumber.plugin.event.Location;
+import io.cucumber.plugin.event.TestCase;
+import io.cucumber.plugin.event.TestStep;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+public class StubTestCase implements TestCase {
+    private final URI uri;
+    private final Location location;
+
+    public StubTestCase() {
+        this.uri = null;
+        this.location = null;
+    }
+
+    public StubTestCase(URI uri, Location location) {
+        this.uri = uri;
+        this.location = location;
+    }
+
+    @Override
+    public Integer getLine() {
+        return null;
+    }
+
+    @Override
+    public Location getLocation() {
+        return location;
+    }
+
+    @Override
+    public String getKeyword() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public String getScenarioDesignation() {
+        return null;
+    }
+
+    @Override
+    public List<String> getTags() {
+        return null;
+    }
+
+    @Override
+    public List<TestStep> getTestSteps() {
+        return null;
+    }
+
+    @Override
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public UUID getId() {
+        return null;
+    }
+}

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
@@ -1,14 +1,7 @@
 package io.cucumber.core.plugin;
 
 import io.cucumber.core.runtime.TimeServiceEventBus;
-import io.cucumber.plugin.event.Result;
-import io.cucumber.plugin.event.Status;
-import io.cucumber.plugin.event.StepDefinedEvent;
-import io.cucumber.plugin.event.StepDefinition;
-import io.cucumber.plugin.event.TestCase;
-import io.cucumber.plugin.event.TestRunFinished;
-import io.cucumber.plugin.event.TestStep;
-import io.cucumber.plugin.event.TestStepFinished;
+import io.cucumber.plugin.event.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -19,8 +12,6 @@ import java.util.UUID;
 import static io.cucumber.core.plugin.Bytes.bytes;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.IsEqualCompressingWhiteSpace.equalToCompressingWhiteSpace;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class UnusedStepsSummaryPrinterTest {
 
@@ -36,12 +27,12 @@ class UnusedStepsSummaryPrinterTest {
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/belly.feature:3", "a few cukes")));
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/tummy.feature:5", "some more cukes")));
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/gut.feature:7", "even more cukes")));
-        bus.send(new TestStepFinished(bus.getInstant(), mock(TestCase.class), mockTestStep("my/belly.feature:3"),
+        bus.send(new TestStepFinished(bus.getInstant(), new StubTestCase(), new StubTestStep("my/belly.feature:3"),
             new Result(Status.UNUSED, Duration.ZERO, null)));
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/belly.feature:3", "a few cukes")));
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/tummy.feature:5", "some more cukes")));
         bus.send(new StepDefinedEvent(bus.getInstant(), mockStepDef("my/gut.feature:7", "even more cukes")));
-        bus.send(new TestStepFinished(bus.getInstant(), mock(TestCase.class), mockTestStep("my/gut.feature:7"),
+        bus.send(new TestStepFinished(bus.getInstant(), new StubTestCase(), new StubTestStep("my/gut.feature:7"),
             new Result(Status.UNUSED, Duration.ZERO, null)));
         bus.send(new TestRunFinished(bus.getInstant(), new Result(Status.PASSED, Duration.ZERO, null)));
 
@@ -54,10 +45,21 @@ class UnusedStepsSummaryPrinterTest {
         return new StepDefinition(location, pattern);
     }
 
-    private static TestStep mockTestStep(String location) {
-        TestStep testStep = mock(TestStep.class);
-        when(testStep.getCodeLocation()).thenReturn(location);
-        return testStep;
-    }
+    public static class StubTestStep implements TestStep {
+        private final String codeLocation;
 
+        public StubTestStep(String codeLocation) {
+            this.codeLocation = codeLocation;
+        }
+
+        @Override
+        public String getCodeLocation() {
+            return codeLocation;
+        }
+
+        @Override
+        public UUID getId() {
+            return null;
+        }
+    }
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/UsageFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/UsageFormatterTest.java
@@ -1,15 +1,9 @@
 package io.cucumber.core.plugin;
 
-import io.cucumber.plugin.event.PickleStepTestStep;
-import io.cucumber.plugin.event.Result;
-import io.cucumber.plugin.event.Status;
-import io.cucumber.plugin.event.TestCase;
-import io.cucumber.plugin.event.TestStep;
-import io.cucumber.plugin.event.TestStepFinished;
+import io.cucumber.plugin.event.*;
 import org.json.JSONException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -26,8 +20,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 class UsageFormatterTest {
@@ -38,11 +30,11 @@ class UsageFormatterTest {
     void resultWithPassedStep() {
         OutputStream out = new ByteArrayOutputStream();
         UsageFormatter usageFormatter = new UsageFormatter(out);
-        TestStep testStep = mockTestStep();
+        TestStep testStep = new StubPickleStepTestStep();
         Result result = new Result(Status.PASSED, Duration.ofMillis(12345L), null);
 
         usageFormatter
-                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, result));
+                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, new StubTestCase(), testStep, result));
 
         Map<String, List<UsageFormatter.StepContainer>> usageMap = usageFormatter.usageMap;
         assertThat(usageMap.size(), is(equalTo(1)));
@@ -53,26 +45,19 @@ class UsageFormatterTest {
         assertThat(durationEntries.get(0).getDurations().get(0).getDuration(), is(closeTo(12.345, EPSILON)));
     }
 
-    private PickleStepTestStep mockTestStep() {
-        PickleStepTestStep testStep = mock(PickleStepTestStep.class, Mockito.RETURNS_MOCKS);
-        when(testStep.getPattern()).thenReturn("stepDef");
-        when(testStep.getStepText()).thenReturn("step");
-        return testStep;
-    }
-
     @Test
     void resultWithPassedAndFailedStep() {
         OutputStream out = new ByteArrayOutputStream();
         UsageFormatter usageFormatter = new UsageFormatter(out);
-        TestStep testStep = mockTestStep();
+        TestStep testStep = new StubPickleStepTestStep();
 
         Result passed = new Result(Status.PASSED, Duration.ofSeconds(12345L), null);
         usageFormatter
-                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, passed));
+                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, new StubTestCase(), testStep, passed));
 
         Result failed = new Result(Status.FAILED, Duration.ZERO, null);
         usageFormatter
-                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, failed));
+                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, new StubTestCase(), testStep, failed));
 
         Map<String, List<UsageFormatter.StepContainer>> usageMap = usageFormatter.usageMap;
         assertThat(usageMap.size(), is(equalTo(1)));
@@ -87,11 +72,11 @@ class UsageFormatterTest {
     void resultWithZeroDuration() {
         OutputStream out = new ByteArrayOutputStream();
         UsageFormatter usageFormatter = new UsageFormatter(out);
-        TestStep testStep = mockTestStep();
+        TestStep testStep = new StubPickleStepTestStep();
         Result result = new Result(Status.PASSED, Duration.ZERO, null);
 
         usageFormatter
-                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, result));
+                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, new StubTestCase(), testStep, result));
 
         Map<String, List<UsageFormatter.StepContainer>> usageMap = usageFormatter.usageMap;
         assertThat(usageMap.size(), is(equalTo(1)));
@@ -107,11 +92,11 @@ class UsageFormatterTest {
     void resultWithNullDuration() {
         OutputStream out = new ByteArrayOutputStream();
         UsageFormatter usageFormatter = new UsageFormatter(out);
-        PickleStepTestStep testStep = mockTestStep();
+        PickleStepTestStep testStep = new StubPickleStepTestStep();
         Result result = new Result(Status.PASSED, Duration.ZERO, null);
 
         usageFormatter
-                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, mock(TestCase.class), testStep, result));
+                .handleTestStepFinished(new TestStepFinished(Instant.EPOCH, new StubTestCase(), testStep, result));
 
         Map<String, List<UsageFormatter.StepContainer>> usageMap = usageFormatter.usageMap;
         assertThat(usageMap.size(), is(equalTo(1)));

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionMatchTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionMatchTest.java
@@ -1,8 +1,10 @@
 package io.cucumber.core.runner;
 
+import io.cucumber.core.eventbus.IncrementingUuidGenerator;
 import io.cucumber.core.feature.TestFeatureParser;
 import io.cucumber.core.gherkin.Feature;
 import io.cucumber.core.gherkin.Step;
+import io.cucumber.core.plugin.StubTestCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -13,7 +15,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 class AmbiguousStepDefinitionMatchTest {
 
@@ -25,10 +26,12 @@ class AmbiguousStepDefinitionMatchTest {
     private final AmbiguousStepDefinitionsException e = new AmbiguousStepDefinitionsException(step, emptyList());
     private final AmbiguousPickleStepDefinitionsMatch match = new AmbiguousPickleStepDefinitionsMatch(
         URI.create("file:path/to.feature"), step, e);
+    private final TestCaseState mockTestCaseState = new TestCaseState(new StubEventBus(),
+        new IncrementingUuidGenerator().generateId(), new StubTestCase());
 
     @Test
     void throws_ambiguous_step_definitions_exception_when_run() {
-        Executable testMethod = () -> match.runStep(mock(TestCaseState.class));
+        Executable testMethod = () -> match.runStep(mockTestCaseState);
         AmbiguousStepDefinitionsException actualThrown = assertThrows(AmbiguousStepDefinitionsException.class,
             testMethod);
         assertThat(actualThrown.getMessage(), is(equalTo(
@@ -37,7 +40,7 @@ class AmbiguousStepDefinitionMatchTest {
 
     @Test
     void throws_ambiguous_step_definitions_exception_when_dry_run() {
-        Executable testMethod = () -> match.dryRunStep(mock(TestCaseState.class));
+        Executable testMethod = () -> match.dryRunStep(mockTestCaseState);
         AmbiguousStepDefinitionsException actualThrown = assertThrows(AmbiguousStepDefinitionsException.class,
             testMethod);
         assertThat(actualThrown.getMessage(), is(equalTo(

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionsExceptionTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/AmbiguousStepDefinitionsExceptionTest.java
@@ -1,10 +1,12 @@
 package io.cucumber.core.runner;
 
+import io.cucumber.core.backend.StubStepDefinition;
 import io.cucumber.core.feature.TestFeatureParser;
 import io.cucumber.core.gherkin.Feature;
 import io.cucumber.core.gherkin.Step;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -13,8 +15,6 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class AmbiguousStepDefinitionsExceptionTest {
 
@@ -27,13 +27,13 @@ class AmbiguousStepDefinitionsExceptionTest {
 
         Step mockPickleStep = feature.getPickles().get(0).getSteps().get(0);
 
-        PickleStepDefinitionMatch mockPickleStepDefinitionMatchOne = mock(PickleStepDefinitionMatch.class);
-        when(mockPickleStepDefinitionMatchOne.getPattern()).thenReturn("PickleStepDefinitionMatchOne_Pattern");
-        when(mockPickleStepDefinitionMatchOne.getLocation()).thenReturn("PickleStepDefinitionMatchOne_Location");
+        PickleStepDefinitionMatch mockPickleStepDefinitionMatchOne = new PickleStepDefinitionMatch(new ArrayList<>(),
+            new StubStepDefinition("PickleStepDefinitionMatchOne_Pattern", "PickleStepDefinitionMatchOne_Location"),
+            null, null);
 
-        PickleStepDefinitionMatch mockPickleStepDefinitionMatchTwo = mock(PickleStepDefinitionMatch.class);
-        when(mockPickleStepDefinitionMatchTwo.getPattern()).thenReturn("PickleStepDefinitionMatchTwo_Pattern");
-        when(mockPickleStepDefinitionMatchTwo.getLocation()).thenReturn("PickleStepDefinitionMatchTwo_Location");
+        PickleStepDefinitionMatch mockPickleStepDefinitionMatchTwo = new PickleStepDefinitionMatch(new ArrayList<>(),
+            new StubStepDefinition("PickleStepDefinitionMatchTwo_Pattern", "PickleStepDefinitionMatchTwo_Location"),
+            null, null);
 
         List<PickleStepDefinitionMatch> matches = asList(mockPickleStepDefinitionMatchOne,
             mockPickleStepDefinitionMatchTwo);

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -1,15 +1,6 @@
 package io.cucumber.core.runner;
 
-import io.cucumber.core.backend.DataTableTypeDefinition;
-import io.cucumber.core.backend.DefaultDataTableCellTransformerDefinition;
-import io.cucumber.core.backend.DefaultDataTableEntryTransformerDefinition;
-import io.cucumber.core.backend.DefaultParameterTransformerDefinition;
-import io.cucumber.core.backend.DocStringTypeDefinition;
-import io.cucumber.core.backend.HookDefinition;
-import io.cucumber.core.backend.ParameterTypeDefinition;
-import io.cucumber.core.backend.ScenarioScoped;
-import io.cucumber.core.backend.SourceReference;
-import io.cucumber.core.backend.StepDefinition;
+import io.cucumber.core.backend.*;
 import io.cucumber.core.backend.TestCaseState;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.feature.TestFeatureParser;
@@ -31,10 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.time.Clock;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.Locale.ENGLISH;
@@ -44,8 +32,6 @@ import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class CachingGlueTest {
 
@@ -54,14 +40,10 @@ class CachingGlueTest {
 
     @Test
     void throws_duplicate_error_on_dupe_stepdefs() {
-        StepDefinition a = mock(StepDefinition.class);
-        when(a.getPattern()).thenReturn("hello");
-        when(a.getLocation()).thenReturn("foo.bf:10");
+        StepDefinition a = new StubStepDefinitionWithPatternAndLocation("hello", "foo.bf:10");
         glue.addStepDefinition(a);
 
-        StepDefinition b = mock(StepDefinition.class);
-        when(b.getPattern()).thenReturn("hello");
-        when(b.getLocation()).thenReturn("bar.bf:90");
+        StepDefinition b = new StubStepDefinitionWithPatternAndLocation("hello", "bar.bf:90");
         glue.addStepDefinition(b);
 
         DuplicateStepDefinitionException exception = assertThrows(
@@ -848,5 +830,40 @@ class CachingGlueTest {
             return disposed;
         }
 
+    }
+
+    private static class StubStepDefinitionWithPatternAndLocation implements StepDefinition {
+        private final String pattern;
+        private final String location;
+
+        public StubStepDefinitionWithPatternAndLocation(String pattern, String location) {
+            this.pattern = pattern;
+            this.location = location;
+        }
+
+        @Override
+        public boolean isDefinedAt(StackTraceElement stackTraceElement) {
+            return false;
+        }
+
+        @Override
+        public String getLocation() {
+            return location;
+        }
+
+        @Override
+        public void execute(Object[] args) throws CucumberBackendException, CucumberInvocationTargetException {
+
+        }
+
+        @Override
+        public List<ParameterInfo> parameterInfos() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String getPattern() {
+            return pattern;
+        }
     }
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/DuplicateStepDefinitionExceptionTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/DuplicateStepDefinitionExceptionTest.java
@@ -1,31 +1,62 @@
 package io.cucumber.core.runner;
 
+import io.cucumber.core.backend.CucumberBackendException;
+import io.cucumber.core.backend.CucumberInvocationTargetException;
+import io.cucumber.core.backend.ParameterInfo;
 import io.cucumber.core.backend.StepDefinition;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class DuplicateStepDefinitionExceptionTest {
 
     @Test
     void can_report_duplicate_step_definitions() {
-        final StepDefinition mockStepDefinitionA = mock(StepDefinition.class);
-        when(mockStepDefinitionA.getLocation()).thenReturn("StepDefinitionA_Location");
-        final StepDefinition mockStepDefinitionB = mock(StepDefinition.class);
-        when(mockStepDefinitionB.getLocation()).thenReturn("StepDefinitionB_Location");
-
-        DuplicateStepDefinitionException expectedThrown = new DuplicateStepDefinitionException(mockStepDefinitionA,
-            mockStepDefinitionB);
+        DuplicateStepDefinitionException expectedThrown = new DuplicateStepDefinitionException(
+            new StubStepDefinition("StepDefinitionA_Location"),
+            new StubStepDefinition("StepDefinitionB_Location"));
         assertAll(
             () -> assertThat(expectedThrown.getMessage(),
                 is(equalTo("Duplicate step definitions in StepDefinitionA_Location and StepDefinitionB_Location"))),
             () -> assertThat(expectedThrown.getCause(), is(nullValue())));
     }
 
+    public static class StubStepDefinition implements StepDefinition {
+        private final String location;
+
+        public StubStepDefinition(String location) {
+            this.location = location;
+        }
+
+        @Override
+        public boolean isDefinedAt(StackTraceElement stackTraceElement) {
+            return false;
+        }
+
+        @Override
+        public String getLocation() {
+            return location;
+        }
+
+        @Override
+        public void execute(Object[] args) throws CucumberBackendException, CucumberInvocationTargetException {
+
+        }
+
+        @Override
+        public List<ParameterInfo> parameterInfos() {
+            return null;
+        }
+
+        @Override
+        public String getPattern() {
+            return null;
+        }
+    }
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/StubEventBus.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/StubEventBus.java
@@ -1,0 +1,39 @@
+package io.cucumber.core.runner;
+
+import io.cucumber.core.eventbus.EventBus;
+import io.cucumber.plugin.event.EventHandler;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class StubEventBus implements EventBus {
+    @Override
+    public Instant getInstant() {
+        return null;
+    }
+
+    @Override
+    public UUID generateId() {
+        return null;
+    }
+
+    @Override
+    public <T> void send(T event) {
+
+    }
+
+    @Override
+    public <T> void sendAll(Iterable<T> queue) {
+
+    }
+
+    @Override
+    public <T> void registerHandlerFor(Class<T> eventType, EventHandler<T> handler) {
+
+    }
+
+    @Override
+    public <T> void removeHandlerFor(Class<T> eventType, EventHandler<T> handler) {
+
+    }
+}

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/UndefinedStepDefinitionMatchTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/UndefinedStepDefinitionMatchTest.java
@@ -1,7 +1,9 @@
 package io.cucumber.core.runner;
 
+import io.cucumber.core.eventbus.IncrementingUuidGenerator;
 import io.cucumber.core.feature.TestFeatureParser;
 import io.cucumber.core.gherkin.Feature;
+import io.cucumber.core.plugin.StubTestCase;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -9,7 +11,6 @@ import java.net.URI;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 class UndefinedStepDefinitionMatchTest {
 
@@ -21,18 +22,19 @@ class UndefinedStepDefinitionMatchTest {
     private final UndefinedPickleStepDefinitionMatch match = new UndefinedPickleStepDefinitionMatch(
         URI.create("file:path/to.feature"),
         feature.getPickles().get(0).getSteps().get(0));
-
+    private final TestCaseState mockTestCaseState = new TestCaseState(new StubEventBus(),
+        new IncrementingUuidGenerator().generateId(), new StubTestCase());
     @Test
     void throws_undefined_step_definitions_exception_when_run() {
         UndefinedStepDefinitionException expectedThrown = assertThrows(UndefinedStepDefinitionException.class,
-            () -> match.runStep(mock(TestCaseState.class)));
+            () -> match.runStep(mockTestCaseState));
         assertThat(expectedThrown.getMessage(), equalTo("No step definitions found"));
     }
 
     @Test
     void throws_undefined_step_definitions_exception_when_dry_run() {
         UndefinedStepDefinitionException expectedThrown = assertThrows(UndefinedStepDefinitionException.class,
-            () -> match.dryRunStep(mock(TestCaseState.class)));
+            () -> match.dryRunStep(mockTestCaseState));
         assertThat(expectedThrown.getMessage(), equalTo("No step definitions found"));
     }
 

--- a/cucumber-core/src/test/java/io/cucumber/core/runtime/CucumberExecutionContextTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runtime/CucumberExecutionContextTest.java
@@ -3,12 +3,8 @@ package io.cucumber.core.runtime;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.options.RuntimeOptionsBuilder;
-import io.cucumber.plugin.event.Result;
-import io.cucumber.plugin.event.Status;
-import io.cucumber.plugin.event.TestCase;
-import io.cucumber.plugin.event.TestCaseFinished;
-import io.cucumber.plugin.event.TestRunFinished;
-import io.cucumber.plugin.event.TestRunStarted;
+import io.cucumber.core.plugin.StubTestCase;
+import io.cucumber.plugin.event.*;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
@@ -24,7 +20,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 class CucumberExecutionContextTest {
 
@@ -55,7 +50,7 @@ class CucumberExecutionContextTest {
     public void rethrows_but_does_not_collect_failures_in_test_case() {
         IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> context.runTestCase(runner -> {
             try (TestCaseResultObserver r = new TestCaseResultObserver(bus)) {
-                bus.send(new TestCaseFinished(bus.getInstant(), mock(TestCase.class),
+                bus.send(new TestCaseFinished(bus.getInstant(), new StubTestCase(),
                     new Result(Status.FAILED, Duration.ZERO, failure)));
                 r.assertTestCasePassed(
                     Exception::new,

--- a/cucumber-core/src/test/java/io/cucumber/core/runtime/ExitStatusTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runtime/ExitStatusTest.java
@@ -3,9 +3,9 @@ package io.cucumber.core.runtime;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.options.RuntimeOptionsBuilder;
+import io.cucumber.core.plugin.StubTestCase;
 import io.cucumber.plugin.event.Result;
 import io.cucumber.plugin.event.Status;
-import io.cucumber.plugin.event.TestCase;
 import io.cucumber.plugin.event.TestCaseFinished;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +17,6 @@ import static java.time.Duration.ZERO;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.mockito.Mockito.mock;
 
 class ExitStatusTest {
 
@@ -55,7 +54,7 @@ class ExitStatusTest {
     }
 
     private TestCaseFinished testCaseFinishedWithStatus(Status resultStatus) {
-        return new TestCaseFinished(ANY_INSTANT, mock(TestCase.class), new Result(resultStatus, ZERO, null));
+        return new TestCaseFinished(ANY_INSTANT, new StubTestCase(), new Result(resultStatus, ZERO, null));
     }
 
     @Test

--- a/cucumber-core/src/test/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplierTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runtime/ThreadLocalRunnerSupplierTest.java
@@ -2,8 +2,8 @@ package io.cucumber.core.runtime;
 
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.options.RuntimeOptions;
+import io.cucumber.core.plugin.StubTestCase;
 import io.cucumber.core.runner.Runner;
-import io.cucumber.plugin.event.TestCase;
 import io.cucumber.plugin.event.TestCaseStarted;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,7 +20,6 @@ import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
 
 class ThreadLocalRunnerSupplierTest {
 
@@ -83,7 +82,7 @@ class ThreadLocalRunnerSupplierTest {
         runnerSupplier.get().getBus().registerHandlerFor(
             TestCaseStarted.class,
             event -> fail("Should not receive event"));
-        eventBus.send(new TestCaseStarted(EPOCH, mock(TestCase.class)));
+        eventBus.send(new TestCaseStarted(EPOCH, new StubTestCase()));
     }
 
 }

--- a/cucumber-guice/pom.xml
+++ b/cucumber-guice/pom.xml
@@ -17,7 +17,6 @@
         <hamcrest.version>2.2</hamcrest.version>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
         <project.Automatic-Module-Name>io.cucumber.guice</project.Automatic-Module-Name>
-        <mockito.version>5.3.1</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -74,12 +73,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/cucumber-guice/src/test/java/io/cucumber/guice/GuiceBackendTest.java
+++ b/cucumber-guice/src/test/java/io/cucumber/guice/GuiceBackendTest.java
@@ -1,15 +1,12 @@
 package io.cucumber.guice;
 
-import io.cucumber.core.backend.BackendProviderService;
-import io.cucumber.core.backend.Glue;
-import io.cucumber.core.backend.ObjectFactory;
+import io.cucumber.core.backend.*;
 import io.cucumber.guice.integration.YourInjectorSource;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 
 import static java.lang.Thread.currentThread;
@@ -19,38 +16,35 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.*;
 
-@ExtendWith({ MockitoExtension.class })
 class GuiceBackendTest {
 
     public final Supplier<ClassLoader> classLoader = currentThread()::getContextClassLoader;
 
-    @Mock
-    private Glue glue;
-
-    @Mock
-    private ObjectFactory factory;
+    private final Glue glue = new StubGlue();
 
     @Test
     void finds_injector_source_impls_by_classpath_url() {
+        MockObjectFactory factory = new MockObjectFactory();
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
         backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/guice/integration")));
-        verify(factory).addClass(YourInjectorSource.class);
+        assertTrue(factory.classes.contains(YourInjectorSource.class));
     }
 
     @Test
     void finds_injector_source_impls_once_by_classpath_url() {
+        MockObjectFactory factory = new MockObjectFactory();
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
         backend.loadGlue(glue, asList(URI.create("classpath:io/cucumber/guice/integration"),
             URI.create("classpath:io/cucumber/guice/integration")));
-        verify(factory, times(1)).addClass(YourInjectorSource.class);
+        assertTrue(factory.classes.contains(YourInjectorSource.class));
+        assertEquals(1, factory.classes.size());
     }
 
     @Test
     void world_and_snippet_methods_do_nothing() {
+        MockObjectFactory factory = new MockObjectFactory();
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
         backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/guice/integration")));
         backend.buildWorld();
@@ -60,21 +54,121 @@ class GuiceBackendTest {
 
     @Test
     void doesnt_save_anything_in_glue() {
+        MockObjectFactory factory = new MockObjectFactory();
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
         backend.loadGlue(null, singletonList(URI.create("classpath:io/cucumber/guice/integration")));
-        verify(factory).addClass(YourInjectorSource.class);
+        assertTrue(factory.classes.contains(YourInjectorSource.class));
     }
 
     @Test()
     void list_of_uris_cant_be_null() {
+        MockObjectFactory factory = new MockObjectFactory();
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
         assertThrows(NullPointerException.class, () -> backend.loadGlue(glue, null));
     }
 
     @Test
     void backend_service_creates_backend() {
+        MockObjectFactory factory = new MockObjectFactory();
         BackendProviderService backendProviderService = new GuiceBackendProviderService();
         assertThat(backendProviderService.create(factory, factory, classLoader), is(notNullValue()));
     }
 
+    private static class MockObjectFactory implements ObjectFactory {
+        List<Class<?>> classes = new ArrayList<>();
+        boolean started = false;
+        boolean stopped = false;
+
+        @Override
+        public boolean addClass(Class<?> glueClass) {
+            return classes.add(glueClass);
+        }
+
+        @Override
+        public <T> T getInstance(Class<T> glueClass) {
+            return null;
+        }
+
+        @Override
+        public void start() {
+            started = true;
+        }
+
+        @Override
+        public void stop() {
+            stopped = true;
+        }
+    }
+
+    private static class StubGlue implements Glue {
+
+        @Override
+        public void addBeforeAllHook(StaticHookDefinition beforeAllHook) {
+
+        }
+
+        @Override
+        public void addAfterAllHook(StaticHookDefinition afterAllHook) {
+
+        }
+
+        @Override
+        public void addStepDefinition(StepDefinition stepDefinition) {
+
+        }
+
+        @Override
+        public void addBeforeHook(HookDefinition beforeHook) {
+
+        }
+
+        @Override
+        public void addAfterHook(HookDefinition afterHook) {
+
+        }
+
+        @Override
+        public void addBeforeStepHook(HookDefinition beforeStepHook) {
+
+        }
+
+        @Override
+        public void addAfterStepHook(HookDefinition afterStepHook) {
+
+        }
+
+        @Override
+        public void addParameterType(ParameterTypeDefinition parameterType) {
+
+        }
+
+        @Override
+        public void addDataTableType(DataTableTypeDefinition dataTableType) {
+
+        }
+
+        @Override
+        public void addDefaultParameterTransformer(DefaultParameterTransformerDefinition defaultParameterTransformer) {
+
+        }
+
+        @Override
+        public void addDefaultDataTableEntryTransformer(
+                DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer
+        ) {
+
+        }
+
+        @Override
+        public void addDefaultDataTableCellTransformer(
+                DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer
+        ) {
+
+        }
+
+        @Override
+        public void addDocStringType(DocStringTypeDefinition docStringType) {
+
+        }
+    }
 }

--- a/cucumber-junit/src/test/java/io/cucumber/junit/PickleRunnerWithNoStepDescriptionsTest.java
+++ b/cucumber-junit/src/test/java/io/cucumber/junit/PickleRunnerWithNoStepDescriptionsTest.java
@@ -18,13 +18,12 @@ import java.util.UUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.mockito.Mockito.mock;
 
 class PickleRunnerWithNoStepDescriptionsTest {
 
     final EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
     final Options options = RuntimeOptions.defaultOptions();
-    final RunnerSupplier runnerSupplier = mock(RunnerSupplier.class);
+    final RunnerSupplier runnerSupplier = new StubRunnerSupplier();
     final CucumberExecutionContext context = new CucumberExecutionContext(bus, new ExitStatus(options), runnerSupplier);
 
     @Test

--- a/cucumber-junit/src/test/java/io/cucumber/junit/PickleRunnerWithStepDescriptionsTest.java
+++ b/cucumber-junit/src/test/java/io/cucumber/junit/PickleRunnerWithStepDescriptionsTest.java
@@ -22,13 +22,12 @@ import java.util.UUID;
 import static io.cucumber.junit.TestPickleBuilder.picklesFromFeature;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.mockito.Mockito.mock;
 
 class PickleRunnerWithStepDescriptionsTest {
 
     final EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
     final Options options = RuntimeOptions.defaultOptions();
-    final RunnerSupplier runnerSupplier = mock(RunnerSupplier.class);
+    final RunnerSupplier runnerSupplier = new StubRunnerSupplier();
     final CucumberExecutionContext context = new CucumberExecutionContext(bus, new ExitStatus(options), runnerSupplier);
 
     @Test

--- a/cucumber-junit/src/test/java/io/cucumber/junit/StubRunnerSupplier.java
+++ b/cucumber-junit/src/test/java/io/cucumber/junit/StubRunnerSupplier.java
@@ -1,0 +1,11 @@
+package io.cucumber.junit;
+
+import io.cucumber.core.runner.Runner;
+import io.cucumber.core.runtime.RunnerSupplier;
+
+class StubRunnerSupplier implements RunnerSupplier {
+    @Override
+    public Runner get() {
+        return null;
+    }
+}

--- a/cucumber-spring/src/test/java/io/cucumber/spring/SpringBackendTest.java
+++ b/cucumber-spring/src/test/java/io/cucumber/spring/SpringBackendTest.java
@@ -1,38 +1,33 @@
 package io.cucumber.spring;
 
-import io.cucumber.core.backend.Glue;
-import io.cucumber.core.backend.ObjectFactory;
+import io.cucumber.core.backend.*;
 import io.cucumber.spring.annotationconfig.AnnotationContextConfiguration;
 import io.cucumber.spring.cucumbercontextconfigannotation.AbstractWithComponentAnnotation;
 import io.cucumber.spring.cucumbercontextconfigannotation.AnnotatedInterface;
 import io.cucumber.spring.cucumbercontextconfigannotation.WithMetaAnnotation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
 import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.*;
 
-@ExtendWith(MockitoExtension.class)
 class SpringBackendTest {
 
-    @Mock
-    private Glue glue;
+    private final Glue glue = new MockGlue();
 
-    @Mock
-    private ObjectFactory factory;
+    private MockObjectFactory factory;
 
     private SpringBackend backend;
 
     @BeforeEach
     void createBackend() {
+        this.factory = new MockObjectFactory();
         this.backend = new SpringBackend(factory, currentThread()::getContextClassLoader);
     }
 
@@ -40,7 +35,7 @@ class SpringBackendTest {
     void finds_annotation_context_configuration_by_classpath_url() {
         backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/spring/annotationconfig")));
         backend.buildWorld();
-        verify(factory).addClass(AnnotationContextConfiguration.class);
+        assertTrue(factory.classes.contains(AnnotationContextConfiguration.class));
     }
 
     @Test
@@ -49,7 +44,8 @@ class SpringBackendTest {
             URI.create("classpath:io/cucumber/spring/annotationconfig"),
             URI.create("classpath:io/cucumber/spring/annotationconfig")));
         backend.buildWorld();
-        verify(factory, times(1)).addClass(AnnotationContextConfiguration.class);
+        assertTrue(factory.classes.contains(AnnotationContextConfiguration.class));
+        assertEquals(1, factory.classes.size());
     }
 
     @Test
@@ -57,7 +53,7 @@ class SpringBackendTest {
         backend.loadGlue(glue, singletonList(
             URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")));
         backend.buildWorld();
-        verify(factory, times(0)).addClass(AbstractWithComponentAnnotation.class);
+        assertFalse(factory.classes.contains(AbstractWithComponentAnnotation.class));
     }
 
     @Test
@@ -65,7 +61,7 @@ class SpringBackendTest {
         backend.loadGlue(glue, singletonList(
             URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")));
         backend.buildWorld();
-        verify(factory, times(0)).addClass(AnnotatedInterface.class);
+        assertFalse(factory.classes.contains(AnnotatedInterface.class));
     }
 
     @Test
@@ -73,7 +69,105 @@ class SpringBackendTest {
         backend.loadGlue(glue, singletonList(
             URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")));
         backend.buildWorld();
-        verify(factory, times(1)).addClass(WithMetaAnnotation.class);
+        assertTrue(factory.classes.contains(WithMetaAnnotation.class));
+    }
+
+    private static class MockObjectFactory implements ObjectFactory {
+        List<Class<?>> classes = new ArrayList<>();
+        boolean started = false;
+        boolean stopped = false;
+
+        @Override
+        public boolean addClass(Class<?> glueClass) {
+            return classes.add(glueClass);
+        }
+
+        @Override
+        public <T> T getInstance(Class<T> glueClass) {
+            return null;
+        }
+
+        @Override
+        public void start() {
+            started = true;
+        }
+
+        @Override
+        public void stop() {
+            stopped = true;
+        }
+    }
+
+    private static class MockGlue implements Glue {
+
+        @Override
+        public void addBeforeAllHook(StaticHookDefinition beforeAllHook) {
+
+        }
+
+        @Override
+        public void addAfterAllHook(StaticHookDefinition afterAllHook) {
+
+        }
+
+        @Override
+        public void addStepDefinition(StepDefinition stepDefinition) {
+
+        }
+
+        @Override
+        public void addBeforeHook(HookDefinition beforeHook) {
+
+        }
+
+        @Override
+        public void addAfterHook(HookDefinition afterHook) {
+
+        }
+
+        @Override
+        public void addBeforeStepHook(HookDefinition beforeStepHook) {
+
+        }
+
+        @Override
+        public void addAfterStepHook(HookDefinition afterStepHook) {
+
+        }
+
+        @Override
+        public void addParameterType(ParameterTypeDefinition parameterType) {
+
+        }
+
+        @Override
+        public void addDataTableType(DataTableTypeDefinition dataTableType) {
+
+        }
+
+        @Override
+        public void addDefaultParameterTransformer(DefaultParameterTransformerDefinition defaultParameterTransformer) {
+
+        }
+
+        @Override
+        public void addDefaultDataTableEntryTransformer(
+                DefaultDataTableEntryTransformerDefinition defaultDataTableEntryTransformer
+        ) {
+
+        }
+
+        @Override
+        public void addDefaultDataTableCellTransformer(
+                DefaultDataTableCellTransformerDefinition defaultDataTableCellTransformer
+        ) {
+
+        }
+
+        @Override
+        public void addDocStringType(DocStringTypeDefinition docStringType) {
+
+        }
     }
 
 }

--- a/cucumber-testng/pom.xml
+++ b/cucumber-testng/pom.xml
@@ -16,7 +16,6 @@
         <hamcrest.version>2.2</hamcrest.version>
         <testng.version>7.8.0</testng.version>
         <apiguardian-api.version>1.1.2</apiguardian-api.version>
-        <mockito.version>5.3.1</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -46,12 +45,6 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${testng.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/cucumber-testng/src/test/java/io/cucumber/testng/TestCaseResultObserverTest.java
+++ b/cucumber-testng/src/test/java/io/cucumber/testng/TestCaseResultObserverTest.java
@@ -2,21 +2,14 @@ package io.cucumber.testng;
 
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.runtime.TimeServiceEventBus;
-import io.cucumber.plugin.event.Location;
-import io.cucumber.plugin.event.PickleStepTestStep;
-import io.cucumber.plugin.event.Result;
-import io.cucumber.plugin.event.SnippetsSuggestedEvent;
+import io.cucumber.plugin.event.*;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent.Suggestion;
-import io.cucumber.plugin.event.Status;
-import io.cucumber.plugin.event.Step;
-import io.cucumber.plugin.event.TestCase;
-import io.cucumber.plugin.event.TestCaseFinished;
-import io.cucumber.plugin.event.TestStepFinished;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.time.Clock;
+import java.util.List;
 import java.util.UUID;
 
 import static io.cucumber.plugin.event.Status.AMBIGUOUS;
@@ -31,8 +24,6 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.expectThrows;
 
@@ -43,16 +34,11 @@ public class TestCaseResultObserverTest {
     private final URI uri = URI.create("file:path/to.feature");
     private final Location location = new Location(0, -1);
     private final Exception error = new Exception();
-    private final TestCase testCase = mock(TestCase.class);
+    private final TestCase testCase = new MockTestCase();
     private final PickleStepTestStep step = createPickleStepTestStep();
 
     private PickleStepTestStep createPickleStepTestStep() {
-        PickleStepTestStep testStep = mock(PickleStepTestStep.class);
-        Step step = mock(Step.class);
-        when(step.getLocation()).thenReturn(location);
-        when(testStep.getStep()).thenReturn(step);
-        when(testStep.getUri()).thenReturn(uri);
-        return testStep;
+        return new MockPickleStepTestStep(new MockStep(location), uri);
     }
 
     @Test
@@ -200,4 +186,138 @@ public class TestCaseResultObserverTest {
         assertThat(exception.getCause(), instanceOf(SkipException.class));
     }
 
+    private static final class MockStep implements Step {
+        Location location;
+        public MockStep(Location location) {
+            this.location = location;
+        }
+
+        @Override
+        public StepArgument getArgument() {
+            return null;
+        }
+
+        @Override
+        public String getKeyword() {
+            return null;
+        }
+
+        @Override
+        public String getText() {
+            return null;
+        }
+
+        @Override
+        public int getLine() {
+            return 0;
+        }
+
+        @Override
+        public Location getLocation() {
+            return location;
+        }
+    }
+
+    private static class MockPickleStepTestStep implements PickleStepTestStep {
+        private final Step step;
+        private final URI uri;
+
+        public MockPickleStepTestStep(Step step, URI uri) {
+            this.step = step;
+            this.uri = uri;
+        }
+
+        @Override
+        public String getPattern() {
+            return null;
+        }
+
+        @Override
+        public Step getStep() {
+            return step;
+        }
+
+        @Override
+        public List<Argument> getDefinitionArgument() {
+            return null;
+        }
+
+        @Override
+        public StepArgument getStepArgument() {
+            return null;
+        }
+
+        @Override
+        public int getStepLine() {
+            return 0;
+        }
+
+        @Override
+        public URI getUri() {
+            return uri;
+        }
+
+        @Override
+        public String getStepText() {
+            return null;
+        }
+
+        @Override
+        public String getCodeLocation() {
+            return null;
+        }
+
+        @Override
+        public UUID getId() {
+            return null;
+        }
+    }
+
+    private static class MockTestCase implements TestCase {
+
+        @Override
+        public Integer getLine() {
+            return null;
+        }
+
+        @Override
+        public Location getLocation() {
+            return null;
+        }
+
+        @Override
+        public String getKeyword() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getScenarioDesignation() {
+            return null;
+        }
+
+        @Override
+        public List<String> getTags() {
+            return null;
+        }
+
+        @Override
+        public List<TestStep> getTestSteps() {
+            return null;
+        }
+
+        @Override
+        public URI getUri() {
+            return null;
+        }
+
+        @Override
+        public UUID getId() {
+            return null;
+        }
+    }
 }

--- a/datatable/pom.xml
+++ b/datatable/pom.xml
@@ -20,7 +20,6 @@
         <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.15.2</jackson.version>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
-        <mockito.version>5.3.1</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -72,13 +71,6 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
### 🤔 What's changed?

I reduced the usage of the Mockito framework. This is a first pass, focused on the simple cases (typically: replacing the mock+when constructs with stub classes).

### ⚡️ What's your motivation? 

Fixes #2707 .

By focusing on the simple cases we have a big pull request of stuff that is simple to review. The other replacements are more complex and prone to more discussions, so I will make another pull request for them.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

N/A

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
