### PR TITLE
Memoize configuration parameters that are costly to create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Core] Update dependency io.cucumber:testng-xml-formatter.version to v0.8.0
 - [Core] Update dependency io.cucumber:usage-formatter.version to v0.2.0
 - [JUnit Platform Engine] Use JUnit Platform 6.0.2 (JUnit Jupiter 6.0.2) ([#3162](https://github.com/cucumber/cucumber-jvm/pull/3162))
+- [JUnit Platform Engine] Performance: Memoize configuration parameters ([#3167](https://github.com/cucumber/cucumber-jvm/pull/3167))
 - [All] Classes not designed for extension are now final. See [api-changes.json](./.revapi/api-changes.json) for details.
 - [All] Utility classes are no longer instantiatable. See [api-changes.json](./.revapi/api-changes.json) for details.
 

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberConfigurationTest.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberConfigurationTest.java
@@ -4,6 +4,7 @@ import io.cucumber.core.backend.DefaultObjectFactory;
 import io.cucumber.core.eventbus.IncrementingUuidGenerator;
 import io.cucumber.core.plugin.Options;
 import io.cucumber.core.snippets.SnippetType;
+import io.cucumber.tagexpressions.Expression;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.DiscoveryIssue;
@@ -13,10 +14,13 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.IsIterableContaining.hasItem;
@@ -192,5 +196,24 @@ class CucumberConfigurationTest {
 
         assertThat(new CucumberConfiguration(configurationParameters, issueReporter).getUuidGeneratorClass(),
             is(IncrementingUuidGenerator.class));
+    }
+
+    @Test
+    void tagFilter() {
+        ConfigurationParameters tags = new MapConfigurationParameters(Constants.FILTER_TAGS_PROPERTY_NAME, "@foo");
+        CucumberConfiguration cucumberConfiguration = new CucumberConfiguration(tags, issueReporter);
+        Optional<Expression> expression = cucumberConfiguration.tagFilter();
+        assertTrue(expression.orElseThrow().evaluate(List.of("@foo")));
+        assertThat(expression, sameInstance(cucumberConfiguration.tagFilter()));
+    }
+
+    @Test
+    void nameFilter() {
+        ConfigurationParameters nameFilter = new MapConfigurationParameters(Constants.FILTER_NAME_PROPERTY_NAME,
+            ".*foo.*");
+        CucumberConfiguration cucumberConfiguration = new CucumberConfiguration(nameFilter, issueReporter);
+        Optional<Pattern> pattern = cucumberConfiguration.nameFilter();
+        assertTrue(pattern.orElseThrow().matcher("aaa foo zzz").matches());
+        assertThat(pattern, sameInstance(cucumberConfiguration.nameFilter()));
     }
 }


### PR DESCRIPTION
### 🤔 What's changed?

Remember the value of a configuration parameter to return the same result next time.

### ⚡️ What's your motivation? 

Configuration parameters like Pattern are really costly to create. And they are accessed repetitively for each scenario. In benchmarks generating tests to run without running them, it's more than 50% of the time.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

If possible, I would like to see it included in the 7.x cycle but didn't know which branch to target.

### ♻️ Anything particular you want feedback on?

I haven't tested memoization everywhere I used it because there's often more manipulation afterwards. If we go crazy, we could always keep the final returned result instead of the one after the compute. But I think that's a good start.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
