### PR TITLE
Generate annotations for Emoji dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [Java] Generate annotations for Emoji dialect ([#3062](https://github.com/cucumber/cucumber-jvm/pull/3062) M.P. Korstanje)
 
 ## [7.28.1] - 2025-09-03
 ### Fixed

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/Runner.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/Runner.java
@@ -71,7 +71,7 @@ public final class Runner {
             buildBackendWorlds();
 
             glue.prepareGlue(localeForPickle(pickle));
-            snippetGenerators = createSnippetGeneratorsForPickle(glue.getStepTypeRegistry());
+            snippetGenerators = createSnippetGeneratorsForPickle(pickle.getLanguage(), glue.getStepTypeRegistry());
 
             TestCase testCase = createTestCaseForPickle(pickle);
             testCase.run(bus);
@@ -123,11 +123,13 @@ public final class Runner {
         }
     }
 
-    private List<SnippetGenerator> createSnippetGeneratorsForPickle(StepTypeRegistry stepTypeRegistry) {
+    private List<SnippetGenerator> createSnippetGeneratorsForPickle(
+            String language, StepTypeRegistry stepTypeRegistry
+    ) {
         return backends.stream()
                 .map(Backend::getSnippet)
                 .filter(Objects::nonNull)
-                .map(s -> new SnippetGenerator(s, stepTypeRegistry.parameterTypeRegistry()))
+                .map(s -> new SnippetGenerator(language, s, stepTypeRegistry.parameterTypeRegistry()))
                 .collect(Collectors.toList());
     }
 

--- a/cucumber-core/src/main/java/io/cucumber/core/snippets/SnippetGenerator.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/snippets/SnippetGenerator.java
@@ -12,14 +12,19 @@ import io.cucumber.plugin.event.DocStringArgument;
 import io.cucumber.plugin.event.StepArgument;
 
 import java.lang.reflect.Type;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static io.cucumber.core.snippets.SnippetType.CAMELCASE;
+import static java.util.stream.Collectors.joining;
 
 public final class SnippetGenerator {
 
@@ -31,8 +36,14 @@ public final class SnippetGenerator {
 
     private final Snippet snippet;
     private final CucumberExpressionGenerator generator;
+    private final String language;
 
     public SnippetGenerator(Snippet snippet, ParameterTypeRegistry parameterTypeRegistry) {
+        this(null, snippet, parameterTypeRegistry);
+    }
+
+    public SnippetGenerator(String language, Snippet snippet, ParameterTypeRegistry parameterTypeRegistry) {
+        this.language = language;
         this.snippet = snippet;
         this.generator = new CucumberExpressionGenerator(parameterTypeRegistry);
     }
@@ -56,7 +67,7 @@ public final class SnippetGenerator {
         List<String> parameterNames = toParameterNames(expression, parameterNameGenerator);
         Map<String, Type> arguments = arguments(step, parameterNames, expression.getParameterTypes());
         return snippet.template().format(new String[] {
-                sanitize(keyword),
+                getNormalizedKeyWord(language, keyword),
                 snippet.escapePattern(source),
                 functionName,
                 snippet.arguments(arguments),
@@ -72,17 +83,60 @@ public final class SnippetGenerator {
                 .collect(Collectors.toList());
     }
 
-    private static String sanitize(String keyWord) {
-        return keyWord.replaceAll("[\\s',!]", "");
+    private static String capitalize(String str) {
+        return str.substring(0, 1).toUpperCase() + str.substring(1);
+    }
+
+    private static String getNormalizedKeyWord(String language, String keyword) {
+        // Exception: Use the symbol names for the Emoj language.
+        // Emoji are not legal identifiers in Java.
+        if ("em".equals(language)) {
+            return getNormalizedEmojiKeyWord(keyword);
+        }
+        return getNormalizedKeyWord(keyword);
+    }
+
+    private static String getNormalizedEmojiKeyWord(String keyword) {
+        String titleCasedName = getCodePoints(keyword).mapToObj(Character::getName)
+                .map(s -> s.split(" "))
+                .flatMap(Arrays::stream)
+                .map(String::toLowerCase)
+                .map(SnippetGenerator::capitalize)
+                .collect(joining(" "));
+        return getNormalizedKeyWord(titleCasedName);
+    }
+
+    private static IntStream getCodePoints(String s) {
+        int length = s.length();
+        List<Integer> codePoints = new ArrayList<>();
+        for (int offset = 0; offset < length;) {
+            int codepoint = s.codePointAt(offset);
+            codePoints.add(codepoint);
+            offset += Character.charCount(codepoint);
+        }
+        return codePoints.stream().mapToInt(value -> value);
+    }
+
+    private static String getNormalizedKeyWord(String keyword) {
+        return normalize(keyword.replaceAll("[\\s',!\u00AD’]", ""));
+    }
+
+    static String normalize(CharSequence s) {
+        return Normalizer.normalize(s, Normalizer.Form.NFC);
     }
 
     private String functionName(String sentence, IdentifierGenerator functionNameGenerator) {
-        return Stream.of(sentence)
+        String functionName = Stream.of(sentence)
                 .map(DEFAULT_ARGUMENT_PATTERN::replaceMatchesWithSpace)
                 .map(functionNameGenerator::generate)
                 .filter(s -> !s.isEmpty())
                 .findFirst()
                 .orElseGet(() -> functionNameGenerator.generate(sentence));
+        if (!functionName.isEmpty()) {
+            return functionName;
+        }
+        // Example: All emoji
+        return functionNameGenerator.generate("step without java identifiers");
     }
 
     private Map<String, Type> arguments(Step step, List<String> parameterNames, List<ParameterType<?>> parameterTypes) {

--- a/cucumber-java/src/codegen/java/GenerateI18n.java
+++ b/cucumber-java/src/codegen/java/GenerateI18n.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.Normalizer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -19,6 +20,7 @@ import java.util.Map;
 import static java.nio.file.Files.newBufferedWriter;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.util.stream.Collectors.joining;
 
 /* This class generates the cucumber-java Interfaces and package-info
  * based on the languages and keywords from the GherkinDialects
@@ -26,8 +28,8 @@ import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
  */
 public class GenerateI18n {
 
-    // The generated files for and Emoij do not compile :(
-    private static final List<String> unsupported = Arrays.asList("em", "en-tx");
+    // For any language that does not compile
+    private static final List<String> unsupported = Collections.emptyList();
 
     public static void main(String[] args) throws Exception {
         if (args.length != 2) {
@@ -78,7 +80,7 @@ public class GenerateI18n {
 
         private void writeKeyWordAnnotation(GherkinDialect dialect, String keyword) {
             String normalizedLanguage = getNormalizedLanguage(dialect);
-            String normalizedKeyword = getNormalizedKeyWord(keyword);
+            String normalizedKeyword = getNormalizedKeyWord(dialect, keyword);
 
             Map<String, String> binding = new LinkedHashMap<>();
             binding.put("lang", normalizedLanguage);
@@ -101,8 +103,31 @@ public class GenerateI18n {
             }
         }
 
+        private static String capitalize(String s) {
+            return s.substring(0, 1).toUpperCase() + s.substring(1);
+        }
+
+        private static String getNormalizedKeyWord(GherkinDialect dialect, String keyword) {
+            // Exception: Use the symbol names for the Emoj language. 
+            // Emoji are not legal identifiers in Java.
+            if (dialect.getLanguage().equals("em")) {
+                return getNormalizedEmojiKeyWord(keyword);
+            }
+            return getNormalizedKeyWord(keyword);
+        }
+        
+        private static String getNormalizedEmojiKeyWord(String keyword) {
+            String titleCasedName = keyword.codePoints().mapToObj(Character::getName)
+                    .map(s -> s.split(" "))
+                    .flatMap(Arrays::stream)
+                    .map(String::toLowerCase)
+                    .map(DialectWriter::capitalize)
+                    .collect(joining(" "));
+            return getNormalizedKeyWord(titleCasedName);
+        }
+
         private static String getNormalizedKeyWord(String keyword) {
-            return normalize(keyword.replaceAll("[\\s',!\u00AD]", ""));
+            return normalize(keyword.replaceAll("[\\s',!\u00AD’]", ""));
         }
 
         private static String normalize(CharSequence s) {
@@ -133,5 +158,6 @@ public class GenerateI18n {
         private static String getNormalizedLanguage(GherkinDialect dialect) {
             return dialect.getLanguage().replaceAll("[\\s-]", "_").toLowerCase();
         }
+
     }
 }

--- a/cucumber-java/src/test/java/io/cucumber/java/JavaSnippetTest.java
+++ b/cucumber-java/src/test/java/io/cucumber/java/JavaSnippetTest.java
@@ -434,6 +434,31 @@ class JavaSnippetTest {
         return String.join("\n", snippet);
     }
 
+    @Test
+    void generatesEmojiSnippet() {
+        String expected = "" +
+                "@NeutralFace(\"\uD83C\uDFB8\")\n" +
+                "public void step_without_java_identifiers() {\n" +
+                "    // Write code here that turns the phrase above into concrete actions\n" +
+                "    throw new io.cucumber.java.PendingException();\n" +
+                "}";
+        String source = "" +
+                "# language: em\n" +
+                "\uD83D\uDCDA: \uD83D\uDE48\uD83D\uDE49\uD83D\uDE4A\n" +
+                "\n" +
+                "  \uD83D\uDCD5: \uD83D\uDC83\n" +
+                "    \uD83D\uDE10\uD83C\uDFB8\n";
+
+        Feature feature = TestFeatureParser.parse(source);
+        Step step = feature.getPickles().get(0).getSteps().get(0);
+        String language = "em";
+        ParameterTypeRegistry registry = new ParameterTypeRegistry(new Locale(language));
+        JavaSnippet snippet = new JavaSnippet();
+        SnippetGenerator generator = new SnippetGenerator(language, snippet, registry);
+        List<String> snippets = generator.getSnippet(step, snippetType);
+        assertThat(String.join("\n", snippets), is(equalTo(expected)));
+    }
+
     private static class Size {
         // Dummy. Makes the test readable
     }

--- a/cucumber-java8/src/codegen/java/GenerateI18n.java
+++ b/cucumber-java8/src/codegen/java/GenerateI18n.java
@@ -11,15 +11,16 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.Normalizer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.nio.file.Files.newBufferedWriter;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 /* This class generates the cucumber-java Interfaces and package-info
@@ -28,8 +29,8 @@ import static java.util.stream.Collectors.toList;
  */
 public class GenerateI18n {
 
-    // The generated files for and Emoij do not compile :(
-    private static final List<String> unsupported = Arrays.asList("em", "en-tx");
+    // For any language that does not compile
+    private static final List<String> unsupported = Collections.emptyList();
 
     public static void main(String[] args) throws Exception {
         if (args.length != 2) {
@@ -95,14 +96,37 @@ public class GenerateI18n {
             return dialect.getStepKeywords().stream()
                     .sorted()
                     .filter(it -> !it.contains(String.valueOf('*')))
-                    .filter(it -> !it.matches("^\\d.*")).distinct()
-                    .map(keyword -> keyword.replaceAll("[\\s',!\u00AD]", ""))
-                    .map(DialectWriter::normalize)
+                    .filter(it -> !it.matches("^\\d.*"))
+                    .distinct()
+                    .map(keyword -> getNormalizedKeyWord(dialect, keyword))
                     .collect(toList());
         }
 
         private static String capitalize(String str) {
             return str.substring(0, 1).toUpperCase() + str.substring(1);
+        }
+
+        private static String getNormalizedKeyWord(GherkinDialect dialect, String keyword) {
+            // Exception: Use the symbol names for the Emoj language. 
+            // Emoji are not legal identifiers in Java.
+            if (dialect.getLanguage().equals("em")) {
+                return getNormalizedEmojiKeyWord(keyword);
+            }
+            return getNormalizedKeyWord(keyword);
+        }
+
+        private static String getNormalizedEmojiKeyWord(String keyword) {
+            String titleCasedName = keyword.codePoints().mapToObj(Character::getName)
+                    .map(s -> s.split(" "))
+                    .flatMap(Arrays::stream)
+                    .map(String::toLowerCase)
+                    .map(DialectWriter::capitalize)
+                    .collect(joining(" "));
+            return getNormalizedKeyWord(titleCasedName);
+        }
+
+        private static String getNormalizedKeyWord(String keyword) {
+            return normalize(keyword.replaceAll("[\\s',!\u00AD’]", ""));
         }
 
         static String normalize(CharSequence s) {


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Step definition annotations and methods were not generated for the Emoji dialect because Emoji are not valid Java identifiers. By making a small exception in the script that generates these annotations we can instead use their symbol names.

So when using an Emoji feature file:

```feature
# language: em
📚: 🙈🙉🙊

  📕: 💃
    😐🎸
```

This scenario can be made to pass with:

```java
public class StepDefinitions {
    @NeutralFace("\uD83C\uDFB8")
    public void guitar() {
    }
}
```

Closes: https://github.com/cucumber/cucumber-jvm/issues/3061

Additionally, by removing the `’` from the Texan keywords we can also make the Texan dialect work. Like the `em` dialect `en-tx` is intended
 to be humorous. I hope all Texans will look at it with that spirit.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
