### PR TITLE
[Spring] Document CucumberContextConfiguration semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [Spring] Document `@CucumberContextConfiguration` semantics ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2887) M.P. Korstanje)
 
 ## [7.18.0] - 2024-05-17
 ### Added

--- a/cucumber-spring/README.md
+++ b/cucumber-spring/README.md
@@ -47,10 +47,14 @@ As a result, a single Cucumber scenario will mostly behave like a JUnit test.
 
 The class annotated with `@CucumberContextConfiguration` is instantiated but not
 initialized by Spring. Instead, this instance is processed by Springs test
-execution listeners. So features that depend on a test execution listener such
-as mock beans will work on the annotated class - but not on other step definition
-classes. Features that depend on initializing beans - such as AspectJ - will not
-work on the annotated class - but will work on other step definition classes.
+execution listeners. So Spring features that depend on a test execution
+listeners, such as mock beans, will work on the annotated class - but not on
+other step definition classes. 
+
+Step definition classes are instantiated and initialized by Spring. Features
+that depend on beans initialisation, such as AspectJ, will work on step
+definition classes - but not on the `@CucumberContextConfiguration` annotated
+class.
 
 For more information configuring Spring tests see:
  - [Spring Framework Documentation - Testing](https://docs.spring.io/spring-framework/docs/current/spring-framework-reference/testing.html)

--- a/cucumber-spring/src/main/java/io/cucumber/spring/CucumberContextConfiguration.java
+++ b/cucumber-spring/src/main/java/io/cucumber/spring/CucumberContextConfiguration.java
@@ -21,7 +21,7 @@ import java.lang.annotation.Target;
  * public class CucumberSpringConfiguration {
  * }
  * </pre>
- * 
+ * <p>
  * Notes:
  * <ul>
  * <li>Only one glue class should be annotated with
@@ -30,6 +30,15 @@ import java.lang.annotation.Target;
  * <li>Cucumber Spring uses Spring's {@code TestContextManager} framework
  * internally. As a result a single Cucumber scenario will mostly behave like a
  * JUnit test.</li>
+ * <li>The class annotated with {@code CucumberContextConfiguration} is
+ * instantiated but not initialized by Spring. This instance is processed by
+ * Springs {@link org.springframework.test.context.TestExecutionListener
+ * TestExecutionListeners}. So features that depend on a test execution listener
+ * such as mock beans will work on the annotated class - but not on other step
+ * definition classes. Features that depend on initializing beans - such as
+ * AspectJ - will not work on the annotated class - but will work on other step
+ * definition classes.</li>
+ * <li></li>
  * </ul>
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/cucumber-spring/src/main/java/io/cucumber/spring/CucumberContextConfiguration.java
+++ b/cucumber-spring/src/main/java/io/cucumber/spring/CucumberContextConfiguration.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  * TestExecutionListeners}. So features that depend on a test execution listener
  * such as mock beans will work on the annotated class - but not on other step
  * definition classes. Features that depend on initializing beans - such as
- * AspectJ - will not work on the annotated class - but will work on other step
+ * AspectJ - will not work on the annotated class - but will work on step
  * definition classes.</li>
  * <li></li>
  * </ul>


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Cucumber uses Spring Test Context Manager framework. This framework was written for JUnit and assumes that there is a "test instance". Cucumber however uses multiple step definition classes and so it has multiple test instances.

Originally `@CucumberContextConfiguration` was added to signal to Spring which class should be used to configure the application context from. But as people also expected mock beans and other features provided by Springs test execution listeners to work (#2661) the annotated instance was only instantiated but never initialized by Spring.

This changed the semantics somewhat as now features that depend on the bean being initialized stopped working (#2886). Unfortunately, there is little that can be done here. Spring expects that the instance provided to the Test Context Manager to be an uninitialized bean. The solution for this is to put the context configuration and step definitions in different classes.

Cleaning up the examples to follow this pattern should avoid this problem somewhat in the future. Though I won't go as far as recommending people do this. Putting everything in one class looks quite nice. And generally still works.

Closes: #2886

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
