### PR TITLE
Add ParameterNamesModule to Jackson mapper with proper shading

### DIFF
--- a/cucumber-core/pom.xml
+++ b/cucumber-core/pom.xml
@@ -138,6 +138,10 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.xmlunit</groupId>
@@ -279,6 +283,7 @@
                                     <include>com.fasterxml.jackson.core:jackson-core</include>
                                     <include>com.fasterxml.jackson.core:jackson-annotations</include>
                                     <include>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</include>
+                                    <include>com.fasterxml.jackson.module:jackson-module-parameter-names</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -316,6 +321,14 @@
                                 </filter>
                                 <filter>
                                     <artifact>com.fasterxml.jackson.datatype:jackson-datatype-jdk8</artifact>
+                                    <excludes>
+                                        <exclude>**/module-info.class</exclude>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/services/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.fasterxml.jackson.module:jackson-module-parameter-names</artifact>
                                     <excludes>
                                         <exclude>**/module-info.class</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>

--- a/cucumber-core/src/main/java/io/cucumber/core/plugin/Jackson.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/plugin/Jackson.java
@@ -1,5 +1,6 @@
 package io.cucumber.core.plugin;
 
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -8,12 +9,14 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Value.construct;
 
 final class Jackson {
     public static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
             .addModule(new Jdk8Module())
+            .addModule(new ParameterNamesModule(Mode.PROPERTIES))
             .defaultPropertyInclusion(construct(
                 Include.NON_ABSENT,
                 Include.NON_ABSENT))


### PR DESCRIPTION
I noticed that the `OBJECT_MAPPER` here is no longer able to de-serialize the JSON because of the change in the generated message class to be constant classes. It took me a while to realize that the `ParameterNamesModule` is missing.

This now adds the missing module.