### PR TITLE
Fix flaky test-cases in HtmlFormatterTest

### DIFF
--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/Jackson.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/Jackson.java
@@ -3,7 +3,6 @@ package io.cucumber.core.plugin;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
@@ -16,7 +15,6 @@ final class Jackson {
             .serializationInclusion(Include.NON_ABSENT)
             .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
             .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
-            .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
             .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
             .enable(DeserializationFeature.USE_LONG_FOR_INTS)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/Jackson.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/Jackson.java
@@ -3,6 +3,7 @@ package io.cucumber.core.plugin;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
@@ -15,6 +16,7 @@ final class Jackson {
             .serializationInclusion(Include.NON_ABSENT)
             .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
             .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
+            .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
             .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)
             .enable(DeserializationFeature.USE_LONG_FOR_INTS)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/HtmlFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/HtmlFormatterTest.java
@@ -1,5 +1,7 @@
 package io.cucumber.core.plugin;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.messages.types.Envelope;
@@ -12,15 +14,20 @@ import io.cucumber.messages.types.StepDefinitionPatternType;
 import io.cucumber.messages.types.TestRunFinished;
 import io.cucumber.messages.types.TestRunStarted;
 import io.cucumber.messages.types.Timestamp;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import static io.cucumber.core.plugin.Bytes.bytes;
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class HtmlFormatterTest {
@@ -37,12 +44,14 @@ class HtmlFormatterTest {
 
         TestRunFinished testRunFinished = new TestRunFinished(null, true, new Timestamp(15L, 0L), null);
         bus.send(Envelope.of(testRunFinished));
-
-        assertThat(bytes, bytes(containsString("" +
+        List<LinkedHashMap<String, Object>> actual = rectifiedRepresentation(getWindowCucumberMessagesFromBytes(bytes));
+        List<LinkedHashMap<String, Object>> expected = rectifiedRepresentation("" +
                 "window.CUCUMBER_MESSAGES = [" +
                 "{\"testRunStarted\":{\"timestamp\":{\"seconds\":10,\"nanos\":0}}}," +
                 "{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"seconds\":15,\"nanos\":0}}}" +
-                "];\n")));
+                "];\n");
+
+        assertThat(actual, equalTo(expected));
     }
 
     @Test
@@ -56,41 +65,81 @@ class HtmlFormatterTest {
         bus.send(Envelope.of(testRunStarted));
 
         StepDefinition stepDefinition = new StepDefinition(
-            "",
-            new StepDefinitionPattern("", StepDefinitionPatternType.CUCUMBER_EXPRESSION),
-            SourceReference.of("https://example.com"));
+                "",
+                new StepDefinitionPattern("", StepDefinitionPatternType.CUCUMBER_EXPRESSION),
+                SourceReference.of("https://example.com"));
         bus.send(Envelope.of(stepDefinition));
 
         Hook hook = new Hook("",
-            null,
-            SourceReference.of("https://example.com"),
-            null);
+                null,
+                SourceReference.of("https://example.com"),
+                null);
         bus.send(Envelope.of(hook));
 
         // public ParameterType(String name, List<String> regularExpressions,
         // Boolean preferForRegularExpressionMatch, Boolean useForSnippets,
         // String id) {
         ParameterType parameterType = new ParameterType(
-            "",
-            Collections.emptyList(),
-            true,
-            false,
-            "",
-            null);
+                "",
+                Collections.emptyList(),
+                true,
+                false,
+                "",
+                null);
         bus.send(Envelope.of(parameterType));
 
         TestRunFinished testRunFinished = new TestRunFinished(
-            null,
-            true,
-            new Timestamp(15L, 0L),
-            null);
+                null,
+                true,
+                new Timestamp(15L, 0L),
+                null);
         bus.send(Envelope.of(testRunFinished));
-
-        assertThat(bytes, bytes(containsString("" +
+        List<LinkedHashMap<String, Object>> expected = rectifiedRepresentation("" +
                 "window.CUCUMBER_MESSAGES = [" +
                 "{\"testRunStarted\":{\"timestamp\":{\"seconds\":10,\"nanos\":0}}}," +
                 "{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"seconds\":15,\"nanos\":0}}}" +
-                "];\n")));
+                "];\n");
+        List<LinkedHashMap<String, Object>> actual = rectifiedRepresentation(getWindowCucumberMessagesFromBytes(bytes));
+        assertThat(actual, equalTo(expected));
+    }
+
+    private String getWindowCucumberMessagesFromBytes(ByteArrayOutputStream bytes) {
+        String result = bytes.toString(StandardCharsets.UTF_8);
+        Pattern scriptTag = Pattern.compile("<script>\n(.*?)</script>", Pattern.DOTALL);
+        Matcher contentMatcher = scriptTag.matcher(result);
+        String output = null;
+        while (contentMatcher.find()) {
+            if (contentMatcher.group(1).contains("window.CUCUMBER_MESSAGES = ")) {
+                output = contentMatcher.group(1);
+            }
+        }
+        if (output == null) {
+            Assertions.fail();
+        }
+        return output;
+    }
+
+    private List<LinkedHashMap<String, Object>> rectifiedRepresentation(String inputContainingListOfObjects) {
+        Pattern pattern = Pattern.compile("\\[.*?]");
+        Matcher matcher = pattern.matcher(inputContainingListOfObjects);
+        String parsedInput = null;
+        while (matcher.find()) {
+            parsedInput = matcher.group();
+        }
+        if (parsedInput == null) {
+            Assertions.fail();
+            return null;
+        }
+        List<LinkedHashMap<String, Object>> output = null;
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            output = objectMapper.readValue(parsedInput, new TypeReference<List<LinkedHashMap<String, Object>>>() {
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assertions.fail();
+        }
+        return output;
     }
 
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/HtmlFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/HtmlFormatterTest.java
@@ -18,10 +18,13 @@ import java.io.ByteArrayOutputStream;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import static io.cucumber.core.plugin.Bytes.bytes;
-import static org.hamcrest.CoreMatchers.containsString;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import static org.skyscreamer.jsonassert.JSONCompareMode.STRICT;
 
 class HtmlFormatterTest {
 
@@ -38,11 +41,11 @@ class HtmlFormatterTest {
         TestRunFinished testRunFinished = new TestRunFinished(null, true, new Timestamp(15L, 0L), null);
         bus.send(Envelope.of(testRunFinished));
 
-        assertThat(bytes, bytes(containsString("" +
-                "window.CUCUMBER_MESSAGES = [" +
+        assertEquals("[" +
                 "{\"testRunStarted\":{\"timestamp\":{\"nanos\":0,\"seconds\":10}}}," +
                 "{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"nanos\":0,\"seconds\":15}}}" +
-                "];\n")));
+                "]",
+            extractCucumberMessages(bytes), STRICT);
     }
 
     @Test
@@ -86,11 +89,17 @@ class HtmlFormatterTest {
             null);
         bus.send(Envelope.of(testRunFinished));
 
-        assertThat(bytes, bytes(containsString("" +
-                "window.CUCUMBER_MESSAGES = [" +
+        assertEquals("[" +
                 "{\"testRunStarted\":{\"timestamp\":{\"nanos\":0,\"seconds\":10}}}," +
                 "{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"nanos\":0,\"seconds\":15}}}" +
-                "];\n")));
+                "]",
+            extractCucumberMessages(bytes), STRICT);
     }
 
+    private static String extractCucumberMessages(ByteArrayOutputStream bytes) {
+        Pattern pattern = Pattern.compile("^.*window\\.CUCUMBER_MESSAGES = (\\[.+]);.*$", Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(new String(bytes.toByteArray(), UTF_8));
+        assertThat("bytes must match " + pattern, matcher.find());
+        return matcher.group(1);
+    }
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/HtmlFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/HtmlFormatterTest.java
@@ -1,7 +1,5 @@
 package io.cucumber.core.plugin;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.messages.types.Envelope;
@@ -14,20 +12,15 @@ import io.cucumber.messages.types.StepDefinitionPatternType;
 import io.cucumber.messages.types.TestRunFinished;
 import io.cucumber.messages.types.TestRunStarted;
 import io.cucumber.messages.types.Timestamp;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import static org.hamcrest.CoreMatchers.equalTo;
+import static io.cucumber.core.plugin.Bytes.bytes;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 class HtmlFormatterTest {
@@ -44,14 +37,12 @@ class HtmlFormatterTest {
 
         TestRunFinished testRunFinished = new TestRunFinished(null, true, new Timestamp(15L, 0L), null);
         bus.send(Envelope.of(testRunFinished));
-        List<LinkedHashMap<String, Object>> actual = rectifiedRepresentation(getWindowCucumberMessagesFromBytes(bytes));
-        List<LinkedHashMap<String, Object>> expected = rectifiedRepresentation("" +
-                "window.CUCUMBER_MESSAGES = [" +
-                "{\"testRunStarted\":{\"timestamp\":{\"seconds\":10,\"nanos\":0}}}," +
-                "{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"seconds\":15,\"nanos\":0}}}" +
-                "];\n");
 
-        assertThat(actual, equalTo(expected));
+        assertThat(bytes, bytes(containsString("" +
+                "window.CUCUMBER_MESSAGES = [" +
+                "{\"testRunStarted\":{\"timestamp\":{\"nanos\":0,\"seconds\":10}}}," +
+                "{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"nanos\":0,\"seconds\":15}}}" +
+                "];\n")));
     }
 
     @Test
@@ -65,81 +56,41 @@ class HtmlFormatterTest {
         bus.send(Envelope.of(testRunStarted));
 
         StepDefinition stepDefinition = new StepDefinition(
-                "",
-                new StepDefinitionPattern("", StepDefinitionPatternType.CUCUMBER_EXPRESSION),
-                SourceReference.of("https://example.com"));
+            "",
+            new StepDefinitionPattern("", StepDefinitionPatternType.CUCUMBER_EXPRESSION),
+            SourceReference.of("https://example.com"));
         bus.send(Envelope.of(stepDefinition));
 
         Hook hook = new Hook("",
-                null,
-                SourceReference.of("https://example.com"),
-                null);
+            null,
+            SourceReference.of("https://example.com"),
+            null);
         bus.send(Envelope.of(hook));
 
         // public ParameterType(String name, List<String> regularExpressions,
         // Boolean preferForRegularExpressionMatch, Boolean useForSnippets,
         // String id) {
         ParameterType parameterType = new ParameterType(
-                "",
-                Collections.emptyList(),
-                true,
-                false,
-                "",
-                null);
+            "",
+            Collections.emptyList(),
+            true,
+            false,
+            "",
+            null);
         bus.send(Envelope.of(parameterType));
 
         TestRunFinished testRunFinished = new TestRunFinished(
-                null,
-                true,
-                new Timestamp(15L, 0L),
-                null);
+            null,
+            true,
+            new Timestamp(15L, 0L),
+            null);
         bus.send(Envelope.of(testRunFinished));
-        List<LinkedHashMap<String, Object>> expected = rectifiedRepresentation("" +
+
+        assertThat(bytes, bytes(containsString("" +
                 "window.CUCUMBER_MESSAGES = [" +
-                "{\"testRunStarted\":{\"timestamp\":{\"seconds\":10,\"nanos\":0}}}," +
-                "{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"seconds\":15,\"nanos\":0}}}" +
-                "];\n");
-        List<LinkedHashMap<String, Object>> actual = rectifiedRepresentation(getWindowCucumberMessagesFromBytes(bytes));
-        assertThat(actual, equalTo(expected));
-    }
-
-    private String getWindowCucumberMessagesFromBytes(ByteArrayOutputStream bytes) {
-        String result = bytes.toString(StandardCharsets.UTF_8);
-        Pattern scriptTag = Pattern.compile("<script>\n(.*?)</script>", Pattern.DOTALL);
-        Matcher contentMatcher = scriptTag.matcher(result);
-        String output = null;
-        while (contentMatcher.find()) {
-            if (contentMatcher.group(1).contains("window.CUCUMBER_MESSAGES = ")) {
-                output = contentMatcher.group(1);
-            }
-        }
-        if (output == null) {
-            Assertions.fail();
-        }
-        return output;
-    }
-
-    private List<LinkedHashMap<String, Object>> rectifiedRepresentation(String inputContainingListOfObjects) {
-        Pattern pattern = Pattern.compile("\\[.*?]");
-        Matcher matcher = pattern.matcher(inputContainingListOfObjects);
-        String parsedInput = null;
-        while (matcher.find()) {
-            parsedInput = matcher.group();
-        }
-        if (parsedInput == null) {
-            Assertions.fail();
-            return null;
-        }
-        List<LinkedHashMap<String, Object>> output = null;
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
-            output = objectMapper.readValue(parsedInput, new TypeReference<List<LinkedHashMap<String, Object>>>() {
-            });
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assertions.fail();
-        }
-        return output;
+                "{\"testRunStarted\":{\"timestamp\":{\"nanos\":0,\"seconds\":10}}}," +
+                "{\"testRunFinished\":{\"success\":true,\"timestamp\":{\"nanos\":0,\"seconds\":15}}}" +
+                "];\n")));
     }
 
 }


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?
Changed the way of asserting fields in class `HtmlFormatterTest.java`

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

The Assertion for `bytes` to contain the string:
```js
 window.CUCUMBER_MESSAGES = [
                {"testRunStarted":{"timestamp":{"seconds":10,"nanos":0}}},
                {"testRunFinished":{"success":true,"timestamp":{"seconds":15,"nanos":0}}}
       ];"
```
is **flaky** in nature. Precisely, the value assigned to  `window.CUCUMBER_MESSAGES` is a *list of objects* in `js`, but apparently derived from a *List of HashMaps* in java. HashMaps being unordered, can sometimes return a result like:
```js
 window.CUCUMBER_MESSAGES = [
                {"testRunStarted":{"timestamp":{"nanos":0, "seconds":10}}}, # different order, same object/contents
                {"testRunFinished":{"success":true,"timestamp":{"seconds":15,"nanos":0}}}
       ];"
```
The test may fail on a **different jvm** pertaining to the hashcode implementation. <br>
~The fix contains logic that parses the bytes, converting them to `List<LinkedHashMap<String, Object>>` which can be safely used for **equals check** (safer than string/bytes comparison).~ (fix modified in the commit : https://github.com/cucumber/cucumber-jvm/pull/2939/commits/6ae3bf6ce42de987284c35b79334bd02172bd463)

**Fixed using nondex plugin to identify Flaky tests**
Use the following command to test the flakiness of a test:
>mvn -pl ./cucumber-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=io.cucumber.core.plugin.HtmlFormatterTest -DnondexRuns=5 -Dmode=ONE

For entire repo:
>mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dmode=ONE
<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
