### PR TITLE
[JUnit Platform] Use ParallelHierarchicalTestExecutorServiceFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - [Java] Add optional names to `@Before`, `@After`, `@BeforeStep` and `@AfterStep` hooks and emit hook names in messages ([#2917](https://github.com/cucumber/cucumber-jvm/issues/2917), [#3173](https://github.com/cucumber/cucumber-jvm/pull/3173))
+- [JUnit Platform] Use `ParallelHierarchicalTestExecutorServiceFactory` ([#3105](https://github.com/cucumber/cucumber-jvm/pull/3105))
 
 ### Fixed
-- [JUnit Platform Engine] Accept partial matches with `cucumber.filter.name` and align the behavior with JUnit 4 and CLI  ([#3174](https://github.com/cucumber/cucumber-jvm/pull/3174))
+- [JUnit Platform Engine] Accept partial matches with `cucumber.filter.name` and align the behavior with JUnit 4 and CLI ([#3174](https://github.com/cucumber/cucumber-jvm/pull/3174))
 - [JUnit Platform Engine] Don't require global read lock ([#3103](https://github.com/cucumber/cucumber-jvm/pull/3103))
 
 ### Changed

--- a/cucumber-junit-platform-engine/README.md
+++ b/cucumber-junit-platform-engine/README.md
@@ -557,6 +557,9 @@ cucumber.execution.parallel.config.dynamic.factor=             # positive double
 cucumber.execution.parallel.config.custom.class=               # class name.
                                                                # example: com.example.MyCustomParallelStrategy
 
+cucumber.execution.parallel.config.executor-service            # FORK_JOIN_POOL, WORKER_THREAD_POOL
+                                                               # default: depends on JUnit version
+
 cucumber.execution.exclusive-resources.<tag-name>.read-write=  # a comma separated list of strings
                                                                # example: resource-a, resource-b.
 

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -459,17 +459,20 @@ public final class Constants {
     /**
      * Property name used to determine the desired
      * {@link ParallelExecutorServiceType ParallelExecutorServiceType}: {@value}
-     *
-     * <p>Value must be
-     * {@link ParallelExecutorServiceType#FORK_JOIN_POOL FORK_JOIN_POOL} or
-     * {@link ParallelExecutorServiceType#WORKER_THREAD_POOL WORKER_THREAD_POOL},
-     * ignoring case.
+     * <p>
+     * Value must be {@link ParallelExecutorServiceType#FORK_JOIN_POOL
+     * FORK_JOIN_POOL} or {@link ParallelExecutorServiceType#WORKER_THREAD_POOL
+     * WORKER_THREAD_POOL}, ignoring case.
      * <p>
      * Defaults to {@code FORK_JOIN_POOL FORK_JOIN_POOL} with JUnit 6.1,
-     * defaults to {@code WORKER_THREAD_POOL WORKER_THREAD_POOL} with JUnit 6.2 (presumably).
+     * defaults to {@code WORKER_THREAD_POOL WORKER_THREAD_POOL} with JUnit 6.2
+     * (presumably).
      *
      * @see ParallelHierarchicalTestExecutorServiceFactory#EXECUTOR_SERVICE_PROPERTY_NAME
-     * @see <a href="https://github.com/junit-team/junit-framework/issues/5291">JUnit Framework - #5291 - Change default executor service implementation to worker_thread_pool</a>.
+     * @see <a href=
+     *      "https://github.com/junit-team/junit-framework/issues/5291">JUnit
+     *      Framework - #5291 - Change default executor service implementation
+     *      to worker_thread_pool</a>.
      */
     public static final String PARALLEL_CONFIG_EXECUTOR_SERVICE_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
             + EXECUTOR_SERVICE_PROPERTY_NAME;

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -464,9 +464,9 @@ public final class Constants {
      * FORK_JOIN_POOL} or {@link ParallelExecutorServiceType#WORKER_THREAD_POOL
      * WORKER_THREAD_POOL}, ignoring case.
      * <p>
-     * Defaults to {@code FORK_JOIN_POOL FORK_JOIN_POOL} with JUnit 6.1,
-     * defaults to {@code WORKER_THREAD_POOL WORKER_THREAD_POOL} with JUnit 6.2
-     * (presumably).
+     * Defaults to {@code FORK_JOIN_POOL FORK_JOIN_POOL} with JUnit 6.1, will
+     * presumably default to {@code WORKER_THREAD_POOL WORKER_THREAD_POOL}
+     * with JUnit 6.2.
      *
      * @see ParallelHierarchicalTestExecutorServiceFactory#EXECUTOR_SERVICE_PROPERTY_NAME
      * @see <a href=

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -4,12 +4,15 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy;
 import org.junit.platform.engine.support.hierarchical.ParallelExecutionConfigurationStrategy;
+import org.junit.platform.engine.support.hierarchical.ParallelHierarchicalTestExecutorServiceFactory;
+import org.junit.platform.engine.support.hierarchical.ParallelHierarchicalTestExecutorServiceFactory.ParallelExecutorServiceType;
 
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_CUSTOM_CLASS_PROPERTY_NAME;
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME;
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_FIXED_MAX_POOL_SIZE_PROPERTY_NAME;
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_FIXED_PARALLELISM_PROPERTY_NAME;
 import static org.junit.platform.engine.support.hierarchical.DefaultParallelExecutionConfigurationStrategy.CONFIG_STRATEGY_PROPERTY_NAME;
+import static org.junit.platform.engine.support.hierarchical.ParallelHierarchicalTestExecutorServiceFactory.EXECUTOR_SERVICE_PROPERTY_NAME;
 
 @API(status = API.Status.STABLE)
 public final class Constants {
@@ -452,6 +455,24 @@ public final class Constants {
      */
     public static final String PARALLEL_CONFIG_CUSTOM_CLASS_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
             + CONFIG_CUSTOM_CLASS_PROPERTY_NAME;
+
+    /**
+     * Property name used to determine the desired
+     * {@link ParallelExecutorServiceType ParallelExecutorServiceType}: {@value}
+     *
+     * <p>Value must be
+     * {@link ParallelExecutorServiceType#FORK_JOIN_POOL FORK_JOIN_POOL} or
+     * {@link ParallelExecutorServiceType#WORKER_THREAD_POOL WORKER_THREAD_POOL},
+     * ignoring case.
+     * <p>
+     * Defaults to {@code FORK_JOIN_POOL FORK_JOIN_POOL} with JUnit 6.1,
+     * defaults to {@code WORKER_THREAD_POOL WORKER_THREAD_POOL} with JUnit 6.2 (presumably).
+     *
+     * @see ParallelHierarchicalTestExecutorServiceFactory#EXECUTOR_SERVICE_PROPERTY_NAME
+     * @see <a href="https://github.com/junit-team/junit-framework/issues/5291">JUnit Framework - #5291</a>.
+     */
+    public static final String PARALLEL_CONFIG_EXECUTOR_SERVICE_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
+            + EXECUTOR_SERVICE_PROPERTY_NAME;
 
     private Constants() {
 

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -379,7 +379,7 @@ public final class Constants {
      * scenarios with the same tag.
      *
      * @see <a href=
-     *      "https://docs.junit.org/current/writing-tests/parallel-execution.html#synchronization">Junit
+     *      "https://docs.junit.org/current/writing-tests/parallel-execution.html#synchronization">JUnit
      *      6 User Guide - Synchronization</a>
      */
     public static final String EXECUTION_EXCLUSIVE_RESOURCES_READ_WRITE_TEMPLATE = EXECUTION_EXCLUSIVE_RESOURCES_PREFIX
@@ -469,7 +469,7 @@ public final class Constants {
      * defaults to {@code WORKER_THREAD_POOL WORKER_THREAD_POOL} with JUnit 6.2 (presumably).
      *
      * @see ParallelHierarchicalTestExecutorServiceFactory#EXECUTOR_SERVICE_PROPERTY_NAME
-     * @see <a href="https://github.com/junit-team/junit-framework/issues/5291">JUnit Framework - #5291</a>.
+     * @see <a href="https://github.com/junit-team/junit-framework/issues/5291">JUnit Framework - #5291 - Change default executor service implementation to worker_thread_pool</a>.
      */
     public static final String PARALLEL_CONFIG_EXECUTOR_SERVICE_PROPERTY_NAME = PARALLEL_CONFIG_PREFIX
             + EXECUTOR_SERVICE_PROPERTY_NAME;

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/Constants.java
@@ -465,8 +465,8 @@ public final class Constants {
      * WORKER_THREAD_POOL}, ignoring case.
      * <p>
      * Defaults to {@code FORK_JOIN_POOL FORK_JOIN_POOL} with JUnit 6.1, will
-     * presumably default to {@code WORKER_THREAD_POOL WORKER_THREAD_POOL}
-     * with JUnit 6.2.
+     * presumably default to {@code WORKER_THREAD_POOL WORKER_THREAD_POOL} with
+     * JUnit 6.2.
      *
      * @see ParallelHierarchicalTestExecutorServiceFactory#EXECUTOR_SERVICE_PROPERTY_NAME
      * @see <a href=

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberTestEngine.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberTestEngine.java
@@ -11,9 +11,9 @@ import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.config.PrefixedConfigurationParameters;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter;
-import org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine;
 import org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutorService;
+import org.junit.platform.engine.support.hierarchical.ParallelHierarchicalTestExecutorServiceFactory;
 
 import static io.cucumber.junit.platform.engine.Constants.FEATURES_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_DISCOVERY_AS_ROOT_ENGINE_PROPERTY_NAME;
@@ -93,7 +93,7 @@ public final class CucumberTestEngine extends HierarchicalTestEngine<CucumberEng
     protected HierarchicalTestExecutorService createExecutorService(ExecutionRequest request) {
         CucumberConfiguration configuration = getCucumberConfiguration(request);
         if (configuration.isParallelExecutionEnabled()) {
-            return new ForkJoinPoolHierarchicalTestExecutorService(
+            return ParallelHierarchicalTestExecutorServiceFactory.create(
                 new PrefixedConfigurationParameters(request.getConfigurationParameters(), PARALLEL_CONFIG_PREFIX));
         }
         return super.createExecutorService(request);

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
@@ -51,6 +51,8 @@ import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_DISCOVE
 import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_LONG_NAMING_STRATEGY_EXAMPLE_NAME_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.JUNIT_PLATFORM_SHORT_NAMING_STRATEGY_EXAMPLE_NAME_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PARALLEL_CONFIG_EXECUTOR_SERVICE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.READ_SUFFIX;
 import static io.cucumber.junit.platform.engine.Constants.READ_WRITE_SUFFIX;
 import static io.cucumber.junit.platform.engine.CucumberEngineDescriptor.ENGINE_ID;
@@ -1180,6 +1182,43 @@ class CucumberTestEngineTest {
                 .haveExactly(2, event(feature("single.feature", "A feature with a single scenario")))
                 .haveExactly(2, event(scenario("scenario:3", "A single scenario")));
     }
+
+
+    @Test
+    void supportsParallelExecutionWithForkJoinPool() {
+        EngineTestKit.engine(ENGINE_ID)
+                .selectors(selectClasspathResource("io/cucumber/junit/platform/engine/rule.feature"))
+                .configurationParameter(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, "true")
+                .configurationParameter(PARALLEL_CONFIG_EXECUTOR_SERVICE_PROPERTY_NAME, "FORK_JOIN_POOL")
+                .execute()
+                .allEvents()
+                .assertThatEvents()
+                .haveExactly(1, event( //
+                        scenario("scenario:5", "An example of this rule"), //
+                        finishedSuccessfully()))
+                .haveExactly(1, event( //
+                        scenario("scenario:11", "An other example of this rule"), //
+                        finishedSuccessfully()));
+    }
+
+
+    @Test
+    void supportsParallelExecutionWithWorkerThreadPool() {
+        EngineTestKit.engine(ENGINE_ID)
+                .selectors(selectClasspathResource("io/cucumber/junit/platform/engine/rule.feature"))
+                .configurationParameter(PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, "true")
+                .configurationParameter(PARALLEL_CONFIG_EXECUTOR_SERVICE_PROPERTY_NAME, "WORKER_THREAD_POOL")
+                .execute()
+                .allEvents()
+                .assertThatEvents()
+                .haveExactly(1, event( //
+                        scenario("scenario:5", "An example of this rule"), //
+                        finishedSuccessfully()))
+                .haveExactly(1, event( //
+                        scenario("scenario:11", "An other example of this rule"), //
+                        finishedSuccessfully()));
+    }
+
 
     @Suite
     @IncludeEngines("cucumber")

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
@@ -1183,7 +1183,6 @@ class CucumberTestEngineTest {
                 .haveExactly(2, event(scenario("scenario:3", "A single scenario")));
     }
 
-
     @Test
     void supportsParallelExecutionWithForkJoinPool() {
         EngineTestKit.engine(ENGINE_ID)
@@ -1194,13 +1193,12 @@ class CucumberTestEngineTest {
                 .allEvents()
                 .assertThatEvents()
                 .haveExactly(1, event( //
-                        scenario("scenario:5", "An example of this rule"), //
-                        finishedSuccessfully()))
+                    scenario("scenario:5", "An example of this rule"), //
+                    finishedSuccessfully()))
                 .haveExactly(1, event( //
-                        scenario("scenario:11", "An other example of this rule"), //
-                        finishedSuccessfully()));
+                    scenario("scenario:11", "An other example of this rule"), //
+                    finishedSuccessfully()));
     }
-
 
     @Test
     void supportsParallelExecutionWithWorkerThreadPool() {
@@ -1212,13 +1210,12 @@ class CucumberTestEngineTest {
                 .allEvents()
                 .assertThatEvents()
                 .haveExactly(1, event( //
-                        scenario("scenario:5", "An example of this rule"), //
-                        finishedSuccessfully()))
+                    scenario("scenario:5", "An example of this rule"), //
+                    finishedSuccessfully()))
                 .haveExactly(1, event( //
-                        scenario("scenario:11", "An other example of this rule"), //
-                        finishedSuccessfully()));
+                    scenario("scenario:11", "An other example of this rule"), //
+                    finishedSuccessfully()));
     }
-
 
     @Suite
     @IncludeEngines("cucumber")


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Utilize https://github.com/junit-team/junit-framework/pull/5060.

Depending on the JUnit version this will either use the fork join pool or thread pool based executor. The latter is a new executor that should prevent running too many when other tools (e.g. WebDriver) also use a fork join pool.

The executor is configurable via `cucumber.execution.parallel.config.executor-service` and will for now default to the forkjoin pool but in the future switch to the thread based version at some point in the future (see https://github.com/junit-team/junit-framework/issues/5291).

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
