### PR TITLE
Improve DuplicateTypeNameException with location details

### DIFF
--- a/cucumber-core/src/main/java/io/cucumber/core/runner/CachingGlue.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/CachingGlue.java
@@ -20,6 +20,7 @@ import io.cucumber.core.stepexpression.StepExpression;
 import io.cucumber.core.stepexpression.StepExpressionFactory;
 import io.cucumber.core.stepexpression.StepTypeRegistry;
 import io.cucumber.cucumberexpressions.CucumberExpression;
+import io.cucumber.cucumberexpressions.DuplicateTypeNameException;
 import io.cucumber.cucumberexpressions.Expression;
 import io.cucumber.cucumberexpressions.ParameterByTypeTransformer;
 import io.cucumber.cucumberexpressions.ParameterType;
@@ -276,11 +277,21 @@ final class CachingGlue implements Glue {
 
         // TODO: separate prepared and unprepared glue into different classes
         // parameters changed from the previous scenario => re-register them
-        parameterTypeDefinitions.forEach(ptd -> {
-            ParameterType<?> parameterType = ptd.parameterType();
-            stepTypeRegistry.defineParameterType(parameterType);
-            emitParameterTypeDefined(ptd);
-        });
+        Map<String, ParameterTypeDefinition> parameterTypesByName = new HashMap<>();
+        for (ParameterTypeDefinition parameterTypeDefinition : parameterTypeDefinitions) {
+            ParameterType<?> parameterType = parameterTypeDefinition.parameterType();
+            String name = parameterType.getName();
+            ParameterTypeDefinition previous = parameterTypesByName.put(name, parameterTypeDefinition);
+            if (previous != null) {
+                throw new DuplicateParameterTypeException(previous, parameterTypeDefinition);
+            }
+            try {
+                stepTypeRegistry.defineParameterType(parameterType);
+            } catch (DuplicateTypeNameException e) {
+                throw new DuplicateParameterTypeException(parameterTypeDefinition, name, e);
+            }
+            emitParameterTypeDefined(parameterTypeDefinition);
+        }
         dataTableTypeDefinitions.forEach(dtd -> stepTypeRegistry.defineDataTableType(dtd.dataTableType()));
         docStringTypeDefinitions.forEach(dtd -> stepTypeRegistry.defineDocStringType(dtd.docStringType()));
 

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateParameterTypeException.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateParameterTypeException.java
@@ -1,0 +1,37 @@
+package io.cucumber.core.runner;
+
+import io.cucumber.core.backend.ParameterTypeDefinition;
+import io.cucumber.core.exception.CucumberException;
+import io.cucumber.cucumberexpressions.DuplicateTypeNameException;
+
+import static java.util.Objects.requireNonNull;
+
+final class DuplicateParameterTypeException extends CucumberException {
+
+    DuplicateParameterTypeException(ParameterTypeDefinition a, ParameterTypeDefinition b) {
+        super(createMessage(a, b));
+    }
+
+    DuplicateParameterTypeException(ParameterTypeDefinition definition, String name, DuplicateTypeNameException cause) {
+        super(createBuiltInConflictMessage(definition, name), cause);
+    }
+
+    private static String createMessage(ParameterTypeDefinition a, ParameterTypeDefinition b) {
+        requireNonNull(a);
+        requireNonNull(b);
+
+        String name = b.parameterType().getName();
+        return "Duplicate parameter type '%s' in %s and %s".formatted(
+            name,
+            a.getLocation(),
+            b.getLocation());
+    }
+
+    private static String createBuiltInConflictMessage(ParameterTypeDefinition definition, String name) {
+        requireNonNull(definition);
+        return "Parameter type '%s' at %s conflicts with an existing parameter type of the same name".formatted(
+            name,
+            definition.getLocation());
+    }
+
+}

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -93,6 +93,30 @@ class CachingGlueTest {
     }
 
     @Test
+    void throws_duplicate_error_on_dupe_parameter_types() {
+        glue.addParameterType(new MockedNamedParameterTypeDefinition("iso8601Date", "first location"));
+        glue.addParameterType(new MockedNamedParameterTypeDefinition("iso8601Date", "second location"));
+
+        DuplicateParameterTypeException exception = assertThrows(
+            DuplicateParameterTypeException.class,
+            () -> glue.prepareGlue(language));
+        assertThat(exception.getMessage(), equalTo(
+            "Duplicate parameter type 'iso8601Date' in first location and second location"));
+    }
+
+    @Test
+    void throws_on_builtin_parameter_type_conflict() {
+        glue.addParameterType(new MockedNamedParameterTypeDefinition("int", "custom int location"));
+
+        DuplicateParameterTypeException exception = assertThrows(
+            DuplicateParameterTypeException.class,
+            () -> glue.prepareGlue(language));
+        assertThat(exception.getMessage(), equalTo(
+            "Parameter type 'int' at custom int location conflicts with an existing parameter type of the same name"));
+        assertTrue(exception.getCause() instanceof io.cucumber.cucumberexpressions.DuplicateTypeNameException);
+    }
+
+    @Test
     void throws_on_duplicate_default_table_entry_transformer() {
         glue.addDefaultDataTableEntryTransformer(new MockedDefaultDataTableEntryTransformer());
         glue.addDefaultDataTableEntryTransformer(new MockedDefaultDataTableEntryTransformer());
@@ -681,6 +705,33 @@ class CachingGlueTest {
 
         boolean isDisposed() {
             return disposed;
+        }
+
+    }
+
+    private static final class MockedNamedParameterTypeDefinition implements ParameterTypeDefinition {
+
+        private final String name;
+        private final String location;
+
+        private MockedNamedParameterTypeDefinition(String name, String location) {
+            this.name = name;
+            this.location = location;
+        }
+
+        @Override
+        public ParameterType<?> parameterType() {
+            return new ParameterType<>(name, "[ab]", Object.class, (String arg) -> new Object());
+        }
+
+        @Override
+        public boolean isDefinedAt(StackTraceElement stackTraceElement) {
+            return false;
+        }
+
+        @Override
+        public String getLocation() {
+            return location;
         }
 
     }

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/DuplicateParameterTypeExceptionTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/DuplicateParameterTypeExceptionTest.java
@@ -1,0 +1,56 @@
+package io.cucumber.core.runner;
+
+import io.cucumber.core.backend.ParameterTypeDefinition;
+import io.cucumber.cucumberexpressions.ParameterType;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("NullAway")
+class DuplicateParameterTypeExceptionTest {
+
+    @Test
+    void can_report_duplicate_parameter_types() {
+        ParameterTypeDefinition a = new StubParameterTypeDefinition("iso8601Date", "ParameterTypeA_Location");
+        ParameterTypeDefinition b = new StubParameterTypeDefinition("iso8601Date", "ParameterTypeB_Location");
+
+        DuplicateParameterTypeException expectedThrown = new DuplicateParameterTypeException(a, b);
+        assertAll(
+            () -> assertThat(expectedThrown.getMessage(),
+                is(equalTo(
+                    "Duplicate parameter type 'iso8601Date' in ParameterTypeA_Location and ParameterTypeB_Location"))),
+            () -> assertThat(expectedThrown.getCause(), is(nullValue())));
+    }
+
+    private static final class StubParameterTypeDefinition implements ParameterTypeDefinition {
+
+        private final String name;
+        private final String location;
+
+        private StubParameterTypeDefinition(String name, String location) {
+            this.name = name;
+            this.location = location;
+        }
+
+        @Override
+        public ParameterType<?> parameterType() {
+            return new ParameterType<>(name, "[ab]", Object.class, (String arg) -> new Object());
+        }
+
+        @Override
+        public boolean isDefinedAt(StackTraceElement stackTraceElement) {
+            return false;
+        }
+
+        @Override
+        public String getLocation() {
+            return location;
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Summary

- Add `DuplicateParameterTypeException` mirroring the pattern used by `DuplicateStepDefinitionException`
- Detect duplicate user-defined parameter types before registration and report both locations
- Wrap built-in name conflicts from `cucumber-expressions` with the offending custom definition location

Fixes #3144

## Problem

`DuplicateTypeNameException` only reported that a name already exists (e.g. `There is already a parameter type with name iso8601Date`) without indicating where the duplicate definitions are, making misconfigured glue code hard to locate.

## Example messages

- User-defined duplicate: `Duplicate parameter type 'iso8601Date' in first location and second location`
- Built-in conflict: `Parameter type 'int' at custom int location conflicts with an existing parameter type of the same name`

## Test plan

- [x] `mvn -pl cucumber-core test -Dtest=DuplicateParameterTypeExceptionTest,CachingGlueTest`