### PR TITLE
[Archetype] Replace JUnit Jupiter with AssertJ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [JUnit Platform Engine] Set Engine-Version-cucumber attribute ([#2963](https://github.com/cucumber/cucumber-jvm/pull/2963) M.P. Korstanje)
 
 ### Changed
+- [Archetype] Replace JUnit Jupiter with AssertJ ([#2969](https://github.com/cucumber/cucumber-jvm/pull/2969) M.P. Korstanje)
 - [JUnit Platform Engine] Use JUnit Platform 1.11.3 (JUnit Jupiter 5.11.3)
 
 ### Added

--- a/cucumber-archetype/README.md
+++ b/cucumber-archetype/README.md
@@ -6,5 +6,5 @@ This is a Maven Archetype for setting up an empty Cucumber project. Used by the 
 mvn archetype:generate                                  \
   -DarchetypeGroupId=io.cucumber                        \
   -DarchetypeArtifactId=cucumber-archetype              \
-  -DarchetypeVersion=${cucumber.version}                \
+  -DarchetypeVersion=${cucumber.version}
 ```

--- a/cucumber-archetype/pom.xml
+++ b/cucumber-archetype/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
+        <assertj.version>3.25.3</assertj.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
     </properties>
@@ -36,6 +37,16 @@
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Not used by this module. But ensures the assertj.version
+                 in the archetype template is also automatically updated by renovate
+                 bot. -->
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-bom</artifactId>
+                <version>${assertj.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/cucumber-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cucumber-archetype/src/main/resources/archetype-resources/pom.xml
@@ -29,6 +29,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-bom</artifactId>
+                <version>${assertj.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -52,8 +59,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cucumber-archetype/src/main/resources/archetype-resources/src/test/java/StepDefinitions.java
+++ b/cucumber-archetype/src/main/resources/archetype-resources/src/test/java/StepDefinitions.java
@@ -2,7 +2,7 @@ package ${package};
 
 import io.cucumber.java.en.*;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StepDefinitions {
 

--- a/cucumber-archetype/src/test/resources/projects/should-generate-project/reference/pom.xml
+++ b/cucumber-archetype/src/test/resources/projects/should-generate-project/reference/pom.xml
@@ -29,6 +29,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-bom</artifactId>
+                <version>${assertj.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -52,8 +59,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cucumber-archetype/src/test/resources/projects/should-generate-project/reference/src/test/java/com/example/StepDefinitions.java
+++ b/cucumber-archetype/src/test/resources/projects/should-generate-project/reference/src/test/java/com/example/StepDefinitions.java
@@ -2,7 +2,7 @@ package com.example;
 
 import io.cucumber.java.en.*;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StepDefinitions {
 


### PR DESCRIPTION
### ⚡️ What's your motivation? 

As a JUnit Platform Engine, Cucumber does not need JUnit Jupiter. It was included as a dependency to allow users to use Assertions. This is better done with AssertJ.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
