### PR TITLE
Fixed failing flaky test-case caused by usage of HashMap in class RerunFormatter

### DIFF
--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
@@ -11,7 +11,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static io.cucumber.core.feature.FeatureWithLines.create;
@@ -24,7 +24,7 @@ import static io.cucumber.core.plugin.PrettyFormatter.relativize;
 public final class RerunFormatter implements ConcurrentEventListener {
 
     private final UTF8PrintWriter out;
-    private final Map<URI, Collection<Integer>> featureAndFailedLinesMapping = new HashMap<>();
+    private final Map<URI, Collection<Integer>> featureAndFailedLinesMapping = new LinkedHashMap<>();
 
     public RerunFormatter(OutputStream out) {
         this.out = new UTF8PrintWriter(out);


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?
Changed the type of container for `featureAndFailedLinesMapping` in `RerunFormatter.java` in order to fix the flaky test: 
`io.cucumber.core.plugin.RerunFormatterTest.should_one_entry_for_each_failing_feature`
<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 
The following container uses HashMap implementation for storing `URI => Collection<Integer>` mapping in the class `RerunFormatter` :

```java
private final Map<URI, Collection<Integer>> featureAndFailedLinesMapping = new HashMap<>();
```
Entries are added to it by the eventPublisher: `TestCaseFinished.class`<br>
In the test-case `RerunFormatterTest.should_one_entry_for_each_failing_feature`, before assertion, the `featureAndFailedLinesMapping` looks like:
```java
{
    URI("classpath:path/first.feature")=[2],
    URI("classpath:path/second.feature")=[2]
}
```
With string representation: `classpath:path/first.feature:2\nclasspath:path/second.feature:2\n`<br> 
**As HashMap is unordered**, the the order of content in the above map is not guaranteed, and may change the string representation to: `classpath:path/second.feature:2\nclasspath:path/first.feature:2\n`, which fails the assertion<br>  

The fix contains usage of `LinkedHashMap`, which guarantees the order of content based on insertion, ergo, occurrence of `eventPublisher` call (Which I assume is followed in the assertion).

**Fixed using nondex plugin to identify Flaky tests**
Use the following command to test the flakiness of a test:
>mvn -pl ./cucumber-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=io.cucumber.core.plugin.RerunFormatterTest.should_one_entry_for_each_failing_feature -DnondexRuns=5 -Dmode=ONE

For entire repo:
>mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dmode=ONE
<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [X] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*

