### PR TITLE
Use a message based RerunFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Core] Emit StepMatchArgumentsList for ambiguous steps ([#3066](https://github.com/cucumber/cucumber-jvm/pull/3066) M.P. Korstanje)
 
 ### Changed
+- [Core] Use a message based `RerunFormatter` ([#3075](https://github.com/cucumber/cucumber-jvm/pull/3075) M.P. Korstanje)
 - [Core] Update dependency io.cucumber:cucumber-json-formatter to v0.2.0
 - [Core] Update dependency io.cucumber:gherkin to v35.0.0
 - [Core] Update dependency io.cucumber:html-formatter to v21.15.0

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
@@ -46,9 +46,9 @@ public final class RerunFormatter implements ConcurrentEventListener {
 
     private static PrintWriter createPrintWriter(OutputStream out) {
         return new PrintWriter(
-                new OutputStreamWriter(
-                        requireNonNull(out),
-                        StandardCharsets.UTF_8));
+            new OutputStreamWriter(
+                requireNonNull(out),
+                StandardCharsets.UTF_8));
     }
 
     static URI relativize(URI uri) {
@@ -113,14 +113,13 @@ public final class RerunFormatter implements ConcurrentEventListener {
 
     private static Collector<UriAndLine, ?, TreeMap<String, TreeSet<Long>>> groupByUriAndThenCollectLines() {
         return groupingBy(
-                UriAndLine::getUri,
-                // Sort URIs
-                TreeMap::new,
-                mapping(
-                        UriAndLine::getLine,
-                        // Sort lines
-                        toCollection(TreeSet::new)
-                ));
+            UriAndLine::getUri,
+            // Sort URIs
+            TreeMap::new,
+            mapping(
+                UriAndLine::getLine,
+                // Sort lines
+                toCollection(TreeSet::new)));
     }
 
     private static StringBuilder renderFeatureWithLines(String uri, TreeSet<Long> lines) {

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/RerunFormatter.java
@@ -1,65 +1,54 @@
 package io.cucumber.core.plugin;
 
-import io.cucumber.core.feature.FeatureWithLines;
+import io.cucumber.messages.types.Envelope;
+import io.cucumber.messages.types.Location;
+import io.cucumber.messages.types.Pickle;
+import io.cucumber.messages.types.TestCaseStarted;
+import io.cucumber.messages.types.TestStepResult;
+import io.cucumber.messages.types.TestStepResultStatus;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.cucumber.plugin.event.EventPublisher;
-import io.cucumber.plugin.event.TestCase;
-import io.cucumber.plugin.event.TestCaseFinished;
-import io.cucumber.plugin.event.TestRunFinished;
+import io.cucumber.query.Query;
+import io.cucumber.query.Repository;
 
 import java.io.File;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collector;
 
-import static io.cucumber.core.feature.FeatureWithLines.create;
+import static io.cucumber.query.Repository.RepositoryFeature.INCLUDE_GHERKIN_DOCUMENTS;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toCollection;
 
 /**
- * Formatter for reporting all failed test cases and print their locations
- * Failed means: results that make the exit code non-zero.
+ * Formatter for reporting all failed test cases and print their locations.
  */
 public final class RerunFormatter implements ConcurrentEventListener {
 
-    private final UTF8PrintWriter out;
-    private final Map<URI, Collection<Integer>> featureAndFailedLinesMapping = new LinkedHashMap<>();
+    private final PrintWriter writer;
+    private final Repository repository = Repository.builder()
+            .feature(INCLUDE_GHERKIN_DOCUMENTS, true)
+            .build();
+    private final Query query = new Query(repository);
 
     public RerunFormatter(OutputStream out) {
-        this.out = new UTF8PrintWriter(out);
+        this.writer = createPrintWriter(out);
     }
 
-    @Override
-    public void setEventPublisher(EventPublisher publisher) {
-        publisher.registerHandlerFor(TestCaseFinished.class, this::handleTestCaseFinished);
-        publisher.registerHandlerFor(TestRunFinished.class, event -> finishReport());
-    }
-
-    private void handleTestCaseFinished(TestCaseFinished event) {
-        if (!event.getResult().getStatus().isOk()) {
-            recordTestFailed(event.getTestCase());
-        }
-    }
-
-    private void finishReport() {
-        for (Map.Entry<URI, Collection<Integer>> entry : featureAndFailedLinesMapping.entrySet()) {
-            FeatureWithLines featureWithLines = create(relativize(entry.getKey()), entry.getValue());
-            out.println(featureWithLines.toString());
-        }
-
-        out.close();
-    }
-
-    private void recordTestFailed(TestCase testCase) {
-        URI uri = testCase.getUri();
-        Collection<Integer> failedTestCaseLines = getFailedTestCaseLines(uri);
-        failedTestCaseLines.add(testCase.getLocation().getLine());
-    }
-
-    private Collection<Integer> getFailedTestCaseLines(URI uri) {
-        return featureAndFailedLinesMapping.computeIfAbsent(uri, k -> new ArrayList<>());
+    private static PrintWriter createPrintWriter(OutputStream out) {
+        return new PrintWriter(
+                new OutputStreamWriter(
+                        requireNonNull(out),
+                        StandardCharsets.UTF_8));
     }
 
     static URI relativize(URI uri) {
@@ -79,4 +68,83 @@ public final class RerunFormatter implements ConcurrentEventListener {
             throw new IllegalArgumentException(e.getMessage(), e);
         }
     }
+
+    @Override
+    public void setEventPublisher(EventPublisher publisher) {
+        publisher.registerHandlerFor(Envelope.class, event -> {
+            repository.update(event);
+            event.getTestRunFinished().ifPresent(testRunFinished -> finishReport());
+        });
+    }
+
+    private static final class UriAndLine {
+        private final String uri;
+        private final Long line;
+
+        private UriAndLine(String uri, Long line) {
+            this.uri = uri;
+            this.line = line;
+        }
+
+        public String getUri() {
+            return uri;
+        }
+
+        public Long getLine() {
+            return line;
+        }
+    }
+
+    private void finishReport() {
+        query.findAllTestCaseStarted().stream()
+                .filter(this::isNotPassingOrSkipped)
+                .map(query::findPickleBy)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(this::createUriAndLine)
+                .collect(groupByUriAndThenCollectLines())
+                .forEach(this::printUriWithLines);
+        writer.close();
+    }
+
+    private void printUriWithLines(String uri, TreeSet<Long> lines) {
+        writer.println(renderFeatureWithLines(uri, lines));
+    }
+
+    private static Collector<UriAndLine, ?, TreeMap<String, TreeSet<Long>>> groupByUriAndThenCollectLines() {
+        return groupingBy(
+                UriAndLine::getUri,
+                // Sort URIs
+                TreeMap::new,
+                mapping(
+                        UriAndLine::getLine,
+                        // Sort lines
+                        toCollection(TreeSet::new)
+                ));
+    }
+
+    private static StringBuilder renderFeatureWithLines(String uri, TreeSet<Long> lines) {
+        String path = relativize(URI.create(uri)).toString();
+        StringBuilder builder = new StringBuilder(path);
+        for (Long line : lines) {
+            builder.append(':');
+            builder.append(line);
+        }
+        return builder;
+    }
+
+    private UriAndLine createUriAndLine(Pickle pickle) {
+        String uri = pickle.getUri();
+        Long line = query.findLocationOf(pickle).map(Location::getLine).orElse(null);
+        return new UriAndLine(uri, line);
+    }
+
+    private boolean isNotPassingOrSkipped(TestCaseStarted event) {
+        return query.findMostSevereTestStepResultBy(event)
+                .map(TestStepResult::getStatus)
+                .filter(status -> status != TestStepResultStatus.PASSED)
+                .filter(status -> status != TestStepResultStatus.SKIPPED)
+                .isPresent();
+    }
+
 }


### PR DESCRIPTION
### 🤔 What's changed?

Replace the `RerunFormatter` with the message based implementation.

This achieves several goals:
 * Move the internal code base away from the events from the plugin module.
 * Extract common parts of Cucumber into modules that can be shared.

### ⚡️ What's your motivation? 

Partially implement: https://github.com/cucumber/cucumber-jvm/issues/3001

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
