### PR TITLE
docs: Center align README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   Cucumber JVM
 </h1>
 <p align="center">
-  <b>Automated tests in plain language, for JVM</b>
+  <b>Automated tests in plain language, for the JVM</b>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -7,26 +7,16 @@
   <b>Automated tests in plain language, for the JVM</b>
 </p>
 
-<p align="center">
-  <a href="https://central.sonatype.com/artifact/io.cucumber/cucumber-java" style="text-decoration: none">
-    <img src="https://img.shields.io/maven-central/v/io.cucumber/cucumber-java?style=flat&color=dark-green&label=Maven%20Central" alt="Cucumber JVM version">
-  </a>
-  <a href="https://github.com/cucumber/cucumber-jvm/actions" style="text-decoration: none">
-    <img src="https://github.com/cucumber/cucumber-jvm/actions/workflows/release-java.yml/badge.svg" alt="Build status">
-  </a>
-  <a href="https://codecov.io/gh/cucumber/cucumber-jvm/branch/main" style="text-decoration: none">
-    <img src="https://codecov.io/gh/cucumber/cucumber-jvm/branch/main/graph/badge.svg" alt="Coverage">
-  </a>
-  <a href="https://opencollective.com/cucumber">
-    <img src="https://opencollective.com/cucumber/backers/badge.svg" alt="Cucumber backers">
-  </a>
-  <a href="https://opencollective.com/cucumber">
-    <img src="https://opencollective.com/cucumber/sponsors/badge.svg" alt="Cucumber sponsors">
-  </a>
-  <a href="https://vshymanskyy.github.io/StandWithUkraine">
-    <img src="https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg" alt="Ukraine solidarity">
-  </a>
-</p>
+<div align="center">
+
+[![Maven Central](https://img.shields.io/maven-central/v/io.cucumber/cucumber-java?style=flat&color=dark-green&label=Maven%20Central)](https://central.sonatype.com/artifact/io.cucumber/cucumber-java)
+[![Build Status](https://github.com/cucumber/cucumber-jvm/actions/workflows/release-java.yml/badge.svg)](https://github.com/cucumber/cucumber-jvm/actions)
+[![Coverage Status](https://codecov.io/gh/cucumber/cucumber-jvm/branch/main/graph/badge.svg)](https://codecov.io/gh/cucumber/cucumber-jvm/branch/main)
+[![OpenCollective](https://opencollective.com/cucumber/backers/badge.svg)](https://opencollective.com/cucumber)
+[![OpenCollective](https://opencollective.com/cucumber/sponsors/badge.svg)](https://opencollective.com/cucumber)
+[![#StandWithUkraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://vshymanskyy.github.io/StandWithUkraine)
+
+</div>
 
 [Cucumber](https://github.com/cucumber) is a tool for running automated tests written in plain language. Because they're
 written in plain language, they can be read by anyone on your team. Because they can be

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ your team.
 
 This is the Java implementation of Cucumber. You can [run](https://cucumber.io/docs/cucumber/api/#running-cucumber) it with
 the tool of your choice - including with popular
-[Dependency Injection containers](https://cucumber.io/docs/installation/java/#dependency-injection).
+[dependency injection containers](https://cucumber.io/docs/installation/java/#dependency-injection).
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,40 @@
-# Cucumber JVM
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/cucumber/cucumber-js/46a5a78107be27e99c6e044c69b6e8f885ce456c/docs/images/logo.svg" alt="Cucumber logo" width="75">
+  <br>
+  Cucumber JVM
+</h1>
+<p align="center">
+  <b>Automated tests in plain language, for JVM</b>
+</p>
 
-[![#StandWithUkraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://vshymanskyy.github.io/StandWithUkraine)
-[![OpenCollective](https://opencollective.com/cucumber/backers/badge.svg)](https://opencollective.com/cucumber)
-[![OpenCollective](https://opencollective.com/cucumber/sponsors/badge.svg)](https://opencollective.com/cucumber)
-[![Maven Central](https://img.shields.io/maven-central/v/io.cucumber/cucumber-java.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.cucumber/cucumber-java)
-[![Build Status](https://github.com/cucumber/cucumber-jvm/workflows/Cucumber%20CI/badge.svg)](https://github.com/cucumber/cucumber-jvm/actions)
-[![Coverage Status](https://codecov.io/gh/cucumber/cucumber-jvm/branch/main/graph/badge.svg)](https://codecov.io/gh/cucumber/cucumber-jvm/branch/main)
+<p align="center">
+  <a href="https://central.sonatype.com/artifact/io.cucumber/cucumber-java" style="text-decoration: none">
+    <img src="https://img.shields.io/maven-central/v/io.cucumber/cucumber-java?style=flat&color=dark-green&label=Maven%20Central" alt="Cucumber JVM version">
+  </a>
+  <a href="https://github.com/cucumber/cucumber-jvm/actions" style="text-decoration: none">
+    <img src="https://github.com/cucumber/cucumber-jvm/actions/workflows/release-java.yml/badge.svg" alt="Build status">
+  </a>
+  <a href="https://codecov.io/gh/cucumber/cucumber-jvm/branch/main" style="text-decoration: none">
+    <img src="https://codecov.io/gh/cucumber/cucumber-jvm/branch/main/graph/badge.svg" alt="Coverage">
+  </a>
+  <a href="https://opencollective.com/cucumber">
+    <img src="https://opencollective.com/cucumber/backers/badge.svg" alt="Cucumber backers">
+  </a>
+  <a href="https://opencollective.com/cucumber">
+    <img src="https://opencollective.com/cucumber/sponsors/badge.svg" alt="Cucumber sponsors">
+  </a>
+  <a href="https://vshymanskyy.github.io/StandWithUkraine">
+    <img src="https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg" alt="Ukraine solidarity">
+  </a>
+</p>
 
-Cucumber-JVM is a pure Java implementation of Cucumber.
-You can [run](https://cucumber.io/docs/cucumber/api/#running-cucumber) it with
-the tool of your choice.
+[Cucumber](https://github.com/cucumber) is a tool for running automated tests written in plain language. Because they're
+written in plain language, they can be read by anyone on your team. Because they can be
+read by anyone, you can use them to help improve communication, collaboration and trust on
+your team.
 
-Cucumber-JVM also integrates with all the popular
+This is the Java implementation of Cucumber. You can [run](https://cucumber.io/docs/cucumber/api/#running-cucumber) it with
+the tool of your choice - including with popular
 [Dependency Injection containers](https://cucumber.io/docs/installation/java/#dependency-injection).
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/io.cucumber/cucumber-java?style=flat&color=dark-green&label=Maven%20Central)](https://central.sonatype.com/artifact/io.cucumber/cucumber-java)
 [![Build Status](https://github.com/cucumber/cucumber-jvm/actions/workflows/release-java.yml/badge.svg)](https://github.com/cucumber/cucumber-jvm/actions)
-[![Coverage Status](https://codecov.io/gh/cucumber/cucumber-jvm/branch/main/graph/badge.svg)](https://codecov.io/gh/cucumber/cucumber-jvm/branch/main)
 [![OpenCollective](https://opencollective.com/cucumber/backers/badge.svg)](https://opencollective.com/cucumber)
 [![OpenCollective](https://opencollective.com/cucumber/sponsors/badge.svg)](https://opencollective.com/cucumber)
 [![#StandWithUkraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://vshymanskyy.github.io/StandWithUkraine)


### PR DESCRIPTION
### 🤔 What's changed?

- Center align README badges
- Change version badge color from blue to green
- Fix GitHub workflow badge
- Extended summary description and linked logo

#### Before

[![#StandWithUkraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://vshymanskyy.github.io/StandWithUkraine) [![OpenCollective](https://opencollective.com/cucumber/backers/badge.svg)](https://opencollective.com/cucumber) [![OpenCollective](https://opencollective.com/cucumber/sponsors/badge.svg)](https://opencollective.com/cucumber) [![Maven Central](https://img.shields.io/maven-central/v/io.cucumber/cucumber-java.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.cucumber/cucumber-java) [![Build Status](https://github.com/cucumber/cucumber-jvm/workflows/Cucumber%20CI/badge.svg)](https://github.com/cucumber/cucumber-jvm/actions) [![Coverage Status](https://codecov.io/gh/cucumber/cucumber-jvm/branch/main/graph/badge.svg)](https://codecov.io/gh/cucumber/cucumber-jvm/branch/main)

#### After

<p align="center">
  <a href="https://central.sonatype.com/artifact/io.cucumber/cucumber-java" style="text-decoration: none">
    <img src="https://img.shields.io/maven-central/v/io.cucumber/cucumber-java?style=flat&color=dark-green&label=Maven%20Central" alt="Cucumber JVM version">
  </a>
  <a href="https://github.com/cucumber/cucumber-jvm/actions" style="text-decoration: none">
    <img src="https://github.com/cucumber/cucumber-jvm/actions/workflows/release-java.yml/badge.svg" alt="Build status">
  </a>
  <a href="https://codecov.io/gh/cucumber/cucumber-jvm/branch/main" style="text-decoration: none">
    <img src="https://codecov.io/gh/cucumber/cucumber-jvm/branch/main/graph/badge.svg" alt="Coverage">
  </a>
  <a href="https://opencollective.com/cucumber">
    <img src="https://opencollective.com/cucumber/backers/badge.svg" alt="Cucumber backers">
  </a>
  <a href="https://opencollective.com/cucumber">
    <img src="https://opencollective.com/cucumber/sponsors/badge.svg" alt="Cucumber sponsors">
  </a>
  <a href="https://vshymanskyy.github.io/StandWithUkraine">
    <img src="https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg" alt="Ukraine solidarity">
  </a>
</p>

### ⚡️ What's your motivation? 

- Consistency across Cucumber implementations - aligning with the [JavaScript implementation](https://github.com/cucumber/cucumber-js)
- Overall visual consistency

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

- "Automated tests in plain language, for JVM" tagline suitability
- External permalink logo suitability - or whether to include a copy of the SVG in the repository alternatively
- Whether the summary description is suitable or requires updates

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
