### PR TITLE
Reuse internal Locale's cache instead of custom cache

### DIFF
--- a/cucumber-core/src/main/java/io/cucumber/core/runner/Runner.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/Runner.java
@@ -22,10 +22,8 @@ import io.cucumber.plugin.event.SnippetsSuggestedEvent.Suggestion;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 
 import static io.cucumber.core.exception.ExceptionUtils.throwAsUncheckedException;
@@ -42,7 +40,6 @@ public final class Runner {
     private final Collection<? extends Backend> backends;
     private final Options runnerOptions;
     private final ObjectFactory objectFactory;
-    private final Map<String, Locale> localeCache = new HashMap<>();
     private List<SnippetGenerator> snippetGenerators;
 
     public Runner(
@@ -84,7 +81,7 @@ public final class Runner {
 
     private Locale localeForPickle(Pickle pickle) {
         String language = pickle.getLanguage();
-        return localeCache.computeIfAbsent(language, (lang) -> new Locale(language));
+        return new Locale.Builder().setLanguage(language).build();
     }
 
     public void runBeforeAllHooks() {


### PR DESCRIPTION
### 🤔 What's changed?

As a side-effect of [your response within #376](https://github.com/cucumber/cucumber-expressions/issues/376#issuecomment-3569731107) I took a deeper look to all positions where the `Locale` information is stored. Doing so, I found a custom `Locale` cache even though the `Locale` class already provides an internal caching mechanism (`Locale#LOCALECACHE`). Admittedly, this cache will not be used when creating `Locale` instances by any of the `Locale` constructors. Instead, one must use the `Locale.Builder`.

This PR removes the custom `Locale` cache and reuses the Java built-in cache mechanism.

### ⚡️ What's your motivation? 

I like the idea of having ["a single source of truth"](https://github.com/cucumber/cucumber-expressions/issues/376#issuecomment-3569731107), and this PR removes one of the code positions where the current `Locale` information is stored a second time.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

No.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)