### PR TITLE
[Pico] Fixed missing calls to start, stop and dispose handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [TestNG] Update dependency org.testng:testng to v7.8.0
 
+### Fixed
+- [Pico] Fixed missing calls to start, stop and dispose handles ([#2772](https://github.com/cucumber/cucumber-jvm/pull/2772) Julien Kronegg)
+
 ## [7.12.1] - 2023-06-02
 ### Fixed
 - [Core] Set html report viewport width to device width ([html-formatter/#238](https://github.com/cucumber/html-formatter/pull/238)  Tim Yao )

--- a/cucumber-picocontainer/src/test/java/io/cucumber/picocontainer/DisposableCucumberBelly.java
+++ b/cucumber-picocontainer/src/test/java/io/cucumber/picocontainer/DisposableCucumberBelly.java
@@ -3,7 +3,10 @@ package io.cucumber.picocontainer;
 import org.picocontainer.Disposable;
 import org.picocontainer.Startable;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * A test helper class which simulates a class that holds system resources which
@@ -13,6 +16,7 @@ import java.util.List;
  */
 public class DisposableCucumberBelly
         implements Disposable, Startable {
+    static final List<String> events = new ArrayList<>();
 
     private List<String> contents;
     private boolean isDisposed = false;
@@ -20,12 +24,12 @@ public class DisposableCucumberBelly
     private boolean wasStopped = false;
 
     public List<String> getContents() {
-        assert !isDisposed;
+        assertFalse(isDisposed);
         return contents;
     }
 
     public void setContents(List<String> contents) {
-        assert !isDisposed;
+        assertFalse(isDisposed);
         this.contents = contents;
     }
 
@@ -36,6 +40,7 @@ public class DisposableCucumberBelly
      */
     @Override
     public void dispose() {
+        events.add("Disposed");
         isDisposed = true;
     }
 
@@ -45,6 +50,7 @@ public class DisposableCucumberBelly
 
     @Override
     public void start() {
+        events.add("Started");
         wasStarted = true;
     }
 
@@ -54,6 +60,7 @@ public class DisposableCucumberBelly
 
     @Override
     public void stop() {
+        events.add("Stopped");
         wasStopped = true;
     }
 

--- a/cucumber-picocontainer/src/test/java/io/cucumber/picocontainer/StepDefinitions.java
+++ b/cucumber-picocontainer/src/test/java/io/cucumber/picocontainer/StepDefinitions.java
@@ -1,8 +1,6 @@
 package io.cucumber.picocontainer;
 
-import io.cucumber.java.After;
-import io.cucumber.java.Before;
-import io.cucumber.java.Scenario;
+import io.cucumber.java.*;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -11,11 +9,12 @@ import org.opentest4j.TestAbortedException;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StepDefinitions {
 
     private final DisposableCucumberBelly belly;
+    private static int scenarioCount = 0;
 
     public StepDefinitions(DisposableCucumberBelly belly) {
         this.belly = belly;
@@ -35,9 +34,37 @@ public class StepDefinitions {
 
     @After
     public void after() {
+        scenarioCount++;
         // We might need to clean up the belly here, if it represented an
         // external resource.
-        assert !belly.isDisposed();
+
+        // Call order should be Started > After > Stopped > Disposed, so here we
+        // expect only Started
+        assertTrue(belly.wasStarted());
+        assertFalse(belly.wasStopped());
+        assertFalse(belly.isDisposed());
+    }
+
+    @BeforeAll
+    @SuppressWarnings("unused")
+    public static void beforeAll() {
+        // reset static variables
+        DisposableCucumberBelly.events.clear();
+        scenarioCount = 0;
+    }
+
+    @AfterAll
+    @SuppressWarnings("unused")
+    public static void afterAll() {
+        List<String> events = DisposableCucumberBelly.events;
+        // Call order should be Start > Stopped > Disposed, for each test
+        // scenario
+        assertEquals(3 * scenarioCount, events.size());
+        for (int i = 0; i < scenarioCount; i += 3) {
+            assertEquals("Started", events.get(i));
+            assertEquals("Stopped", events.get(i + 1));
+            assertEquals("Disposed", events.get(i + 2));
+        }
     }
 
     @Given("I have {int} {word} in my belly")


### PR DESCRIPTION
### 🤔 What's changed?

Corrected the pico-container lifecycle: the start, stop and dispose methods are now called for every test scenarios.

The code is the same as before #2725 (so it's safer in terms of lifecycle), except that the pico container is recycled in the `start()` method when it already exists. 

When a second call to `start()` is done (e.g. for the 2nd scenario), the container component instances are all in disposed state and the container lifecycle is in disposed state. The recycling operation consists in removing all container component instances (i.e. flushing the cache) and resetting the container lifecycle.

### ⚡️ What's your motivation? 

Fixes #2771

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

I tested the new version on a project with ~480 test scenarios and saw no performance difference when compared to Cucumber 7.12.0.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
