### PR TITLE
[JUnit Platform Engine] @SelectPackages not @SelectClasspathResource

### DIFF
--- a/cucumber-archetype/src/main/resources/archetype-resources/src/test/java/RunCucumberTest.java
+++ b/cucumber-archetype/src/main/resources/archetype-resources/src/test/java/RunCucumberTest.java
@@ -2,14 +2,14 @@ package ${package};
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("${packageInPathFormat}")
+@SelectPackages("${package}")
 @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
 public class RunCucumberTest {
 }

--- a/cucumber-archetype/src/test/resources/projects/should-generate-project/reference/src/test/java/com/example/RunCucumberTest.java
+++ b/cucumber-archetype/src/test/resources/projects/should-generate-project/reference/src/test/java/com/example/RunCucumberTest.java
@@ -2,14 +2,14 @@ package com.example;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("com/example")
+@SelectPackages("com.example")
 @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
 public class RunCucumberTest {
 }

--- a/cucumber-cdi2/src/test/java/io/cucumber/cdi2/example/RunCucumberTest.java
+++ b/cucumber-cdi2/src/test/java/io/cucumber/cdi2/example/RunCucumberTest.java
@@ -1,11 +1,11 @@
 package io.cucumber.cdi2.example;
 
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/cdi2/example")
+@SelectPackages("io.cucumber.cdi2.example")
 public class RunCucumberTest {
 }

--- a/cucumber-deltaspike/src/test/java/io/cucumber/deltaspike/RunCucumberTest.java
+++ b/cucumber-deltaspike/src/test/java/io/cucumber/deltaspike/RunCucumberTest.java
@@ -2,14 +2,14 @@ package io.cucumber.deltaspike;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/deltaspike")
+@SelectPackages("io.cucumber.deltaspike")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "io.cucumber.deltaspike")
 public class RunCucumberTest {
 

--- a/cucumber-guice/src/test/java/io/cucumber/guice/integration/RunCucumberTest.java
+++ b/cucumber-guice/src/test/java/io/cucumber/guice/integration/RunCucumberTest.java
@@ -2,7 +2,7 @@ package io.cucumber.guice.integration;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
@@ -15,7 +15,7 @@ import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
  */
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/guice/integration")
+@SelectPackages("io.cucumber.guice.integration")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "io.cucumber.guice.integration")
 public class RunCucumberTest {
 

--- a/cucumber-jakarta-cdi/src/test/java/io/cucumber/jakarta/cdi/example/RunCucumberTest.java
+++ b/cucumber-jakarta-cdi/src/test/java/io/cucumber/jakarta/cdi/example/RunCucumberTest.java
@@ -2,14 +2,14 @@ package io.cucumber.jakarta.cdi.example;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/jakarta/cdi/example")
+@SelectPackages("io.cucumber.jakarta.cdi.example")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "io.cucumber.jakarta.cdi.example")
 public class RunCucumberTest {
 

--- a/cucumber-jakarta-openejb/src/test/java/io/cucumber/jakarta/openejb/RunCucumberTest.java
+++ b/cucumber-jakarta-openejb/src/test/java/io/cucumber/jakarta/openejb/RunCucumberTest.java
@@ -2,14 +2,14 @@ package io.cucumber.jakarta.openejb;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/jakarta/openejb")
+@SelectPackages("io.cucumber.jakarta.openejb")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "io.cucumber.jakarta.openejb")
 public class RunCucumberTest {
 

--- a/cucumber-java/src/test/java/io/cucumber/java/annotation/RunCucumberTest.java
+++ b/cucumber-java/src/test/java/io/cucumber/java/annotation/RunCucumberTest.java
@@ -2,14 +2,14 @@ package io.cucumber.java.annotation;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/java/annotation")
+@SelectPackages("io.cucumber.java.annotation")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "io.cucumber.java.annotation")
 public class RunCucumberTest {
 

--- a/cucumber-java/src/test/java/io/cucumber/java/defaultstransformer/RunCucumberTest.java
+++ b/cucumber-java/src/test/java/io/cucumber/java/defaultstransformer/RunCucumberTest.java
@@ -2,14 +2,14 @@ package io.cucumber.java.defaultstransformer;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/java/defaultstransformer")
+@SelectPackages("io.cucumber.java.defaultstransformer")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "io.cucumber.java.defaultstransformer")
 public class RunCucumberTest {
 

--- a/cucumber-java8/src/test/java/io/cucumber/java8/RunCucumberTest.java
+++ b/cucumber-java8/src/test/java/io/cucumber/java8/RunCucumberTest.java
@@ -2,14 +2,14 @@ package io.cucumber.java8;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/java8")
+@SelectPackages("io.cucumber.java8")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "io.cucumber.java8")
 public class RunCucumberTest {
 

--- a/cucumber-junit-platform-engine/README.md
+++ b/cucumber-junit-platform-engine/README.md
@@ -187,14 +187,14 @@ package com.example;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("com/example")
+@SelectPackages("com.example")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "com.example")
 public class RunCucumberTest {
 }

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Cucumber.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Cucumber.java
@@ -28,13 +28,13 @@ import java.lang.annotation.Target;
  *package com.example;
  *
  *import org.junit.platform.suite.api.ConfigurationParameter;
- *import org.junit.platform.suite.api.SelectClasspathResource;
+ *import org.junit.platform.suite.api.SelectPackages;
  *import org.junit.platform.suite.api.Suite;
  *
  *import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
  *
  *&#64;Suite
- *&#64;SelectClasspathResource("com/example")
+ *&#64;SelectPackages("com.example")
  *&#64;ConfigurationParameter(
  *   key = GLUE_PROPERTY_NAME,
  *   value = "com.example"

--- a/cucumber-kotlin-java8/src/test/kotlin/io/cucumber/kotlin/RunCucumberTest.kt
+++ b/cucumber-kotlin-java8/src/test/kotlin/io/cucumber/kotlin/RunCucumberTest.kt
@@ -3,11 +3,11 @@ package io.cucumber.kotlin
 import io.cucumber.junit.platform.engine.Constants
 import org.junit.platform.suite.api.ConfigurationParameter
 import org.junit.platform.suite.api.IncludeEngines
-import org.junit.platform.suite.api.SelectClasspathResource
+import org.junit.platform.suite.api.SelectPackages
 import org.junit.platform.suite.api.Suite
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/kotlin")
+@SelectPackages("io.cucumber.kotlin")
 @ConfigurationParameter(key = Constants.GLUE_PROPERTY_NAME, value = "io.cucumber.kotlin")
 class RunCucumberTest

--- a/cucumber-openejb/src/test/java/io/cucumber/openejb/RunCucumberTest.java
+++ b/cucumber-openejb/src/test/java/io/cucumber/openejb/RunCucumberTest.java
@@ -2,14 +2,14 @@ package io.cucumber.openejb;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/openejb")
+@SelectPackages("io.cucumber.openejb")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "io.cucumber.openejb")
 public class RunCucumberTest {
 

--- a/cucumber-spring/README.md
+++ b/cucumber-spring/README.md
@@ -79,13 +79,13 @@ Repeat as needed.
 package com.example;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 @Suite
-@SelectClasspathResource("com/example/application/one")
+@SelectPackages("com.example.application.one")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "com.example.application.one")
 public class ApplicationOneTest {
 

--- a/examples/calculator-java-junit5/src/test/java/io/cucumber/examples/calculator/RunCucumberTest.java
+++ b/examples/calculator-java-junit5/src/test/java/io/cucumber/examples/calculator/RunCucumberTest.java
@@ -2,7 +2,7 @@ package io.cucumber.examples.calculator;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
@@ -14,7 +14,7 @@ import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
  */
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/examples/calculator")
+@SelectPackages("io.cucumber.examples.calculator")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "io.cucumber.examples.calculator")
 public class RunCucumberTest {
 }

--- a/examples/spring-java-junit5/src/test/java/io/cucumber/examples/spring/application/RunCucumberTest.java
+++ b/examples/spring-java-junit5/src/test/java/io/cucumber/examples/spring/application/RunCucumberTest.java
@@ -2,14 +2,14 @@ package io.cucumber.examples.spring.application;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("io/cucumber/examples/spring/application")
+@SelectPackages("io.cucumber.examples.spring.application")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "io.cucumber.examples.spring.application")
 public class RunCucumberTest {
 }

--- a/release-notes/v7.0.0.md
+++ b/release-notes/v7.0.0.md
@@ -79,14 +79,14 @@ package com.example;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("com/example/application")
+@SelectPackages("com.example.application")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "com.example.application")
 public class RunCucumberTest {
 


### PR DESCRIPTION
### 🤔 What's changed?

`@SelectClasspathResource` is intended to be used for single resources whereas `@SelectPackages` is intended for packages containing those resources.

Currently, it doesn't matter because Cucumber is smart enough to scan everything given a directory. But we may want to change that in the future when we use JUnits `EngineDiscoveryRequestResolver` API (https://github.com/cucumber/cucumber-jvm/pull/2835).

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without 

