### PR TITLE
[JUnit Platform Engine] Accept partial matches in name filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Java] Add optional names to `@Before`, `@After`, `@BeforeStep` and `@AfterStep` hooks and emit hook names in messages ([#2917](https://github.com/cucumber/cucumber-jvm/issues/2917), [#3173](https://github.com/cucumber/cucumber-jvm/pull/3173))
 
 ### Fixed
-- [JUnit Platform Engine] Use `find()` instead of `matches()` for `cucumber.filter.name` to align with JUnit 4 and CLI behaviour ([#3174](https://github.com/cucumber/cucumber-jvm/pull/3174))
+- [JUnit Platform Engine] Accept partial matches with `cucumber.filter.name` and align the behavior with JUnit 4 and CLI  ([#3174](https://github.com/cucumber/cucumber-jvm/pull/3174))
 
 ### Changed
 - [All] Set baseline to Java 17 ([#3116](https://github.com/cucumber/cucumber-jvm/pull/3116))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [Java] Add optional names to `@Before`, `@After`, `@BeforeStep` and `@AfterStep` hooks and emit hook names in messages ([#2917](https://github.com/cucumber/cucumber-jvm/issues/2917), [#3173](https://github.com/cucumber/cucumber-jvm/pull/3173))
 
+### Fixed
+- [JUnit Platform Engine] Use `find()` instead of `matches()` for `cucumber.filter.name` to align with JUnit 4 and CLI behaviour ([#3174](https://github.com/cucumber/cucumber-jvm/pull/3174))
+
 ### Changed
 - [All] Set baseline to Java 17 ([#3116](https://github.com/cucumber/cucumber-jvm/pull/3116))
 - [All] Adopt [JSpecify](https://jspecify.dev/) to declare nullability ([#3116](https://github.com/cucumber/cucumber-jvm/pull/3116))

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberTestDescriptor.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberTestDescriptor.java
@@ -292,7 +292,7 @@ abstract class CucumberTestDescriptor extends AbstractTestDescriptor {
 
         private Optional<SkipResult> shouldBeSkippedByNameFilter(CucumberEngineExecutionContext context) {
             return context.getConfiguration().nameFilter().map(pattern -> {
-                if (pattern.matcher(pickle.getName()).matches()) {
+                if (pattern.matcher(pickle.getName()).find()) {
                     return SkipResult.doNotSkip();
                 }
                 return SkipResult

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
@@ -691,6 +691,51 @@ class CucumberTestEngineTest {
     }
 
     @Test
+    void anchoredNamePatternMatchesExactName() {
+        EngineTestKit.engine(ENGINE_ID)
+                .configurationParameter(FILTER_NAME_PROPERTY_NAME, "^A single scenario$")
+                .selectors(selectFile("src/test/resources/io/cucumber/junit/platform/engine/single.feature"))
+                .execute()
+                .testEvents()
+                .assertThatEvents()
+                .haveExactly(1, event(test(), finishedSuccessfully()));
+    }
+
+    @Test
+    void anchoredNamePatternDoesNotMatchPartOfName() {
+        EngineTestKit.engine(ENGINE_ID)
+                .configurationParameter(FILTER_NAME_PROPERTY_NAME, "^A single$")
+                .selectors(selectFile("src/test/resources/io/cucumber/junit/platform/engine/single.feature"))
+                .execute()
+                .testEvents()
+                .assertThatEvents()
+                .haveExactly(1, event(test(),
+                    event(skippedWithReason("'cucumber.filter.name=^A single$' did not match this scenario"))));
+    }
+
+    @Test
+    void nonAnchoredNamePatternMatchesPartOfName() {
+        EngineTestKit.engine(ENGINE_ID)
+                .configurationParameter(FILTER_NAME_PROPERTY_NAME, "single")
+                .selectors(selectFile("src/test/resources/io/cucumber/junit/platform/engine/single.feature"))
+                .execute()
+                .testEvents()
+                .assertThatEvents()
+                .haveExactly(1, event(test(), finishedSuccessfully()));
+    }
+
+    @Test
+    void wildcardNamePatternMatchesPartOfName() {
+        EngineTestKit.engine(ENGINE_ID)
+                .configurationParameter(FILTER_NAME_PROPERTY_NAME, "single .*")
+                .selectors(selectFile("src/test/resources/io/cucumber/junit/platform/engine/single.feature"))
+                .execute()
+                .testEvents()
+                .assertThatEvents()
+                .haveExactly(1, event(test(), finishedSuccessfully()));
+    }
+
+    @Test
     void cucumberTagsAreConvertedToJunitTags() {
         EngineTestKit.engine(ENGINE_ID)
                 .selectors(selectClasspathResource("io/cucumber/junit/platform/engine/scenario-outline.feature"))


### PR DESCRIPTION
### 🤔 What's changed?

In 'CucumberTestDescriptor', 'cucumber.filter.name' was evaluated using 'matches()'which requires the pattern to cover the full scenario name. Replaced with 'find()' to align with 'NamePredicate' used by JUnit 4 and CLI.

### ⚡️ What's your motivation? 
Fixes #3166. Non-anchored patterns like 'Cool test' now correctly match any scenario whose name contains that substring, consistent with JUnit 4 and the CLI.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
