### PR TITLE
[Core] Include stack traces in html report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [Core] Include stack traces in html report ([#2862](https://github.com/cucumber/cucumber-jvm/pull/2862) M.P. Korstanje)
 
 ## [7.16.0] - 2024-03-21
 ### Added

--- a/cucumber-bom/pom.xml
+++ b/cucumber-bom/pom.xml
@@ -16,8 +16,8 @@
         <cucumber-expressions.version>17.1.0</cucumber-expressions.version>
         <gherkin.version>28.0.0</gherkin.version>
         <html-formatter.version>21.3.0</html-formatter.version>
-        <junit-xml-formatter.version>0.2.1</junit-xml-formatter.version>
-        <messages.version>24.0.1</messages.version>
+        <junit-xml-formatter.version>0.3.0</junit-xml-formatter.version>
+        <messages.version>24.1.0</messages.version>
         <tag-expressions.version>6.1.0</tag-expressions.version>
     </properties>
 

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/TestStep.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/TestStep.java
@@ -10,9 +10,6 @@ import io.cucumber.plugin.event.TestCase;
 import io.cucumber.plugin.event.TestStepFinished;
 import io.cucumber.plugin.event.TestStepStarted;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
@@ -117,7 +114,7 @@ abstract class TestStep implements io.cucumber.plugin.event.TestStep {
 
         TestStepResult testStepResult = new TestStepResult(
             toMessage(duration),
-            result.getError() != null ? extractStackTrace(result.getError()) : null,
+            result.getError() != null ? result.getError().getMessage() : null,
             from(result.getStatus()),
             result.getError() != null ? toMessage(result.getError()) : null);
 
@@ -128,12 +125,4 @@ abstract class TestStep implements io.cucumber.plugin.event.TestStep {
             toMessage(stopTime)));
         bus.send(envelope);
     }
-
-    private String extractStackTrace(Throwable error) {
-        ByteArrayOutputStream s = new ByteArrayOutputStream();
-        PrintStream printStream = new PrintStream(s);
-        error.printStackTrace(printStream);
-        return new String(s.toByteArray(), StandardCharsets.UTF_8);
-    }
-
 }

--- a/cucumber-core/src/main/java/io/cucumber/core/runtime/CucumberExecutionContext.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runtime/CucumberExecutionContext.java
@@ -24,7 +24,6 @@ import java.util.ResourceBundle;
 import java.util.function.Consumer;
 
 import static io.cucumber.cienvironment.DetectCiEnvironment.detectCiEnvironment;
-import static io.cucumber.core.exception.ExceptionUtils.printStackTrace;
 import static io.cucumber.core.exception.ExceptionUtils.throwAsUncheckedException;
 import static io.cucumber.core.exception.UnrecoverableExceptions.rethrowIfUnrecoverable;
 import static io.cucumber.messages.Convertor.toMessage;
@@ -118,7 +117,7 @@ public final class CucumberExecutionContext {
         bus.send(new TestRunFinished(instant, result));
 
         io.cucumber.messages.types.TestRunFinished testRunFinished = new io.cucumber.messages.types.TestRunFinished(
-            exception != null ? printStackTrace(exception) : null,
+            exception != null ? exception.getMessage() : null,
             exception == null && exitStatus.isSuccess(),
             toMessage(instant),
             exception == null ? null : toMessage(exception));


### PR DESCRIPTION
### 🤔 What's changed?

Before

![image](https://github.com/cucumber/cucumber-jvm/assets/6946919/e2c59a74-85b9-43ae-a55a-7455f62e1ca2)

After

![image](https://github.com/cucumber/cucumber-jvm/assets/6946919/4fda04d5-271b-439f-b477-9295268ac7ad)

Depends on https://github.com/cucumber/messages/pull/213
Depends on https://github.com/cucumber/cucumber-junit-xml-formatter/pull/30

### ⚡️ What's your motivation? 

With https://github.com/cucumber/react-components/pull/345 the html formatter started to support rendering stack traces. Unfortunately this also broke the regular rendering of stacktrace. And fixing this required including the stack trace the xml report aswell so that when the `Convertor` in messages was fixed to always include the stacktrace, we wouldn't render the stacktrace in the xml formatter twice.


### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

