### PR TITLE
Feature parameterized name for example display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [JUnit Platform Engine] Improve Maven and Gradle compatibility ([#2832](https://github.com/cucumber/cucumber-jvm/pull/2832) M.P. Korstanje)
+- [JUnit Platform Engine] Support for parameters `cucumber.junit-platform.naming-strategy.short.example-name` and `cucumber.junit-platform.naming-strategy.long.example-name` ([#2743](https://github.com/cucumber/cucumber-jvm/issues/2743) V.V. Belov)
 
 ## [7.15.0] - 2023-12-11
 ### Changed

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -140,6 +140,35 @@ public final class Constants {
     public static final String JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME = "cucumber.junit-platform.naming-strategy";
 
     /**
+     * Property name used to configure the naming strategy of examples in case
+     * of short naming strategy: {@value}
+     * <p>
+     * Value must be one of {@code example-number} or {@code pickle-name}. By
+     * default, example-numbers are used.
+     * <p>
+     * When set to pickle-name the parent scenario name is used. So for scenario
+     * name {@code Adding <a> and <b>} and example with params {@code a = 10}
+     * and {@code b = 20} the following name would be produced:
+     * {@code Adding 10 and 20}. This is useful in case of parametrised scenario
+     * names.
+     */
+    @API(status = Status.EXPERIMENTAL, since = "7.16.0")
+    public static final String JUNIT_PLATFORM_SHORT_NAMING_STRATEGY_EXAMPLE_NAME = "cucumber.junit-platform.naming-strategy.short.example-name";
+
+    /**
+     * Property name used to configure the naming strategy of examples in case
+     * of long naming strategy: {@value}
+     * <p>
+     * Same as {@code JUNIT_PLATFORM_SHORT_NAMING_STRATEGY_EXAMPLE_NAME} except
+     * for scenario name {@code Adding <a> and <b>} and example with params
+     * {@code a = 10} and {@code b = 20} the following name would be produced:
+     * {@code Feature Name - Rule Name - Adding <a> and <b> - Examples Name - Adding 10 and 20}.
+     * This is useful in case of parametrised scenario names.
+     */
+    @API(status = Status.EXPERIMENTAL, since = "7.16.0")
+    public static final String JUNIT_PLATFORM_LONG_NAMING_STRATEGY_EXAMPLE_NAME = "cucumber.junit-platform.naming-strategy.long.example-name";
+
+    /**
      * Property name to enable plugins: {@value}
      * <p>
      * A comma separated list of {@code [PLUGIN[:PATH_OR_URL]]} e.g:

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
@@ -32,7 +32,9 @@ import static io.cucumber.junit.platform.engine.Constants.FEATURES_PROPERTY_NAME
 import static io.cucumber.junit.platform.engine.Constants.FILTER_NAME_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.FILTER_TAGS_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_LONG_NAMING_STRATEGY_EXAMPLE_NAME;
 import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_SHORT_NAMING_STRATEGY_EXAMPLE_NAME;
 import static io.cucumber.junit.platform.engine.Constants.OBJECT_FACTORY_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
@@ -171,9 +173,17 @@ class CucumberEngineOptions implements
     }
 
     NamingStrategy namingStrategy() {
-        return configurationParameters
+        DefaultNamingStrategy defaultNamingStrategy = configurationParameters
                 .get(JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME, DefaultNamingStrategy::getStrategy)
                 .orElse(DefaultNamingStrategy.SHORT);
+
+        String exampleNamingStrategyVar = defaultNamingStrategy == DefaultNamingStrategy.SHORT
+                ? JUNIT_PLATFORM_SHORT_NAMING_STRATEGY_EXAMPLE_NAME
+                : JUNIT_PLATFORM_LONG_NAMING_STRATEGY_EXAMPLE_NAME;
+
+        return configurationParameters
+                .get(exampleNamingStrategyVar, defaultNamingStrategy::specify)
+                .orElse(defaultNamingStrategy);
     }
 
     List<FeatureWithLines> featuresWithLines() {

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DefaultNamingStrategy.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DefaultNamingStrategy.java
@@ -1,26 +1,23 @@
 package io.cucumber.junit.platform.engine;
 
+import io.cucumber.core.gherkin.Feature;
 import io.cucumber.plugin.event.Node;
 
 import java.util.Locale;
 import java.util.function.Supplier;
 
 enum DefaultNamingStrategy implements NamingStrategy {
-
     LONG {
         @Override
         public String name(Node node) {
-            StringBuilder builder = new StringBuilder();
-            builder.append(nameOrKeyword(node));
-            node = node.getParent().orElse(null);
+            return longStrategy(node, nameOrKeyword(node));
+        }
+    },
 
-            while (node != null) {
-                builder.insert(0, " - ");
-                builder.insert(0, nameOrKeyword(node));
-                node = node.getParent().orElse(null);
-            }
-
-            return builder.toString();
+    LONG_WITH_PICKLE_NAME {
+        @Override
+        public String name(Node node) {
+            return longStrategy(node, pickleName(node));
         }
     },
 
@@ -29,10 +26,28 @@ enum DefaultNamingStrategy implements NamingStrategy {
         public String name(Node node) {
             return nameOrKeyword(node);
         }
+    },
+
+    SHORT_WITH_PICKLE_NAME {
+        @Override
+        public String name(Node node) {
+            return pickleName(node);
+        }
     };
 
     static DefaultNamingStrategy getStrategy(String s) {
         return valueOf(s.toUpperCase(Locale.ROOT));
+    }
+
+    NamingStrategy specify(String exampleStrategy) {
+        switch (exampleStrategy) {
+            case "example-number":
+                return this;
+            case "pickle-name":
+                return this == LONG ? LONG_WITH_PICKLE_NAME : SHORT_WITH_PICKLE_NAME;
+            default:
+                throw new IllegalArgumentException("Unrecognized example NamingStrategy " + exampleStrategy);
+        }
     }
 
     private static String nameOrKeyword(Node node) {
@@ -40,4 +55,33 @@ enum DefaultNamingStrategy implements NamingStrategy {
         return node.getName().orElseGet(keyword);
     }
 
+    private static String longStrategy(Node node, String currentNodeName) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(currentNodeName);
+        node = node.getParent().orElse(null);
+
+        while (node != null) {
+            builder.insert(0, " - ");
+            builder.insert(0, nameOrKeyword(node));
+            node = node.getParent().orElse(null);
+        }
+
+        return builder.toString();
+    }
+
+    private static String pickleName(Node node) {
+        if (!(node instanceof Node.Example)) {
+            return nameOrKeyword(node);
+        }
+
+        Node parent = node;
+        do {
+            parent = parent.getParent().orElse(null);
+        } while (!(parent instanceof Feature) && parent != null);
+
+        if (parent == null) {
+            return nameOrKeyword(node);
+        }
+        return ((Feature) parent).getPickleAt(node).getName();
+    }
 }

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
@@ -12,6 +12,7 @@ import org.junit.platform.engine.support.hierarchical.Node;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -19,7 +20,9 @@ import java.util.stream.Collectors;
 import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME_PREFIX;
 import static io.cucumber.junit.platform.engine.Constants.EXECUTION_EXCLUSIVE_RESOURCES_PREFIX;
 import static io.cucumber.junit.platform.engine.Constants.EXECUTION_MODE_FEATURE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_LONG_NAMING_STRATEGY_EXAMPLE_NAME;
 import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_SHORT_NAMING_STRATEGY_EXAMPLE_NAME;
 import static io.cucumber.junit.platform.engine.Constants.READ_SUFFIX;
 import static io.cucumber.junit.platform.engine.Constants.READ_WRITE_SUFFIX;
 import static java.util.Arrays.asList;
@@ -156,6 +159,36 @@ class FeatureResolverTest {
         TestDescriptor example = getExample();
         assertEquals("A feature with scenario outlines - A scenario outline - With some text - Example #1.1",
             example.getDisplayName());
+    }
+
+    @Test
+    void longNamesWithPickleNames() {
+        configurationParameters = new MapConfigurationParameters(Map.of(
+            JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME, "long",
+            JUNIT_PLATFORM_LONG_NAMING_STRATEGY_EXAMPLE_NAME, "pickle-name"));
+
+        TestDescriptor example = getExample();
+        assertEquals("A feature with scenario outlines - A scenario outline - With some text - A scenario outline",
+            example.getDisplayName());
+    }
+
+    @Test
+    void shortNamesWithExampleNumbers() {
+        configurationParameters = new MapConfigurationParameters(
+            JUNIT_PLATFORM_SHORT_NAMING_STRATEGY_EXAMPLE_NAME, "example-number");
+
+        TestDescriptor example = getExample();
+        assertEquals("Example #1.1", example.getDisplayName());
+    }
+
+    @Test
+    void shortNamesWithPickleNames() {
+        configurationParameters = new MapConfigurationParameters(Map.of(
+            JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME, "short",
+            JUNIT_PLATFORM_SHORT_NAMING_STRATEGY_EXAMPLE_NAME, "pickle-name"));
+
+        TestDescriptor example = getExample();
+        assertEquals("A scenario outline", example.getDisplayName());
     }
 
     private TestDescriptor getExample() {


### PR DESCRIPTION
Hi, this closes [#2743](https://github.com/cucumber/cucumber-jvm/issues/2743). changes:

- new param `cucumber.junit-platform.naming-strategy.short.example-name` for example naming in case of short naming strategy
- new param `cucumber.junit-platform.naming-strategy.long.example-name` for example naming in case of long naming strategy
- tests for the above 

Comments and advice are welcome!

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.