### PR TITLE
Snippet.template() Now Accepts a Step Parameter

### DIFF
--- a/cucumber-core/src/main/java/io/cucumber/core/backend/Snippet.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/Snippet.java
@@ -1,5 +1,6 @@
 package io.cucumber.core.backend;
 
+import io.cucumber.core.gherkin.Step;
 import org.apiguardian.api.API;
 
 import java.lang.reflect.Type;
@@ -10,19 +11,21 @@ import java.util.Map;
 public interface Snippet {
 
     /**
-     * @return a {@link java.text.MessageFormat} template used to generate a
-     *         snippet. The template can access the following variables:
-     *         <ul>
-     *         <li>{0} : Step Keyword</li>
-     *         <li>{1} : Value of {@link #escapePattern(String)}</li>
-     *         <li>{2} : Function name</li>
-     *         <li>{3} : Value of {@link #arguments(Map)}</li>
-     *         <li>{4} : Regexp hint comment</li>
-     *         <li>{5} : value of {@link #tableHint()} if the step has a
-     *         table</li>
-     *         </ul>
+     * @param  step information about the step that could determine how the
+     *              snippet template will be generated
+     * @return      a {@link java.text.MessageFormat} template used to generate
+     *              a snippet. The template can access the following variables:
+     *              <ul>
+     *              <li>{0} : Step Keyword</li>
+     *              <li>{1} : Value of {@link #escapePattern(String)}</li>
+     *              <li>{2} : Function name</li>
+     *              <li>{3} : Value of {@link #arguments(Map)}</li>
+     *              <li>{4} : Regexp hint comment</li>
+     *              <li>{5} : value of {@link #tableHint()} if the step has a
+     *              table</li>
+     *              </ul>
      */
-    MessageFormat template();
+    MessageFormat template(Step step);
 
     /**
      * @return a hint about alternative ways to declare a table argument

--- a/cucumber-core/src/main/java/io/cucumber/core/snippets/SnippetGenerator.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/snippets/SnippetGenerator.java
@@ -55,7 +55,7 @@ public final class SnippetGenerator {
         String functionName = functionName(source, functionNameGenerator);
         List<String> parameterNames = toParameterNames(expression, parameterNameGenerator);
         Map<String, Type> arguments = arguments(step, parameterNames, expression.getParameterTypes());
-        return snippet.template().format(new String[] {
+        return snippet.template(step).format(new String[] {
                 sanitize(keyword),
                 snippet.escapePattern(source),
                 functionName,

--- a/cucumber-core/src/test/java/io/cucumber/core/snippets/TestSnippet.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/snippets/TestSnippet.java
@@ -1,6 +1,7 @@
 package io.cucumber.core.snippets;
 
 import io.cucumber.core.backend.Snippet;
+import io.cucumber.core.gherkin.Step;
 
 import java.lang.reflect.Type;
 import java.text.MessageFormat;
@@ -11,7 +12,7 @@ public class TestSnippet implements Snippet {
     private int i;
 
     @Override
-    public MessageFormat template() {
+    public MessageFormat template(Step step) {
         return new MessageFormat("test snippet " + i++);
     }
 

--- a/cucumber-java/src/main/java/io/cucumber/java/JavaSnippet.java
+++ b/cucumber-java/src/main/java/io/cucumber/java/JavaSnippet.java
@@ -1,11 +1,13 @@
 package io.cucumber.java;
 
+import io.cucumber.core.gherkin.Step;
+
 import java.text.MessageFormat;
 
 final class JavaSnippet extends AbstractJavaSnippet {
 
     @Override
-    public MessageFormat template() {
+    public MessageFormat template(Step step) {
         return new MessageFormat("" +
                 "@{0}(\"{1}\")\n" +
                 "public void {2}({3}) '{'\n" +

--- a/cucumber-java8/src/main/java/io/cucumber/java8/Java8Snippet.java
+++ b/cucumber-java8/src/main/java/io/cucumber/java8/Java8Snippet.java
@@ -1,11 +1,13 @@
 package io.cucumber.java8;
 
+import io.cucumber.core.gherkin.Step;
+
 import java.text.MessageFormat;
 
 final class Java8Snippet extends AbstractJavaSnippet {
 
     @Override
-    public MessageFormat template() {
+    public MessageFormat template(Step step) {
         return new MessageFormat("" +
                 "{0}(\"{1}\", ({3}) -> '{'\n" +
                 "    // {4}\n" +

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/StubBackendProviderService.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/StubBackendProviderService.java
@@ -8,6 +8,7 @@ import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.ParameterInfo;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.backend.StepDefinition;
+import io.cucumber.core.gherkin.Step;
 
 import java.lang.reflect.Type;
 import java.net.URI;
@@ -93,7 +94,7 @@ public class StubBackendProviderService implements BackendProviderService {
                 private int i = 1;
 
                 @Override
-                public MessageFormat template() {
+                public MessageFormat template(Step step) {
                     return new MessageFormat("stub snippet " + i++);
                 }
 

--- a/cucumber-junit/src/test/java/io/cucumber/junit/StubBackendProviderService.java
+++ b/cucumber-junit/src/test/java/io/cucumber/junit/StubBackendProviderService.java
@@ -11,6 +11,7 @@ import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.backend.StaticHookDefinition;
 import io.cucumber.core.backend.StepDefinition;
 import io.cucumber.core.backend.TestCaseState;
+import io.cucumber.core.gherkin.Step;
 
 import java.lang.reflect.Type;
 import java.net.URI;
@@ -169,7 +170,7 @@ public class StubBackendProviderService implements BackendProviderService {
                 private int i = 1;
 
                 @Override
-                public MessageFormat template() {
+                public MessageFormat template(Step step) {
                     return new MessageFormat("stub snippet " + i++);
                 }
 

--- a/cucumber-testng/src/test/java/io/cucumber/testng/StubBackendProviderService.java
+++ b/cucumber-testng/src/test/java/io/cucumber/testng/StubBackendProviderService.java
@@ -8,6 +8,7 @@ import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.ParameterInfo;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.backend.StepDefinition;
+import io.cucumber.core.gherkin.Step;
 
 import java.lang.reflect.Type;
 import java.net.URI;
@@ -99,7 +100,7 @@ public class StubBackendProviderService implements BackendProviderService {
                 private int i = 1;
 
                 @Override
-                public MessageFormat template() {
+                public MessageFormat template(Step step) {
                     return new MessageFormat("stub snippet" + i++);
                 }
 


### PR DESCRIPTION
### 🤔 What's changed?

`Snippet.template()` Now Accepts a `Step` Parameter

### ⚡️ What's your motivation? 

Although none of the `Snippet` implementations within the project itself need it, receiving the current `step` as a parameter would allow certain external snippet implementations (specifically, in my case, my [burpless](https://github.com/danielmiladinov/burpless) library that wraps Cucumber-JVM and makes it easier to use from Clojure) to decide, based on information about the step argument, which `MessageFormat` to return: a default value, one specialized for steps with a `DataTableArgument`, and one specialized for steps with a `DocStringArgument`.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct]