### PR TITLE
[Core] Allow feature with line syntax to target rules and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
+### Added
 - [Core] The TeamCityPlugin for IntelliJ IDEA now uses the hook's method name for the name of the hook itself. ([#2798](https://github.com/cucumber/cucumber-jvm/issues/2798) V.V. Belov)
+- [Core] Allow feature with line syntax to target rules and examples. ([#2884](https://github.com/cucumber/cucumber-jvm/issues/2884) M.P. Korstanje)
 
 ## [7.17.0] - 2024-04-18
 ### Added

--- a/cucumber-core/src/main/java/io/cucumber/core/feature/FeatureWithLines.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/feature/FeatureWithLines.java
@@ -14,8 +14,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * Identifies either a directory containing feature files, a specific feature or
- * specific scenarios and examples (pickles) in a feature.
+ * Identifies either a directory containing feature files, a specific feature
+ * file or a feature, rules, scenarios, and/or examples in a feature file.
  * <p>
  * The syntax of a feature with lines defined as either a {@link FeaturePath} or
  * a {@link FeatureIdentifier} followed by a sequence of line numbers each

--- a/cucumber-core/src/main/java/io/cucumber/core/filter/LinePredicate.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/filter/LinePredicate.java
@@ -1,6 +1,7 @@
 package io.cucumber.core.filter;
 
 import io.cucumber.core.gherkin.Pickle;
+import io.cucumber.plugin.event.Location;
 
 import java.net.URI;
 import java.util.Collection;
@@ -24,7 +25,10 @@ final class LinePredicate implements Predicate<Pickle> {
         }
         for (Integer line : lineFilters.get(picklePath)) {
             if (Objects.equals(line, pickle.getLocation().getLine())
-                    || Objects.equals(line, pickle.getScenarioLocation().getLine())) {
+                    || Objects.equals(line, pickle.getScenarioLocation().getLine())
+                    || pickle.getExamplesLocation().map(Location::getLine).map(line::equals).orElse(false)
+                    || pickle.getRuleLocation().map(Location::getLine).map(line::equals).orElse(false)
+                    || pickle.getFeatureLocation().map(Location::getLine).map(line::equals).orElse(false)) {
                 return true;
             }
         }

--- a/cucumber-core/src/test/java/io/cucumber/core/filter/LinePredicateTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/filter/LinePredicateTest.java
@@ -21,13 +21,23 @@ class LinePredicateTest {
         featurePath,
         "" +
                 "Feature: Test feature\n" +
-                "  Scenario Outline: Test scenario\n" +
-                "     Given I have 4 <thing> in my belly\n" +
-                "     Examples:\n" +
-                "       | thing    | \n" +
-                "       | cucumber | \n" +
-                "       | gherkin  | \n");
-    private final Pickle pickle = feature.getPickles().get(0);
+                "  Rule: Test rule\n" +
+                "    Scenario Outline: Test scenario\n" +
+                "       Given I have 4 <thing> in my belly\n" +
+                "       Examples: First\n" +
+                "         | thing    | \n" +
+                "         | cucumber | \n" +
+                "         | gherkin  | \n" +
+                "\n" +
+                "       Examples: Second\n" +
+                "         | thing    | \n" +
+                "         | zukini   | \n" +
+                "         | pickle   | \n"
+    );
+    private final Pickle firstPickle = feature.getPickles().get(0);
+    private final Pickle secondPickle = feature.getPickles().get(1);
+    private final Pickle thirdPickle = feature.getPickles().get(2);
+    private final Pickle fourthPickle = feature.getPickles().get(3);
 
     @Test
     void matches_pickles_from_files_not_in_the_predicate_map() {
@@ -37,47 +47,168 @@ class LinePredicateTest {
         LinePredicate predicate = new LinePredicate(singletonMap(
             URI.create("classpath:another_path/file.feature"),
             singletonList(8)));
-        assertTrue(predicate.test(pickle));
+        assertTrue(predicate.test(firstPickle));
     }
 
     @Test
-    void does_not_matches_pickles_for_no_lines_in_predicate() {
+    void empty() {
         LinePredicate predicate = new LinePredicate(singletonMap(
             featurePath,
             emptyList()));
-        assertFalse(predicate.test(pickle));
+        assertFalse(predicate.test(firstPickle));
+        assertFalse(predicate.test(secondPickle));
+        assertFalse(predicate.test(thirdPickle));
+        assertFalse(predicate.test(fourthPickle));
     }
 
     @Test
-    void matches_pickles_for_any_line_in_predicate() {
+    void matches_at_least_one_line() {
         LinePredicate predicate = new LinePredicate(singletonMap(
             featurePath,
-            asList(2, 4)));
-        assertTrue(predicate.test(pickle));
+            asList(3, 4)));
+        assertTrue(predicate.test(firstPickle));
+        assertTrue(predicate.test(secondPickle));
+        assertTrue(predicate.test(thirdPickle));
+        assertTrue(predicate.test(fourthPickle));
     }
 
     @Test
-    void matches_pickles_on_scenario_location_of_the_pickle() {
+    void matches_feature() {
+        LinePredicate predicate = new LinePredicate(singletonMap(
+            featurePath,
+            singletonList(1)));
+        assertTrue(predicate.test(firstPickle));
+        assertTrue(predicate.test(secondPickle));
+        assertTrue(predicate.test(thirdPickle));
+        assertTrue(predicate.test(fourthPickle));
+    }
+
+    @Test
+    void matches_rule() {
         LinePredicate predicate = new LinePredicate(singletonMap(
             featurePath,
             singletonList(2)));
-        assertTrue(predicate.test(pickle));
+        assertTrue(predicate.test(firstPickle));
+        assertTrue(predicate.test(secondPickle));
+        assertTrue(predicate.test(thirdPickle));
+        assertTrue(predicate.test(fourthPickle));
     }
 
     @Test
-    void matches_pickles_on_example_location_of_the_pickle() {
+    void matches_scenario() {
         LinePredicate predicate = new LinePredicate(singletonMap(
             featurePath,
-            singletonList(6)));
-        assertTrue(predicate.test(pickle));
+            singletonList(3)));
+        assertTrue(predicate.test(firstPickle));
+        assertTrue(predicate.test(secondPickle));
+        assertTrue(predicate.test(thirdPickle));
+        assertTrue(predicate.test(fourthPickle));
     }
 
     @Test
-    void does_not_matches_pickles_not_on_any_line_of_the_predicate() {
+    void does_not_match_step() {
         LinePredicate predicate = new LinePredicate(singletonMap(
             featurePath,
             singletonList(4)));
-        assertFalse(predicate.test(pickle));
+        assertFalse(predicate.test(firstPickle));
+        assertFalse(predicate.test(secondPickle));
+        assertFalse(predicate.test(thirdPickle));
+        assertFalse(predicate.test(fourthPickle));
+    }
+
+    @Test
+    void matches_first_examples() {
+        LinePredicate predicate = new LinePredicate(singletonMap(
+            featurePath,
+            singletonList(5)));
+        assertTrue(predicate.test(firstPickle));
+        assertTrue(predicate.test(secondPickle));
+        assertFalse(predicate.test(thirdPickle));
+        assertFalse(predicate.test(fourthPickle));
+    }
+
+    @Test
+    void does_not_match_example_header() {
+        LinePredicate predicate = new LinePredicate(singletonMap(
+                featurePath,
+                singletonList(6)));
+        assertFalse(predicate.test(firstPickle));
+        assertFalse(predicate.test(secondPickle));
+        assertFalse(predicate.test(thirdPickle));
+        assertFalse(predicate.test(fourthPickle));
+    }
+
+    @Test
+    void matches_first_example() {
+        LinePredicate predicate = new LinePredicate(singletonMap(
+            featurePath,
+            singletonList(7)));
+        assertTrue(predicate.test(firstPickle));
+        assertFalse(predicate.test(secondPickle));
+        assertFalse(predicate.test(thirdPickle));
+        assertFalse(predicate.test(fourthPickle));
+    }
+    @Test
+    void Matches_second_example() {
+        LinePredicate predicate = new LinePredicate(singletonMap(
+            featurePath,
+            singletonList(8)));
+        assertFalse(predicate.test(firstPickle));
+        assertTrue(predicate.test(secondPickle));
+        assertFalse(predicate.test(thirdPickle));
+        assertFalse(predicate.test(fourthPickle));
+    }
+
+    @Test
+    void does_not_match_empty_line() {
+        LinePredicate predicate = new LinePredicate(singletonMap(
+            featurePath,
+            singletonList(9)));
+        assertFalse(predicate.test(firstPickle));
+        assertFalse(predicate.test(secondPickle));
+        assertFalse(predicate.test(thirdPickle));
+        assertFalse(predicate.test(fourthPickle));
+    }
+
+    @Test
+    void matches_second_examples() {
+        LinePredicate predicate = new LinePredicate(singletonMap(
+            featurePath,
+            singletonList(10)));
+        assertFalse(predicate.test(firstPickle));
+        assertFalse(predicate.test(secondPickle));
+        assertTrue(predicate.test(thirdPickle));
+        assertTrue(predicate.test(fourthPickle));
+    }
+    @Test
+    void does_not_match_second_examples_header() {
+        LinePredicate predicate = new LinePredicate(singletonMap(
+            featurePath,
+            singletonList(11)));
+        assertFalse(predicate.test(firstPickle));
+        assertFalse(predicate.test(secondPickle));
+        assertFalse(predicate.test(thirdPickle));
+        assertFalse(predicate.test(fourthPickle));
+    }
+    @Test
+    void matches_third_example() {
+        LinePredicate predicate = new LinePredicate(singletonMap(
+            featurePath,
+            singletonList(12)));
+        assertFalse(predicate.test(firstPickle));
+        assertFalse(predicate.test(secondPickle));
+        assertTrue(predicate.test(thirdPickle));
+        assertFalse(predicate.test(fourthPickle));
+    }
+    @Test
+    void matches_fourth_example() {
+        LinePredicate predicate = new LinePredicate(singletonMap(
+            featurePath,
+            singletonList(13)));
+        assertFalse(predicate.test(firstPickle));
+        assertFalse(predicate.test(secondPickle));
+        assertFalse(predicate.test(thirdPickle));
+        assertTrue(predicate.test(fourthPickle));
     }
 
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/filter/LinePredicateTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/filter/LinePredicateTest.java
@@ -32,8 +32,7 @@ class LinePredicateTest {
                 "       Examples: Second\n" +
                 "         | thing    | \n" +
                 "         | zukini   | \n" +
-                "         | pickle   | \n"
-    );
+                "         | pickle   | \n");
     private final Pickle firstPickle = feature.getPickles().get(0);
     private final Pickle secondPickle = feature.getPickles().get(1);
     private final Pickle thirdPickle = feature.getPickles().get(2);
@@ -130,8 +129,8 @@ class LinePredicateTest {
     @Test
     void does_not_match_example_header() {
         LinePredicate predicate = new LinePredicate(singletonMap(
-                featurePath,
-                singletonList(6)));
+            featurePath,
+            singletonList(6)));
         assertFalse(predicate.test(firstPickle));
         assertFalse(predicate.test(secondPickle));
         assertFalse(predicate.test(thirdPickle));
@@ -148,6 +147,7 @@ class LinePredicateTest {
         assertFalse(predicate.test(thirdPickle));
         assertFalse(predicate.test(fourthPickle));
     }
+
     @Test
     void Matches_second_example() {
         LinePredicate predicate = new LinePredicate(singletonMap(
@@ -180,6 +180,7 @@ class LinePredicateTest {
         assertTrue(predicate.test(thirdPickle));
         assertTrue(predicate.test(fourthPickle));
     }
+
     @Test
     void does_not_match_second_examples_header() {
         LinePredicate predicate = new LinePredicate(singletonMap(
@@ -190,6 +191,7 @@ class LinePredicateTest {
         assertFalse(predicate.test(thirdPickle));
         assertFalse(predicate.test(fourthPickle));
     }
+
     @Test
     void matches_third_example() {
         LinePredicate predicate = new LinePredicate(singletonMap(
@@ -200,6 +202,7 @@ class LinePredicateTest {
         assertTrue(predicate.test(thirdPickle));
         assertFalse(predicate.test(fourthPickle));
     }
+
     @Test
     void matches_fourth_example() {
         LinePredicate predicate = new LinePredicate(singletonMap(

--- a/cucumber-gherkin/src/main/java/io/cucumber/core/gherkin/Pickle.java
+++ b/cucumber-gherkin/src/main/java/io/cucumber/core/gherkin/Pickle.java
@@ -4,6 +4,7 @@ import io.cucumber.plugin.event.Location;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 public interface Pickle {
 
@@ -14,7 +15,7 @@ public interface Pickle {
     String getName();
 
     /**
-     * Returns the location in feature file of the Scenario this pickle was
+     * Returns the location in the feature file of the Scenario this pickle was
      * created from. If this pickle was created from a Scenario Outline this
      * location is the location in the Example section used to fill in the place
      * holders.
@@ -24,13 +25,43 @@ public interface Pickle {
     Location getLocation();
 
     /**
-     * Returns the location in feature file of the Scenario this pickle was
+     * Returns the location in the feature file of the Scenario this pickle was
      * created from. If this pickle was created from a Scenario Outline this
      * location is that of the Scenario
      *
      * @return location in the feature file
      */
     Location getScenarioLocation();
+
+    /**
+     * Returns the location in the feature file of the Rule this pickle was
+     * created from.
+     *
+     * @return location in the feature file
+     */
+    default Optional<Location> getRuleLocation() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the location in the feature file of the Feature this pickle was
+     * created from.
+     *
+     * @return location in the feature file
+     */
+    default Optional<Location> getFeatureLocation() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the location in the feature file of the examples this pickle was
+     * created from.
+     *
+     * @return location in the feature file
+     */
+    default Optional<Location> getExamplesLocation() {
+        return Optional.empty();
+    }
 
     List<Step> getSteps();
 


### PR DESCRIPTION
### 🤔 What's changed?

Given a feature file, it should be possible to provide the line of a Feature, Rule, Scenario, Example and Example. Cucumber should then run all pickles contained in these elements.

For example `example.feature:5:13` should run the cucumber, gherkin and pickle pickles. While `example.feature:10` runs the zukini and pickle pickles. And using either lines 1, 2 or 3 would run all pickles.

```feature
Feature: Example feature                      #  1
  Rule: Example rule                          #  2
    Scenario Outline: Example scenario        #  3
       Given I have 4 <thing> in my belly     #  4
       Examples: First                        #  5
         | thing    |                         #  6
         | cucumber |                         #  7
         | gherkin  |                         #  8
                                              #  9
       Examples: Second                       # 10
         | thing    |                         # 11
         | zukini   |                         # 12
         | pickle   |                         # 13
```

This should make it possible to target (groups of) pickles with a bit more flexibility. And also allow IDEA to select rules.

Note: Using the lines of backgrounds and steps will still not select any pickles.


### ⚡️ What's your motivation? 

Provides the possibility for IDEA to fix  #2882.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
