### PR TITLE
Make duplicate glue exceptions public and expose details

### DIFF
--- a/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateDefaultDataTableCellTransformers.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateDefaultDataTableCellTransformers.java
@@ -6,12 +6,21 @@ import io.cucumber.core.exception.CucumberException;
 
 import java.util.List;
 
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
-class DuplicateDefaultDataTableCellTransformers extends CucumberException {
+public final class DuplicateDefaultDataTableCellTransformers extends CucumberException {
 
-    DuplicateDefaultDataTableCellTransformers(List<DefaultDataTableCellTransformerDefinition> definitions) {
+    private final List<DefaultDataTableCellTransformerDefinition> definitions;
+
+    public DuplicateDefaultDataTableCellTransformers(List<DefaultDataTableCellTransformerDefinition> definitions) {
         super(createMessage(definitions));
+        this.definitions = unmodifiableList(requireNonNull(definitions));
+    }
+
+    public List<DefaultDataTableCellTransformerDefinition> getDefinitions() {
+        return definitions;
     }
 
     private static String createMessage(List<DefaultDataTableCellTransformerDefinition> definitions) {

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateDefaultDataTableEntryTransformers.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateDefaultDataTableEntryTransformers.java
@@ -4,12 +4,23 @@ import io.cucumber.core.exception.CucumberException;
 
 import java.util.List;
 
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
-class DuplicateDefaultDataTableEntryTransformers extends CucumberException {
+public final class DuplicateDefaultDataTableEntryTransformers extends CucumberException {
 
-    DuplicateDefaultDataTableEntryTransformers(List<CoreDefaultDataTableEntryTransformerDefinition> definitions) {
+    private final List<CoreDefaultDataTableEntryTransformerDefinition> definitions;
+
+    public DuplicateDefaultDataTableEntryTransformers(
+            List<CoreDefaultDataTableEntryTransformerDefinition> definitions
+    ) {
         super(createMessage(definitions));
+        this.definitions = unmodifiableList(requireNonNull(definitions));
+    }
+
+    public List<CoreDefaultDataTableEntryTransformerDefinition> getDefinitions() {
+        return definitions;
     }
 
     private static String createMessage(List<CoreDefaultDataTableEntryTransformerDefinition> definitions) {

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateDefaultParameterTransformers.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateDefaultParameterTransformers.java
@@ -5,12 +5,21 @@ import io.cucumber.core.exception.CucumberException;
 
 import java.util.List;
 
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
-class DuplicateDefaultParameterTransformers extends CucumberException {
+public final class DuplicateDefaultParameterTransformers extends CucumberException {
 
-    DuplicateDefaultParameterTransformers(List<DefaultParameterTransformerDefinition> definitions) {
+    private final List<DefaultParameterTransformerDefinition> definitions;
+
+    public DuplicateDefaultParameterTransformers(List<DefaultParameterTransformerDefinition> definitions) {
         super(createMessage(definitions));
+        this.definitions = unmodifiableList(requireNonNull(definitions));
+    }
+
+    public List<DefaultParameterTransformerDefinition> getDefinitions() {
+        return definitions;
     }
 
     private static String createMessage(List<DefaultParameterTransformerDefinition> definitions) {

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateStepDefinitionException.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateStepDefinitionException.java
@@ -5,10 +5,23 @@ import io.cucumber.core.exception.CucumberException;
 
 import static java.util.Objects.requireNonNull;
 
-final class DuplicateStepDefinitionException extends CucumberException {
+public final class DuplicateStepDefinitionException extends CucumberException {
 
-    DuplicateStepDefinitionException(StepDefinition a, StepDefinition b) {
+    private final StepDefinition stepDefinitionA;
+    private final StepDefinition stepDefinitionB;
+
+    public DuplicateStepDefinitionException(StepDefinition a, StepDefinition b) {
         super(createMessage(a, b));
+        this.stepDefinitionA = requireNonNull(a);
+        this.stepDefinitionB = requireNonNull(b);
+    }
+
+    public StepDefinition getStepDefinitionA() {
+        return stepDefinitionA;
+    }
+
+    public StepDefinition getStepDefinitionB() {
+        return stepDefinitionB;
     }
 
     private static String createMessage(StepDefinition a, StepDefinition b) {

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/DuplicateStepDefinitionExceptionTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/DuplicateStepDefinitionExceptionTest.java
@@ -25,7 +25,9 @@ class DuplicateStepDefinitionExceptionTest {
         assertAll(
             () -> assertThat(expectedThrown.getMessage(),
                 is(equalTo("Duplicate step definitions in StepDefinitionA_Location and StepDefinitionB_Location"))),
-            () -> assertThat(expectedThrown.getCause(), is(nullValue())));
+            () -> assertThat(expectedThrown.getCause(), is(nullValue())),
+            () -> assertThat(expectedThrown.getStepDefinitionA(), is(mockStepDefinitionA)),
+            () -> assertThat(expectedThrown.getStepDefinitionB(), is(mockStepDefinitionB)));
     }
 
 }


### PR DESCRIPTION
## Summary

- Make duplicate glue `CucumberException` subclasses public so embedders can catch them with fine-grained handling
- Expose the conflicting glue definitions via getters:
  - `DuplicateStepDefinitionException#getStepDefinitionA()` / `#getStepDefinitionB()`
  - `DuplicateDefaultParameterTransformers#getDefinitions()`
  - `DuplicateDefaultDataTableEntryTransformers#getDefinitions()`
  - `DuplicateDefaultDataTableCellTransformers#getDefinitions()`

Fixes #3142

## Notes

This covers the duplicate glue exceptions that already carry structured conflict data. `DuplicateParameterTypeException` is handled separately in #3196.

## Test plan

- [x] `mvn -pl cucumber-core test -Dtest=DuplicateStepDefinitionExceptionTest,CachingGlueTest`