### PR TITLE
Pretty-Print DocStringArgument Step Arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [JUnit Platform Engine] Use JUnit Platform 1.11.3 (JUnit Jupiter 5.11.3)
-### Fixed
+### Added
 - [Core] Pretty-Print DocStringArgument Step Arguments([#2953](https://github.com/cucumber/cucumber-jvm/pull/2953) Daniel Miladinov)
 
 ## [7.20.1] - 2024-10-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [JUnit Platform Engine] Use JUnit Platform 1.11.3 (JUnit Jupiter 5.11.3)
+### Fixed
+- [Core] Pretty-Print DocStringArgument Step Arguments([#2953](https://github.com/cucumber/cucumber-jvm/pull/2953) Daniel Miladinov)
 
 ## [7.20.1] - 2024-10-09
 ### Fixed

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
@@ -2,6 +2,7 @@ package io.cucumber.core.plugin;
 
 import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.gherkin.DataTableArgument;
+import io.cucumber.core.gherkin.DocStringArgument;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.datatable.DataTableFormatter;
 import io.cucumber.plugin.ColorAware;
@@ -141,18 +142,28 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
             String locationComment = formatLocationComment(event, testStep, keyword, stepText);
             out.println(STEP_INDENT + formattedStepText + locationComment);
             StepArgument stepArgument = testStep.getStep().getArgument();
-            if (DataTableArgument.class.isInstance(stepArgument)) {
+            if (stepArgument instanceof DataTableArgument) {
                 DataTableFormatter tableFormatter = DataTableFormatter
-                        .builder()
-                        .prefixRow(STEP_SCENARIO_INDENT)
-                        .escapeDelimiters(false)
-                        .build();
+                    .builder()
+                    .prefixRow(STEP_SCENARIO_INDENT)
+                    .escapeDelimiters(false)
+                    .build();
                 DataTableArgument dataTableArgument = (DataTableArgument) stepArgument;
                 try {
                     tableFormatter.formatTo(DataTable.create(dataTableArgument.cells()), out);
                 } catch (IOException e) {
                     throw new CucumberException(e);
                 }
+            } else if (stepArgument instanceof DocStringArgument) {
+                DocStringArgument docStringArgument = (DocStringArgument) stepArgument;
+                String contentType = docStringArgument.getContentType();
+                String printableContentType = contentType == null ? "" : contentType;
+                out.println(STEP_INDENT + "\"\"\"" + printableContentType);
+                for (String l : docStringArgument.getContent().split("\\r?\\n|\\r")) {
+                    String s = STEP_INDENT + l;
+                    out.println(s);
+                }
+                out.println(STEP_INDENT + "\"\"\"");
             }
         }
     }

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
@@ -144,10 +144,10 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
             StepArgument stepArgument = testStep.getStep().getArgument();
             if (stepArgument instanceof DataTableArgument) {
                 DataTableFormatter tableFormatter = DataTableFormatter
-                    .builder()
-                    .prefixRow(STEP_SCENARIO_INDENT)
-                    .escapeDelimiters(false)
-                    .build();
+                        .builder()
+                        .prefixRow(STEP_SCENARIO_INDENT)
+                        .escapeDelimiters(false)
+                        .build();
                 DataTableArgument dataTableArgument = (DataTableArgument) stepArgument;
                 try {
                     tableFormatter.formatTo(DataTable.create(dataTableArgument.cells()), out);

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/PrettyFormatter.java
@@ -5,6 +5,8 @@ import io.cucumber.core.gherkin.DataTableArgument;
 import io.cucumber.core.gherkin.DocStringArgument;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.datatable.DataTableFormatter;
+import io.cucumber.docstring.DocString;
+import io.cucumber.docstring.DocStringFormatter;
 import io.cucumber.plugin.ColorAware;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.cucumber.plugin.event.Argument;
@@ -149,21 +151,25 @@ public final class PrettyFormatter implements ConcurrentEventListener, ColorAwar
                         .escapeDelimiters(false)
                         .build();
                 DataTableArgument dataTableArgument = (DataTableArgument) stepArgument;
+                DataTable table = DataTable.create(dataTableArgument.cells());
                 try {
-                    tableFormatter.formatTo(DataTable.create(dataTableArgument.cells()), out);
+                    tableFormatter.formatTo(table, out);
                 } catch (IOException e) {
                     throw new CucumberException(e);
                 }
             } else if (stepArgument instanceof DocStringArgument) {
+                DocStringFormatter docStringFormatter = DocStringFormatter
+                        .builder()
+                        .indentation(STEP_SCENARIO_INDENT)
+                        .build();
                 DocStringArgument docStringArgument = (DocStringArgument) stepArgument;
-                String contentType = docStringArgument.getContentType();
-                String printableContentType = contentType == null ? "" : contentType;
-                out.println(STEP_INDENT + "\"\"\"" + printableContentType);
-                for (String l : docStringArgument.getContent().split("\\r?\\n|\\r")) {
-                    String s = STEP_INDENT + l;
-                    out.println(s);
+                DocString docString = DocString.create(docStringArgument.getContent(),
+                    docStringArgument.getContentType());
+                try {
+                    docStringFormatter.formatTo(docString, out);
+                } catch (IOException e) {
+                    throw new CucumberException(e);
                 }
-                out.println(STEP_INDENT + "\"\"\"");
             }
         }
     }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/PrettyFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/PrettyFormatterTest.java
@@ -613,39 +613,6 @@ class PrettyFormatterTest {
     }
 
     @Test
-    void should_print_docstring_without_content_type() {
-        Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-                "Feature: Test feature\n" +
-                "  Scenario: Test Scenario\n" +
-                "    Given first step\n" +
-                "    \"\"\"\n" +
-                "    {\"key1\": \"value1\",\n" +
-                "     \"key2\": \"value2\",\n" +
-                "     \"another1\": \"another2\"}\n" +
-                "    \"\"\"\n");
-
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        Runtime.builder()
-                .withFeatureSupplier(new StubFeatureSupplier(feature))
-                .withAdditionalPlugins(new PrettyFormatter(out))
-                .withRuntimeOptions(new RuntimeOptionsBuilder().setMonochrome().build())
-                .withBackendSupplier(new StubBackendSupplier(
-                    new StubStepDefinition("first step", "path/step_definitions.java:7", DocString.class)))
-                .build()
-                .run();
-
-        assertThat(out, bytes(equalToCompressingWhiteSpace("" +
-                "\n" +
-                "Scenario: Test Scenario # path/test.feature:2\n" +
-                "  Given first step      # path/step_definitions.java:7\n" +
-                "    \"\"\"\n" +
-                "    {\"key1\": \"value1\",\n" +
-                "     \"key2\": \"value2\",\n" +
-                "     \"another1\": \"another2\"}\n" +
-                "    \"\"\"\n")));
-    }
-
-    @Test
     void should_print_docstring_including_content_type() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
                 "Feature: Test feature\n" +

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/PrettyFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/PrettyFormatterTest.java
@@ -615,66 +615,66 @@ class PrettyFormatterTest {
     @Test
     void should_print_docstring_without_content_type() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test Scenario\n" +
-            "    Given first step\n" +
-            "    \"\"\"\n" +
-            "    {\"key1\": \"value1\",\n" +
-            "     \"key2\": \"value2\",\n" +
-            "     \"another1\": \"another2\"}\n" +
-            "    \"\"\"\n");
+                "Feature: Test feature\n" +
+                "  Scenario: Test Scenario\n" +
+                "    Given first step\n" +
+                "    \"\"\"\n" +
+                "    {\"key1\": \"value1\",\n" +
+                "     \"key2\": \"value2\",\n" +
+                "     \"another1\": \"another2\"}\n" +
+                "    \"\"\"\n");
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         Runtime.builder()
-            .withFeatureSupplier(new StubFeatureSupplier(feature))
-            .withAdditionalPlugins(new PrettyFormatter(out))
-            .withRuntimeOptions(new RuntimeOptionsBuilder().setMonochrome().build())
-            .withBackendSupplier(new StubBackendSupplier(
-                new StubStepDefinition("first step", "path/step_definitions.java:7", DocString.class)))
-            .build()
-            .run();
+                .withFeatureSupplier(new StubFeatureSupplier(feature))
+                .withAdditionalPlugins(new PrettyFormatter(out))
+                .withRuntimeOptions(new RuntimeOptionsBuilder().setMonochrome().build())
+                .withBackendSupplier(new StubBackendSupplier(
+                    new StubStepDefinition("first step", "path/step_definitions.java:7", DocString.class)))
+                .build()
+                .run();
 
         assertThat(out, bytes(equalToCompressingWhiteSpace("" +
-            "\n" +
-            "Scenario: Test Scenario # path/test.feature:2\n" +
-            "  Given first step      # path/step_definitions.java:7\n" +
-            "    \"\"\"\n" +
-            "    {\"key1\": \"value1\",\n" +
-            "     \"key2\": \"value2\",\n" +
-            "     \"another1\": \"another2\"}\n" +
-            "    \"\"\"\n")));
+                "\n" +
+                "Scenario: Test Scenario # path/test.feature:2\n" +
+                "  Given first step      # path/step_definitions.java:7\n" +
+                "    \"\"\"\n" +
+                "    {\"key1\": \"value1\",\n" +
+                "     \"key2\": \"value2\",\n" +
+                "     \"another1\": \"another2\"}\n" +
+                "    \"\"\"\n")));
     }
 
     @Test
     void should_print_docstring_including_content_type() {
         Feature feature = TestFeatureParser.parse("path/test.feature", "" +
-            "Feature: Test feature\n" +
-            "  Scenario: Test Scenario\n" +
-            "    Given first step\n" +
-            "    \"\"\"json\n" +
-            "    {\"key1\": \"value1\",\n" +
-            "     \"key2\": \"value2\",\n" +
-            "     \"another1\": \"another2\"}\n" +
-            "    \"\"\"\n");
+                "Feature: Test feature\n" +
+                "  Scenario: Test Scenario\n" +
+                "    Given first step\n" +
+                "    \"\"\"json\n" +
+                "    {\"key1\": \"value1\",\n" +
+                "     \"key2\": \"value2\",\n" +
+                "     \"another1\": \"another2\"}\n" +
+                "    \"\"\"\n");
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         Runtime.builder()
-            .withFeatureSupplier(new StubFeatureSupplier(feature))
-            .withAdditionalPlugins(new PrettyFormatter(out))
-            .withRuntimeOptions(new RuntimeOptionsBuilder().setMonochrome().build())
-            .withBackendSupplier(new StubBackendSupplier(
-                new StubStepDefinition("first step", "path/step_definitions.java:7", DocString.class)))
-            .build()
-            .run();
+                .withFeatureSupplier(new StubFeatureSupplier(feature))
+                .withAdditionalPlugins(new PrettyFormatter(out))
+                .withRuntimeOptions(new RuntimeOptionsBuilder().setMonochrome().build())
+                .withBackendSupplier(new StubBackendSupplier(
+                    new StubStepDefinition("first step", "path/step_definitions.java:7", DocString.class)))
+                .build()
+                .run();
 
         assertThat(out, bytes(equalToCompressingWhiteSpace("" +
-            "\n" +
-            "Scenario: Test Scenario # path/test.feature:2\n" +
-            "  Given first step      # path/step_definitions.java:7\n" +
-            "    \"\"\"json\n" +
-            "    {\"key1\": \"value1\",\n" +
-            "     \"key2\": \"value2\",\n" +
-            "     \"another1\": \"another2\"}\n" +
-            "    \"\"\"\n")));
+                "\n" +
+                "Scenario: Test Scenario # path/test.feature:2\n" +
+                "  Given first step      # path/step_definitions.java:7\n" +
+                "    \"\"\"json\n" +
+                "    {\"key1\": \"value1\",\n" +
+                "     \"key2\": \"value2\",\n" +
+                "     \"another1\": \"another2\"}\n" +
+                "    \"\"\"\n")));
     }
 }

--- a/docstring/src/main/java/io/cucumber/docstring/DocString.java
+++ b/docstring/src/main/java/io/cucumber/docstring/DocString.java
@@ -5,9 +5,7 @@ import org.apiguardian.api.API;
 import java.lang.reflect.Type;
 import java.util.Objects;
 
-import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.joining;
 
 /**
  * A doc string. For example:
@@ -81,11 +79,9 @@ public final class DocString {
 
     @Override
     public String toString() {
-        return stream(content.split("\n"))
-                .collect(joining(
-                    "\n      ",
-                    "      \"\"\"" + contentType + "\n      ",
-                    "\n      \"\"\""));
+        return DocStringFormatter.builder()
+                .build()
+                .format(this);
     }
 
     public interface DocStringConverter {

--- a/docstring/src/main/java/io/cucumber/docstring/DocStringFormatter.java
+++ b/docstring/src/main/java/io/cucumber/docstring/DocStringFormatter.java
@@ -12,7 +12,6 @@ public final class DocStringFormatter {
     private final String indentation;
 
     private DocStringFormatter(String indentation) {
-        requireNonNull(indentation, "indentation should be null");
         this.indentation = indentation;
     }
 
@@ -27,6 +26,8 @@ public final class DocStringFormatter {
     }
 
     public void formatTo(DocString docString, StringBuilder appendable) {
+        requireNonNull(docString, "docString may not be null");
+        requireNonNull(appendable, "appendable may not be null");
         try {
             formatTo(docString, (Appendable) appendable);
         } catch (IOException e) {
@@ -52,7 +53,7 @@ public final class DocStringFormatter {
         }
 
         public Builder indentation(String indentation) {
-            requireNonNull(indentation, "indentation should be null");
+            requireNonNull(indentation, "indentation may not be null");
             this.indentation = indentation;
             return this;
         }

--- a/docstring/src/main/java/io/cucumber/docstring/DocStringFormatter.java
+++ b/docstring/src/main/java/io/cucumber/docstring/DocStringFormatter.java
@@ -1,0 +1,64 @@
+package io.cucumber.docstring;
+
+import org.apiguardian.api.API;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+@API(status = API.Status.EXPERIMENTAL)
+public final class DocStringFormatter {
+
+    private final String indentation;
+
+    private DocStringFormatter(String indentation) {
+        requireNonNull(indentation, "indentation should be null");
+        this.indentation = indentation;
+    }
+
+    public static DocStringFormatter.Builder builder() {
+        return new Builder();
+    }
+
+    public String format(DocString docString) {
+        StringBuilder result = new StringBuilder();
+        formatTo(docString, result);
+        return result.toString();
+    }
+
+    public void formatTo(DocString docString, StringBuilder appendable) {
+        try {
+            formatTo(docString, (Appendable) appendable);
+        } catch (IOException e) {
+            throw new CucumberDocStringException(e.getMessage(), e);
+        }
+    }
+
+    public void formatTo(DocString docString, Appendable out) throws IOException {
+        String printableContentType = docString.getContentType() == null ? "" : docString.getContentType();
+        out.append(indentation).append("\"\"\"").append(printableContentType).append("\n");
+        for (String l : docString.getContent().split("\\n")) {
+            out.append(indentation).append(l).append("\n");
+        }
+        out.append(indentation).append("\"\"\"").append("\n");
+    }
+
+    public static final class Builder {
+
+        private String indentation = "";
+
+        private Builder() {
+
+        }
+
+        public Builder indentation(String indentation) {
+            requireNonNull(indentation, "indentation should be null");
+            this.indentation = indentation;
+            return this;
+        }
+
+        public DocStringFormatter build() {
+            return new DocStringFormatter(indentation);
+        }
+    }
+}

--- a/docstring/src/test/java/io/cucumber/docstring/DocStringFormatterTest.java
+++ b/docstring/src/test/java/io/cucumber/docstring/DocStringFormatterTest.java
@@ -1,0 +1,64 @@
+package io.cucumber.docstring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class DocStringFormatterTest {
+
+    @Test
+    void should_print_docstring_with_content_type() {
+        DocString docString = DocString.create("{\n" +
+                "  \"key1\": \"value1\",\n" +
+                "  \"key2\": \"value2\",\n" +
+                "  \"another1\": \"another2\"\n" +
+                "}\n",
+            "application/json");
+
+        DocStringFormatter formatter = DocStringFormatter.builder().build();
+        String format = formatter.format(docString);
+        assertThat(format, equalTo(
+            "\"\"\"application/json\n" +
+                    "{\n" +
+                    "  \"key1\": \"value1\",\n" +
+                    "  \"key2\": \"value2\",\n" +
+                    "  \"another1\": \"another2\"\n" +
+                    "}\n" +
+                    "\"\"\"\n"));
+    }
+
+    @Test
+    void should_print_docstring_without_content_type() {
+        DocString docString = DocString.create("{\n" +
+                "  \"key1\": \"value1\",\n" +
+                "  \"key2\": \"value2\",\n" +
+                "  \"another1\": \"another2\"\n" +
+                "}\n");
+
+        DocStringFormatter formatter = DocStringFormatter.builder().build();
+        String format = formatter.format(docString);
+        assertThat(format, equalTo(
+            "\"\"\"\n" +
+                    "{\n" +
+                    "  \"key1\": \"value1\",\n" +
+                    "  \"key2\": \"value2\",\n" +
+                    "  \"another1\": \"another2\"\n" +
+                    "}\n" +
+                    "\"\"\"\n"));
+    }
+
+    @Test
+    void should_print_docstring_with_indentation() {
+        DocString docString = DocString.create("Hello",
+            "text/plain");
+
+        DocStringFormatter formatter = DocStringFormatter.builder().indentation("   ").build();
+        String format = formatter.format(docString);
+        assertThat(format, equalTo(
+            "   \"\"\"text/plain\n" +
+                    "   Hello\n" +
+                    "   \"\"\"\n"));
+    }
+
+}

--- a/docstring/src/test/java/io/cucumber/docstring/DocStringTest.java
+++ b/docstring/src/test/java/io/cucumber/docstring/DocStringTest.java
@@ -28,11 +28,11 @@ class DocStringTest {
             "application/json");
 
         assertThat(docString.toString(), is("" +
-                "      \"\"\"application/json\n" +
-                "      {\n" +
-                "        \"hello\":\"world\"\n" +
-                "      }\n" +
-                "      \"\"\""));
+                "\"\"\"application/json\n" +
+                "{\n" +
+                "  \"hello\":\"world\"\n" +
+                "}\n" +
+                "\"\"\"\n"));
     }
 
     @Test
@@ -60,9 +60,9 @@ class DocStringTest {
             "application/json");
 
         assertThat(docString.toString(), is("" +
-                "      \"\"\"application/json\n" +
-                "      \n" +
-                "      \"\"\""));
+                "\"\"\"application/json\n" +
+                "\n" +
+                "\"\"\"\n"));
     }
 
 }

--- a/docstring/src/test/java/io/cucumber/docstring/DocStringTypeRegistryDocStringConverterTest.java
+++ b/docstring/src/test/java/io/cucumber/docstring/DocStringTypeRegistryDocStringConverterTest.java
@@ -151,9 +151,9 @@ class DocStringTypeRegistryDocStringConverterTest {
             () -> converter.convert(docString, JsonNode.class));
         assertThat(exception.getMessage(), is(equalToCompressingWhiteSpace("" +
                 "'json' could not transform\n" +
-                "      \"\"\"json\n" +
-                "      {\"hello\":\"world\"}\n" +
-                "      \"\"\"")));
+                " \"\"\"json\n" +
+                " {\"hello\":\"world\"}\n" +
+                " \"\"\"")));
     }
 
     @Test


### PR DESCRIPTION
### 🤔 What's changed?

The pretty formatter now also prints docstring step arguments, in addition to datatable step arguments

### ⚡️ What's your motivation? 

I use the pretty formatter to print out my test results, and I noticed that everything gets printed except for docstring step arguments. It felt like this was a missing or incomplete feature. Regardless, I want to have my formatted test results include the contents of the step docstrings.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)
- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

I'm not sure what else needs to be done before this pull request can be merged. I don't know if this needs to be announced or if I should update anything in the documentation or changelog. If that's required, please let me know what other changes I should make, and I will make them!

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
