### PR TITLE
[Core] Add hook method name to TeamCityPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [Core] The TeamCityPlugin for IntelliJ IDEA now uses the hook's method name for the name of the hook itself. ([#2798](https://github.com/cucumber/cucumber-jvm/issues/2798) V.V. Belov)
 
 ## [7.17.0] - 2024-04-18
 ### Added

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/TeamCityPlugin.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/TeamCityPlugin.java
@@ -254,16 +254,20 @@ public class TeamCityPlugin implements EventListener {
             return pickleStepTestStep.getUri() + ":" + pickleStepTestStep.getStep().getLine();
         }
         if (testStep instanceof HookTestStep) {
-            return hookStepLocationFormatter(
+            return formatHookStepLocation(
                 (HookTestStep) testStep,
-                (fqDeclaringClassName, classOrMethodName) -> String.format("java:test://%s/%s", fqDeclaringClassName,
-                    classOrMethodName),
+                javaTestLocationUri(),
                 TestStep::getCodeLocation);
         }
         return testStep.getCodeLocation();
     }
 
-    private String hookStepLocationFormatter(
+    private static BiFunction<String, String, String> javaTestLocationUri() {
+        return (fqDeclaringClassName, classOrMethodName) -> String.format("java:test://%s/%s", fqDeclaringClassName,
+            classOrMethodName);
+    }
+
+    private String formatHookStepLocation(
             HookTestStep hookTestStep, BiFunction<String, String, String> hookStepCase,
             Function<HookTestStep, String> defaultHookName
     ) {
@@ -357,13 +361,17 @@ public class TeamCityPlugin implements EventListener {
         }
         if (testStep instanceof HookTestStep) {
             HookTestStep hookTestStep = (HookTestStep) testStep;
-            return hookStepLocationFormatter(
+            return formatHookStepLocation(
                 hookTestStep,
-                (fqDeclaringClassName, classOrMethodName) -> String.format("%s(%s)", getHookName(hookTestStep),
-                    classOrMethodName),
+                hookNameFormat(hookTestStep),
                 this::getHookName);
         }
         return "Unknown step";
+    }
+
+    private BiFunction<String, String, String> hookNameFormat(HookTestStep hookTestStep) {
+        return (fqDeclaringClassName, classOrMethodName) -> String.format("%s(%s)", getHookName(hookTestStep),
+            classOrMethodName);
     }
 
     private String getSnippets(TestCase testCase) {

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/TeamCityPlugin.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/TeamCityPlugin.java
@@ -255,9 +255,10 @@ public class TeamCityPlugin implements EventListener {
         }
         if (testStep instanceof HookTestStep) {
             return hookStepLocationFormatter(
-                    (HookTestStep) testStep,
-                    (fqDeclaringClassName, classOrMethodName) -> String.format("java:test://%s/%s", fqDeclaringClassName, classOrMethodName),
-                    TestStep::getCodeLocation);
+                (HookTestStep) testStep,
+                (fqDeclaringClassName, classOrMethodName) -> String.format("java:test://%s/%s", fqDeclaringClassName,
+                    classOrMethodName),
+                TestStep::getCodeLocation);
         }
         return testStep.getCodeLocation();
     }
@@ -357,9 +358,10 @@ public class TeamCityPlugin implements EventListener {
         if (testStep instanceof HookTestStep) {
             HookTestStep hookTestStep = (HookTestStep) testStep;
             return hookStepLocationFormatter(
-                    hookTestStep,
-                    (fqDeclaringClassName, classOrMethodName) -> String.format("%s(%s)", getHookName(hookTestStep), classOrMethodName),
-                    this::getHookName);
+                hookTestStep,
+                (fqDeclaringClassName, classOrMethodName) -> String.format("%s(%s)", getHookName(hookTestStep),
+                    classOrMethodName),
+                this::getHookName);
         }
         return "Unknown step";
     }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/TeamCityPluginTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/TeamCityPluginTest.java
@@ -287,7 +287,7 @@ class TeamCityPluginTest {
                 .run();
 
         assertThat(out, bytes(containsString("" +
-                "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = 'java:test://com.example.HookDefinition/beforeHook' captureStandardOutput = 'true' name = 'Before']\n")));
+                "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = 'java:test://com.example.HookDefinition/beforeHook' captureStandardOutput = 'true' name = 'Before(beforeHook)']\n")));
     }
 
     @Test
@@ -310,7 +310,7 @@ class TeamCityPluginTest {
                 .run();
 
         assertThat(out, bytes(containsString("" +
-                "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = 'java:test://com.example.HookDefinition/HookDefinition' captureStandardOutput = 'true' name = 'Before']\n")));
+                "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = 'java:test://com.example.HookDefinition/HookDefinition' captureStandardOutput = 'true' name = 'Before(HookDefinition)']\n")));
     }
 
     @Test


### PR DESCRIPTION
Hi, this closes [#2798](https://github.com/cucumber/cucumber-jvm/issues/2798). changes:

### 🤔 What's changed?

The TeamCityPlugin for IntelliJ IDEA now uses the hook's method name for the name of the hook itself.
For example, if we have a hook with the method name `com.example.HookDefinition.beforeHook()`, the generated name will be `Before(beforeHook)`.
If we have a hook with the method name `com.example.HookDefinition.<init>(HookDefinition.java:12)`, the generated name will be `Before(HookDefinition)`.
If the hook's method can't be identified then fallback to simple hook name.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.