### PR TITLE
Add reference to Gradle's Cucumber-Companion plugins

### DIFF
--- a/cucumber-junit-platform-engine/README.md
+++ b/cucumber-junit-platform-engine/README.md
@@ -30,7 +30,7 @@ or the [JUnit Platform Console Launcher](https://junit.org/junit5/docs/current/u
 
 The JUnit Platform Suite Engine can be used to run Cucumber. See
 [Suites with different configurations](#suites-with-different-configurations)
-for a brief how to.
+for a brief how to. You can also check out the [Cucumber-Companion](https://github.com/gradle/cucumber-companion) plugins for Gradle/Maven which help in automatically applying this workaround.
 
 Because Surefire and Gradle reports provide the results in a `<Class Name> - <Method Name>`
 format, only scenario names or example numbers are reported. This


### PR DESCRIPTION
### 🤔 What's changed?

This PR just adds a link to https://github.com/gradle/cucumber-companion to the cucumber-junit-platform-engine's README.md

### ⚡️ What's your motivation? 

Gradle/Maven support for running Cucumber tests has been a frequent request among the Cucumber community. As native support in Surefire/Gradle is unlikely to come in the foreseeable future, we (Gradle Inc.) created the _Cucumber-Companion_ to simplify implementing the suggested junit-suite-engine workaround.
While we haven't advertised the plugins publicly yet, we reckoned it might be a nice fit to mention them here.

### 🏷️ What kind of change is this?

- 📖 Minor documentation update

### ♻️ Anything particular you want feedback on?

Is this the proper location/wording to mention the plugin? Just let me know what you think about mentioning the plugin here.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
