### PR TITLE
[Core] Add property to skip execution of tagged scenarios

### DIFF
--- a/cucumber-core/src/main/java/io/cucumber/core/options/Constants.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/options/Constants.java
@@ -32,7 +32,7 @@ public final class Constants {
      * <p>
      * Limits the number of scenarios to be executed to a specific amount.
      * <p>
-     * By default scenarios are executed.
+     * By default, scenarios are executed.
      */
     public static final String EXECUTION_LIMIT_PROPERTY_NAME = "cucumber.execution.limit";
 
@@ -42,9 +42,11 @@ public final class Constants {
      * Valid values are {@code lexical}, {@code reverse}, {@code random} or
      * {@code random:[seed]}.
      * <p>
-     * By default features are executed in lexical file name order
+     * By default, features are executed in lexical file name order
      */
     public static final String EXECUTION_ORDER_PROPERTY_NAME = "cucumber.execution.order";
+
+    public static final String EXECUTION_SKIP_TAGS_PROPERTY_NAME = "cucumber.execution.skip.tags";
 
     /**
      * Property name used to enable wip execution: {@value}

--- a/cucumber-core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
@@ -62,6 +62,7 @@ public final class RuntimeOptions implements
     // For context see: https://mattwynne.net/new-beginning
     private boolean publishQuiet = true;
     private boolean enablePublishPlugin;
+    private List<Expression> skipTagExpressions = new ArrayList<>();
 
     private RuntimeOptions() {
 
@@ -172,6 +173,11 @@ public final class RuntimeOptions implements
     @Override
     public Class<? extends UuidGenerator> getUuidGeneratorClass() {
         return uuidGeneratorClass;
+    }
+
+    @Override
+    public List<Expression> getSkipTagExpressions() {
+        return skipTagExpressions;
     }
 
     void setUuidGeneratorClass(Class<? extends UuidGenerator> uuidGeneratorClass) {

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/Options.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/Options.java
@@ -3,6 +3,7 @@ package io.cucumber.core.runner;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.eventbus.UuidGenerator;
 import io.cucumber.core.snippets.SnippetType;
+import io.cucumber.tagexpressions.Expression;
 
 import java.net.URI;
 import java.util.List;
@@ -18,5 +19,7 @@ public interface Options {
     Class<? extends ObjectFactory> getObjectFactoryClass();
 
     Class<? extends UuidGenerator> getUuidGeneratorClass();
+
+    List<Expression> getSkipTagExpressions();
 
 }

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/TestCase.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/TestCase.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static io.cucumber.core.runner.ExecutionMode.DRY_RUN;
-import static io.cucumber.core.runner.ExecutionMode.RUN;
 import static io.cucumber.messages.Convertor.toMessage;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -42,14 +40,14 @@ final class TestCase implements io.cucumber.plugin.event.TestCase {
             List<HookTestStep> beforeHooks,
             List<HookTestStep> afterHooks,
             Pickle pickle,
-            boolean dryRun
+            ExecutionMode executionMode
     ) {
         this.id = id;
         this.testSteps = testSteps;
         this.beforeHooks = beforeHooks;
         this.afterHooks = afterHooks;
         this.pickle = pickle;
-        this.executionMode = dryRun ? DRY_RUN : RUN;
+        this.executionMode = executionMode;
     }
 
     private static io.cucumber.messages.types.Group makeMessageGroup(

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/HookTestStepTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/HookTestStepTest.java
@@ -39,7 +39,7 @@ class HookTestStepTest {
         Collections.emptyList(),
         Collections.emptyList(),
         feature.getPickles().get(0),
-        false);
+        ExecutionMode.RUN);
     private final EventBus bus = mock(EventBus.class);
     private final UUID testExecutionId = UUID.randomUUID();
     private final TestCaseState state = new TestCaseState(bus, testExecutionId, testCase);

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/PickleStepTestStepTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/PickleStepTestStepTest.java
@@ -58,7 +58,7 @@ class PickleStepTestStepTest {
             "     Given I have 4 cukes in my belly\n");
     private final Pickle pickle = feature.getPickles().get(0);
     private final TestCase testCase = new TestCase(UUID.randomUUID(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList(), pickle, false);
+        Collections.emptyList(), pickle, ExecutionMode.RUN);
     private final EventBus bus = mock(EventBus.class);
     private final UUID testExecutionId = UUID.randomUUID();
     private final TestCaseState state = new TestCaseState(bus, testExecutionId, testCase);

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/TestCaseStateResultTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/TestCaseStateResultTest.java
@@ -49,7 +49,7 @@ class TestCaseStateResultTest {
             Collections.emptyList(),
             Collections.emptyList(),
             feature.getPickles().get(0),
-            false));
+            ExecutionMode.RUN));
 
     @BeforeEach
     void setup() {

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/TestCaseStateTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/TestCaseStateTest.java
@@ -45,7 +45,7 @@ class TestCaseStateTest {
                 Collections.emptyList(),
                 Collections.emptyList(),
                 feature.getPickles().get(0),
-                false));
+                ExecutionMode.RUN));
     }
 
     @Test

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/TestCaseTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/TestCaseTest.java
@@ -88,7 +88,7 @@ class TestCaseTest {
 
     private TestCase createTestCase(PickleStepTestStep... steps) {
         return new TestCase(UUID.randomUUID(), asList(steps), Collections.emptyList(), Collections.emptyList(),
-            pickle(), false);
+            pickle(), ExecutionMode.RUN);
     }
 
     private Pickle pickle() {

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -35,6 +35,8 @@ public final class Constants {
      */
     public static final String EXECUTION_DRY_RUN_PROPERTY_NAME = io.cucumber.core.options.Constants.EXECUTION_DRY_RUN_PROPERTY_NAME;
 
+    public static final String EXECUTION_SKIP_TAGS_PROPERTY_NAME = io.cucumber.core.options.Constants.EXECUTION_SKIP_TAGS_PROPERTY_NAME;
+
     /**
      * Tag replacement pattern for the exclusive resource templates: {@value}
      *

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberEngineOptions.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME_PREFIX;
 import static io.cucumber.junit.platform.engine.Constants.ANSI_COLORS_DISABLED_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.EXECUTION_DRY_RUN_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.EXECUTION_SKIP_TAGS_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.FEATURES_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.FILTER_NAME_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.FILTER_TAGS_PROPERTY_NAME;
@@ -41,6 +42,7 @@ import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PUBLISH_QUIET_P
 import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PUBLISH_TOKEN_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.SNIPPET_TYPE_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.UUID_GENERATOR_PROPERTY_NAME;
+import static java.util.Collections.emptyList;
 
 class CucumberEngineOptions implements
         io.cucumber.core.plugin.Options,
@@ -164,6 +166,14 @@ class CucumberEngineOptions implements
                 .orElse(null);
     }
 
+    @Override
+    public List<Expression> getSkipTagExpressions() {
+        return configurationParameters
+                .get(EXECUTION_SKIP_TAGS_PROPERTY_NAME, TagExpressionParser::parse)
+                .map(Collections::singletonList)
+                .orElse(emptyList());
+    }
+
     boolean isParallelExecutionEnabled() {
         return configurationParameters
                 .getBoolean(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME)
@@ -185,6 +195,6 @@ class CucumberEngineOptions implements
                     .sorted(Comparator.comparing(FeatureWithLines::uri))
                     .distinct()
                     .collect(Collectors.toList()))
-                .orElse(Collections.emptyList());
+                .orElse(emptyList());
     }
 }


### PR DESCRIPTION
### 🤔 What's changed?

Adds `cucumber.execution.skip.tags`. This will skip execution of all steps and hooks in any pickle that matches the tag expressions. This differs from `cucumber.filter.tags` which removes the matching pickle from execution altogether.

Note: Conceptually Cucumber and the JUnit Platform have different definitions for what it means to skip test. This makes things complicated.

* When using `cucumber.execution.skip.tags` JUnit will consider the test to be aborted because from its perspective Cucumber started the execution and then skipped all steps, thus aborting the test.
* When using `cucumber.filter.tags` JUnit will skip the test, never starting the execution and thus omitting it from any Cucumber reports.
* When using JUnit tag filters, JUnit will remove the test, never starting the execution and thus omitting it from any Cucumber reports. Only in this case the Cucumber and JUnit report will agree.

### ⚡️ What's your motivation? 

Quick proof of concept for: #2951. 

### 🏷️ What kind of change is this?
- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
