### PR TITLE
[Core] Indent stacktrace in pretty formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - [Core] Include root cause when using DataTable.asList and friends ([#2949](https://github.com/cucumber/cucumber-jvm/pull/2949) M.P. Korstanje)
+- [Core] Indent stacktrace in pretty formatter ([#2970](https://github.com/cucumber/cucumber-jvm/pull/2970) M.P. Korstanje)
 - [JUnit Platform Engine] Set Engine-Version-cucumber attribute ([#2963](https://github.com/cucumber/cucumber-jvm/pull/2963) M.P. Korstanje)
 
 ### Changed

--- a/cucumber-core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 import static io.cucumber.core.options.Constants.FILTER_TAGS_PROPERTY_NAME;
+import static io.cucumber.core.plugin.IsEqualCompressingLineSeparators.equalCompressingLineSeparators;
 import static io.cucumber.core.resource.ClasspathSupport.rootPackageUri;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
@@ -50,7 +51,6 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
@@ -411,7 +411,7 @@ class CommandlineOptionsParserTest {
         parser
                 .parse("--threads", "0")
                 .build();
-        assertThat(output(), equalToCompressingWhiteSpace("--threads must be > 0"));
+        assertThat(output(), equalCompressingLineSeparators("--threads must be > 0"));
         assertThat(parser.exitStatus(), is(Optional.of((byte) 0x1)));
     }
 
@@ -518,7 +518,7 @@ class CommandlineOptionsParserTest {
         parser
                 .parse("--count", "0")
                 .build();
-        assertThat(output(), equalToCompressingWhiteSpace("--count must be > 0"));
+        assertThat(output(), equalCompressingLineSeparators("--count must be > 0"));
         assertThat(parser.exitStatus(), is(Optional.of((byte) 0x1)));
     }
 

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/DefaultSummaryPrinterTest.java
@@ -19,11 +19,11 @@ import java.time.ZoneId;
 import java.util.Locale;
 import java.util.UUID;
 
+import static io.cucumber.core.plugin.IsEqualCompressingLineSeparators.equalCompressingLineSeparators;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Instant.ofEpochSecond;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.text.IsEqualCompressingWhiteSpace.equalToCompressingWhiteSpace;
 
 class DefaultSummaryPrinterTest {
 
@@ -56,7 +56,7 @@ class DefaultSummaryPrinterTest {
 
         bus.send(new TestRunFinished(bus.getInstant(), new Result(Status.PASSED, Duration.ZERO, null)));
 
-        assertThat(new String(out.toByteArray(), UTF_8), equalToCompressingWhiteSpace("" +
+        assertThat(new String(out.toByteArray(), UTF_8), equalCompressingLineSeparators("" +
                 "\n" +
                 "0 Scenarios\n" +
                 "0 Steps\n" +

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/IsEqualCompressingLineSeparators.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/IsEqualCompressingLineSeparators.java
@@ -1,0 +1,47 @@
+package io.cucumber.core.plugin;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.Objects;
+
+public class IsEqualCompressingLineSeparators extends TypeSafeMatcher<String> {
+
+    private final String expected;
+
+    public IsEqualCompressingLineSeparators(String expected) {
+        Objects.requireNonNull(expected);
+        this.expected = expected;
+    }
+
+    public String getExpected() {
+        return expected;
+    }
+
+    @Override
+    public boolean matchesSafely(String actual) {
+        return compressNewLines(expected).equals(compressNewLines(actual));
+    }
+
+    @Override
+    public void describeMismatchSafely(String item, Description mismatchDescription) {
+        mismatchDescription.appendText("was ").appendValue(item);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a string equal to ")
+                .appendValue(expected)
+                .appendText(" compressing newlines");
+    }
+
+    public String compressNewLines(String actual) {
+        return actual.replaceAll("[\r\n]+", "\n").trim();
+    }
+
+    public static Matcher<String> equalCompressingLineSeparators(String expectedString) {
+        return new IsEqualCompressingLineSeparators(expectedString);
+    }
+
+}

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/JsonFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/JsonFormatterTest.java
@@ -230,7 +230,7 @@ class JsonFormatterTest {
                 .withEventBus(new TimeServiceEventBus(timeService, UUID::randomUUID))
                 .withBackendSupplier(new StubBackendSupplier(
                     new StubStepDefinition("there are bananas", "StepDefs.there_are_bananas()",
-                        new StubException())))
+                        new StubException("the stack trace"))))
                 .build()
                 .run();
 
@@ -1485,5 +1485,4 @@ class JsonFormatterTest {
                 "]";
         assertJsonEquals(expected, out);
     }
-
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/ProgressFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/ProgressFormatterTest.java
@@ -18,12 +18,12 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static io.cucumber.core.plugin.Bytes.bytes;
+import static io.cucumber.core.plugin.IsEqualCompressingLineSeparators.equalCompressingLineSeparators;
 import static io.cucumber.plugin.event.Status.FAILED;
 import static io.cucumber.plugin.event.Status.PASSED;
 import static io.cucumber.plugin.event.Status.UNDEFINED;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.text.IsEqualCompressingWhiteSpace.equalToCompressingWhiteSpace;
 import static org.mockito.Mockito.mock;
 
 class ProgressFormatterTest {
@@ -41,7 +41,7 @@ class ProgressFormatterTest {
     void prints_empty_line_for_empty_test_run() {
         Result result = new Result(PASSED, Duration.ZERO, null);
         bus.send(new TestRunFinished(Instant.now(), result));
-        assertThat(out, bytes(equalToCompressingWhiteSpace("\n")));
+        assertThat(out, bytes(equalCompressingLineSeparators("\n")));
     }
 
     @Test
@@ -49,7 +49,7 @@ class ProgressFormatterTest {
         Result result = new Result(PASSED, Duration.ZERO, null);
         bus.send(new TestStepFinished(Instant.now(), mock(TestCase.class), mock(PickleStepTestStep.class), result));
         bus.send(new TestRunFinished(Instant.now(), result));
-        assertThat(out, bytes(equalToCompressingWhiteSpace(AnsiEscapes.GREEN + "." + AnsiEscapes.RESET + "\n")));
+        assertThat(out, bytes(equalCompressingLineSeparators(AnsiEscapes.GREEN + "." + AnsiEscapes.RESET + "\n")));
     }
 
     @Test

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/RerunFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/RerunFormatterTest.java
@@ -14,12 +14,12 @@ import org.opentest4j.TestAbortedException;
 import java.io.ByteArrayOutputStream;
 
 import static io.cucumber.core.plugin.Bytes.bytes;
+import static io.cucumber.core.plugin.IsEqualCompressingLineSeparators.equalCompressingLineSeparators;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.text.IsEqualCompressingWhiteSpace.equalToCompressingWhiteSpace;
 
 class RerunFormatterTest {
 
@@ -66,7 +66,7 @@ class RerunFormatterTest {
                 .build()
                 .run();
 
-        assertThat(out, bytes(equalToCompressingWhiteSpace("classpath:path/test.feature:2:4:6\n")));
+        assertThat(out, bytes(equalCompressingLineSeparators("classpath:path/test.feature:2:4:6\n")));
     }
 
     @Test
@@ -89,7 +89,7 @@ class RerunFormatterTest {
                 .build()
                 .run();
 
-        assertThat(out, bytes(equalToCompressingWhiteSpace("file:path/test.feature:2\n")));
+        assertThat(out, bytes(equalCompressingLineSeparators("file:path/test.feature:2\n")));
     }
 
     @Test
@@ -113,7 +113,7 @@ class RerunFormatterTest {
                 .build()
                 .run();
 
-        assertThat(out, bytes(equalToCompressingWhiteSpace("file:path/test.feature:4\n")));
+        assertThat(out, bytes(equalCompressingLineSeparators("file:path/test.feature:4\n")));
     }
 
     @Test
@@ -139,7 +139,7 @@ class RerunFormatterTest {
                 .build()
                 .run();
 
-        assertThat(out, bytes(equalToCompressingWhiteSpace("classpath:path/test.feature:8\n")));
+        assertThat(out, bytes(equalCompressingLineSeparators("classpath:path/test.feature:8\n")));
     }
 
     @Test
@@ -165,7 +165,7 @@ class RerunFormatterTest {
                 .build()
                 .run();
 
-        assertThat(out, bytes(equalToCompressingWhiteSpace("classpath:path/test.feature:2\n")));
+        assertThat(out, bytes(equalCompressingLineSeparators("classpath:path/test.feature:2\n")));
     }
 
     @Test
@@ -191,7 +191,7 @@ class RerunFormatterTest {
                 .build()
                 .run();
 
-        assertThat(out, bytes(equalToCompressingWhiteSpace("classpath:path/test.feature:2\n")));
+        assertThat(out, bytes(equalCompressingLineSeparators("classpath:path/test.feature:2\n")));
     }
 
     @Test
@@ -217,7 +217,7 @@ class RerunFormatterTest {
                 .build()
                 .run();
 
-        assertThat(out, bytes(equalToCompressingWhiteSpace("classpath:path/test.feature:2:5\n")));
+        assertThat(out, bytes(equalCompressingLineSeparators("classpath:path/test.feature:2:5\n")));
     }
 
     @Test
@@ -247,7 +247,7 @@ class RerunFormatterTest {
 
         assertThat(out,
             bytes(
-                equalToCompressingWhiteSpace("classpath:path/first.feature:2\nclasspath:path/second.feature:2\n")));
+                equalCompressingLineSeparators("classpath:path/first.feature:2\nclasspath:path/second.feature:2\n")));
     }
 
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/StubException.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/StubException.java
@@ -6,24 +6,82 @@ import java.io.PrintWriter;
 class StubException extends RuntimeException {
 
     private final String stacktrace;
+    private final String className;
 
-    StubException(String message, String stacktrace) {
+    private StubException(String className, String message, String stacktrace) {
         super(message);
+        this.className = className;
         this.stacktrace = stacktrace;
     }
 
     public StubException() {
-        this("message", "the stack trace");
+        this("the stack trace");
+    }
+
+    public StubException(String message) {
+        this(null, message, null);
+    }
+
+    public StubException withClassName() {
+        return new StubException(StubException.class.getName(), getMessage(), stacktrace);
+    }
+
+    public StubException withStacktrace(String stacktrace) {
+        return new StubException(className, getMessage(), stacktrace);
     }
 
     @Override
-    public void printStackTrace(PrintWriter printWriter) {
-        printWriter.print(stacktrace);
+    public void printStackTrace(PrintWriter writer) {
+        printStackTrace(new PrintWriterOrStream(writer));
     }
 
     @Override
-    public void printStackTrace(PrintStream printStream) {
-        printStream.print(stacktrace);
+    public void printStackTrace(PrintStream stream) {
+        printStackTrace(new PrintWriterOrStream(stream));
+    }
+
+    private void printStackTrace(PrintWriterOrStream p) {
+        if (className != null) {
+            p.println(className);
+        }
+        p.print(getMessage());
+        if (stacktrace != null) {
+            p.println("");
+            p.println("\t" + stacktrace);
+        }
+    }
+
+    private static class PrintWriterOrStream {
+        private final PrintWriter writer;
+        private final PrintStream stream;
+
+        private PrintWriterOrStream(PrintWriter writer) {
+            this.writer = writer;
+            this.stream = null;
+        }
+
+        private PrintWriterOrStream(PrintStream stream) {
+            this.writer = null;
+            this.stream = stream;
+        }
+
+        void println(String s) {
+            if (writer != null) {
+                writer.println(s);
+            }
+            if (stream != null) {
+                stream.println(s);
+            }
+        }
+
+        void print(String s) {
+            if (writer != null) {
+                writer.print(s);
+            }
+            if (stream != null) {
+                stream.print(s);
+            }
+        }
     }
 
 }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/TeamCityPluginTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/TeamCityPluginTest.java
@@ -191,12 +191,14 @@ class TeamCityPluginTest {
                 .withAdditionalPlugins(new TeamCityPlugin(new PrintStream(out)))
                 .withEventBus(new TimeServiceEventBus(fixed(EPOCH, of("UTC")), UUID::randomUUID))
                 .withBackendSupplier(new StubBackendSupplier(
-                    new StubStepDefinition("first step", new StubException("Step failed", "the stack trace"))))
+                    new StubStepDefinition("first step",
+                        new StubException("Step failed")
+                                .withStacktrace("the stack trace"))))
                 .build()
                 .run();
 
         assertThat(out, bytes(containsString("" +
-                "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step failed' details = 'the stack trace' name = 'first step']\n")));
+                "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step failed' details = 'Step failed|n\tthe stack trace|n' name = 'first step']\n")));
     }
 
     @Test
@@ -255,7 +257,9 @@ class TeamCityPluginTest {
                 .withAdditionalPlugins(new TeamCityPlugin(new PrintStream(out)))
                 .withEventBus(new TimeServiceEventBus(fixed(EPOCH, of("UTC")), UUID::randomUUID))
                 .withBackendSupplier(new StubBackendSupplier(
-                    singletonList(new StubHookDefinition(new StubException("Step failed", "the stack trace"))),
+                    singletonList(
+                        new StubHookDefinition(new StubException("Step failed")
+                                .withStacktrace("the stack trace"))),
                     singletonList(new StubStepDefinition("first step")),
                     emptyList()))
                 .build()
@@ -264,7 +268,7 @@ class TeamCityPluginTest {
         assertThat(out, bytes(containsString("" +
                 "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' locationHint = '{stubbed location with details}' captureStandardOutput = 'true' name = 'Before']\n"
                 +
-                "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step failed' details = 'the stack trace' name = 'Before']")));
+                "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' duration = '0' message = 'Step failed' details = 'Step failed|n\tthe stack trace|n' name = 'Before']")));
     }
 
     @Test
@@ -333,13 +337,15 @@ class TeamCityPluginTest {
                     emptyList(),
                     emptyList(),
                     emptyList(),
-                    singletonList(new StubStaticHookDefinition(new StubException("Hook failed", "the stack trace")))))
+                    singletonList(new StubStaticHookDefinition(
+                        new StubException("Hook failed")
+                                .withStacktrace("the stack trace")))))
                 .build()
                 .run());
 
         assertThat(out, bytes(containsString("" +
                 "##teamcity[testStarted timestamp = '1970-01-01T12:00:00.000+0000' name = 'Before All/After All']\n" +
-                "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' message = 'Before All/After All failed' details = 'the stack trace' name = 'Before All/After All']\n"
+                "##teamcity[testFailed timestamp = '1970-01-01T12:00:00.000+0000' message = 'Before All/After All failed' details = 'Hook failed|n\tthe stack trace|n' name = 'Before All/After All']\n"
                 +
                 "##teamcity[testFinished timestamp = '1970-01-01T12:00:00.000+0000' name = 'Before All/After All']")));
     }

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/UnusedStepsSummaryPrinterTest.java
@@ -17,8 +17,8 @@ import java.time.Duration;
 import java.util.UUID;
 
 import static io.cucumber.core.plugin.Bytes.bytes;
+import static io.cucumber.core.plugin.IsEqualCompressingLineSeparators.equalCompressingLineSeparators;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.text.IsEqualCompressingWhiteSpace.equalToCompressingWhiteSpace;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,7 +47,7 @@ class UnusedStepsSummaryPrinterTest {
 
         // Verify produced output
         assertThat(out,
-            bytes(equalToCompressingWhiteSpace("1 Unused steps:\n" + "my/tummy.feature:5 # some more cukes\n")));
+            bytes(equalCompressingLineSeparators("1 Unused steps:\n" + "my/tummy.feature:5 # some more cukes\n")));
     }
 
     private static StepDefinition mockStepDef(String location, String pattern) {


### PR DESCRIPTION
### 🤔 What's changed?

Renders the stack trace in the pretty formatter with the same indent as the step that failed it.

Before

```
[INFO] Running io.cucumber.skeleton.RunCucumberTest

Scenario: a few cukes               # io/cucumber/skeleton/belly.feature:3
  Given I have 42 cukes in my belly # io.cucumber.skeleton.StepDefinitions.I_have_cukes_in_my_belly(int)
    org.opentest4j.AssertionFailedError:
expected: "b"
 but was: "a"
  at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
  at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
  at io.cucumber.skeleton.StepDefinitions.I_have_cukes_in_my_belly(StepDefinitions.java:12)
  at ✽.I have 42 cukes in my belly(classpath:io/cucumber/skeleton/belly.feature:4)
```

After

```
[INFO] Running io.cucumber.skeleton.RunCucumberTest

Scenario: a few cukes               # io/cucumber/skeleton/belly.feature:3
  Given I have 42 cukes in my belly # io.cucumber.skeleton.StepDefinitions.I_have_cukes_in_my_belly(int)
      org.opentest4j.AssertionFailedError:
      expected: "b"
       but was: "a"
        at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
        at io.cucumber.skeleton.StepDefinitions.I_have_cukes_in_my_belly(StepDefinitions.java:12)
        at ✽.I have 42 cukes in my belly(classpath:io/cucumber/skeleton/belly.feature:4)
```

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
