### PR TITLE
[JUnit Platform Engine] Use number-and-pickle-if-parameterized strategy

### DIFF
--- a/cucumber-junit-platform-engine/README.md
+++ b/cucumber-junit-platform-engine/README.md
@@ -420,13 +420,13 @@ cucumber.junit-platform.naming-strategy=                       # long or short.
                                                                # default: short
                                                                # include parent descriptor name in test descriptor.
 
-cucumber.junit-platform.naming-strategy.short.example-name=    # number or pickle.
-                                                               # default: number
+cucumber.junit-platform.naming-strategy.short.example-name=    # number, number-and-pickle-if-parameterized or pickle.
+                                                               # default: number-and-pickle-if-parameterized
                                                                # Use example number or pickle name for examples when
                                                                # short naming strategy is used
 
-cucumber.junit-platform.naming-strategy.long.example-name=     # number or pickle.
-                                                               # default: number
+cucumber.junit-platform.naming-strategy.long.example-name=     # number, number-and-pickle-if-parameterized or pickle.
+                                                               # default: number-and-pickle-if-parameterized
                                                                # Use example number or pickle name for examples when
                                                                # long naming strategy is used
 

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -143,17 +143,19 @@ public final class Constants {
      * Property name used to configure the naming strategy of examples in case
      * of short naming strategy: {@value}
      * <p>
-     * Value must be one of {@code number} or {@code pickle}. By default,
-     * numbers are used.
-     * <p>
-     * When set to {@code pickle} the pickle name is used. So for scenario name
-     * {@code Adding <a> and <b>} and example with params {@code a = 10} and
-     * {@code b = 20} the following name would be produced:
+     * Value must be one of {@code number}, {@code pickle}, or
+     * {@code number-and-pickle-if-parameterized}. By default,
+     * {@code number-and-pickle-if-parameterized} is used.
+     * <ul>
+     * <li>When set to {@code number} examples are numbered. So the first
+     * example of the first examples section would be named {@code #1.1}
+     * <li>When set to {@code pickle} the pickle name is used. So for scenario
+     * name {@code Adding <a> and <b>} and example with params {@code a = 10}
+     * and {@code b = 20} the following name would be produced:
      * {@code Adding 10 and 20}.
-     * <p>
-     * Using example numbers works well in all scenarios, but if parameterized
-     * scenario names are used consistently, the pickle name provides more
-     * clarity.
+     * <li>When set to {@code number-and-pickle-if-parameterized} the name would
+     * be rendered as {@code #1.1: Adding 10 and 20}.
+     * </ul>
      */
     @API(status = Status.EXPERIMENTAL, since = "7.16.2")
     public static final String JUNIT_PLATFORM_SHORT_NAMING_STRATEGY_EXAMPLE_NAME_PROPERTY_NAME = "cucumber.junit-platform.naming-strategy.short.example-name";
@@ -162,17 +164,19 @@ public final class Constants {
      * Property name used to configure the naming strategy of examples in case
      * of long naming strategy: {@value}
      * <p>
-     * Value must be one of {@code number} or {@code pickle}. By default,
-     * numbers are used.
-     * <p>
-     * When set to {@code pickle} the pickle name is used. So for scenario name
-     * {@code Adding <a> and <b>} and example with params {@code a = 10} and
-     * {@code b = 20} the following name would be produced:
-     * {@code Feature Name - Rule Name - Adding <a> and <b> - Examples Name - Adding 10 and 20}.
-     * <p>
-     * Using example numbers works well in all scenarios, but if parameterized
-     * scenario names are used consistently, the pickle name provides more
-     * clarity.
+     * Value must be one of {@code number}, {@code pickle}, or
+     * {@code number-and-pickle-if-parameterized}. By default,
+     * {@code number-and-pickle-if-parameterized} is used.
+     * <ul>
+     * <li>When set to {@code number} examples are numbered. So the first
+     * example of the first examples section would be named {@code #1.1}
+     * <li>When set to {@code pickle} the pickle name is used. So for scenario
+     * name {@code Adding <a> and <b>} and example with params {@code a = 10}
+     * and {@code b = 20} the following name would be produced:
+     * {@code Adding 10 and 20}.
+     * <li>When set to {@code number-and-pickle-if-parameterized} the name would
+     * be rendered as {@code #1.1: Adding 10 and 20}.
+     * </ul>
      */
     @API(status = Status.EXPERIMENTAL, since = "7.16.2")
     public static final String JUNIT_PLATFORM_LONG_NAMING_STRATEGY_EXAMPLE_NAME_PROPERTY_NAME = "cucumber.junit-platform.naming-strategy.long.example-name";

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DefaultNamingStrategyProvider.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/DefaultNamingStrategyProvider.java
@@ -18,7 +18,7 @@ enum DefaultNamingStrategyProvider {
         NamingStrategy create(ConfigurationParameters configuration) {
             return configuration.get(JUNIT_PLATFORM_LONG_NAMING_STRATEGY_EXAMPLE_NAME_PROPERTY_NAME)
                     .map(DefaultNamingStrategyProvider::parseStrategy)
-                    .orElse(DefaultNamingStrategyProvider::exampleNumberStrategy)
+                    .orElse(DefaultNamingStrategyProvider::exampleNumberAndPickleIfParameterizedStrategy)
                     .apply(DefaultNamingStrategyProvider::longStrategy);
         }
     },
@@ -28,7 +28,7 @@ enum DefaultNamingStrategyProvider {
         NamingStrategy create(ConfigurationParameters configuration) {
             return configuration.get(JUNIT_PLATFORM_SHORT_NAMING_STRATEGY_EXAMPLE_NAME_PROPERTY_NAME)
                     .map(DefaultNamingStrategyProvider::parseStrategy)
-                    .orElse(DefaultNamingStrategyProvider::exampleNumberStrategy)
+                    .orElse(DefaultNamingStrategyProvider::exampleNumberAndPickleIfParameterizedStrategy)
                     .apply(DefaultNamingStrategyProvider::shortStrategy);
         }
     };
@@ -43,11 +43,36 @@ enum DefaultNamingStrategyProvider {
         switch (exampleStrategy) {
             case "number":
                 return DefaultNamingStrategyProvider::exampleNumberStrategy;
+            case "number-and-pickle-if-parameterized":
+                return DefaultNamingStrategyProvider::exampleNumberAndPickleIfParameterizedStrategy;
             case "pickle":
                 return DefaultNamingStrategyProvider::pickleNameStrategy;
             default:
                 throw new IllegalArgumentException("Unrecognized example naming strategy " + exampleStrategy);
         }
+    }
+
+    private static NamingStrategy exampleNumberAndPickleIfParameterizedStrategy(
+            BiFunction<Node, String, String> baseStrategy
+    ) {
+        return createNamingStrategy(
+            (node) -> baseStrategy.apply(node, nameOrKeyword(node)),
+            (node, pickle) -> baseStrategy.apply(node, nameOrKeyword(node) + pickleNameIfParameterized(node, pickle)));
+    }
+
+    private static String pickleNameIfParameterized(Node node, Pickle pickle) {
+        if (node instanceof Node.Example) {
+            String pickleName = pickle.getName();
+            boolean parameterized = !node.getParent()
+                    .flatMap(Node::getParent)
+                    .flatMap(Node::getName)
+                    .filter(pickleName::equals)
+                    .isPresent();
+            if (parameterized) {
+                return ": " + pickleName;
+            }
+        }
+        return "";
     }
 
     private static NamingStrategy exampleNumberStrategy(BiFunction<Node, String, String> baseStrategy) {

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/FeatureResolverTest.java
@@ -130,6 +130,14 @@ class FeatureResolverTest {
         return iterator.next();
     }
 
+    private TestDescriptor getParameterizedOutline() {
+        Iterator<? extends TestDescriptor> iterator = getFeature().getChildren().iterator();
+        iterator.next();
+        iterator.next();
+        iterator.next();
+        return iterator.next();
+    }
+
     @Test
     void example() {
         TestDescriptor example = getExample();
@@ -153,8 +161,9 @@ class FeatureResolverTest {
 
     @Test
     void longNames() {
-        configurationParameters = new MapConfigurationParameters(
-            JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME, "long");
+        configurationParameters = new MapConfigurationParameters(Map.of(
+            JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME, "long",
+            JUNIT_PLATFORM_LONG_NAMING_STRATEGY_EXAMPLE_NAME_PROPERTY_NAME, "number"));
 
         TestDescriptor example = getExample();
         assertEquals("A feature with scenario outlines - A scenario outline - With some text - Example #1.1",
@@ -169,6 +178,17 @@ class FeatureResolverTest {
 
         TestDescriptor example = getExample();
         assertEquals("A feature with scenario outlines - A scenario outline - With some text - A scenario outline",
+            example.getDisplayName());
+    }
+
+    @Test
+    void longNamesWithPickleNamesIfParameterized() {
+        configurationParameters = new MapConfigurationParameters(
+            JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME, "long");
+
+        TestDescriptor example = getParametrizedExample();
+        assertEquals(
+            "A feature with scenario outlines - A scenario with <example> - Examples - Example #1.1: A scenario with A",
             example.getDisplayName());
     }
 
@@ -191,8 +211,21 @@ class FeatureResolverTest {
         assertEquals("A scenario outline", example.getDisplayName());
     }
 
+    @Test
+    void shortNamesWithPickleNamesIfParameterized() {
+        configurationParameters = new MapConfigurationParameters(
+            JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME, "short");
+
+        TestDescriptor example = getParametrizedExample();
+        assertEquals("Example #1.1: A scenario with A", example.getDisplayName());
+    }
+
     private TestDescriptor getExample() {
         return getOutline().getChildren().iterator().next().getChildren().iterator().next();
+    }
+
+    private TestDescriptor getParametrizedExample() {
+        return getParameterizedOutline().getChildren().iterator().next().getChildren().iterator().next();
     }
 
     @Test

--- a/cucumber-junit-platform-engine/src/test/resources/io/cucumber/junit/platform/engine/feature-with-outline.feature
+++ b/cucumber-junit-platform-engine/src/test/resources/io/cucumber/junit/platform/engine/feature-with-outline.feature
@@ -36,3 +36,15 @@ Feature: A feature with scenario outlines
       | example |
       | A       |
       | B       |
+  
+  @ScenarioOutlineTag
+  Scenario Outline: A scenario with <example>
+    Given a parameterized scenario outline
+    When it is executed
+    Then <example> is used
+
+    @Example1Tag
+    Examples:
+      | example |
+      | A       |
+      | B       |


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Given a feature with parameterized and unparameterized examples:

```feature
Feature: Examples Tables

  Scenario Outline: Eating cucumbers
    Given there are <start> cucumbers
    When I eat <eat> cucumbers
    Then I should have <left> cucumbers

    Examples: These are passing
      | start | eat | left |
      |    12 |   5 |    7 |
      |    20 |   5 |   15 |

    Examples: These are failing
      | start | eat | left |
      |    12 |  20 |    0 |
      |     0 |   1 |    0 |

  Scenario Outline: Eating <color> cucumbers
    Given I am transparent
    When I eat <color> cucumbers
    Then I become <color>

    Examples:
      | color |
      |   red |
      | green |
      |  blue |
```

When the scenario name is parameterized, instead of only numbering the examples, the interpolated scenario name is also included.

```
Examples Tables
 - Eating cucumbers
   - These are passing
     - Example #1.1
     - Example #1.2
  - These are failing
  - Eating <color> cucumbers
   - Examples
    - Example #1.1: Eating red cucumbers
    - Example #1.2: Eating green cucumbers
    - Example #1.3: Eating blue cucumbers
```

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
