### PR TITLE
Let JsonFormatter implement Serializer

### DIFF
--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/JsonFormatter.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/JsonFormatter.java
@@ -1,6 +1,7 @@
 package io.cucumber.core.plugin;
 
 import io.cucumber.jsonformatter.MessagesToJsonWriter;
+import io.cucumber.messages.MessageToNdjsonWriter.Serializer;
 import io.cucumber.messages.types.Envelope;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.cucumber.plugin.event.EventPublisher;
@@ -8,11 +9,12 @@ import io.cucumber.plugin.event.EventPublisher;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Writer;
 import java.net.URI;
 
 import static io.cucumber.jsonformatter.MessagesToJsonWriter.builder;
 
-public final class JsonFormatter implements ConcurrentEventListener {
+public final class JsonFormatter implements ConcurrentEventListener, Serializer {
 
     private final MessagesToJsonWriter writer;
 
@@ -44,5 +46,10 @@ public final class JsonFormatter implements ConcurrentEventListener {
                 throw new IllegalStateException(e);
             }
         }
+    }
+
+    @Override
+    public void writeValue(Writer writer, Envelope value) throws IOException {
+        Jackson.OBJECT_MAPPER.writeValue(writer, value);
     }
 }


### PR DESCRIPTION
Once in a while I need to write json output in some of my plugins as well but it is surprisingly hard to do so as the API to do so is all internal and non trivial to implement.

On the other hand the JsonFormatter already has everything we need here, so this lets JsonFormatter now implement Serializer to conviently support this use-case

@mpkorstanje what do you think? I just (again) encountered the problem that my custom hack for this broke the Eclipse-Cucumber plugin, having a semi official API for that would be great and it does not exposes to much of the internals but still allow to reliable write out the JSON (e.g. to a file or websocket) in custom plugins.