### PR TITLE
[JUnit Platform Engine] Improve Maven and Gradle compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [JUnit Platform Engine] Improve Maven and Gradle compatibility ([#2832](https://github.com/cucumber/cucumber-jvm/pull/2832) M.P. Korstanje)
 
 ## [7.15.0] - 2023-12-11
 ### Changed

--- a/cucumber-junit-platform-engine/README.md
+++ b/cucumber-junit-platform-engine/README.md
@@ -342,9 +342,9 @@ cucumber.features=                                             # comma separated
                                                                # Platform will be ignored. This may lead to multiple
                                                                # executions of Cucumber. For example when used in
                                                                # combination with the JUnit Platform Suite Engine.
-                                                               # When using cucumber through the JUnit Platform
+                                                               # When using Cucumber through the JUnit Platform
                                                                # Launcher API or the JUnit Platform Suite Engine, it is
-                                                               # recommended to respectively use JUnits
+                                                               # recommended to respectively use JUnit's
                                                                # DiscoverySelectors or equivalent annotations.
 
 cucumber.filter.tags=                                          # a cucumber tag expression.

--- a/cucumber-junit-platform-engine/README.md
+++ b/cucumber-junit-platform-engine/README.md
@@ -160,9 +160,6 @@ To select the scenario on line 10 of the `example.feature` file use:
 mvn test -Dsurefire.includeJUnit5Engines=cucumber -Dcucumber.plugin=pretty -Dcucumber.features=path/to/example.feature:10 
 ```
 
-Note: Add `-Dcucumber.plugin=pretty` to get test reports. Maven will not
-report on tests without a class.
-
 #### Gradle
 
 TODO: (Feel free to send a pull request. ;))
@@ -342,7 +339,13 @@ cucumber.filter.name=                                          # a regular expre
 cucumber.features=                                             # comma separated paths to feature files. 
                                                                # example: path/to/example.feature, path/to/other.feature
                                                                # note: When used any discovery selectors from the JUnit
-                                                               # Platform will be ignored. Use with caution and care.
+                                                               # Platform will be ignored. This may lead to multiple
+                                                               # executions of Cucumber. For example when used in
+                                                               # combination with the JUnit Platform Suite Engine.
+                                                               # When using cucumber through the JUnit Platform
+                                                               # Launcher API or the JUnit Platform Suite Engine, it is
+                                                               # recommended to respectively use JUnits
+                                                               # DiscoverySelectors or equivalent annotations.
 
 cucumber.filter.tags=                                          # a cucumber tag expression.
                                                                # only scenarios with matching tags are executed.

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -61,7 +61,7 @@ public final class Constants {
      * scenario or example at line 42 in the example feature file</li>
      * </ul>
      * <p>
-     * Note: When used any discovery selectors from the JUnit Platform will be
+     * Note: When used, any discovery selectors from the JUnit Platform will be
      * ignored. This may lead to multiple executions of Cucumber. For example
      * when used in combination with the JUnit Platform Suite Engine.
      * <p>

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -61,8 +61,19 @@ public final class Constants {
      * scenario or example at line 42 in the example feature file</li>
      * </ul>
      * <p>
-     * NOTE: When used any discovery selectors from the JUnit Platform will be
-     * ignored. Use with caution and care.
+     * Note: When used any discovery selectors from the JUnit Platform will be
+     * ignored. This may lead to multiple executions of Cucumber. For example
+     * when used in combination with the JUnit Platform Suite Engine.
+     * <p>
+     * When using cucumber through the JUnit Platform Launcher API or the JUnit
+     * Platform Suite Engine, it is recommended to respectively use the
+     * {@link org.junit.platform.engine.discovery.DiscoverySelectors} or
+     * equivalent annotations.
+     * <p>
+     * Additionally, when this property is used, to work around limitations in
+     * Maven Surefire and Gradle, the Cucumber Engine will report its
+     * {@link org.junit.platform.engine.TestSource} as
+     * {@link CucumberTestEngine}.
      *
      * @see io.cucumber.core.feature.FeatureWithLines
      */

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -65,7 +65,7 @@ public final class Constants {
      * ignored. This may lead to multiple executions of Cucumber. For example
      * when used in combination with the JUnit Platform Suite Engine.
      * <p>
-     * When using cucumber through the JUnit Platform Launcher API or the JUnit
+     * When using Cucumber through the JUnit Platform Launcher API or the JUnit
      * Platform Suite Engine, it is recommended to respectively use the
      * {@link org.junit.platform.engine.discovery.DiscoverySelectors} or
      * equivalent annotations.

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineDescriptor.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineDescriptor.java
@@ -1,6 +1,7 @@
 package io.cucumber.junit.platform.engine;
 
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 import org.junit.platform.engine.support.hierarchical.Node;
@@ -11,9 +12,20 @@ import java.util.function.Consumer;
 class CucumberEngineDescriptor extends EngineDescriptor implements Node<CucumberEngineExecutionContext> {
 
     static final String ENGINE_ID = "cucumber";
+    private final TestSource source;
 
     CucumberEngineDescriptor(UniqueId uniqueId) {
+        this(uniqueId, null);
+    }
+
+    CucumberEngineDescriptor(UniqueId uniqueId, TestSource source) {
         super(uniqueId, "Cucumber");
+        this.source = source;
+    }
+
+    @Override
+    public Optional<TestSource> getSource() {
+        return Optional.ofNullable(this.source);
     }
 
     @Override

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberTestEngine.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberTestEngine.java
@@ -5,12 +5,15 @@ import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.EngineDiscoveryRequest;
 import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.config.PrefixedConfigurationParameters;
+import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutorService;
 
+import static io.cucumber.junit.platform.engine.Constants.FEATURES_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.PARALLEL_CONFIG_PREFIX;
 import static io.cucumber.junit.platform.engine.Constants.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME;
 
@@ -39,9 +42,22 @@ public final class CucumberTestEngine extends HierarchicalTestEngine<CucumberEng
 
     @Override
     public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
-        CucumberEngineDescriptor engineDescriptor = new CucumberEngineDescriptor(uniqueId);
+        TestSource testSource = createEngineTestSource(discoveryRequest);
+        CucumberEngineDescriptor engineDescriptor = new CucumberEngineDescriptor(uniqueId, testSource);
         new DiscoverySelectorResolver().resolveSelectors(discoveryRequest, engineDescriptor);
         return engineDescriptor;
+    }
+
+    private static TestSource createEngineTestSource(EngineDiscoveryRequest discoveryRequest) {
+        // Workaround. Test Engines do not normally have test source.
+        // Maven does not count tests that do not have a ClassSource somewhere
+        // in the test descriptor tree.
+        // Gradle will report all tests as coming from an "Unknown Class"
+        ConfigurationParameters configuration = discoveryRequest.getConfigurationParameters();
+        if (configuration.get(FEATURES_PROPERTY_NAME).isPresent()) {
+            return ClassSource.from(CucumberTestEngine.class);
+        }
+        return null;
     }
 
     @Override

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberTestEngine.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberTestEngine.java
@@ -53,6 +53,7 @@ public final class CucumberTestEngine extends HierarchicalTestEngine<CucumberEng
         // Maven does not count tests that do not have a ClassSource somewhere
         // in the test descriptor tree.
         // Gradle will report all tests as coming from an "Unknown Class"
+        // See: https://github.com/cucumber/cucumber-jvm/pull/2498
         ConfigurationParameters configuration = discoveryRequest.getConfigurationParameters();
         if (configuration.get(FEATURES_PROPERTY_NAME).isPresent()) {
             return ClassSource.from(CucumberTestEngine.class);


### PR DESCRIPTION
### 🤔 What's changed?

Maven Surefire and Gradle do not (yet?) fully support the JUnit Platform API[1]. To work around this problem the `cucumber.features` can be used.

However, because Maven Surefire and Gradle only attempt to discover class based tests, they do expect a class source. As a result of this missing source, Maven Surefire will not report on the executed tests while Gradle reports the tests as having been executed by an "Unknown Class".

By having the Cucumber TestEngine pretend to have a ClassSource when `cucumber.features` is used both these problems go away.

1. https://github.com/cucumber/cucumber-jvm/pull/2498

### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [X] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [X] My change requires a change to the documentation.
  - [X] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
