### PR TITLE
[Core] Support custom UUID generators in test runners

### DIFF
--- a/.revapi/api-changes.json
+++ b/.revapi/api-changes.json
@@ -69,6 +69,26 @@
       }
     }
   ],
+  "7.20.0": [
+    {
+      "extension": "revapi.differences",
+      "id": "intentional-api-changes",
+      "ignore": true,
+      "configuration": {
+        "differences": [
+          {
+            "ignore": true,
+            "code": "java.method.visibilityIncreased",
+            "old": "method io.cucumber.core.eventbus.UuidGenerator io.cucumber.core.runtime.UuidGeneratorServiceLoader::loadUuidGenerator()",
+            "new": "method io.cucumber.core.eventbus.UuidGenerator io.cucumber.core.runtime.UuidGeneratorServiceLoader::loadUuidGenerator()",
+            "oldVisibility": "package",
+            "newVisibility": "public",
+            "justification": "Expose internal API to other internal components"
+          }
+        ]
+      }
+    }
+  ],
   "internal": [
     {
       "extension": "revapi.differences",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+[JUnit Platform Engine] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
+[JUnit] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
+[TestNG] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
+
 
 ## [7.19.0] - 2024-09-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [JUnit Platform Engine] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
+
 ### Fixed
-[JUnit Platform Engine] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
-[JUnit] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
-[TestNG] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
+- [Core] Use custom UUID generators for hooks ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
+- [JUnit] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
+- [TestNG] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
 
 
 ## [7.19.0] - 2024-09-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- [JUnit Platform Engine] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
+- [JUnit Platform Engine] Enable use of custom UUID generators ([#2926](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
+- [JUnit] Enable use of custom UUID generators ([#2926](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
+- [TestNG] Enable use of custom UUID generators ([#2926](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
 
 ### Fixed
-- [Core] Use custom UUID generators for hooks ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
-- [JUnit] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
-- [TestNG] Enable use of custom UUID generators ([#2887](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
+- [Core] Use custom UUID generators for hooks ([#2926](https://github.com/cucumber/cucumber-jvm/pull/2926) M.P. Korstanje)
 
 
 ## [7.19.0] - 2024-09-19

--- a/cucumber-core/README.md
+++ b/cucumber-core/README.md
@@ -53,7 +53,8 @@ cucumber.plugin=                # comma separated plugin strings.
 cucumber.object-factory=        # object factory class name.
                                 # example: com.example.MyObjectFactory
 
-cucumber.uuid-generator=        # UUID generator class name.
+cucumber.uuid-generator         # uuid generator class name of a registered service provider.
+                                # default: io.cucumber.core.eventbus.RandomUuidGenerator
                                 # example: com.example.MyUuidGenerator
 
 cucumber.publish.enabled        # true or false. default: false
@@ -89,12 +90,13 @@ Cucumber emits events on an event bus in many cases:
 - during the feature file parsing
 - when the test scenarios are executed
 
-An event has a UUID. The UUID generator can be configured using the `cucumber.uuid-generator` property:
+An event has a UUID. The UUID generator can be configured using the
+`cucumber.uuid-generator` property:
 
 | UUID generator                                      | Features                                | Performance [Millions UUID/second] | Typical usage example                                                                                                                                                                                                                                                          | 
 |-----------------------------------------------------|-----------------------------------------|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | io.cucumber.core.eventbus.RandomUuidGenerator       | Thread-safe, collision-free, multi-jvm  | ~1                                 | Reports may be generated on different JVMs at the same time. A typical example would be one suite that tests against Firefox and another against Safari. The exact browser is configured through a property. These are then executed concurrently on different Gitlab runners. |
-| io.cucumber.core.eventbus.IncrementingUuidGenerator | Thread-safe, collision-free, single-jvm | ~130                               | Reports are generated on a single JVM                                                                                                                                                                                                                                          |
+| io.cucumber.core.eventbus.IncrementingUuidGenerator | Thread-safe, collision-free, single-jvm | ~130                               | Reports are generated on a single JVM in a single execution of Cucumber.                                                                                                                                                                                                       |
 
 The performance gain on real projects depends on the feature size.
 

--- a/cucumber-core/src/main/java/io/cucumber/core/eventbus/IncrementingUuidGenerator.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/eventbus/IncrementingUuidGenerator.java
@@ -10,20 +10,20 @@ import java.util.concurrent.atomic.AtomicLong;
  * Thread-safe and collision-free UUID generator for single JVM. This is a
  * sequence generator and each instance has its own counter. This generator is
  * about 100 times faster than #RandomUuidGenerator.
- *
- * Properties:
- * - thread-safe
- * - collision-free in the same classloader
- * - almost collision-free in different classloaders / JVMs
- * - UUIDs generated using the instances from the same classloader are sortable
- *
- * UUID version 8 (custom) / variant 2 <a href=
- * "https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html#name-uuid-version-8">...</a>
- * <!-- @formatter:off -->
+ * <p>
+ * Properties: - thread-safe - collision-free in the same classloader - almost
+ * collision-free in different classloaders / JVMs - UUIDs generated using the
+ * instances from the same classloader are sortable
+ * <p>
+ * <a href=
+ * "https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html#name-uuid-version-8">UUID
+ * version 8 (custom) / variant 2 </a>
+ * 
+ * <pre>
  * |       40 bits      |      8 bits    |  4 bits |    12 bits    |  2 bits | 62 bits |
  * | -------------------| -------------- | ------- | ------------- | ------- | ------- |
  * | LSBs of epoch-time | sessionCounter | version | classloaderId | variant | counter |
- * <!-- @formatter:on -->
+ * </pre>
  */
 public class IncrementingUuidGenerator implements UuidGenerator {
     /**
@@ -84,7 +84,7 @@ public class IncrementingUuidGenerator implements UuidGenerator {
      * classloaderId which produces about 1% collision rate on the
      * classloaderId, and thus can have UUID collision if the epoch-time,
      * session counter and counter have the same values).
-     * 
+     *
      * @param classloaderId the new classloaderId (only the least significant 12
      *                      bits are used)
      * @see                 IncrementingUuidGenerator#classloaderId

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/CachingGlue.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/CachingGlue.java
@@ -105,25 +105,25 @@ final class CachingGlue implements Glue {
 
     @Override
     public void addBeforeHook(HookDefinition hookDefinition) {
-        beforeHooks.add(CoreHookDefinition.create(hookDefinition));
+        beforeHooks.add(CoreHookDefinition.create(hookDefinition, bus::generateId));
         beforeHooks.sort(HOOK_ORDER_ASCENDING);
     }
 
     @Override
     public void addAfterHook(HookDefinition hookDefinition) {
-        afterHooks.add(CoreHookDefinition.create(hookDefinition));
+        afterHooks.add(CoreHookDefinition.create(hookDefinition, bus::generateId));
         afterHooks.sort(HOOK_ORDER_ASCENDING);
     }
 
     @Override
     public void addBeforeStepHook(HookDefinition hookDefinition) {
-        beforeStepHooks.add(CoreHookDefinition.create(hookDefinition));
+        beforeStepHooks.add(CoreHookDefinition.create(hookDefinition, bus::generateId));
         beforeStepHooks.sort(HOOK_ORDER_ASCENDING);
     }
 
     @Override
     public void addAfterStepHook(HookDefinition hookDefinition) {
-        afterStepHooks.add(CoreHookDefinition.create(hookDefinition));
+        afterStepHooks.add(CoreHookDefinition.create(hookDefinition, bus::generateId));
         afterStepHooks.sort(HOOK_ORDER_ASCENDING);
     }
 

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/CoreHookDefinition.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/CoreHookDefinition.java
@@ -11,6 +11,7 @@ import io.cucumber.tagexpressions.TagExpressionParser;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -33,13 +34,13 @@ class CoreHookDefinition {
         }
     }
 
-    static CoreHookDefinition create(HookDefinition hookDefinition) {
+    static CoreHookDefinition create(HookDefinition hookDefinition, Supplier<UUID> uuidGenerator) {
         // Ideally we would avoid this by keeping the scenario scoped
         // glue in a different bucket from the globally scoped glue.
         if (hookDefinition instanceof ScenarioScoped) {
-            return new ScenarioScopedCoreHookDefinition(hookDefinition);
+            return new ScenarioScopedCoreHookDefinition(uuidGenerator.get(), hookDefinition);
         }
-        return new CoreHookDefinition(UUID.randomUUID(), hookDefinition);
+        return new CoreHookDefinition(uuidGenerator.get(), hookDefinition);
     }
 
     void execute(TestCaseState scenario) {
@@ -72,8 +73,8 @@ class CoreHookDefinition {
 
     static class ScenarioScopedCoreHookDefinition extends CoreHookDefinition implements ScenarioScoped {
 
-        private ScenarioScopedCoreHookDefinition(HookDefinition delegate) {
-            super(UUID.randomUUID(), delegate);
+        private ScenarioScopedCoreHookDefinition(UUID id, HookDefinition delegate) {
+            super(id, delegate);
         }
 
         @Override

--- a/cucumber-core/src/main/java/io/cucumber/core/runtime/UuidGeneratorServiceLoader.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runtime/UuidGeneratorServiceLoader.java
@@ -38,7 +38,7 @@ public final class UuidGeneratorServiceLoader {
         this.options = requireNonNull(options);
     }
 
-    UuidGenerator loadUuidGenerator() {
+    public UuidGenerator loadUuidGenerator() {
         Class<? extends UuidGenerator> objectFactoryClass = options.getUuidGeneratorClass();
         ClassLoader classLoader = classLoaderSupplier.get();
         ServiceLoader<UuidGenerator> loader = ServiceLoader.load(UuidGenerator.class, classLoader);

--- a/cucumber-junit-platform-engine/README.md
+++ b/cucumber-junit-platform-engine/README.md
@@ -373,6 +373,10 @@ cucumber.junit-platform.naming-strategy.long.example-name=     # number or pickl
 
 cucumber.plugin=                                               # comma separated plugin strings.
                                                                # example: pretty, json:path/to/report.json
+
+cucumber.uuid-generator                                        # uuid generator class name of a registered service provider.
+                                                               # default: io.cucumber.core.eventbus.RandomUuidGenerator
+                                                               # example: com.example.MyUuidGenerator
  
 cucumber.object-factory=                                       # object factory class name.
                                                                # example: com.example.MyObjectFactory

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineExecutionContext.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineExecutionContext.java
@@ -19,12 +19,12 @@ import io.cucumber.core.runtime.SingletonRunnerSupplier;
 import io.cucumber.core.runtime.ThreadLocalObjectFactorySupplier;
 import io.cucumber.core.runtime.ThreadLocalRunnerSupplier;
 import io.cucumber.core.runtime.TimeServiceEventBus;
+import io.cucumber.core.runtime.UuidGeneratorServiceLoader;
 import org.apiguardian.api.API;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.support.hierarchical.EngineExecutionContext;
 
 import java.time.Clock;
-import java.util.UUID;
 import java.util.function.Supplier;
 
 import static io.cucumber.core.runtime.SynchronizedEventBus.synchronize;
@@ -48,8 +48,10 @@ public final class CucumberEngineExecutionContext implements EngineExecutionCont
 
     private CucumberExecutionContext createCucumberExecutionContext() {
         Supplier<ClassLoader> classLoader = CucumberEngineExecutionContext.class::getClassLoader;
+        UuidGeneratorServiceLoader uuidGeneratorServiceLoader = new UuidGeneratorServiceLoader(classLoader, options);
+        EventBus bus = synchronize(
+            new TimeServiceEventBus(Clock.systemUTC(), uuidGeneratorServiceLoader.loadUuidGenerator()));
         ObjectFactoryServiceLoader objectFactoryServiceLoader = new ObjectFactoryServiceLoader(classLoader, options);
-        EventBus bus = synchronize(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
         Plugins plugins = new Plugins(new PluginFactory(), options);
         ExitStatus exitStatus = new ExitStatus(options);
         plugins.addPlugin(exitStatus);

--- a/cucumber-testng/src/main/java/io/cucumber/testng/TestNGCucumberRunner.java
+++ b/cucumber-testng/src/main/java/io/cucumber/testng/TestNGCucumberRunner.java
@@ -23,11 +23,11 @@ import io.cucumber.core.runtime.ObjectFactorySupplier;
 import io.cucumber.core.runtime.ThreadLocalObjectFactorySupplier;
 import io.cucumber.core.runtime.ThreadLocalRunnerSupplier;
 import io.cucumber.core.runtime.TimeServiceEventBus;
+import io.cucumber.core.runtime.UuidGeneratorServiceLoader;
 import org.apiguardian.api.API;
 
 import java.time.Clock;
 import java.util.List;
-import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -98,9 +98,12 @@ public final class TestNGCucumberRunner {
                 .enablePublishPlugin()
                 .build(environmentOptions);
 
-        EventBus bus = synchronize(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
-
         Supplier<ClassLoader> classLoader = ClassLoaders::getDefaultClassLoader;
+        UuidGeneratorServiceLoader uuidGeneratorServiceLoader = new UuidGeneratorServiceLoader(classLoader,
+            runtimeOptions);
+        EventBus bus = synchronize(
+            new TimeServiceEventBus(Clock.systemUTC(), uuidGeneratorServiceLoader.loadUuidGenerator()));
+
         FeatureParser parser = new FeatureParser(bus::generateId);
         FeaturePathFeatureSupplier featureSupplier = new FeaturePathFeatureSupplier(classLoader, runtimeOptions,
             parser);

--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,7 @@
                                 <roots>
                                     <root>7.0.0</root>
                                     <root>7.2.0</root>
+                                    <root>7.20.0</root>
                                     <root>internal</root>
                                     <root>testng</root>
                                     <root>guice</root>


### PR DESCRIPTION
### 🤔 What's changed?

Made it  possible to actually use the custom UUID generators in test runners

### ⚡️ What's your motivation? 

With #2703 a faster UUID generator was introduced. And while the
configuration options were added, they were not actually used by 
`cucumber-junit`, `cucumber-junit-platform-engine` and
`cucumber-testng`.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
