### PR TITLE
feat: Add Plugin for OpenTelemetry tracing support

### DIFF
--- a/cucumber-bom/pom.xml
+++ b/cucumber-bom/pom.xml
@@ -137,6 +137,11 @@
             </dependency>
             <dependency>
                 <groupId>io.cucumber</groupId>
+                <artifactId>cucumber-opentelemetry</artifactId>
+                <version>7.14.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-picocontainer</artifactId>
                 <version>7.14.0-SNAPSHOT</version>
             </dependency>

--- a/cucumber-opentelemetry/pom.xml
+++ b/cucumber-opentelemetry/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.cucumber</groupId>
+        <artifactId>cucumber-jvm</artifactId>
+        <version>7.14.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cucumber-opentelemetry</artifactId>
+    <packaging>jar</packaging>
+    <name>Cucumber-JVM: OpenTelemetry</name>
+
+    <properties>
+        <opentelemetry.version>1.25.0</opentelemetry.version>
+        <project.Automatic-Module-Name>io.cucumber.opentelemetry</project.Automatic-Module-Name>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.cucumber</groupId>
+                <artifactId>cucumber-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>${opentelemetry.version}-alpha</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/cucumber-opentelemetry/src/main/java/io/cucumber/opentelemetry/OpenTelemetryTracingEventListener.java
+++ b/cucumber-opentelemetry/src/main/java/io/cucumber/opentelemetry/OpenTelemetryTracingEventListener.java
@@ -1,0 +1,289 @@
+package io.cucumber.opentelemetry;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.cucumber.plugin.ConcurrentEventListener;
+import io.cucumber.plugin.event.EventPublisher;
+import io.cucumber.plugin.event.HookTestStep;
+import io.cucumber.plugin.event.PickleStepTestStep;
+import io.cucumber.plugin.event.Result;
+import io.cucumber.plugin.event.Status;
+import io.cucumber.plugin.event.TestCaseEvent;
+import io.cucumber.plugin.event.TestCaseFinished;
+import io.cucumber.plugin.event.TestCaseStarted;
+import io.cucumber.plugin.event.TestStep;
+import io.cucumber.plugin.event.TestStepFinished;
+import io.cucumber.plugin.event.TestStepStarted;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+
+public class OpenTelemetryTracingEventListener implements ConcurrentEventListener {
+    // FUTURE: Make this configurable
+    public static final boolean START_NEW_TRACE_FOR_EACH_TEST_CASE = true;
+
+    public static final boolean DEBUG_SPAN_SCOPE = false;
+
+    // Match code locations of the form: <package>.<class>.<method>(<args>)
+    // $1 = package, $2 = class, $3 = method, $4 = args (if any)
+    public static final Pattern CODE_LOCATION_CLASS_METHOD_PATTERN = Pattern
+            .compile("^([^(]*)\\.([^.(]*)\\.([^.(]*)\\((.*)\\)$");
+
+    // OpenTelemetry attribute keys that are not in the standard trace semantic
+    // conventions.
+    public static final AttributeKey<String> ATTRIBUTE_KEY_CUCUMBER_EVENT = AttributeKey.stringKey("cucumber.event");
+    public static final AttributeKey<String> ATTRIBUTE_KEY_CUCUMBER_STATUS = AttributeKey.stringKey("cucumber.status");
+    public static final AttributeKey<List<String>> ATTRIBUTE_KEY_CODE_FUNCTION_ARGS = AttributeKey
+            .stringArrayKey("code.functionargs");
+    public static final AttributeKey<String> ATTRIBUTE_KEY_CODE_LOCATION = AttributeKey.stringKey("code.location");
+    public static final AttributeKey<List<String>> ATTRIBUTE_KEY_SOURCE_TAGS = AttributeKey
+            .stringArrayKey("source.tags");
+    public static final AttributeKey<String> ATTRIBUTE_KEY_CASE_KEYWORD = AttributeKey.stringKey("testcase.keyword");
+    public static final AttributeKey<String> ATTRIBUTE_KEY_CASE_NAME = AttributeKey.stringKey("testcase.name");
+    public static final AttributeKey<String> ATTRIBUTE_KEY_CASE_ID = AttributeKey.stringKey("testcase.id");
+    public static final AttributeKey<String> ATTRIBUTE_KEY_STEP_TYPE = AttributeKey.stringKey("step.type");
+    public static final AttributeKey<String> ATTRIBUTE_KEY_STEP_PATTERN = AttributeKey.stringKey("step.pattern");
+    public static final AttributeKey<String> ATTRIBUTE_KEY_STEP_KEYWORD = AttributeKey.stringKey("step.keyword");
+    public static final AttributeKey<String> ATTRIBUTE_KEY_STEP_TEXT = AttributeKey.stringKey("step.text");
+    public static final AttributeKey<String> ATTRIBUTE_KEY_STEP_ARGUMENT = AttributeKey.stringKey("step.argument");
+    public static final AttributeKey<String> ATTRIBUTE_KEY_HOOK_TYPE = AttributeKey.stringKey("hook.type");
+
+    private Tracer tracer = null; // do not use directly; call getTracer
+
+    // Multiple steps might be executing in parallel, so we might have multiple
+    // Spans/Scopes open at once. This is where we track each individually.
+    // XXX we might be able to simplify this to Map<Span, Scope> and get the
+    // current span with Span.current()
+    private final Map<Pair<UUID, String>, Pair<Span, Scope>> testCaseToSpanScope = new HashMap<>();
+
+    public OpenTelemetryTracingEventListener() {
+        if (DEBUG_SPAN_SCOPE) {
+            Thread hook = new Thread(() -> {
+                if (!testCaseToSpanScope.isEmpty()) {
+                    System.err.println(getClass().getSimpleName() + ": "
+                            + "Test case to Span/Scope Map is not empty. Contents: "
+                            + testCaseToSpanScope);
+                    for (Pair<Span, Scope> spanScope : testCaseToSpanScope.values()) {
+                        spanScope.getKey().addEvent("JVM shutting down while span was not completed");
+                        spanScope.getValue().close();
+                        spanScope.getKey().end();
+                    }
+                }
+            });
+            Runtime.getRuntime().addShutdownHook(hook);
+        }
+    }
+
+    /*
+     * We defer calling GlobalOpenTelemetry.getTracer as late as we can to allow
+     * for the possibility of a @BeforeAll hook to initialize the SDK. Plugins
+     * seem to get initialized before @BeforeAll hooks run, so we can't call
+     * GlobalOpenTelemetry.getTracer at class initialization time.
+     */
+    private Tracer getTracer() {
+        if (tracer == null) {
+            tracer = GlobalOpenTelemetry.getTracer(getClass().getPackageName());
+        }
+        return tracer;
+    }
+
+    @Override
+    public void setEventPublisher(final EventPublisher publisher) {
+        publisher.registerHandlerFor(TestCaseStarted.class, this::onTestCaseStarted);
+        publisher.registerHandlerFor(TestCaseFinished.class, this::onTestCaseFinished);
+        publisher.registerHandlerFor(TestStepStarted.class, this::onTestStepStarted);
+        publisher.registerHandlerFor(TestStepFinished.class, this::onTestStepFinished);
+    }
+
+    private void onTestCaseStarted(TestCaseStarted event) {
+        final SpanBuilder spanBuilder = getTracer()
+                .spanBuilder(event.getTestCase().getKeyword() + ": " + event.getTestCase().getName())
+                .setAttribute(ATTRIBUTE_KEY_CASE_KEYWORD, event.getTestCase().getKeyword())
+                .setAttribute(ATTRIBUTE_KEY_CASE_NAME, event.getTestCase().getName())
+                .setAttribute(ATTRIBUTE_KEY_CASE_ID, event.getTestCase().getId().toString())
+                .setAttribute(SemanticAttributes.CODE_FILEPATH, event.getTestCase().getUri().toString())
+                .setAttribute(SemanticAttributes.CODE_LINENO, (long) event.getTestCase().getLocation().getLine())
+                .setAttribute(SemanticAttributes.CODE_COLUMN, (long) event.getTestCase().getLocation().getColumn())
+                .setAttribute(ATTRIBUTE_KEY_SOURCE_TAGS, event.getTestCase().getTags());
+
+        if (START_NEW_TRACE_FOR_EACH_TEST_CASE) {
+            spanBuilder.setNoParent();
+
+            if (Span.current().getSpanContext().isValid()) {
+                spanBuilder.addLink(Span.current().getSpanContext());
+            }
+        }
+
+        startSpan(event, fileColonLine(event), spanBuilder);
+    }
+
+    private void onTestCaseFinished(TestCaseFinished event) {
+        endSpan(event, fileColonLine(event), event.getResult());
+    }
+
+    private void onTestStepStarted(TestStepStarted event) {
+        final SpanBuilder spanBuilder;
+
+        final TestStep step = event.getTestStep();
+        if (step instanceof PickleStepTestStep) {
+            final PickleStepTestStep pickle = (PickleStepTestStep) step;
+            spanBuilder = getTracer().spanBuilder(pickle.getStep().getKeyword() + " " + pickle.getStep().getText())
+                    .setAttribute(ATTRIBUTE_KEY_STEP_TYPE, "pickle")
+                    .setAttribute(ATTRIBUTE_KEY_STEP_KEYWORD, pickle.getStep().getKeyword())
+                    .setAttribute(ATTRIBUTE_KEY_STEP_TEXT, pickle.getStep().getText())
+                    .setAttribute(ATTRIBUTE_KEY_STEP_PATTERN, pickle.getPattern())
+                    .setAttribute(SemanticAttributes.CODE_FILEPATH, pickle.getUri().toString())
+                    .setAttribute(SemanticAttributes.CODE_LINENO, (long) pickle.getStep().getLocation().getLine())
+                    .setAttribute(SemanticAttributes.CODE_COLUMN, (long) pickle.getStep().getLocation().getColumn());
+
+            if (pickle.getStep().getArgument() != null) {
+                spanBuilder.setAttribute(ATTRIBUTE_KEY_STEP_ARGUMENT, pickle.getStep().getArgument().toString());
+            }
+        } else if (event.getTestStep() instanceof HookTestStep) {
+            final HookTestStep hook = (HookTestStep) event.getTestStep();
+            spanBuilder = getTracer()
+                    .spanBuilder(hook.getHookType().name() + " hook " + getHookDescription(event))
+                    .setAttribute(ATTRIBUTE_KEY_STEP_TYPE, "hook")
+                    .setAttribute(ATTRIBUTE_KEY_HOOK_TYPE, hook.getHookType().name());
+        } else {
+            spanBuilder = getTracer()
+                    .spanBuilder(
+                        event.getClass().getSimpleName() + " TestStep event " + event.getTestStep().getCodeLocation())
+                    .setAttribute(ATTRIBUTE_KEY_STEP_TYPE, step.getClass().getSimpleName());
+        }
+        startSpan(event, event.getTestStep().getCodeLocation(), spanBuilder);
+    }
+
+    private void onTestStepFinished(final TestStepFinished event) {
+        endSpan(event, event.getTestStep().getCodeLocation(), event.getResult());
+    }
+
+    private static String fileColonLine(TestCaseEvent event) {
+        return event.getTestCase().getUri().getSchemeSpecificPart() + ":" + event.getTestCase().getLocation().getLine();
+    }
+
+    private static String getHookDescription(TestStepStarted event) {
+        final Matcher m = CODE_LOCATION_CLASS_METHOD_PATTERN.matcher(event.getTestStep().getCodeLocation());
+        if (m.matches()) {
+            // Just the class name (without package) and method
+            return m.group(2) + "." + m.group(3);
+        } else {
+            return event.getTestStep().getCodeLocation();
+        }
+    }
+
+    private void startSpan(TestCaseEvent event, String codeLocation, SpanBuilder spanBuilder) {
+        spanBuilder.setAttribute(ATTRIBUTE_KEY_CUCUMBER_EVENT, event.getClass().getSimpleName());
+
+        final Matcher m = CODE_LOCATION_CLASS_METHOD_PATTERN.matcher(codeLocation);
+        if (m.matches()) {
+            spanBuilder.setAttribute(SemanticAttributes.CODE_NAMESPACE, m.group(1) + "." + m.group(2));
+            spanBuilder.setAttribute(SemanticAttributes.CODE_FUNCTION, m.group(3));
+            if (!m.group(4).isEmpty()) {
+                spanBuilder.setAttribute(ATTRIBUTE_KEY_CODE_FUNCTION_ARGS,
+                    Arrays.asList(m.group(4).split(",\\s*")));
+            }
+        } else {
+            spanBuilder.setAttribute(ATTRIBUTE_KEY_CODE_LOCATION, codeLocation);
+        }
+
+        final Span span = spanBuilder.startSpan();
+        final Scope scope = span.makeCurrent();
+
+        testCaseToSpanScope.put(Pair.of(event.getTestCase().getId(), codeLocation), Pair.of(span, scope));
+    }
+
+    private void endSpan(TestCaseEvent event, String codeLocation, Result result) {
+        final Span span = Span.current();
+
+        span.setAttribute(ATTRIBUTE_KEY_CUCUMBER_STATUS, result.getStatus().toString());
+
+        if (result.getStatus() == Status.FAILED) {
+            final Throwable error = result.getError();
+            span.recordException(error);
+            span.setStatus(StatusCode.ERROR, error.getMessage());
+        } else if (result.getStatus() == Status.PASSED) {
+            span.setStatus(StatusCode.OK);
+        }
+
+        final Pair<Span, Scope> spanScope = testCaseToSpanScope
+                .remove(Pair.of(event.getTestCase().getId(), codeLocation));
+        if (spanScope != null) {
+            if (DEBUG_SPAN_SCOPE) {
+                if (!span.equals(spanScope.getKey())) {
+                    System.err.println(getClass().getSimpleName() + ": " +
+                            "endSpan spans don't match:\n" + span.hashCode() + " (" + span.getSpanContext().toString()
+                            + ")\n" + spanScope.getKey().hashCode() + " ("
+                            + spanScope.getKey().getSpanContext().toString() + ")");
+                }
+            }
+            spanScope.getValue().close();
+            spanScope.getKey().end();
+        } else {
+            if (DEBUG_SPAN_SCOPE) {
+                System.err.println(getClass().getSimpleName() + ": "
+                        + "Could not find stored Span and Scope for " + event.getTestCase().getId() + "/"
+                        + codeLocation + " (current span is " + span + ")");
+            }
+        }
+    }
+
+    private static class Pair<K, V> {
+        private final K k;
+        private final V v;
+
+        private Pair(K k, V v) {
+            this.k = k;
+            this.v = v;
+        }
+
+        public static <K, V> Pair<K, V> of(K k, V v) {
+            return new Pair<>(k, v);
+        }
+
+        public K getKey() {
+            return k;
+        }
+
+        public V getValue() {
+            return v;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final Pair<?, ?> pair = (Pair<?, ?>) o;
+            return Objects.equals(getKey(), pair.getKey()) && Objects.equals(getValue(), pair.getValue());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getKey(), getValue());
+        }
+
+        @Override
+        public String toString() {
+            return "Pair{" +
+                    "key=" + getKey() +
+                    ", value=" + getValue() +
+                    '}';
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>cucumber-junit-platform-engine</module>
         <module>cucumber-kotlin-java8</module>
         <module>cucumber-openejb</module>
+        <module>cucumber-opentelemetry</module>
         <module>cucumber-picocontainer</module>
         <module>cucumber-plugin</module>
         <module>cucumber-spring</module>


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

This adds a new plugin that integrates OpenTelemetry tracing with Cucumber. A new trace is started for each test case and each test step is a span underneath.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

This is most useful when downstream code is also OpenTelemetry-tracing enabled, as it provides a very clear linkage between cucumber test case/steps and application interaction. E.g.: 
<img width="1470" alt="image" src="https://github.com/cucumber/cucumber-jvm/assets/4461073/c1141f43-f104-4058-b695-994ecfe52a4b">

See previous discussion in Slack: https://cucumberbdd.slack.com/archives/C5YHPPJMP/p1688522812400979

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

OpenTelemetry uses a ThreadLocal to pass span context information downstream. If I start a span in the plugin with TestCaseStarted/TestStepStarted events (note: it is the Scope that updates the ThreadLocal) and end the span on TestCaseFinished/TestStepFinished events, this seems to work properly. I've seen in https://github.com/cucumber/cucumber-jvm/issues/2052#issuecomment-659966397, that this isn't guaranteed, however:
> The ConcurrentEventListener does not suffer from this problem but also does not guarantee that you'll be able to use ThreadLocal to share data between your step execution and the plugin.

So, I'm curious if this approach is correct at all (or correct enough for this usage), or if something else should be done.

The other main question I have: because I need to find the same Span/Scope objects that were created in the Test*Started events later when the Test*Finished events come in, I keep a Map containing these and it is keyed on the TestCase ID and codeLocation, which seems to be unique in my testing--but I'm not sure if it is unique enough. Also, I realized that I can get the Span by calling Span.current() (as long as I see this in the same thread), and then I can use that to lookup the Scope with a simple map and then eliminate the need for the Pair class altogether. Unless there seem to be any issues with this approach, I will plan on making this change, which should nicely simplify things a good bit.

Do the names of the Maven module, Java package, and Java class for the plugin sound good?

One thing that would help related to this would be to include the trace ID for each trace in the scenario log output. I couldn't find a way to do this within the plugin, but I could do it with a hook:

```
    @Before
    public void logTraceId(Scenario scenario) {
        Span current = Span.current();
        if (current.getSpanContext().isValid()) {
            String link = "http://localhost:16686/trace/" + current.getSpanContext().getTraceId();
            scenario.log("trace ID: " + current.getSpanContext().getTraceId() + " -- " + link);
        }
    }
```

If we were able to find a good way to include something like this, the link pattern that is hardcoded to "http://localhost:16686/trace/..."  would be configurable.

I also have a tweak to PrettyFormatter that will add clickable hyperlinks for terminals that support it (like iTerm on macOS). See the commit on this branch: https://github.com/deejgregor/cucumber-jvm/commit/63ae9f20ce1408f1fc3f3e3d14b8b92d49528d00.

The combination of the plugin, the hook that logs the trace ID and link, and the tweak to the PrettyFormatter make it quite nice and easy to see the tracing details as a test is running.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

### Quick documentation

This will be moved into formal documentation as the approach solidifies.

#### Trying it out

The easy way to try this out, assuming you have Docker and some application you can try this on (something that is client-server based can be particularly cool to try, as long as it uses common libraries that are auto-instrumented by the OpenTelemetry Java Agent):
1. Run the Jaeger all-in-one Docker image: https://www.jaegertracing.io/docs/latest/getting-started/#all-in-one
2. Download the OpenTelemetry Java Agent: https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest
3. Set some environment variables (see below).
4. Build and install cucumber-jvm from this branch.
5. Run your tests with cucumber-jvm from this branch and the OpenTelemetry Java Agent by adding `-javaagent:<path-to-java-agent>/opentelemetry-javaagent.jar` to the JVM command line. Also make sure to active the cucumber-opentelemetry plugin with `--plugin io.cucumber.opentelemetry.OpenTelemetryTracingEventListener`.
6. Visit Jaeger at http://localhost: 16686/ to see the trace information.

Environment variables for item 3 above:
```
export OTEL_TRACES_EXPORTER=otlp # otlp is the default, but including here to be explicit
export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317 # this will be sent to Jaeger
export OTEL_METRICS_EXPORTER=none # Jaeger only supports metrics
export OTEL_LOGS_EXPORTER=none  # Jaeger only supports metrics
export OTEL_SERVICE_NAME=<some descriptive name>
```
Note: you can also use `OTEL_TRACES_EXPORTER=logging` to see the trace information on stdout (or `otlp,logging` to send to both).

Once the trace data starts getting sent, you should see the service name you set in `OTEL_SERVICE_NAME` show up in Jaeger, and then you can select the service and click "Find Traces" to see traces available. You should see one trace for each test case executed. Note: tracing data is sent when a span (in this case each test case or test step), so you won't see it until each of them *ends*. But even if a test case isn't yet finished, you should see each test step in the trace as it finishes. Test steps/cases that fail will be annotated with a red exclamation mark in the Jaeger UI and any exceptions received will be shown in the "Logs" section of a cucumber-genereated span. You can find a good amount of information pulled from the test cases/steps in the "Tags" section of each cucumber-generated span.

#### Random notes I don't want to forget

You don't need the OpenTelemetry Java Agent to use this. You can also use [manual instrumentation](https://opentelemetry.io/docs/instrumentation/java/manual/), as well. The OpenTelemetry SDK would need to be setup before this plugin gets called, and can be done with a `@BeforeAll` hook:
```
    @BeforeAll
    public static void autoConfigureOpenTelemetrySdk() {
        AutoConfiguredOpenTelemetrySdk.builder()
                        .setResultAsGlobal(true)
                        .build();
    }
```

Also, if you don't have the OpenTelemetry SDK initialized, all of this is just a no-op (this is a key part of the design of the OpenTelemetry API--that it can be safely used if the SDK isn't present, so it can be integrated widely).

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
