### PR TITLE
[JUnit Platform Engine] Use FileSource.withPosition

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -21,7 +21,6 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         version: [ 17, 21 ]
-        
     name: 'Build Java ${{ matrix.version }} - ${{ matrix.os }}'
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- [JUnit Platform Engine] Use FileSource.withPosition ([#3084](https://github.com/cucumber/cucumber-jvm/pull/3084) M.P. Korstanje)
+- [JUnit Platform Engine] Use `FileSource.withPosition` ([#3084](https://github.com/cucumber/cucumber-jvm/pull/3084) M.P. Korstanje)
 
 ## [7.29.0] - 2025-09-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [JUnit Platform Engine] Use FileSource.withPosition ([#3084](https://github.com/cucumber/cucumber-jvm/pull/3084) M.P. Korstanje)
 
 ## [7.29.0] - 2025-09-21
 ### Added

--- a/cucumber-junit-platform-engine/pom.xml
+++ b/cucumber-junit-platform-engine/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <hamcrest.version>3.0</hamcrest.version>
-        <junit-jupiter.version>5.13.4</junit-jupiter.version>
+        <junit-jupiter.version>5.14.0-RC1</junit-jupiter.version>
     </properties>
 
     <dependencyManagement>

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureParserWithCaching.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureParserWithCaching.java
@@ -1,7 +1,6 @@
 package io.cucumber.junit.platform.engine;
 
 import io.cucumber.core.exception.CucumberException;
-import io.cucumber.core.gherkin.Feature;
 import io.cucumber.core.resource.Resource;
 
 import java.io.IOException;
@@ -16,22 +15,22 @@ import java.util.Optional;
 
 class FeatureParserWithCaching {
 
-    private final Map<URI, Optional<Feature>> cache = new HashMap<>();
+    private final Map<URI, Optional<FeatureWithSource>> cache = new HashMap<>();
     private final FeatureParserWithIssueReporting delegate;
 
     FeatureParserWithCaching(FeatureParserWithIssueReporting delegate) {
         this.delegate = delegate;
     }
 
-    Optional<Feature> parseResource(Resource resource) {
+    Optional<FeatureWithSource> parseResource(Resource resource) {
         return cache.computeIfAbsent(resource.getUri(), uri -> delegate.parseResource(resource));
     }
 
-    Optional<Feature> parseResource(Path resource) {
+    Optional<FeatureWithSource> parseResource(Path resource) {
         return parseResource(new PathAdapter(resource));
     }
 
-    Optional<Feature> parseResource(org.junit.platform.commons.support.Resource resource) {
+    Optional<FeatureWithSource> parseResource(org.junit.platform.commons.support.Resource resource) {
         return parseResource(new ResourceAdapter(resource));
     }
 

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureParserWithIssueReporting.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureParserWithIssueReporting.java
@@ -1,7 +1,5 @@
 package io.cucumber.junit.platform.engine;
 
-import io.cucumber.core.feature.FeatureParser;
-import io.cucumber.core.gherkin.Feature;
 import io.cucumber.core.gherkin.FeatureParserException;
 import io.cucumber.core.resource.Resource;
 import org.junit.platform.engine.DiscoveryIssue;
@@ -13,25 +11,25 @@ import static org.junit.platform.engine.DiscoveryIssue.Severity.ERROR;
 
 class FeatureParserWithIssueReporting {
 
-    private final FeatureParser delegate;
+    private final FeatureParserWithSource delegate;
     private final DiscoveryIssueReporter issueReporter;
 
-    FeatureParserWithIssueReporting(FeatureParser delegate, DiscoveryIssueReporter issueReporter) {
+    FeatureParserWithIssueReporting(FeatureParserWithSource delegate, DiscoveryIssueReporter issueReporter) {
         this.delegate = delegate;
         this.issueReporter = issueReporter;
     }
 
-    Optional<Feature> parseResource(Resource resource) {
+    Optional<FeatureWithSource> parseResource(Resource resource) {
         try {
             return delegate.parseResource(resource);
         } catch (FeatureParserException e) {
-            FeatureOrigin featureOrigin = FeatureOrigin.fromUri(resource.getUri());
+            FeatureSource featureSource = FeatureSource.of(resource.getUri());
             issueReporter.reportIssue(DiscoveryIssue
                     // TODO: Improve parse exception to separate out source uri
                     // and individual errors.
                     .builder(ERROR, e.getMessage())
                     .cause(e.getCause())
-                    .source(featureOrigin.source()));
+                    .source(featureSource.source()));
             return Optional.empty();
         }
     }

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureParserWithSource.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureParserWithSource.java
@@ -1,0 +1,22 @@
+package io.cucumber.junit.platform.engine;
+
+import io.cucumber.core.feature.FeatureParser;
+import io.cucumber.core.resource.Resource;
+
+import java.util.Optional;
+
+class FeatureParserWithSource {
+
+    private final FeatureParser delegate;
+
+    FeatureParserWithSource(FeatureParser delegate) {
+        this.delegate = delegate;
+    }
+
+    Optional<FeatureWithSource> parseResource(Resource resource) {
+        return delegate.parseResource(resource).map(feature -> {
+            FeatureSource featureSource = FeatureSource.of(resource.getUri());
+            return new FeatureWithSource(feature, featureSource);
+        });
+    }
+}

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureSource.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureSource.java
@@ -10,6 +10,7 @@ import org.junit.platform.engine.support.descriptor.UriSource;
 
 import java.net.URI;
 
+import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME_PREFIX;
 import static org.junit.platform.engine.support.descriptor.ClasspathResourceSource.CLASSPATH_SCHEME;
 
 abstract class FeatureSource {
@@ -20,6 +21,11 @@ abstract class FeatureSource {
 
     static FeatureSource of(URI uri) {
         if (CLASSPATH_SCHEME.equals(uri.getScheme())) {
+            if (!uri.getSchemeSpecificPart().startsWith("/")) {
+                // ClasspathResourceSource.from expects all resources to start
+                // with a forward slash
+                uri = URI.create(CLASSPATH_SCHEME_PREFIX + "/" + uri.getRawSchemeSpecificPart());
+            }
             ClasspathResourceSource source = ClasspathResourceSource.from(uri);
             return new FeatureClasspathSource(source);
         }

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureSource.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureSource.java
@@ -3,7 +3,6 @@ package io.cucumber.junit.platform.engine;
 import io.cucumber.plugin.event.Location;
 import io.cucumber.plugin.event.Node;
 import org.junit.platform.engine.TestSource;
-import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClasspathResourceSource;
 import org.junit.platform.engine.support.descriptor.FilePosition;
 import org.junit.platform.engine.support.descriptor.FileSource;
@@ -11,59 +10,41 @@ import org.junit.platform.engine.support.descriptor.UriSource;
 
 import java.net.URI;
 
-import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME_PREFIX;
+import static org.junit.platform.engine.support.descriptor.ClasspathResourceSource.CLASSPATH_SCHEME;
 
-abstract class FeatureOrigin {
-
-    static final String RULE_SEGMENT_TYPE = "rule";
-    static final String FEATURE_SEGMENT_TYPE = "feature";
-    static final String SCENARIO_SEGMENT_TYPE = "scenario";
-    static final String EXAMPLES_SEGMENT_TYPE = "examples";
-    static final String EXAMPLE_SEGMENT_TYPE = "example";
+abstract class FeatureSource {
 
     private static FilePosition createFilePosition(Location location) {
         return FilePosition.from(location.getLine(), location.getColumn());
     }
 
-    static FeatureOrigin fromUri(URI uri) {
-        if (ClasspathResourceSource.CLASSPATH_SCHEME.equals(uri.getScheme())) {
-            if (!uri.getSchemeSpecificPart().startsWith("/")) {
-                // ClasspathResourceSource.from expects all resources to start
-                // with a forward slash
-                uri = URI.create(CLASSPATH_SCHEME_PREFIX + "/" + uri.getRawSchemeSpecificPart());
-            }
+    static FeatureSource of(URI uri) {
+        if (CLASSPATH_SCHEME.equals(uri.getScheme())) {
             ClasspathResourceSource source = ClasspathResourceSource.from(uri);
-            return new ClasspathFeatureOrigin(source);
+            return new FeatureClasspathSource(source);
         }
-
         UriSource source = UriSource.from(uri);
         if (source instanceof FileSource) {
-            return new FileFeatureOrigin((FileSource) source);
+            return new FeatureFileSource((FileSource) source);
         }
-
-        return new UriFeatureOrigin(source);
-
-    }
-
-    static boolean isFeatureSegment(UniqueId.Segment segment) {
-        return FEATURE_SEGMENT_TYPE.equals(segment.getType());
+        return new FeatureUriSource(source);
     }
 
     abstract TestSource nodeSource(Node node);
 
     abstract TestSource source();
 
-    private static class FileFeatureOrigin extends FeatureOrigin {
+    private static class FeatureFileSource extends FeatureSource {
 
         private final FileSource source;
 
-        FileFeatureOrigin(FileSource source) {
+        FeatureFileSource(FileSource source) {
             this.source = source;
         }
 
         @Override
         TestSource nodeSource(Node node) {
-            return FileSource.from(source.getFile(), createFilePosition(node.getLocation()));
+            return source.withPosition(createFilePosition(node.getLocation()));
         }
 
         @Override
@@ -73,11 +54,11 @@ abstract class FeatureOrigin {
 
     }
 
-    private static class UriFeatureOrigin extends FeatureOrigin {
+    private static class FeatureUriSource extends FeatureSource {
 
         private final UriSource source;
 
-        UriFeatureOrigin(UriSource source) {
+        FeatureUriSource(UriSource source) {
             this.source = source;
         }
 
@@ -92,11 +73,11 @@ abstract class FeatureOrigin {
         }
     }
 
-    private static class ClasspathFeatureOrigin extends FeatureOrigin {
+    private static class FeatureClasspathSource extends FeatureSource {
 
         private final ClasspathResourceSource source;
 
-        ClasspathFeatureOrigin(ClasspathResourceSource source) {
+        FeatureClasspathSource(ClasspathResourceSource source) {
             this.source = source;
         }
 

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureWithSource.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureWithSource.java
@@ -1,0 +1,28 @@
+package io.cucumber.junit.platform.engine;
+
+import io.cucumber.core.gherkin.Feature;
+
+import static java.util.Objects.requireNonNull;
+
+final class FeatureWithSource {
+
+    private final Feature feature;
+    private final FeatureSource source;
+
+    FeatureWithSource(Feature feature, FeatureSource source) {
+        this.feature = requireNonNull(feature);
+        this.source = requireNonNull(source);
+    }
+
+    Feature getFeature() {
+        return feature;
+    }
+
+    FeatureSource getSource() {
+        return source;
+    }
+
+    String getUri() {
+        return feature.getUri().toString();
+    }
+}


### PR DESCRIPTION
### 🤔 What's changed?

Creating a `FileSource` involves a call to `File.getCanonicalFile`. This call can be slow because it involves the file system. Especially if the file system is networked.

By using `FileSource.withPosition` we can reuse the canonical file from the feature for its nodes.


### ⚡️ What's your motivation? 

Fixes: #3010


### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
