### PR TITLE
Add step location in case of datatable conversion error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [Core] Enhanced stack trace to include step location for better debugging in case of datatable conversion errors ([#2908](https://github.com/cucumber/cucumber-jvm/pull/2908) Thomas Deblock)
+
 ## [7.18.1] - 2024-07-18
 ### Changed
 - [Core] Include parameterized scenario name in JUnit and TestNG XML report

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/PickleStepDefinitionMatch.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/PickleStepDefinitionMatch.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static io.cucumber.core.runner.StackManipulation.removeFrameworkFrames;
 import static io.cucumber.core.runner.StackManipulation.removeFrameworkFramesAndAppendStepLocation;
 
 class PickleStepDefinitionMatch extends Match implements StepDefinitionMatch {
@@ -51,13 +50,13 @@ class PickleStepDefinitionMatch extends Match implements StepDefinitionMatch {
         } catch (CucumberExpressionException | CucumberDataTableException | CucumberDocStringException e) {
             CucumberInvocationTargetException targetException;
             if ((targetException = causedByCucumberInvocationTargetException(e)) != null) {
-                throw removeFrameworkFrames(targetException);
+                throw removeFrameworkFramesAndAppendStepLocation(targetException, getStepLocation());
             }
             throw couldNotConvertArguments(e);
         } catch (CucumberBackendException e) {
             throw couldNotInvokeArgumentConversion(e);
         } catch (CucumberInvocationTargetException e) {
-            throw removeFrameworkFrames(e);
+            throw removeFrameworkFramesAndAppendStepLocation(e, getStepLocation());
         }
         try {
             stepDefinition.execute(result.toArray(new Object[0]));

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
@@ -237,7 +236,7 @@ class StepDefinitionMatchTest {
     }
 
     @Test
-    void rethrows_target_invocation_exceptions_from_parameter_type() throws URISyntaxException {
+    void rethrows_target_invocation_exceptions_from_parameter_type() {
         RuntimeException userException = new RuntimeException();
 
         stepTypeRegistry.defineParameterType(new ParameterType<>(
@@ -259,7 +258,7 @@ class StepDefinitionMatchTest {
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition,
-            new URI("test.feature"), step);
+            URI.create("test.feature"), step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         RuntimeException actualThrown = assertThrows(RuntimeException.class, testMethod);
@@ -295,7 +294,7 @@ class StepDefinitionMatchTest {
     }
 
     @Test
-    void rethrows_target_invocation_exceptions_from_data_table() throws URISyntaxException {
+    void rethrows_target_invocation_exceptions_from_data_table() {
         Feature feature = TestFeatureParser.parse("" +
                 "Feature: Test feature\n" +
                 "  Scenario: Test scenario\n" +
@@ -318,7 +317,7 @@ class StepDefinitionMatchTest {
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition,
-            new URI("test.feature"), step);
+            URI.create("test.feature"), step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         RuntimeException actualThrown = assertThrows(RuntimeException.class, testMethod);
@@ -356,7 +355,7 @@ class StepDefinitionMatchTest {
     }
 
     @Test
-    void rethrows_target_invocation_exception_for_docstring() throws URISyntaxException {
+    void rethrows_target_invocation_exception_for_docstring() {
         RuntimeException userException = new RuntimeException();
 
         Feature feature = TestFeatureParser.parse("" +
@@ -377,7 +376,7 @@ class StepDefinitionMatchTest {
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
         StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition,
-            new URI("test.feature"), step);
+            URI.create("test.feature"), step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         RuntimeException actualThrown = assertThrows(RuntimeException.class, testMethod);

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.List;
@@ -236,7 +237,7 @@ class StepDefinitionMatchTest {
     }
 
     @Test
-    void rethrows_target_invocation_exceptions_from_parameter_type() {
+    void rethrows_target_invocation_exceptions_from_parameter_type() throws URISyntaxException {
         RuntimeException userException = new RuntimeException();
 
         stepTypeRegistry.defineParameterType(new ParameterType<>(
@@ -257,11 +258,15 @@ class StepDefinitionMatchTest {
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
-        StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
+        StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition,
+            new URI("test.feature"), step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         RuntimeException actualThrown = assertThrows(RuntimeException.class, testMethod);
         assertThat(actualThrown, sameInstance(userException));
+        assertThat(
+            lastStackElement(actualThrown.getStackTrace()),
+            is(new StackTraceElement("✽", "I have some cukes in my belly", "test.feature", 3)));
     }
 
     @Test
@@ -290,7 +295,7 @@ class StepDefinitionMatchTest {
     }
 
     @Test
-    void rethrows_target_invocation_exceptions_from_data_table() {
+    void rethrows_target_invocation_exceptions_from_data_table() throws URISyntaxException {
         Feature feature = TestFeatureParser.parse("" +
                 "Feature: Test feature\n" +
                 "  Scenario: Test scenario\n" +
@@ -312,11 +317,15 @@ class StepDefinitionMatchTest {
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
-        StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
+        StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition,
+            new URI("test.feature"), step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         RuntimeException actualThrown = assertThrows(RuntimeException.class, testMethod);
         assertThat(actualThrown, sameInstance(userException));
+        assertThat(
+            lastStackElement(actualThrown.getStackTrace()),
+            is(new StackTraceElement("✽", "I have some cukes in my belly", "test.feature", 3)));
     }
 
     @Test
@@ -347,7 +356,7 @@ class StepDefinitionMatchTest {
     }
 
     @Test
-    void rethrows_target_invocation_exception_for_docstring() {
+    void rethrows_target_invocation_exception_for_docstring() throws URISyntaxException {
         RuntimeException userException = new RuntimeException();
 
         Feature feature = TestFeatureParser.parse("" +
@@ -367,11 +376,15 @@ class StepDefinitionMatchTest {
         StepExpression expression = stepExpressionFactory.createExpression(stepDefinition);
         CoreStepDefinition coreStepDefinition = new CoreStepDefinition(id, stepDefinition, expression);
         List<Argument> arguments = coreStepDefinition.matchedArguments(step);
-        StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition, null, step);
+        StepDefinitionMatch stepDefinitionMatch = new PickleStepDefinitionMatch(arguments, stepDefinition,
+            new URI("test.feature"), step);
 
         Executable testMethod = () -> stepDefinitionMatch.runStep(null);
         RuntimeException actualThrown = assertThrows(RuntimeException.class, testMethod);
         assertThat(actualThrown, sameInstance(userException));
+        assertThat(
+            lastStackElement(actualThrown.getStackTrace()),
+            is(new StackTraceElement("✽", "I have some cukes in my belly", "test.feature", 3)));
     }
 
     @Test
@@ -463,6 +476,10 @@ class StepDefinitionMatchTest {
             "Could not invoke step [I have an {word} value] defined at '{stubbed location with details}'.\n" +
                     "It appears there was a problem with the step definition.\n" +
                     "The converted arguments types were (null)")));
+    }
+
+    private StackTraceElement lastStackElement(StackTraceElement[] stackTrace) {
+        return stackTrace[stackTrace.length - 1];
     }
 
     private static final class ItemQuantity {


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Add step location in case of datatable conversion error

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

The goal of this feature is to be able to identify easily the step when a dataTable conversion fail. 
Previous this PR in case of conversion error, we have this type of error: 
```
Step failed
java.lang.RuntimeException: This is an error
	at com.deblock.cucumber.TestStep.convert(TestStep.java:58)
```
By we don't know which step fail. With the new version, the error looks like 
```
java.lang.RuntimeException: This is an error
	at com.deblock.cucumber.TestStep.convert(TestStep.java:58)
	at ✽.this is a test(file:///..../test.feature:4)
```

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->
- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
