### PR TITLE
Fix NPE for optional arguments when using the Cucumber JSON Formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [Core] Fix NPE for optional arguments when using the Cucumber JSON Formatter ([cucumber-json-formatter/#7](https://github.com/cucumber/cucumber-json-formatter/pull/7), [#3060](https://github.com/cucumber/cucumber-jvm/pull/3060) M.P. Korstanje)
 
 ## [7.28.0] - 2025-09-01
 ### Added
@@ -19,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [JUnit Platform Engine] Support rerun files ([#3057](https://github.com/cucumber/cucumber-jvm/pull/3057) M.P. Korstanje)
 
 ### Changed
-- [Core] Use a [message based Cucumber JSON Formatter](https://github.com/cucumber/cucumber-json-formatter) ([##2888](https://github.com/cucumber/cucumber-jvm/pull/#2888) M.P. Korstanje)
+- [Core] Use a [message based Cucumber JSON Formatter](https://github.com/cucumber/cucumber-json-formatter) ([#2888](https://github.com/cucumber/cucumber-jvm/pull/#2888) M.P. Korstanje)
 
 ### Deprecated
 - [Core] Deprecate `--i18n` options ([#3053](https://github.com/cucumber/cucumber-jvm/pull/3053) M.P. Korstanje)

--- a/cucumber-bom/pom.xml
+++ b/cucumber-bom/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <ci-environment.version>10.0.1</ci-environment.version>
         <cucumber-expressions.version>18.0.1</cucumber-expressions.version>
-        <cucumber-json-formatter.version>0.1.1</cucumber-json-formatter.version>
+        <cucumber-json-formatter.version>0.1.2</cucumber-json-formatter.version>
         <gherkin.version>34.0.0</gherkin.version>
         <html-formatter.version>21.13.0</html-formatter.version>
         <junit-xml-formatter.version>0.8.1</junit-xml-formatter.version>


### PR DESCRIPTION
### ⚡️ What's your motivation? 
Fixes:  https://github.com/cucumber/cucumber-jvm/pull/3059 by https://github.com/cucumber/cucumber-json-formatter/pull/7

### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)
### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
