### PR TITLE
[Core] Fix incomplete id for scenarios under rules in json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [JUnit Platform Engine] Don't use Java 9+ APIs ([#3025](https://github.com/cucumber/cucumber-jvm/pull/3025) M.P. Korstanje)
 - [JUnit Platform Engine] Implement toString on custom DiscoverySelectors
+  [Core] Fix incomplete id for scenarios under rules in json output ([#3026](https://github.com/cucumber/cucumber-jvm/pull/3026) M.P. Korstanje)
 
 ## [7.25.0] - 2025-07-10
 ### Changed

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/TestSourcesModel.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/TestSourcesModel.java
@@ -69,7 +69,7 @@ final class TestSourcesModel {
     private static final Pattern replacementPattern = Pattern.compile("[\\s'_,!]");
 
     static String convertToId(String name) {
-        return replacementPattern.matcher(name).replaceAll("-");
+        return replacementPattern.matcher(name).replaceAll("-").toLowerCase();
     }
 
     static URI relativize(URI uri) {

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/TestSourcesModel.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/TestSourcesModel.java
@@ -7,6 +7,7 @@ import io.cucumber.messages.types.Examples;
 import io.cucumber.messages.types.Feature;
 import io.cucumber.messages.types.FeatureChild;
 import io.cucumber.messages.types.GherkinDocument;
+import io.cucumber.messages.types.Rule;
 import io.cucumber.messages.types.RuleChild;
 import io.cucumber.messages.types.Scenario;
 import io.cucumber.messages.types.Source;
@@ -19,8 +20,10 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 final class TestSourcesModel {
@@ -43,6 +46,9 @@ final class TestSourcesModel {
 
     static String calculateId(AstNode astNode) {
         Object node = astNode.node;
+        if (node instanceof Rule) {
+            return calculateId(astNode.parent) + ";" + convertToId(((Rule) node).getName());
+        }
         if (node instanceof Scenario) {
             return calculateId(astNode.parent) + ";" + convertToId(((Scenario) node).getName());
         }
@@ -61,8 +67,10 @@ final class TestSourcesModel {
         return "";
     }
 
+    private static final Pattern replacementPattern = Pattern.compile("[\\s'_,!]");
+
     static String convertToId(String name) {
-        return name.replaceAll("[\\s'_,!]", "-").toLowerCase();
+        return replacementPattern.matcher(name).replaceAll("-").toLowerCase(Locale.ROOT);
     }
 
     static URI relativize(URI uri) {

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/TestSourcesModel.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/TestSourcesModel.java
@@ -70,7 +70,7 @@ final class TestSourcesModel {
     private static final Pattern replacementPattern = Pattern.compile("[\\s'_,!]");
 
     static String convertToId(String name) {
-        return replacementPattern.matcher(name).replaceAll("-").toLowerCase(Locale.ROOT);
+        return replacementPattern.matcher(name).replaceAll("-");
     }
 
     static URI relativize(URI uri) {

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/TestSourcesModel.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/TestSourcesModel.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;

--- a/cucumber-core/src/test/java/io/cucumber/core/plugin/JsonFormatterTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/plugin/JsonFormatterTest.java
@@ -305,7 +305,7 @@ class JsonFormatterTest {
                 "        \"line\": 4,\n" +
                 "        \"name\": \"Monkey eats bananas\",\n" +
                 "        \"description\": \"\",\n" +
-                "        \"id\": \";monkey-eats-bananas\",\n" +
+                "        \"id\": \"banana-party;this-is-all-monkey-business;monkey-eats-bananas\",\n" +
                 "        \"type\": \"scenario\",\n" +
                 "        \"keyword\": \"Scenario\",\n" +
                 "        \"steps\": [\n" +
@@ -405,7 +405,7 @@ class JsonFormatterTest {
                 "        \"line\": 11,\n" +
                 "        \"name\": \"Monkey eats bananas\",\n" +
                 "        \"description\": \"\",\n" +
-                "        \"id\": \";monkey-eats-bananas\",\n" +
+                "        \"id\": \"banana-party;this-is-all-monkey-business;monkey-eats-bananas\",\n" +
                 "        \"type\": \"scenario\",\n" +
                 "        \"keyword\": \"Scenario\",\n" +
                 "        \"steps\": [\n" +


### PR DESCRIPTION
### ⚡️ What's your motivation? 

When rules were added, the TestSourcesModel was not updated to account for these. As a result, the id for a given scenario was incomplete.

Also improved performance a tiny bit by reusing a pre-build regular expression.

### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
