### PR TITLE
Include root cause when using DataTable.asList and friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [Core] Include root cause when using DataTable.asList and friends ([#2949](https://github.com/cucumber/cucumber-jvm/pull/2949) M.P. Korstanje)
 
 ### Changed
 - [JUnit Platform Engine] Use JUnit Platform 1.11.3 (JUnit Jupiter 5.11.3)

--- a/cucumber-core/src/main/java/io/cucumber/core/backend/CucumberInvocationTargetException.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/CucumberInvocationTargetException.java
@@ -20,12 +20,20 @@ public final class CucumberInvocationTargetException extends RuntimeException {
         this.invocationTargetException = invocationTargetException;
     }
 
+    /**
+     * @deprecated use {@link #getCause()} instead.
+     */
+    @Deprecated
     public Throwable getInvocationTargetExceptionCause() {
-        return invocationTargetException.getCause();
+        return getCause();
     }
 
     public Located getLocated() {
         return located;
     }
 
+    @Override
+    public Throwable getCause() {
+        return invocationTargetException.getCause();
+    }
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/StepDefinitionMatchTest.java
@@ -46,7 +46,7 @@ class StepDefinitionMatchTest {
     private final Located stubbedLocation = new Located() {
         @Override
         public boolean isDefinedAt(StackTraceElement stackTraceElement) {
-            return false;
+            return true;
         }
 
         @Override

--- a/cucumber-java/src/test/java/io/cucumber/java/JavaStepDefinitionTest.java
+++ b/cucumber-java/src/test/java/io/cucumber/java/JavaStepDefinitionTest.java
@@ -44,7 +44,7 @@ class JavaStepDefinitionTest {
         JavaStepDefinition definition = new JavaStepDefinition(method, "three (.*) mice", lookup);
         CucumberInvocationTargetException exception = assertThrows(CucumberInvocationTargetException.class,
             () -> definition.execute(new Object[0]));
-        Optional<StackTraceElement> match = stream(exception.getInvocationTargetExceptionCause().getStackTrace())
+        Optional<StackTraceElement> match = stream(exception.getCause().getStackTrace())
                 .filter(definition::isDefinedAt).findFirst();
         StackTraceElement stackTraceElement = match.get();
 

--- a/cucumber-java8/src/test/java/io/cucumber/java8/Java8LambdaStepDefinitionMarksCorrectStackElementTest.java
+++ b/cucumber-java8/src/test/java/io/cucumber/java8/Java8LambdaStepDefinitionMarksCorrectStackElementTest.java
@@ -29,7 +29,7 @@ class Java8LambdaStepDefinitionMarksCorrectStackElementTest {
 
         CucumberInvocationTargetException exception = assertThrows(CucumberInvocationTargetException.class,
             () -> stepDefinition.execute(new Object[0]));
-        assertThat(exception.getInvocationTargetExceptionCause(),
+        assertThat(exception.getCause(),
             new CustomTypeSafeMatcher<Throwable>("exception with matching stack trace") {
                 @Override
                 protected boolean matchesSafely(Throwable item) {


### PR DESCRIPTION
### 🤔 What's changed?

The `CucumberInvocationTargetException` was originally designed to be used as a wrapper around `InvocationTargetException` to track the step definition that caused the exception. The cause of `InvocationTargetException` would then be rewritten to appear to have originated from the step definition. This would effectively hide the whole backend from view.

Unfortunately using DataTable.asList inside a step, this also invokes the backend. And because `CucumberInvocationTargetException` did not have cause, the cause of any exceptions would also be hidden.

By exposing the cause of the `InvocationTargetException` as the cause of the `CucumberInvocationTargetException` and removing any frames before the step definition was invoked we can clean this up somewhat.

```log
io.cucumber.datatable.CucumberDataTableException: 'java.util.List<io.cucumber.skeleton.StepDefinitions$Ingredient>' could not transform
| NAME  | QUANTITY | UNITS |
| Flour | 1        | KG    |
| Water | 0.65     | L     |
| Salt  | 0.08     | KG    |

	at io.cucumber.datatable.DataTableType.transform(DataTableType.java:158)
	at io.cucumber.datatable.DataTableTypeRegistryTableConverter.toListOrProblems(DataTableTypeRegistryTableConverter.java:158)
	at io.cucumber.datatable.DataTableTypeRegistryTableConverter.toList(DataTableTypeRegistryTableConverter.java:139)
	at io.cucumber.datatable.DataTable.asList(DataTable.java:199)
	at io.cucumber.skeleton.StepDefinitions.i_wait_hour(StepDefinitions.java:40)
	at ✽.I mix the following ingredients(classpath:io/cucumber/skeleton/belly.feature:6)
Caused by: io.cucumber.core.backend.CucumberInvocationTargetException
	at io.cucumber.java.Invoker.doInvoke(Invoker.java:73)
	at io.cucumber.java.Invoker.invoke(Invoker.java:24)
	at io.cucumber.java.AbstractGlueDefinition.invokeMethod(AbstractGlueDefinition.java:47)
	at io.cucumber.java.JavaDataTableTypeDefinition.lambda$createDataTableType$2(JavaDataTableTypeDefinition.java:47)
	at io.cucumber.datatable.DataTableType$TableEntryTransformerAdaptor.transform(DataTableType.java:342)
	at io.cucumber.datatable.DataTableType$TableEntryTransformerAdaptor.transform(DataTableType.java:319)
	at io.cucumber.datatable.DataTableType.transform(DataTableType.java:155)
	... 5 more
Caused by: java.lang.IllegalArgumentException: This message is never shown during test execution
	at io.cucumber.skeleton.StepDefinitions.mySystemEntry(StepDefinitions.java:29)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at io.cucumber.java.Invoker.doInvoke(Invoker.java:66)
	... 11 more
```

Unfortunately, it is not possible to remove the
`CucumberInvocationTargetException` entirely.

### ⚡️ What's your motivation? 

Fixes: #2948

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

@jean-michel-gonet do think this stack trace is something the tester you are working with can understand?


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
