### PR TITLE
Exclude Multi-Release files from Jackson while shading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [Core] Exclude Multi-Release files from Jackson while shading ([#2786](https://github.com/cucumber/cucumber-jvm/pull/2786) M.P. Korstanje)
+
 ## [7.13.0] - 2023-07-02
 ### Changed
 - [TestNG] Update dependency org.testng:testng to v7.8.0

--- a/cucumber-core/pom.xml
+++ b/cucumber-core/pom.xml
@@ -232,6 +232,12 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                    <addHeader>false</addHeader>
+                                </transformer>
+                            </transformers>
                             <artifactSet>
                                 <includes>
                                     <include>com.fasterxml.jackson.core:jackson-databind</include>
@@ -253,9 +259,8 @@
                                         <exclude>**/module-info.class</exclude>
                                         <exclude>**/module-info.class</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
-                                        <exclude>META-INF/LICENSE</exclude>
-                                        <exclude>META-INF/NOTICE</exclude>
                                         <exclude>META-INF/services/**</exclude>
+                                        <exclude>META-INF/versions/**</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>
@@ -263,9 +268,8 @@
                                     <excludes>
                                         <exclude>**/module-info.class</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
-                                        <exclude>META-INF/LICENSE</exclude>
-                                        <exclude>META-INF/NOTICE</exclude>
                                         <exclude>META-INF/services/**</exclude>
+                                        <exclude>META-INF/versions/**</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>
@@ -273,7 +277,6 @@
                                     <excludes>
                                         <exclude>**/module-info.class</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
-                                        <exclude>META-INF/LICENSE</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>
@@ -281,7 +284,6 @@
                                     <excludes>
                                         <exclude>**/module-info.class</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
-                                        <exclude>META-INF/LICENSE</exclude>
                                         <exclude>META-INF/services/**</exclude>
                                     </excludes>
                                 </filter>


### PR DESCRIPTION
### 🤔 What's changed?

Cucumber-JVM uses Jackson Databind to write json. Because Jackson is a very common dependency, to ensure we do not interfere with the system under test, we shade it.

Unfortunately the Shade plugin occasionally gets updates and now includes multi-releases. These were not included in the relocation pattern and result in duplicate classes when Cucumber itself is shaded.

As `cucumber-core` is not a multi-release jar, we can exclude the multi- release files altogether.

Fixes: #2786

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
