### PR TITLE
Lazily start IncrementingUuidGenerator sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [Core] Lazily start IncrementingUuidGenerator sessions([#2931](https://github.com/cucumber/cucumber-jvm/pull/2931) M.P. Korstanje)
 
 ## [7.20.0] - 2024-10-04
 ### Added

--- a/cucumber-core/src/main/java/io/cucumber/core/eventbus/IncrementingUuidGenerator.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/eventbus/IncrementingUuidGenerator.java
@@ -68,7 +68,7 @@ public class IncrementingUuidGenerator implements UuidGenerator {
     /**
      * Computed UUID MSB value.
      */
-    final long msb;
+    private long msb;
 
     /**
      * Counter for the UUID LSB.
@@ -77,13 +77,13 @@ public class IncrementingUuidGenerator implements UuidGenerator {
 
     /**
      * Defines a new classloaderId for the class. This only affects instances
-     * created after the call (the instances created before the call keep their
-     * classloaderId). This method should be called to specify a classloaderId
-     * if you are using more than one class loader, and you want to guarantee a
-     * collision-free UUID generation (instead of the default random
-     * classloaderId which produces about 1% collision rate on the
-     * classloaderId, and thus can have UUID collision if the epoch-time,
-     * session counter and counter have the same values).
+     * created after the first call to {@link #generateId()} (the instances
+     * created before the call keep their classloaderId). This method should be
+     * called to specify a {@code classloaderId} if you are using more than one
+     * class loader, and you want to guarantee a collision-free UUID generation
+     * (instead of the default random classloaderId which produces about 1%
+     * collision rate on the classloaderId, and thus can have UUID collision if
+     * the epoch-time, session counter and counter have the same values).
      *
      * @param classloaderId the new classloaderId (only the least significant 12
      *                      bits are used)
@@ -94,6 +94,10 @@ public class IncrementingUuidGenerator implements UuidGenerator {
     }
 
     public IncrementingUuidGenerator() {
+
+    }
+
+    private long initializeMsb() {
         long sessionId = sessionCounter.incrementAndGet();
         if (sessionId == MAX_SESSION_ID) {
             throw new CucumberException(
@@ -103,7 +107,7 @@ public class IncrementingUuidGenerator implements UuidGenerator {
         }
         long epochTime = System.currentTimeMillis();
         // msb = epochTime | sessionId | version | classloaderId
-        msb = ((epochTime & MAX_EPOCH_TIME) << 24) | (sessionId << 16) | (8 << 12) | classloaderId;
+        return ((epochTime & MAX_EPOCH_TIME) << 24) | (sessionId << 16) | (8 << 12) | classloaderId;
     }
 
     /**
@@ -114,6 +118,11 @@ public class IncrementingUuidGenerator implements UuidGenerator {
      */
     @Override
     public UUID generateId() {
+        if (msb == 0) {
+            // Lazy init to avoid starting sessions when not used.
+            msb = initializeMsb();
+        }
+
         long counterValue = counter.incrementAndGet();
         if (counterValue == MAX_COUNTER_VALUE) {
             throw new CucumberException(

--- a/cucumber-core/src/test/java/io/cucumber/core/eventbus/IncrementingUuidGeneratorTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/eventbus/IncrementingUuidGeneratorTest.java
@@ -1,8 +1,8 @@
 package io.cucumber.core.eventbus;
 
 import io.cucumber.core.exception.CucumberException;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.ThrowingSupplier;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -21,6 +21,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -119,20 +121,33 @@ class IncrementingUuidGeneratorTest {
 
         // Then
         assertThat(cucumberException.getMessage(),
-            Matchers.containsString("Out of IncrementingUuidGenerator capacity"));
+            containsString("Out of IncrementingUuidGenerator capacity"));
     }
 
     @Test
     void version_overflow() {
         // Given
+        IncrementingUuidGenerator generator = new IncrementingUuidGenerator();
         IncrementingUuidGenerator.sessionCounter.set(IncrementingUuidGenerator.MAX_SESSION_ID - 1);
 
         // When
-        CucumberException cucumberException = assertThrows(CucumberException.class, IncrementingUuidGenerator::new);
+        CucumberException cucumberException = assertThrows(CucumberException.class, generator::generateId);
 
         // Then
         assertThat(cucumberException.getMessage(),
-            Matchers.containsString("Out of IncrementingUuidGenerator capacity"));
+            containsString("Out of IncrementingUuidGenerator capacity"));
+    }
+
+    @Test
+    void lazy_init() {
+        // Given
+        IncrementingUuidGenerator.sessionCounter.set(IncrementingUuidGenerator.MAX_SESSION_ID - 1);
+
+        // When
+        ThrowingSupplier<IncrementingUuidGenerator> instantiateGenerator = IncrementingUuidGenerator::new;
+
+        // Then
+        assertDoesNotThrow(instantiateGenerator);
     }
 
     private static void checkUuidProperties(List<UUID> uuids) {


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Even when not used, the `IncrementingUuidGenerator` is instantiated with each Cucumber execution. This somewhat fundamental to the way the `ServiceLoader` mechanism works.

Each time an incrementing generator is created, a new session is started for that generator. This means that after 255 executions all sessions are exhausted.

Unfortunately, when using the JUnit Platform, Maven issues a discovery request for each individual class. And Cucumber typically participates in discovery along with JUnit Jupiter. So after requests for 255 classes, Cucumber fails discovery as seen in #2930.

Fixes #2930, #2925

### 🤔 What's changed?

Lazily start IncrementingUuidGenerator sessions

### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

@jkronegg best I could think of. Got any other ideas?

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----
