### PR TITLE
Clarify datatable matcher documentation

### DIFF
--- a/datatable-matchers/README.md
+++ b/datatable-matchers/README.md
@@ -22,26 +22,31 @@ Add the `datatable-matchers` dependency to your pom.
 Use the matcher in your step definition.
 
 ```java
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Then;
+
 import static io.cucumber.datatable.matchers.DataTableHasTheSameRowsAs.hasTheSameRowsAs;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-[...]
+public class StepDefinitions {
 
-private final DataTable expected = DataTable.create(
-    asList(
-        asList("Annie M. G.", "Schmidt"),
-        asList("Roald", "Dahl"),
-));
-    
-@Then("these authors have registered:")
-public void these_authors_have_registered(DataTable registeredAuthors){
-    assertThat(registeredAuthors, hasTheSameRowsAs(expected).inOrder());
-    
-    // java.lang.AssertionError: 
-    // Expected: a datable with the same rows
-    // but: the tables were different
-    // - | Annie M. G. | Schmidt  |
-    //   | Roald       | Dahl     |
-    // + | Astrid      | Lindgren |
-} 
+    // Provided by the system under test
+    DataTable actual = DataTable.create(asList(
+            asList("Annie M. G.", "Schmidt"),
+            asList("Roald", "Dahl")
+    ));
+
+    @Then("these authors have registered:")
+    public void these_authors_have_registered(DataTable expected) {
+        assertThat(actual, hasTheSameRowsAs(expected).inOrder());
+        // java.lang.AssertionError: 
+        // Expected: a datable with the same rows
+        //     but: the tables were different
+        //    + | Annie M. G. | Schmidt  |
+        //      | Roald       | Dahl     |
+        //    - | Astrid      | Lindgren |
+    }
+}
 ```
 


### PR DESCRIPTION
### 🤔 What's changed?

* The actual list of authors should be provided by the SUT
* Flip the actual and expected values
* Add several missing imports for a complete example

### ⚡️ What's your motivation? 

Fixes: #3018

### 🏷️ What kind of change is this?
- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

@gasparnagy do you think a comment is enough?

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
