### PR TITLE
Extract request object for glue discovery

### DIFF
--- a/.revapi/api-changes.json
+++ b/.revapi/api-changes.json
@@ -269,6 +269,18 @@
             "code": "java.method.addedToInterface",
             "new": "method io.cucumber.core.backend.GlueDiscoveryRequest io.cucumber.core.runner.Options::getGlueDiscoveryRequest()",
             "justification": "Internal API."
+          },
+          {
+            "ignore": true,
+            "code": "java.class.externalClassExposedInAPI",
+            "new": "interface io.cucumber.core.backend.GlueDiscoveryRequest",
+            "justification": "Glue Discovery request API"
+          },
+          {
+            "ignore": true,
+            "code": "java.class.externalClassExposedInAPI",
+            "new": "interface io.cucumber.core.backend.GlueDiscoverySelector",
+            "justification": "Glue Discovery request API"
           }
         ]
       }

--- a/.revapi/api-changes.json
+++ b/.revapi/api-changes.json
@@ -251,6 +251,24 @@
             "oldValue": "org.apiguardian.api.API.Status.STABLE",
             "newValue": "org.apiguardian.api.API.Status.DEPRECATED",
             "justification": "Cucumber JUnit (for JUnit 4) was deprecated. Use Cucumber JUnit Platform Engine instead (JUnit 5+)"
+          },
+          {
+            "ignore": true,
+            "code": "java.method.removed",
+            "old": "method java.util.List<java.net.URI> io.cucumber.core.options.RuntimeOptions::getGlue()",
+            "justification": "Internal API. Replaced with GlueDiscovery request"
+          },
+          {
+            "ignore": true,
+            "code": "java.method.removed",
+            "old": "method java.util.List<java.net.URI> io.cucumber.core.runner.Options::getGlue()",
+            "justification": "Internal API. Replaced with GlueDiscovery request"
+          },
+          {
+            "ignore": true,
+            "code": "java.method.addedToInterface",
+            "new": "method io.cucumber.core.backend.GlueDiscoveryRequest io.cucumber.core.runner.Options::getGlueDiscoveryRequest()",
+            "justification": "Internal API."
           }
         ]
       }

--- a/cucumber-core/src/main/java/io/cucumber/core/backend/Backend.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/Backend.java
@@ -13,8 +13,8 @@ public interface Backend {
      * Invoked once before all features. This is where steps and hooks should be
      * loaded.
      *
-     * @param glue      Glue that provides the steps to be executed.
-     * @param request   The request to discover glue for.
+     * @param glue    Glue that provides the steps to be executed.
+     * @param request A request to discover glue code in specific locations.
      */
     default void loadGlue(Glue glue, GlueDiscoveryRequest request) {
         loadGlue(glue, request.getGluePaths());
@@ -24,8 +24,10 @@ public interface Backend {
      * Invoked once before all features. This is where steps and hooks should be
      * loaded.
      *
-     * @param glue      Glue that provides the steps to be executed.
-     * @param gluePaths The locations for the glue to be loaded.
+     * @param      glue      Glue that provides the steps to be executed.
+     * @param      gluePaths The locations for the glue to be loaded.
+     * @deprecated           use {@link #loadGlue(Glue, GlueDiscoveryRequest)}
+     *                       instead.
      */
     @Deprecated
     default void loadGlue(Glue glue, List<URI> gluePaths) {

--- a/cucumber-core/src/main/java/io/cucumber/core/backend/Backend.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/Backend.java
@@ -14,8 +14,20 @@ public interface Backend {
      * loaded.
      *
      * @param glue      Glue that provides the steps to be executed.
+     * @param request   The request to discover glue for.
+     */
+    default void loadGlue(Glue glue, GlueDiscoveryRequest request) {
+        loadGlue(glue, request.getGluePaths());
+    }
+
+    /**
+     * Invoked once before all features. This is where steps and hooks should be
+     * loaded.
+     *
+     * @param glue      Glue that provides the steps to be executed.
      * @param gluePaths The locations for the glue to be loaded.
      */
+    @Deprecated
     default void loadGlue(Glue glue, List<URI> gluePaths) {
 
     }

--- a/cucumber-core/src/main/java/io/cucumber/core/backend/Backend.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/Backend.java
@@ -1,5 +1,6 @@
 package io.cucumber.core.backend;
 
+import io.cucumber.core.backend.GlueDiscoverySelector.UriGlueDiscoverySelector;
 import org.apiguardian.api.API;
 import org.jspecify.annotations.Nullable;
 
@@ -17,7 +18,11 @@ public interface Backend {
      * @param request A request to discover glue code in specific locations.
      */
     default void loadGlue(Glue glue, GlueDiscoveryRequest request) {
-        loadGlue(glue, request.getGluePaths());
+        var gluePaths = request.getSelectorsByType(UriGlueDiscoverySelector.class) //
+                .stream() //
+                .map(UriGlueDiscoverySelector::uri) //
+                .toList();
+        loadGlue(glue, gluePaths);
     }
 
     /**

--- a/cucumber-core/src/main/java/io/cucumber/core/backend/Glue.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/Glue.java
@@ -2,6 +2,16 @@ package io.cucumber.core.backend;
 
 import org.apiguardian.api.API;
 
+/**
+ * A container of glue code.
+ * <p>
+ * Glue code connects steps in files to executable code. It also includes
+ * before-, after-, each and all hooks, parameter types, data table types
+ * and docstrings.
+ * <p>
+ * Glue is provided by a {@link Backend} implementation which discovers it on
+ * request.
+ */
 @API(status = API.Status.STABLE)
 public interface Glue {
 

--- a/cucumber-core/src/main/java/io/cucumber/core/backend/Glue.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/Glue.java
@@ -6,8 +6,8 @@ import org.apiguardian.api.API;
  * A container of glue code.
  * <p>
  * Glue code connects steps in files to executable code. It also includes
- * before-, after-, each and all hooks, parameter types, data table types
- * and docstrings.
+ * before-, after-, each and all hooks, parameter types, data table types and
+ * docstrings.
  * <p>
  * Glue is provided by a {@link Backend} implementation which discovers it on
  * request.

--- a/cucumber-core/src/main/java/io/cucumber/core/backend/GlueDiscoveryRequest.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/GlueDiscoveryRequest.java
@@ -1,8 +1,45 @@
 package io.cucumber.core.backend;
 
 import java.net.URI;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 public interface GlueDiscoveryRequest {
     List<URI> getGluePaths();
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    final class Builder {
+        private final Set<URI> gluePaths = new LinkedHashSet<>();
+
+        private Builder() {
+
+        }
+
+        public Builder gluePath(URI... gluePath) {
+            this.gluePaths.addAll(List.of(gluePath));
+            return this;
+        }
+
+        public GlueDiscoveryRequest build() {
+            return new DefaultGlueDiscoveryRequest(List.copyOf(gluePaths));
+        }
+    }
+
+    final class DefaultGlueDiscoveryRequest implements GlueDiscoveryRequest {
+        private final List<URI> gluePaths;
+
+        public DefaultGlueDiscoveryRequest(List<URI> gluePaths) {
+            this.gluePaths = gluePaths;
+        }
+
+        @Override
+        public List<URI> getGluePaths() {
+            return gluePaths;
+        }
+    }
+
 }

--- a/cucumber-core/src/main/java/io/cucumber/core/backend/GlueDiscoveryRequest.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/GlueDiscoveryRequest.java
@@ -1,6 +1,5 @@
 package io.cucumber.core.backend;
 
-import java.net.URI;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -10,21 +9,27 @@ import java.util.Set;
  * location.
  */
 public interface GlueDiscoveryRequest {
-    List<URI> getGluePaths();
 
     static Builder builder() {
         return new Builder();
     }
 
+    <T extends GlueDiscoverySelector> List<T> getSelectorsByType(Class<T> selector);
+
     final class Builder {
-        private final Set<URI> gluePaths = new LinkedHashSet<>();
+        private final Set<GlueDiscoverySelector> gluePaths = new LinkedHashSet<>();
 
         private Builder() {
 
         }
 
-        public Builder gluePath(URI... gluePath) {
-            this.gluePaths.addAll(List.of(gluePath));
+        public Builder selectors(GlueDiscoverySelector... selectors) {
+            this.gluePaths.addAll(List.of(selectors));
+            return this;
+        }
+
+        public Builder selectors(List<? extends GlueDiscoverySelector> selectors) {
+            this.gluePaths.addAll(selectors);
             return this;
         }
 
@@ -34,15 +39,17 @@ public interface GlueDiscoveryRequest {
     }
 
     final class DefaultGlueDiscoveryRequest implements GlueDiscoveryRequest {
-        private final List<URI> gluePaths;
+        private final List<GlueDiscoverySelector> gluePaths;
 
-        public DefaultGlueDiscoveryRequest(List<URI> gluePaths) {
+        public DefaultGlueDiscoveryRequest(List<GlueDiscoverySelector> gluePaths) {
             this.gluePaths = gluePaths;
         }
 
         @Override
-        public List<URI> getGluePaths() {
-            return gluePaths;
+        public <T extends GlueDiscoverySelector> List<T> getSelectorsByType(Class<T> selectorType) {
+            return gluePaths.stream().filter(selectorType::isInstance) //
+                    .map(selectorType::cast) //
+                    .toList();
         }
     }
 

--- a/cucumber-core/src/main/java/io/cucumber/core/backend/GlueDiscoveryRequest.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/GlueDiscoveryRequest.java
@@ -1,0 +1,8 @@
+package io.cucumber.core.backend;
+
+import java.net.URI;
+import java.util.List;
+
+public interface GlueDiscoveryRequest {
+    List<URI> getGluePaths();
+}

--- a/cucumber-core/src/main/java/io/cucumber/core/backend/GlueDiscoveryRequest.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/GlueDiscoveryRequest.java
@@ -5,6 +5,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * A request for a {@link Backend} to discover {@link Glue} code in specific
+ * location.
+ */
 public interface GlueDiscoveryRequest {
     List<URI> getGluePaths();
 

--- a/cucumber-core/src/main/java/io/cucumber/core/backend/GlueDiscoverySelector.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/backend/GlueDiscoverySelector.java
@@ -1,0 +1,19 @@
+package io.cucumber.core.backend;
+
+import java.net.URI;
+
+public interface GlueDiscoverySelector {
+
+    static UriGlueDiscoverySelector selectUri(URI uri) {
+        return new UriGlueDiscoverySelector(uri);
+    }
+
+    static UriGlueDiscoverySelector selectUri(String uri) {
+        return selectUri(URI.create(uri));
+    }
+
+    record UriGlueDiscoverySelector(URI uri) implements GlueDiscoverySelector {
+
+    }
+
+}

--- a/cucumber-core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
@@ -1,5 +1,6 @@
 package io.cucumber.core.options;
 
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.eventbus.UuidGenerator;
 import io.cucumber.core.feature.FeatureWithLines;
@@ -173,6 +174,16 @@ public final class RuntimeOptions implements
     @Override
     public @Nullable Class<? extends UuidGenerator> getUuidGeneratorClass() {
         return uuidGeneratorClass;
+    }
+
+    @Override
+    public GlueDiscoveryRequest getGlueDiscoveryRequest() {
+        return new GlueDiscoveryRequest() {
+            @Override
+            public List<URI> getGluePaths() {
+                return unmodifiableList(glue);
+            }
+        };
     }
 
     void setUuidGeneratorClass(Class<? extends UuidGenerator> uuidGeneratorClass) {

--- a/cucumber-core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
@@ -148,11 +148,6 @@ public final class RuntimeOptions implements
     }
 
     @Override
-    public List<URI> getGlue() {
-        return unmodifiableList(glue);
-    }
-
-    @Override
     public boolean isDryRun() {
         return dryRun;
     }

--- a/cucumber-core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/options/RuntimeOptions.java
@@ -1,6 +1,7 @@
 package io.cucumber.core.options;
 
 import io.cucumber.core.backend.GlueDiscoveryRequest;
+import io.cucumber.core.backend.GlueDiscoverySelector;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.eventbus.UuidGenerator;
 import io.cucumber.core.feature.FeatureWithLines;
@@ -173,12 +174,9 @@ public final class RuntimeOptions implements
 
     @Override
     public GlueDiscoveryRequest getGlueDiscoveryRequest() {
-        return new GlueDiscoveryRequest() {
-            @Override
-            public List<URI> getGluePaths() {
-                return unmodifiableList(glue);
-            }
-        };
+        return GlueDiscoveryRequest.builder() //
+                .selectors(glue.stream().map(GlueDiscoverySelector::selectUri).toList()) //
+                .build();
     }
 
     void setUuidGeneratorClass(Class<? extends UuidGenerator> uuidGeneratorClass) {

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/Options.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/Options.java
@@ -6,15 +6,7 @@ import io.cucumber.core.eventbus.UuidGenerator;
 import io.cucumber.core.snippets.SnippetType;
 import org.jspecify.annotations.Nullable;
 
-import java.net.URI;
-import java.util.List;
-
 public interface Options {
-
-    @Deprecated
-    default List<URI> getGlue(){
-        return getGlueDiscoveryRequest().getGluePaths();
-    }
 
     boolean isDryRun();
 

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/Options.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/Options.java
@@ -1,5 +1,6 @@
 package io.cucumber.core.runner;
 
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.eventbus.UuidGenerator;
 import io.cucumber.core.snippets.SnippetType;
@@ -10,7 +11,10 @@ import java.util.List;
 
 public interface Options {
 
-    List<URI> getGlue();
+    @Deprecated
+    default List<URI> getGlue(){
+        return getGlueDiscoveryRequest().getGluePaths();
+    }
 
     boolean isDryRun();
 
@@ -21,5 +25,7 @@ public interface Options {
 
     @Nullable
     Class<? extends UuidGenerator> getUuidGeneratorClass();
+
+    GlueDiscoveryRequest getGlueDiscoveryRequest();
 
 }

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/Runner.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/Runner.java
@@ -3,7 +3,6 @@ package io.cucumber.core.runner;
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.CucumberBackendException;
 import io.cucumber.core.backend.CucumberInvocationTargetException;
-import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.backend.StaticHookDefinition;
 import io.cucumber.core.eventbus.EventBus;
@@ -20,7 +19,6 @@ import io.cucumber.plugin.event.HookType;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent;
 import io.cucumber.plugin.event.SnippetsSuggestedEvent.Suggestion;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/Runner.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/Runner.java
@@ -50,7 +50,6 @@ public final class Runner {
         this.glue = new CachingGlue(bus);
         this.objectFactory = objectFactory;
         var request = runnerOptions.getGlueDiscoveryRequest();
-        log.debug(() -> "Loading glue from " + request.getGluePaths());
         for (Backend backend : backends) {
             log.debug(() -> "Loading glue for backend " + backend.getClass().getName());
 

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/Runner.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/Runner.java
@@ -3,6 +3,7 @@ package io.cucumber.core.runner;
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.CucumberBackendException;
 import io.cucumber.core.backend.CucumberInvocationTargetException;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.backend.StaticHookDefinition;
 import io.cucumber.core.eventbus.EventBus;
@@ -50,11 +51,12 @@ public final class Runner {
         this.backends = backends;
         this.glue = new CachingGlue(bus);
         this.objectFactory = objectFactory;
-        List<URI> gluePaths = runnerOptions.getGlue();
-        log.debug(() -> "Loading glue from " + gluePaths);
+        var request = runnerOptions.getGlueDiscoveryRequest();
+        log.debug(() -> "Loading glue from " + request.getGluePaths());
         for (Backend backend : backends) {
             log.debug(() -> "Loading glue for backend " + backend.getClass().getName());
-            backend.loadGlue(this.glue, gluePaths);
+
+            backend.loadGlue(this.glue, request);
         }
     }
 

--- a/cucumber-core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
@@ -205,7 +205,7 @@ class CommandlineOptionsParserTest {
         RuntimeOptions options = parser
                 .parse("--glue", "somewhere")
                 .build();
-        assertThat(options.getGlue(), contains(uri("classpath:/somewhere")));
+        assertThat(options.getGlueDiscoveryRequest().getGluePaths(), contains(uri("classpath:/somewhere")));
     }
 
     @Test
@@ -526,7 +526,7 @@ class CommandlineOptionsParserTest {
                 .parse()
                 .addDefaultGlueIfAbsent()
                 .build();
-        assertThat(options.getGlue(), is(singletonList(rootPackageUri())));
+        assertThat(options.getGlueDiscoveryRequest().getGluePaths(), is(singletonList(rootPackageUri())));
     }
 
     @Test

--- a/cucumber-core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/options/CommandlineOptionsParserTest.java
@@ -1,5 +1,6 @@
 package io.cucumber.core.options;
 
+import io.cucumber.core.backend.GlueDiscoverySelector.UriGlueDiscoverySelector;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.eventbus.IncrementingUuidGenerator;
 import io.cucumber.core.feature.TestFeatureParser;
@@ -37,6 +38,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import static io.cucumber.core.backend.GlueDiscoverySelector.selectUri;
 import static io.cucumber.core.options.Constants.FILTER_TAGS_PROPERTY_NAME;
 import static io.cucumber.core.plugin.IsEqualCompressingLineSeparators.equalCompressingLineSeparators;
 import static io.cucumber.core.resource.ClasspathSupport.rootPackageUri;
@@ -205,7 +207,8 @@ class CommandlineOptionsParserTest {
         RuntimeOptions options = parser
                 .parse("--glue", "somewhere")
                 .build();
-        assertThat(options.getGlueDiscoveryRequest().getGluePaths(), contains(uri("classpath:/somewhere")));
+        assertThat(options.getGlueDiscoveryRequest().getSelectorsByType(UriGlueDiscoverySelector.class),
+            contains(selectUri("classpath:/somewhere")));
     }
 
     @Test
@@ -526,7 +529,8 @@ class CommandlineOptionsParserTest {
                 .parse()
                 .addDefaultGlueIfAbsent()
                 .build();
-        assertThat(options.getGlueDiscoveryRequest().getGluePaths(), is(singletonList(rootPackageUri())));
+        assertThat(options.getGlueDiscoveryRequest().getSelectorsByType(UriGlueDiscoverySelector.class),
+            is(singletonList(selectUri(rootPackageUri()))));
     }
 
     @Test

--- a/cucumber-core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
@@ -1,5 +1,6 @@
 package io.cucumber.core.options;
 
+import io.cucumber.core.backend.GlueDiscoverySelector.UriGlueDiscoverySelector;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.eventbus.IncrementingUuidGenerator;
 import io.cucumber.core.eventbus.UuidGenerator;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import static io.cucumber.core.backend.GlueDiscoverySelector.selectUri;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -48,8 +50,9 @@ class CucumberOptionsAnnotationParserTest {
         assertAll(
             () -> assertThat(runtimeOptions.getObjectFactoryClass(), is(nullValue())),
             () -> assertThat(runtimeOptions.getFeaturePaths(), contains(uri("classpath:/io/cucumber/core/options"))),
-            () -> assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
-                contains(uri("classpath:/io/cucumber/core/options"))));
+            () -> assertThat(
+                runtimeOptions.getGlueDiscoveryRequest().getSelectorsByType(UriGlueDiscoverySelector.class),
+                contains(selectUri("classpath:/io/cucumber/core/options"))));
 
         Plugins plugins = new Plugins(new PluginFactory(), runtimeOptions);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
@@ -89,8 +92,9 @@ class CucumberOptionsAnnotationParserTest {
 
         assertAll(
             () -> assertThat(runtimeOptions.getFeaturePaths(), contains(uri("classpath:/io/cucumber/core/options"))),
-            () -> assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
-                contains(uri("classpath:/io/cucumber/core/options"))),
+            () -> assertThat(
+                runtimeOptions.getGlueDiscoveryRequest().getSelectorsByType(UriGlueDiscoverySelector.class),
+                contains(selectUri("classpath:/io/cucumber/core/options"))),
             () -> assertThat(plugins.getPlugins(), is(empty())));
     }
 
@@ -215,16 +219,17 @@ class CucumberOptionsAnnotationParserTest {
     void create_with_glue() {
         RuntimeOptions runtimeOptions = parser().parse(ClassWithGlue.class).build();
 
-        assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
-            contains(uri("classpath:/app/features/user/registration"), uri("classpath:/app/features/hooks")));
+        assertThat(runtimeOptions.getGlueDiscoveryRequest().getSelectorsByType(UriGlueDiscoverySelector.class),
+            contains(selectUri("classpath:/app/features/user/registration"),
+                selectUri("classpath:/app/features/hooks")));
     }
 
     @Test
     void create_with_extra_glue() {
         RuntimeOptions runtimeOptions = parser().parse(ClassWithExtraGlue.class).build();
 
-        assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
-            contains(uri("classpath:/app/features/hooks"), uri("classpath:/io/cucumber/core/options")));
+        assertThat(runtimeOptions.getGlueDiscoveryRequest().getSelectorsByType(UriGlueDiscoverySelector.class),
+            contains(selectUri("classpath:/app/features/hooks"), selectUri("classpath:/io/cucumber/core/options")));
 
     }
 
@@ -234,18 +239,18 @@ class CucumberOptionsAnnotationParserTest {
                 .parse(SubClassWithExtraGlueOfExtraGlue.class)
                 .build();
 
-        assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
-            contains(uri("classpath:/app/features/user/hooks"), uri("classpath:/app/features/hooks"),
-                uri("classpath:/io/cucumber/core/options")));
+        assertThat(runtimeOptions.getGlueDiscoveryRequest().getSelectorsByType(UriGlueDiscoverySelector.class),
+            contains(selectUri("classpath:/app/features/user/hooks"), selectUri("classpath:/app/features/hooks"),
+                selectUri("classpath:/io/cucumber/core/options")));
     }
 
     @Test
     void create_with_extra_glue_in_subclass_of_glue() {
         RuntimeOptions runtimeOptions = parser().parse(SubClassWithExtraGlueOfGlue.class).build();
 
-        assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
-            contains(uri("classpath:/app/features/user/hooks"),
-                uri("classpath:/app/features/user/registration"), uri("classpath:/app/features/hooks")));
+        assertThat(runtimeOptions.getGlueDiscoveryRequest().getSelectorsByType(UriGlueDiscoverySelector.class),
+            contains(selectUri("classpath:/app/features/user/hooks"),
+                selectUri("classpath:/app/features/user/registration"), selectUri("classpath:/app/features/hooks")));
     }
 
     @Test

--- a/cucumber-core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/options/CucumberOptionsAnnotationParserTest.java
@@ -48,7 +48,8 @@ class CucumberOptionsAnnotationParserTest {
         assertAll(
             () -> assertThat(runtimeOptions.getObjectFactoryClass(), is(nullValue())),
             () -> assertThat(runtimeOptions.getFeaturePaths(), contains(uri("classpath:/io/cucumber/core/options"))),
-            () -> assertThat(runtimeOptions.getGlue(), contains(uri("classpath:/io/cucumber/core/options"))));
+            () -> assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
+                contains(uri("classpath:/io/cucumber/core/options"))));
 
         Plugins plugins = new Plugins(new PluginFactory(), runtimeOptions);
         plugins.setEventBusOnEventListenerPlugins(new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID));
@@ -88,7 +89,8 @@ class CucumberOptionsAnnotationParserTest {
 
         assertAll(
             () -> assertThat(runtimeOptions.getFeaturePaths(), contains(uri("classpath:/io/cucumber/core/options"))),
-            () -> assertThat(runtimeOptions.getGlue(), contains(uri("classpath:/io/cucumber/core/options"))),
+            () -> assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
+                contains(uri("classpath:/io/cucumber/core/options"))),
             () -> assertThat(plugins.getPlugins(), is(empty())));
     }
 
@@ -213,7 +215,7 @@ class CucumberOptionsAnnotationParserTest {
     void create_with_glue() {
         RuntimeOptions runtimeOptions = parser().parse(ClassWithGlue.class).build();
 
-        assertThat(runtimeOptions.getGlue(),
+        assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
             contains(uri("classpath:/app/features/user/registration"), uri("classpath:/app/features/hooks")));
     }
 
@@ -221,7 +223,7 @@ class CucumberOptionsAnnotationParserTest {
     void create_with_extra_glue() {
         RuntimeOptions runtimeOptions = parser().parse(ClassWithExtraGlue.class).build();
 
-        assertThat(runtimeOptions.getGlue(),
+        assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
             contains(uri("classpath:/app/features/hooks"), uri("classpath:/io/cucumber/core/options")));
 
     }
@@ -232,7 +234,7 @@ class CucumberOptionsAnnotationParserTest {
                 .parse(SubClassWithExtraGlueOfExtraGlue.class)
                 .build();
 
-        assertThat(runtimeOptions.getGlue(),
+        assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
             contains(uri("classpath:/app/features/user/hooks"), uri("classpath:/app/features/hooks"),
                 uri("classpath:/io/cucumber/core/options")));
     }
@@ -241,8 +243,9 @@ class CucumberOptionsAnnotationParserTest {
     void create_with_extra_glue_in_subclass_of_glue() {
         RuntimeOptions runtimeOptions = parser().parse(SubClassWithExtraGlueOfGlue.class).build();
 
-        assertThat(runtimeOptions.getGlue(), contains(uri("classpath:/app/features/user/hooks"),
-            uri("classpath:/app/features/user/registration"), uri("classpath:/app/features/hooks")));
+        assertThat(runtimeOptions.getGlueDiscoveryRequest().getGluePaths(),
+            contains(uri("classpath:/app/features/user/hooks"),
+                uri("classpath:/app/features/user/registration"), uri("classpath:/app/features/hooks")));
     }
 
     @Test

--- a/cucumber-core/src/test/java/io/cucumber/core/options/CucumberPropertiesParserTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/options/CucumberPropertiesParserTest.java
@@ -1,5 +1,6 @@
 package io.cucumber.core.options;
 
+import io.cucumber.core.backend.GlueDiscoverySelector.UriGlueDiscoverySelector;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.exception.CucumberException;
 import io.cucumber.core.logging.LogRecordListener;
@@ -20,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.cucumber.core.backend.GlueDiscoverySelector.selectUri;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.WRITE;
 import static java.util.stream.Collectors.toList;
@@ -121,17 +123,17 @@ class CucumberPropertiesParserTest {
     void should_parse_glue() {
         properties.put(Constants.GLUE_PROPERTY_NAME, "com.example.steps");
         RuntimeOptions options = cucumberPropertiesParser.parse(properties).build();
-        assertThat(options.getGlueDiscoveryRequest().getGluePaths(), contains(
-            URI.create("classpath:/com/example/steps")));
+        assertThat(options.getGlueDiscoveryRequest().getSelectorsByType(UriGlueDiscoverySelector.class), contains(
+            selectUri("classpath:/com/example/steps")));
     }
 
     @Test
     void should_parse_glue_list() {
         properties.put(Constants.GLUE_PROPERTY_NAME, "com.example.app.steps, com.example.other.steps");
         RuntimeOptions options = cucumberPropertiesParser.parse(properties).build();
-        assertThat(options.getGlueDiscoveryRequest().getGluePaths(), contains(
-            URI.create("classpath:/com/example/app/steps"),
-            URI.create("classpath:/com/example/other/steps")));
+        assertThat(options.getGlueDiscoveryRequest().getSelectorsByType(UriGlueDiscoverySelector.class), contains(
+            selectUri("classpath:/com/example/app/steps"),
+            selectUri("classpath:/com/example/other/steps")));
     }
 
     @Test

--- a/cucumber-core/src/test/java/io/cucumber/core/options/CucumberPropertiesParserTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/options/CucumberPropertiesParserTest.java
@@ -121,7 +121,7 @@ class CucumberPropertiesParserTest {
     void should_parse_glue() {
         properties.put(Constants.GLUE_PROPERTY_NAME, "com.example.steps");
         RuntimeOptions options = cucumberPropertiesParser.parse(properties).build();
-        assertThat(options.getGlue(), contains(
+        assertThat(options.getGlueDiscoveryRequest().getGluePaths(), contains(
             URI.create("classpath:/com/example/steps")));
     }
 
@@ -129,7 +129,7 @@ class CucumberPropertiesParserTest {
     void should_parse_glue_list() {
         properties.put(Constants.GLUE_PROPERTY_NAME, "com.example.app.steps, com.example.other.steps");
         RuntimeOptions options = cucumberPropertiesParser.parse(properties).build();
-        assertThat(options.getGlue(), contains(
+        assertThat(options.getGlueDiscoveryRequest().getGluePaths(), contains(
             URI.create("classpath:/com/example/app/steps"),
             URI.create("classpath:/com/example/other/steps")));
     }

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/HookOrderTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/HookOrderTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 
-import java.net.URI;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/HookOrderTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/HookOrderTest.java
@@ -1,6 +1,7 @@
 package io.cucumber.core.runner;
 
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.StubStepDefinition;
 import io.cucumber.core.eventbus.EventBus;
@@ -42,7 +43,7 @@ class HookOrderTest {
 
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addStepDefinition(new StubStepDefinition("pattern1"));
                 for (HookDefinition hook : hooks) {
                     glue.addBeforeHook(hook);
@@ -81,7 +82,7 @@ class HookOrderTest {
 
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addStepDefinition(stepDefinition);
                 for (HookDefinition hook : hooks) {
                     glue.addBeforeStepHook(hook);
@@ -108,7 +109,7 @@ class HookOrderTest {
 
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addStepDefinition(stepDefinition);
                 for (HookDefinition hook : hooks) {
                     glue.addAfterHook(hook);
@@ -135,7 +136,7 @@ class HookOrderTest {
 
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addStepDefinition(stepDefinition);
                 for (HookDefinition hook : hooks) {
                     glue.addAfterStepHook(hook);
@@ -163,7 +164,7 @@ class HookOrderTest {
 
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addStepDefinition(stepDefinition);
 
                 for (HookDefinition hook : backend1Hooks) {

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/HookTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/HookTest.java
@@ -2,6 +2,7 @@ package io.cucumber.core.runner;
 
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.eventbus.EventBus;
@@ -12,7 +13,6 @@ import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.cucumber.core.snippets.TestSnippet;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 
 import java.time.Clock;
@@ -56,7 +56,7 @@ class HookTest {
             Glue glue = invocation.getArgument(0);
             glue.addBeforeHook(hook);
             return null;
-        }).when(backend).loadGlue(any(Glue.class), ArgumentMatchers.anyList());
+        }).when(backend).loadGlue(any(Glue.class), any(GlueDiscoveryRequest.class));
 
         Runner runner = new Runner(bus, Collections.singleton(backend), objectFactory, runtimeOptions);
 
@@ -64,7 +64,7 @@ class HookTest {
 
         InOrder inOrder = inOrder(hook, backend);
         inOrder.verify(backend).buildWorld();
-        inOrder.verify(hook).execute(ArgumentMatchers.any());
+        inOrder.verify(hook).execute(any());
         inOrder.verify(backend).disposeWorld();
     }
 
@@ -81,7 +81,7 @@ class HookTest {
             Glue glue = invocation.getArgument(0);
             glue.addBeforeHook(hook);
             return null;
-        }).when(backend).loadGlue(any(Glue.class), ArgumentMatchers.anyList());
+        }).when(backend).loadGlue(any(Glue.class), any(GlueDiscoveryRequest.class));
 
         RuntimeException e = assertThrows(RuntimeException.class,
             () -> new Runner(bus, Collections.singleton(backend), objectFactory,

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/RunnerTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/RunnerTest.java
@@ -18,9 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 
-import java.net.URI;
 import java.time.Clock;
-import java.util.List;
 import java.util.UUID;
 
 import static java.util.Collections.emptyList;
@@ -62,7 +60,7 @@ class RunnerTest {
             glue.addBeforeHook(beforeHook);
             glue.addAfterHook(afterHook);
             return null;
-        }).when(backend).loadGlue(any(Glue.class), ArgumentMatchers.anyList());
+        }).when(backend).loadGlue(any(Glue.class), any(GlueDiscoveryRequest.class));
 
         Runner runner = new Runner(bus, singletonList(backend), objectFactory, runtimeOptions);
         runner.runBeforeAllHooks();

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/RunnerTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/RunnerTest.java
@@ -2,6 +2,7 @@ package io.cucumber.core.runner;
 
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.backend.StaticHookDefinition;
@@ -108,7 +109,7 @@ class RunnerTest {
         doThrow(new RuntimeException("Boom")).when(failingBeforeHook).execute(ArgumentMatchers.any());
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addBeforeHook(failingBeforeHook);
                 glue.addStepDefinition(stepDefinition);
             }
@@ -148,7 +149,7 @@ class RunnerTest {
 
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addAfterHook(afterStepHook);
                 glue.addStepDefinition(stepDefinition);
             }
@@ -171,7 +172,7 @@ class RunnerTest {
 
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addAfterHook(afteStepHook1);
                 glue.addAfterHook(afteStepHook2);
                 glue.addStepDefinition(stepDefinition);
@@ -196,7 +197,7 @@ class RunnerTest {
 
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addBeforeHook(failingBeforeHook);
                 glue.addBeforeHook(beforeHook);
                 glue.addAfterHook(afterHook);
@@ -219,7 +220,7 @@ class RunnerTest {
 
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addBeforeAllHook(beforeAllHook);
                 glue.addBeforeAllHook(failingBeforeAllHook);
             }
@@ -239,7 +240,7 @@ class RunnerTest {
         Pickle pickleMatchingStepDefinitions = createPickleMatchingStepDefinitions(stepDefinition);
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addStepDefinition(stepDefinition);
             }
         };
@@ -254,7 +255,7 @@ class RunnerTest {
         RuntimeOptions runtimeOptions = new RuntimeOptionsBuilder().setDryRun().build();
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addStepDefinition(stepDefinition);
             }
         };
@@ -277,7 +278,7 @@ class RunnerTest {
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
 
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addBeforeAllHook(beforeAllHook);
                 glue.addAfterAllHook(afterAllHook);
                 glue.addBeforeHook(beforeHook);
@@ -308,7 +309,7 @@ class RunnerTest {
         TestRunnerSupplier runnerSupplier = new TestRunnerSupplier(bus, runtimeOptions) {
 
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addBeforeHook(beforeHook);
                 glue.addAfterHook(afterHook);
                 glue.addBeforeStepHook(beforeStepHook);

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/TestRunnerSupplier.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/TestRunnerSupplier.java
@@ -2,6 +2,7 @@ package io.cucumber.core.runner;
 
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.eventbus.EventBus;
@@ -23,21 +24,6 @@ class TestRunnerSupplier implements Backend, RunnerSupplier, ObjectFactory {
     protected TestRunnerSupplier(EventBus bus, RuntimeOptions runtimeOptions) {
         this.bus = bus;
         this.runtimeOptions = runtimeOptions;
-    }
-
-    @Override
-    public void loadGlue(Glue glue, List<URI> gluePaths) {
-
-    }
-
-    @Override
-    public void buildWorld() {
-
-    }
-
-    @Override
-    public void disposeWorld() {
-
     }
 
     @Override

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/TestRunnerSupplier.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/TestRunnerSupplier.java
@@ -1,17 +1,12 @@
 package io.cucumber.core.runner;
 
 import io.cucumber.core.backend.Backend;
-import io.cucumber.core.backend.Glue;
-import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.runtime.RunnerSupplier;
 import io.cucumber.core.snippets.TestSnippet;
-
-import java.net.URI;
-import java.util.List;
 
 import static java.util.Collections.singleton;
 

--- a/cucumber-core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
@@ -2,6 +2,7 @@ package io.cucumber.core.runtime;
 
 import io.cucumber.core.backend.CucumberBackendException;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.ParameterInfo;
 import io.cucumber.core.backend.ScenarioScoped;
@@ -428,7 +429,7 @@ class RuntimeTest {
 
         BackendSupplier backendSupplier = new TestBackendSupplier() {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 glue.addAfterAllHook(mockedStaticHookDefinition);
             }
         };
@@ -512,7 +513,7 @@ class RuntimeTest {
             private @Nullable Glue glue;
 
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 this.glue = glue;
                 glue.addStepDefinition(mockedStepDefinition);
             }

--- a/cucumber-core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runtime/RuntimeTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.ArgumentCaptor;
 
-import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;

--- a/cucumber-core/src/test/java/io/cucumber/core/runtime/StubBackendSupplier.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runtime/StubBackendSupplier.java
@@ -9,7 +9,6 @@ import io.cucumber.core.backend.StaticHookDefinition;
 import io.cucumber.core.backend.StepDefinition;
 import io.cucumber.core.snippets.TestSnippet;
 
-import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;

--- a/cucumber-core/src/test/java/io/cucumber/core/runtime/StubBackendSupplier.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runtime/StubBackendSupplier.java
@@ -2,6 +2,7 @@ package io.cucumber.core.runtime;
 
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.backend.StaticHookDefinition;
@@ -68,7 +69,7 @@ public final class StubBackendSupplier implements BackendSupplier {
     public Collection<? extends Backend> get() {
         return Collections.singletonList(new Backend() {
             @Override
-            public void loadGlue(Glue glue, List<URI> gluePaths) {
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
                 beforeAll.forEach(glue::addBeforeAllHook);
                 before.forEach(glue::addBeforeHook);
                 beforeStep.forEach(glue::addBeforeStepHook);

--- a/cucumber-guice/src/main/java/io/cucumber/guice/GuiceBackend.java
+++ b/cucumber-guice/src/main/java/io/cucumber/guice/GuiceBackend.java
@@ -4,6 +4,7 @@ import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
 import io.cucumber.core.backend.GlueDiscoveryRequest;
+import io.cucumber.core.backend.GlueDiscoverySelector.UriGlueDiscoverySelector;
 import io.cucumber.core.resource.ClasspathScanner;
 import io.cucumber.core.resource.ClasspathSupport;
 
@@ -24,7 +25,8 @@ final class GuiceBackend implements Backend {
 
     @Override
     public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
-        request.getGluePaths().stream()
+        request.getSelectorsByType(UriGlueDiscoverySelector.class).stream()
+                .map(UriGlueDiscoverySelector::uri)
                 .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
                 .map(ClasspathSupport::packageName)
                 .map(classFinder::scanForClassesInPackage)

--- a/cucumber-guice/src/main/java/io/cucumber/guice/GuiceBackend.java
+++ b/cucumber-guice/src/main/java/io/cucumber/guice/GuiceBackend.java
@@ -3,14 +3,11 @@ package io.cucumber.guice;
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
-import io.cucumber.core.backend.Snippet;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.resource.ClasspathScanner;
 import io.cucumber.core.resource.ClasspathSupport;
-import org.jspecify.annotations.Nullable;
 
-import java.net.URI;
 import java.util.Collection;
-import java.util.List;
 import java.util.function.Supplier;
 
 import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME;
@@ -26,8 +23,8 @@ final class GuiceBackend implements Backend {
     }
 
     @Override
-    public void loadGlue(Glue glue, List<URI> gluePaths) {
-        gluePaths.stream()
+    public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
+        request.getGluePaths().stream()
                 .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
                 .map(ClasspathSupport::packageName)
                 .map(classFinder::scanForClassesInPackage)
@@ -36,20 +33,4 @@ final class GuiceBackend implements Backend {
                 .distinct()
                 .forEach(container::addClass);
     }
-
-    @Override
-    public void buildWorld() {
-
-    }
-
-    @Override
-    public void disposeWorld() {
-
-    }
-
-    @Override
-    public @Nullable Snippet getSnippet() {
-        return null;
-    }
-
 }

--- a/cucumber-guice/src/test/java/io/cucumber/guice/GuiceBackendTest.java
+++ b/cucumber-guice/src/test/java/io/cucumber/guice/GuiceBackendTest.java
@@ -6,6 +6,7 @@ import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.guice.integration.YourInjectorSource;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoSettings;
 
 import java.net.URI;
@@ -21,6 +22,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @MockitoSettings
 class GuiceBackendTest {
@@ -58,18 +60,11 @@ class GuiceBackendTest {
     }
 
     @Test
-    @SuppressWarnings("NullAway")
     void doesnt_save_anything_in_glue() {
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
-        backend.loadGlue(null, singletonList(URI.create("classpath:io/cucumber/guice/integration")));
+        backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/guice/integration")));
         verify(factory).addClass(YourInjectorSource.class);
-    }
-
-    @Test
-    @SuppressWarnings("NullAway")
-    void list_of_uris_cant_be_null() {
-        GuiceBackend backend = new GuiceBackend(factory, classLoader);
-        assertThrows(NullPointerException.class, () -> backend.loadGlue(glue, null));
+        verifyNoInteractions(glue);
     }
 
     @Test

--- a/cucumber-guice/src/test/java/io/cucumber/guice/GuiceBackendTest.java
+++ b/cucumber-guice/src/test/java/io/cucumber/guice/GuiceBackendTest.java
@@ -2,24 +2,21 @@ package io.cucumber.guice;
 
 import io.cucumber.core.backend.BackendProviderService;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.guice.integration.YourInjectorSource;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoSettings;
 
 import java.net.URI;
 import java.util.function.Supplier;
 
 import static java.lang.Thread.currentThread;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -38,22 +35,30 @@ class GuiceBackendTest {
     @Test
     void finds_injector_source_impls_by_classpath_url() {
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
-        backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/guice/integration")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/guice/integration")) //
+                .build();
+        backend.loadGlue(glue, request);
         verify(factory).addClass(YourInjectorSource.class);
     }
 
     @Test
     void finds_injector_source_impls_once_by_classpath_url() {
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
-        backend.loadGlue(glue, asList(URI.create("classpath:io/cucumber/guice/integration"),
-            URI.create("classpath:io/cucumber/guice/integration")));
+        backend.loadGlue(glue, GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/guice/integration")) //
+                .gluePath(URI.create("classpath:io/cucumber/guice/integration")) //
+                .build());
         verify(factory, times(1)).addClass(YourInjectorSource.class);
     }
 
     @Test
     void world_and_snippet_methods_do_nothing() {
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
-        backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/guice/integration")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/guice/integration")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         backend.disposeWorld();
         assertThat(backend.getSnippet(), is(nullValue()));
@@ -62,7 +67,10 @@ class GuiceBackendTest {
     @Test
     void doesnt_save_anything_in_glue() {
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
-        backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/guice/integration")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/guice/integration")) //
+                .build();
+        backend.loadGlue(glue, request);
         verify(factory).addClass(YourInjectorSource.class);
         verifyNoInteractions(glue);
     }

--- a/cucumber-guice/src/test/java/io/cucumber/guice/GuiceBackendTest.java
+++ b/cucumber-guice/src/test/java/io/cucumber/guice/GuiceBackendTest.java
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 
-import java.net.URI;
 import java.util.function.Supplier;
 
+import static io.cucumber.core.backend.GlueDiscoverySelector.selectUri;
 import static java.lang.Thread.currentThread;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -36,7 +36,7 @@ class GuiceBackendTest {
     void finds_injector_source_impls_by_classpath_url() {
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/guice/integration")) //
+                .selectors(selectUri("classpath:io/cucumber/guice/integration")) //
                 .build();
         backend.loadGlue(glue, request);
         verify(factory).addClass(YourInjectorSource.class);
@@ -45,18 +45,19 @@ class GuiceBackendTest {
     @Test
     void finds_injector_source_impls_once_by_classpath_url() {
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
-        backend.loadGlue(glue, GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/guice/integration")) //
-                .gluePath(URI.create("classpath:io/cucumber/guice/integration")) //
-                .build());
+        GlueDiscoveryRequest request = GlueDiscoveryRequest.builder() //
+                .selectors(selectUri("classpath:io/cucumber/guice/integration")) //
+                .selectors(selectUri("classpath:io/cucumber/guice/integration")) //
+                .build();
+        backend.loadGlue(glue, request);
         verify(factory, times(1)).addClass(YourInjectorSource.class);
     }
 
     @Test
     void world_and_snippet_methods_do_nothing() {
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
-        var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/guice/integration")) //
+        var request = GlueDiscoveryRequest.builder()
+                .selectors(selectUri("classpath:io/cucumber/guice/integration")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();
@@ -68,7 +69,7 @@ class GuiceBackendTest {
     void doesnt_save_anything_in_glue() {
         GuiceBackend backend = new GuiceBackend(factory, classLoader);
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/guice/integration")) //
+                .selectors(selectUri("classpath:io/cucumber/guice/integration")) //
                 .build();
         backend.loadGlue(glue, request);
         verify(factory).addClass(YourInjectorSource.class);

--- a/cucumber-java/src/main/java/io/cucumber/java/JavaBackend.java
+++ b/cucumber-java/src/main/java/io/cucumber/java/JavaBackend.java
@@ -9,9 +9,7 @@ import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.resource.ClasspathScanner;
 import io.cucumber.core.resource.ClasspathSupport;
 
-import java.net.URI;
 import java.util.Collection;
-import java.util.List;
 import java.util.function.Supplier;
 
 import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME;

--- a/cucumber-java/src/main/java/io/cucumber/java/JavaBackend.java
+++ b/cucumber-java/src/main/java/io/cucumber/java/JavaBackend.java
@@ -4,6 +4,7 @@ import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
 import io.cucumber.core.backend.GlueDiscoveryRequest;
+import io.cucumber.core.backend.GlueDiscoverySelector;
 import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.resource.ClasspathScanner;
@@ -31,7 +32,9 @@ final class JavaBackend implements Backend {
     public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
         GlueAdaptor glueAdaptor = new GlueAdaptor(lookup, glue);
 
-        request.getGluePaths().stream()
+        request.getSelectorsByType(GlueDiscoverySelector.UriGlueDiscoverySelector.class) //
+                .stream() //
+                .map(GlueDiscoverySelector.UriGlueDiscoverySelector::uri) //
                 .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
                 .map(ClasspathSupport::packageName)
                 .map(classFinder::scanForClassesInPackage)

--- a/cucumber-java/src/main/java/io/cucumber/java/JavaBackend.java
+++ b/cucumber-java/src/main/java/io/cucumber/java/JavaBackend.java
@@ -3,6 +3,7 @@ package io.cucumber.java;
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.resource.ClasspathScanner;
@@ -29,10 +30,10 @@ final class JavaBackend implements Backend {
     }
 
     @Override
-    public void loadGlue(Glue glue, List<URI> gluePaths) {
+    public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
         GlueAdaptor glueAdaptor = new GlueAdaptor(lookup, glue);
 
-        gluePaths.stream()
+        request.getGluePaths().stream()
                 .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
                 .map(ClasspathSupport::packageName)
                 .map(classFinder::scanForClassesInPackage)
@@ -42,16 +43,6 @@ final class JavaBackend implements Backend {
                     container.addClass(method.getDeclaringClass());
                     glueAdaptor.addDefinition(method, annotation);
                 }));
-    }
-
-    @Override
-    public void buildWorld() {
-
-    }
-
-    @Override
-    public void disposeWorld() {
-
     }
 
     @Override

--- a/cucumber-java/src/test/java/io/cucumber/java/JavaBackendTest.java
+++ b/cucumber-java/src/test/java/io/cucumber/java/JavaBackendTest.java
@@ -1,6 +1,7 @@
 package io.cucumber.java;
 
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.backend.StepDefinition;
 import io.cucumber.java.steps.Steps;
@@ -17,7 +18,6 @@ import java.util.List;
 
 import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -47,23 +47,34 @@ class JavaBackendTest {
 
     @Test
     void finds_step_definitions_by_classpath_url() {
-        backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/java/steps")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/java/steps")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory).addClass(Steps.class);
     }
 
     @Test
     void finds_step_definitions_once_by_classpath_url() {
-        backend.loadGlue(glue,
-            asList(URI.create("classpath:io/cucumber/java/steps"), URI.create("classpath:io/cucumber/java/steps")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/java/steps")) //
+                .gluePath(URI.create("classpath:io/cucumber/java/steps")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory, times(1)).addClass(Steps.class);
     }
 
     @Test
     void detects_subclassed_glue_and_throws_exception() {
-        Executable testMethod = () -> backend.loadGlue(glue, asList(URI.create("classpath:io/cucumber/java/steps"),
-            URI.create("classpath:io/cucumber/java/incorrectlysubclassedsteps")));
+        Executable testMethod = () -> {
+            var request = GlueDiscoveryRequest.builder() //
+                    .gluePath(URI.create("classpath:io/cucumber/java/steps")) //
+                    .gluePath(URI.create("classpath:io/cucumber/java/incorrectlysubclassedsteps")) //
+                    .build();
+            backend.loadGlue(glue, request);
+        };
         InvalidMethodException expectedThrown = assertThrows(InvalidMethodException.class, testMethod);
         assertThat(expectedThrown.getMessage(), is(equalTo(
             """
@@ -81,7 +92,10 @@ class JavaBackendTest {
 
     @Test
     void detects_repeated_annotations() {
-        backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/java/repeatable")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/java/repeatable")) //
+                .build();
+        backend.loadGlue(glue, request);
         verify(glue, times(2)).addStepDefinition(stepDefinition.capture());
 
         List<String> patterns = stepDefinition.getAllValues()

--- a/cucumber-java/src/test/java/io/cucumber/java/JavaBackendTest.java
+++ b/cucumber-java/src/test/java/io/cucumber/java/JavaBackendTest.java
@@ -13,9 +13,9 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 
-import java.net.URI;
 import java.util.List;
 
+import static io.cucumber.core.backend.GlueDiscoverySelector.selectUri;
 import static java.lang.Thread.currentThread;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
@@ -47,8 +47,8 @@ class JavaBackendTest {
 
     @Test
     void finds_step_definitions_by_classpath_url() {
-        var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/java/steps")) //
+        var request = GlueDiscoveryRequest.builder()
+                .selectors(selectUri("classpath:io/cucumber/java/steps")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();
@@ -57,9 +57,9 @@ class JavaBackendTest {
 
     @Test
     void finds_step_definitions_once_by_classpath_url() {
-        var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/java/steps")) //
-                .gluePath(URI.create("classpath:io/cucumber/java/steps")) //
+        var request = GlueDiscoveryRequest.builder()
+                .selectors(selectUri("classpath:io/cucumber/java/steps"))
+                .selectors(selectUri("classpath:io/cucumber/java/steps")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();
@@ -69,9 +69,9 @@ class JavaBackendTest {
     @Test
     void detects_subclassed_glue_and_throws_exception() {
         Executable testMethod = () -> {
-            var request = GlueDiscoveryRequest.builder() //
-                    .gluePath(URI.create("classpath:io/cucumber/java/steps")) //
-                    .gluePath(URI.create("classpath:io/cucumber/java/incorrectlysubclassedsteps")) //
+            var request = GlueDiscoveryRequest.builder()
+                    .selectors(selectUri("classpath:io/cucumber/java/steps")) //
+                    .selectors(selectUri("classpath:io/cucumber/java/incorrectlysubclassedsteps")) //
                     .build();
             backend.loadGlue(glue, request);
         };
@@ -93,7 +93,7 @@ class JavaBackendTest {
     @Test
     void detects_repeated_annotations() {
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/java/repeatable")) //
+                .selectors(selectUri("classpath:io/cucumber/java/repeatable")) //
                 .build();
         backend.loadGlue(glue, request);
         verify(glue, times(2)).addStepDefinition(stepDefinition.capture());

--- a/cucumber-java8/src/main/java/io/cucumber/java8/Java8Backend.java
+++ b/cucumber-java8/src/main/java/io/cucumber/java8/Java8Backend.java
@@ -4,6 +4,7 @@ import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
 import io.cucumber.core.backend.GlueDiscoveryRequest;
+import io.cucumber.core.backend.GlueDiscoverySelector;
 import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.resource.ClasspathScanner;
@@ -40,7 +41,9 @@ final class Java8Backend implements Backend {
     public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
         this.glue = new ClosureAwareGlueRegistry(glue);
         // Scan for Java8 style glue (lambdas)
-        request.getGluePaths().stream()
+        request.getSelectorsByType(GlueDiscoverySelector.UriGlueDiscoverySelector.class) //
+                .stream() //
+                .map(GlueDiscoverySelector.UriGlueDiscoverySelector::uri)
                 .filter(gluePath -> ClasspathSupport.CLASSPATH_SCHEME.equals(gluePath.getScheme()))
                 .map(ClasspathSupport::packageName)
                 .map(basePackageName -> classFinder.scanForSubClassesInPackage(basePackageName, LambdaGlue.class))

--- a/cucumber-java8/src/main/java/io/cucumber/java8/Java8Backend.java
+++ b/cucumber-java8/src/main/java/io/cucumber/java8/Java8Backend.java
@@ -3,13 +3,13 @@ package io.cucumber.java8;
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.resource.ClasspathScanner;
 import io.cucumber.core.resource.ClasspathSupport;
 import org.jspecify.annotations.Nullable;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -37,10 +37,10 @@ final class Java8Backend implements Backend {
     }
 
     @Override
-    public void loadGlue(Glue glue, List<URI> gluePaths) {
+    public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
         this.glue = new ClosureAwareGlueRegistry(glue);
         // Scan for Java8 style glue (lambdas)
-        gluePaths.stream()
+        request.getGluePaths().stream()
                 .filter(gluePath -> ClasspathSupport.CLASSPATH_SCHEME.equals(gluePath.getScheme()))
                 .map(ClasspathSupport::packageName)
                 .map(basePackageName -> classFinder.scanForSubClassesInPackage(basePackageName, LambdaGlue.class))

--- a/cucumber-java8/src/test/java/io/cucumber/java8/Java8BackendTest.java
+++ b/cucumber-java8/src/test/java/io/cucumber/java8/Java8BackendTest.java
@@ -1,6 +1,7 @@
 package io.cucumber.java8;
 
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.java8.steps.Steps;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,8 +12,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import java.net.URI;
 
 import static java.lang.Thread.currentThread;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -34,15 +33,21 @@ class Java8BackendTest {
 
     @Test
     void finds_step_definitions_by_classpath_url() {
-        backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/java8/steps")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/java8/steps")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory).addClass(Steps.class);
     }
 
     @Test
     void finds_step_definitions_once_by_classpath_url() {
-        backend.loadGlue(glue,
-            asList(URI.create("classpath:io/cucumber/java8/steps"), URI.create("classpath:io/cucumber/java8/steps")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/java8/steps")) //
+                .gluePath(URI.create("classpath:io/cucumber/java8/steps")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory, times(1)).addClass(Steps.class);
     }

--- a/cucumber-java8/src/test/java/io/cucumber/java8/Java8BackendTest.java
+++ b/cucumber-java8/src/test/java/io/cucumber/java8/Java8BackendTest.java
@@ -9,8 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 
-import java.net.URI;
-
+import static io.cucumber.core.backend.GlueDiscoverySelector.selectUri;
 import static java.lang.Thread.currentThread;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -34,7 +33,7 @@ class Java8BackendTest {
     @Test
     void finds_step_definitions_by_classpath_url() {
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/java8/steps")) //
+                .selectors(selectUri("classpath:io/cucumber/java8/steps")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();
@@ -44,8 +43,8 @@ class Java8BackendTest {
     @Test
     void finds_step_definitions_once_by_classpath_url() {
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/java8/steps")) //
-                .gluePath(URI.create("classpath:io/cucumber/java8/steps")) //
+                .selectors(selectUri("classpath:io/cucumber/java8/steps")) //
+                .selectors(selectUri("classpath:io/cucumber/java8/steps")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberConfiguration.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberConfiguration.java
@@ -1,6 +1,7 @@
 package io.cucumber.junit.platform.engine;
 
 import io.cucumber.core.backend.GlueDiscoveryRequest;
+import io.cucumber.core.backend.GlueDiscoverySelector;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.eventbus.UuidGenerator;
 import io.cucumber.core.feature.FeatureWithLines;
@@ -169,13 +170,17 @@ class CucumberConfiguration implements
 
     @Override
     public GlueDiscoveryRequest getGlueDiscoveryRequest() {
-        return () -> configurationParameters
+        var selectors = configurationParameters
                 .get(GLUE_PROPERTY_NAME, s -> Arrays.asList(s.split(",")))
                 .orElse(Collections.singletonList(CLASSPATH_SCHEME_PREFIX))
                 .stream()
                 .map(String::trim)
                 .map(GluePath::parse)
-                .collect(Collectors.toList());
+                .map(GlueDiscoverySelector::selectUri)
+                .toList();
+        return GlueDiscoveryRequest.builder()
+                .selectors(selectors)
+                .build();
     }
 
     boolean isParallelExecutionEnabled() {

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberConfiguration.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/CucumberConfiguration.java
@@ -1,5 +1,6 @@
 package io.cucumber.junit.platform.engine;
 
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.eventbus.UuidGenerator;
 import io.cucumber.core.feature.FeatureWithLines;
@@ -21,7 +22,6 @@ import org.junit.platform.engine.support.config.PrefixedConfigurationParameters;
 import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter;
 import org.junit.platform.engine.support.hierarchical.Node.ExecutionMode;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -140,17 +140,6 @@ class CucumberConfiguration implements
     }
 
     @Override
-    public List<URI> getGlue() {
-        return configurationParameters
-                .get(GLUE_PROPERTY_NAME, s -> Arrays.asList(s.split(",")))
-                .orElse(Collections.singletonList(CLASSPATH_SCHEME_PREFIX))
-                .stream()
-                .map(String::trim)
-                .map(GluePath::parse)
-                .collect(Collectors.toList());
-    }
-
-    @Override
     public boolean isDryRun() {
         return configurationParameters
                 .getBoolean(EXECUTION_DRY_RUN_PROPERTY_NAME)
@@ -176,6 +165,17 @@ class CucumberConfiguration implements
         return configurationParameters
                 .get(UUID_GENERATOR_PROPERTY_NAME, UuidGeneratorParser::parseUuidGenerator)
                 .orElse(null);
+    }
+
+    @Override
+    public GlueDiscoveryRequest getGlueDiscoveryRequest() {
+        return () -> configurationParameters
+                .get(GLUE_PROPERTY_NAME, s -> Arrays.asList(s.split(",")))
+                .orElse(Collections.singletonList(CLASSPATH_SCHEME_PREFIX))
+                .stream()
+                .map(String::trim)
+                .map(GluePath::parse)
+                .collect(Collectors.toList());
     }
 
     boolean isParallelExecutionEnabled() {

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberConfigurationTest.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberConfigurationTest.java
@@ -125,7 +125,7 @@ class CucumberConfigurationTest {
             Constants.GLUE_PROPERTY_NAME,
             "com.example.app, com.example.glue");
 
-        assertThat(new CucumberConfiguration(config, issueReporter).getGlue(),
+        assertThat(new CucumberConfiguration(config, issueReporter).getGlueDiscoveryRequest().getGluePaths(),
             contains(
                 URI.create("classpath:/com/example/app"),
                 URI.create("classpath:/com/example/glue")));

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberConfigurationTest.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberConfigurationTest.java
@@ -1,6 +1,7 @@
 package io.cucumber.junit.platform.engine;
 
 import io.cucumber.core.backend.DefaultObjectFactory;
+import io.cucumber.core.backend.GlueDiscoverySelector.UriGlueDiscoverySelector;
 import io.cucumber.core.eventbus.IncrementingUuidGenerator;
 import io.cucumber.core.plugin.Options;
 import io.cucumber.core.snippets.SnippetType;
@@ -9,11 +10,11 @@ import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.DiscoveryIssue;
 import org.junit.platform.engine.support.discovery.DiscoveryIssueReporter;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static io.cucumber.core.backend.GlueDiscoverySelector.selectUri;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -125,10 +126,12 @@ class CucumberConfigurationTest {
             Constants.GLUE_PROPERTY_NAME,
             "com.example.app, com.example.glue");
 
-        assertThat(new CucumberConfiguration(config, issueReporter).getGlueDiscoveryRequest().getGluePaths(),
+        assertThat(
+            new CucumberConfiguration(config, issueReporter).getGlueDiscoveryRequest()
+                    .getSelectorsByType(UriGlueDiscoverySelector.class),
             contains(
-                URI.create("classpath:/com/example/app"),
-                URI.create("classpath:/com/example/glue")));
+                selectUri("classpath:/com/example/app"),
+                selectUri("classpath:/com/example/glue")));
     }
 
     @Test

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/StubBackendProviderService.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/StubBackendProviderService.java
@@ -4,13 +4,13 @@ import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.BackendProviderService;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.ParameterInfo;
 import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.backend.StepDefinition;
 
 import java.lang.reflect.Type;
-import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
@@ -34,7 +34,7 @@ public final class StubBackendProviderService implements BackendProviderService 
         }
 
         @Override
-        public void loadGlue(Glue glue, List<URI> gluePaths) {
+        public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
             glue.addStepDefinition(createStepDefinition("a single scenario"));
             glue.addStepDefinition(createStepDefinition("it is executed"));
             glue.addStepDefinition(createStepDefinition("nothing else happens"));
@@ -76,14 +76,6 @@ public final class StubBackendProviderService implements BackendProviderService 
                     return "stubbed location";
                 }
             };
-        }
-
-        @Override
-        public void buildWorld() {
-        }
-
-        @Override
-        public void disposeWorld() {
         }
 
         @Override

--- a/cucumber-junit/src/test/java/io/cucumber/junit/StubBackendProviderService.java
+++ b/cucumber-junit/src/test/java/io/cucumber/junit/StubBackendProviderService.java
@@ -4,6 +4,7 @@ import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.BackendProviderService;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.HookDefinition;
 import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.ParameterInfo;
@@ -41,7 +42,7 @@ public final class StubBackendProviderService implements BackendProviderService 
         }
 
         @Override
-        public void loadGlue(Glue glue, List<URI> gluePaths) {
+        public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
             glue.addStepDefinition(createStepDefinition("first step"));
             glue.addStepDefinition(createStepDefinition("second step"));
             glue.addStepDefinition(createStepDefinition("third step"));
@@ -152,14 +153,6 @@ public final class StubBackendProviderService implements BackendProviderService 
                     return "stubbed location";
                 }
             };
-        }
-
-        @Override
-        public void buildWorld() {
-        }
-
-        @Override
-        public void disposeWorld() {
         }
 
         @Override

--- a/cucumber-junit/src/test/java/io/cucumber/junit/StubBackendProviderService.java
+++ b/cucumber-junit/src/test/java/io/cucumber/junit/StubBackendProviderService.java
@@ -14,7 +14,6 @@ import io.cucumber.core.backend.StepDefinition;
 import io.cucumber.core.backend.TestCaseState;
 
 import java.lang.reflect.Type;
-import java.net.URI;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/cucumber-picocontainer/src/main/java/io/cucumber/picocontainer/PicoBackend.java
+++ b/cucumber-picocontainer/src/main/java/io/cucumber/picocontainer/PicoBackend.java
@@ -3,14 +3,11 @@ package io.cucumber.picocontainer;
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
-import io.cucumber.core.backend.Snippet;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.resource.ClasspathScanner;
 import io.cucumber.core.resource.ClasspathSupport;
-import org.jspecify.annotations.Nullable;
 
-import java.net.URI;
 import java.util.Collection;
-import java.util.List;
 import java.util.function.Supplier;
 
 import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME;
@@ -26,8 +23,8 @@ final class PicoBackend implements Backend {
     }
 
     @Override
-    public void loadGlue(Glue glue, List<URI> gluePaths) {
-        gluePaths.stream()
+    public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
+        request.getGluePaths().stream()
                 .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
                 .map(ClasspathSupport::packageName)
                 .map(classFinder::scanForClassesInPackage)
@@ -39,19 +36,6 @@ final class PicoBackend implements Backend {
 
     private static boolean hasCucumberPicoProvider(Class<?> clazz) {
         return clazz.isAnnotationPresent(CucumberPicoProvider.class);
-    }
-
-    @Override
-    public void buildWorld() {
-    }
-
-    @Override
-    public void disposeWorld() {
-    }
-
-    @Override
-    public @Nullable Snippet getSnippet() {
-        return null;
     }
 
 }

--- a/cucumber-picocontainer/src/main/java/io/cucumber/picocontainer/PicoBackend.java
+++ b/cucumber-picocontainer/src/main/java/io/cucumber/picocontainer/PicoBackend.java
@@ -4,6 +4,7 @@ import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
 import io.cucumber.core.backend.GlueDiscoveryRequest;
+import io.cucumber.core.backend.GlueDiscoverySelector;
 import io.cucumber.core.resource.ClasspathScanner;
 import io.cucumber.core.resource.ClasspathSupport;
 
@@ -24,7 +25,9 @@ final class PicoBackend implements Backend {
 
     @Override
     public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
-        request.getGluePaths().stream()
+        request.getSelectorsByType(GlueDiscoverySelector.UriGlueDiscoverySelector.class) //
+                .stream() //
+                .map(GlueDiscoverySelector.UriGlueDiscoverySelector::uri)
                 .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
                 .map(ClasspathSupport::packageName)
                 .map(classFinder::scanForClassesInPackage)

--- a/cucumber-picocontainer/src/test/java/io/cucumber/picocontainer/PicoBackendTest.java
+++ b/cucumber-picocontainer/src/test/java/io/cucumber/picocontainer/PicoBackendTest.java
@@ -12,8 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.net.URI;
-
+import static io.cucumber.core.backend.GlueDiscoverySelector.selectUri;
 import static java.lang.Thread.currentThread;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -38,7 +37,7 @@ final class PicoBackendTest {
     @Test
     void considers_but_does_not_add_annotated_configuration() {
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")) //
+                .selectors(selectUri("classpath:io/cucumber/picocontainer/annotationconfig")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();
@@ -48,7 +47,7 @@ final class PicoBackendTest {
     @Test
     void adds_unnested_provider_classes() {
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")) //
+                .selectors(selectUri("classpath:io/cucumber/picocontainer/annotationconfig")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();
@@ -59,7 +58,7 @@ final class PicoBackendTest {
     @Test
     void adds_nested_provider_classes() {
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")) //
+                .selectors(selectUri("classpath:io/cucumber/picocontainer/annotationconfig")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();
@@ -69,9 +68,9 @@ final class PicoBackendTest {
 
     @Test
     void finds_configured_classes_only_once_when_scanning_twice() {
-        var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")) //
-                .gluePath(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")) //
+        var request = GlueDiscoveryRequest.builder()
+                .selectors(selectUri("classpath:io/cucumber/picocontainer/annotationconfig")) //
+                .selectors(selectUri("classpath:io/cucumber/picocontainer/annotationconfig")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();

--- a/cucumber-picocontainer/src/test/java/io/cucumber/picocontainer/PicoBackendTest.java
+++ b/cucumber-picocontainer/src/test/java/io/cucumber/picocontainer/PicoBackendTest.java
@@ -1,6 +1,7 @@
 package io.cucumber.picocontainer;
 
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.picocontainer.annotationconfig.DatabaseConnectionProvider;
 import io.cucumber.picocontainer.annotationconfig.ExamplePicoConfiguration;
@@ -14,8 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.net.URI;
 
 import static java.lang.Thread.currentThread;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -38,16 +37,20 @@ final class PicoBackendTest {
 
     @Test
     void considers_but_does_not_add_annotated_configuration() {
-        backend.loadGlue(glue,
-            singletonList(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory, never()).addClass(ExamplePicoConfiguration.class);
     }
 
     @Test
     void adds_unnested_provider_classes() {
-        backend.loadGlue(glue,
-            singletonList(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory).addClass(UrlToUriProvider.class);
         verify(factory).addClass(DatabaseConnectionProvider.class);
@@ -55,8 +58,10 @@ final class PicoBackendTest {
 
     @Test
     void adds_nested_provider_classes() {
-        backend.loadGlue(glue,
-            singletonList(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory).addClass(ExamplePicoConfiguration.NestedUrlProvider.class);
         verify(factory).addClass(ExamplePicoConfiguration.NestedUrlConnectionProvider.class);
@@ -64,9 +69,11 @@ final class PicoBackendTest {
 
     @Test
     void finds_configured_classes_only_once_when_scanning_twice() {
-        backend.loadGlue(glue, asList(
-            URI.create("classpath:io/cucumber/picocontainer/annotationconfig"),
-            URI.create("classpath:io/cucumber/picocontainer/annotationconfig")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")) //
+                .gluePath(URI.create("classpath:io/cucumber/picocontainer/annotationconfig")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory, never()).addClass(ExamplePicoConfiguration.class);
         verify(factory, times(1)).addClass(ExamplePicoConfiguration.NestedUrlProvider.class);

--- a/cucumber-spring/src/main/java/io/cucumber/spring/SpringBackend.java
+++ b/cucumber-spring/src/main/java/io/cucumber/spring/SpringBackend.java
@@ -3,13 +3,12 @@ package io.cucumber.spring;
 import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.resource.ClasspathScanner;
 import io.cucumber.core.resource.ClasspathSupport;
 
 import java.lang.reflect.Modifier;
-import java.net.URI;
 import java.util.Collection;
-import java.util.List;
 import java.util.function.Supplier;
 
 import static io.cucumber.core.resource.ClasspathSupport.CLASSPATH_SCHEME;
@@ -25,8 +24,8 @@ final class SpringBackend implements Backend {
     }
 
     @Override
-    public void loadGlue(Glue glue, List<URI> gluePaths) {
-        gluePaths.stream()
+    public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
+        request.getGluePaths().stream()
                 .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
                 .map(ClasspathSupport::packageName)
                 .map(classFinder::scanForClassesInPackage)

--- a/cucumber-spring/src/main/java/io/cucumber/spring/SpringBackend.java
+++ b/cucumber-spring/src/main/java/io/cucumber/spring/SpringBackend.java
@@ -4,6 +4,7 @@ import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
 import io.cucumber.core.backend.GlueDiscoveryRequest;
+import io.cucumber.core.backend.GlueDiscoverySelector;
 import io.cucumber.core.resource.ClasspathScanner;
 import io.cucumber.core.resource.ClasspathSupport;
 
@@ -25,7 +26,9 @@ final class SpringBackend implements Backend {
 
     @Override
     public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
-        request.getGluePaths().stream()
+        request.getSelectorsByType(GlueDiscoverySelector.UriGlueDiscoverySelector.class) //
+                .stream() //
+                .map(GlueDiscoverySelector.UriGlueDiscoverySelector::uri)
                 .filter(gluePath -> CLASSPATH_SCHEME.equals(gluePath.getScheme()))
                 .map(ClasspathSupport::packageName)
                 .map(classFinder::scanForClassesInPackage)

--- a/cucumber-spring/src/test/java/io/cucumber/spring/SpringBackendTest.java
+++ b/cucumber-spring/src/test/java/io/cucumber/spring/SpringBackendTest.java
@@ -1,6 +1,7 @@
 package io.cucumber.spring;
 
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.spring.annotationconfig.AnnotationContextConfiguration;
 import io.cucumber.spring.cucumbercontextconfigannotation.AbstractWithComponentAnnotation;
@@ -14,8 +15,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import java.net.URI;
 
 import static java.lang.Thread.currentThread;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -37,40 +36,51 @@ final class SpringBackendTest {
 
     @Test
     void finds_annotation_context_configuration_by_classpath_url() {
-        backend.loadGlue(glue, singletonList(URI.create("classpath:io/cucumber/spring/annotationconfig")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/spring/annotationconfig")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory).addClass(AnnotationContextConfiguration.class);
     }
 
     @Test
     void finds_annotaiton_context_configuration_once_by_classpath_url() {
-        backend.loadGlue(glue, asList(
-            URI.create("classpath:io/cucumber/spring/annotationconfig"),
-            URI.create("classpath:io/cucumber/spring/annotationconfig")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/spring/annotationconfig")) //
+                .gluePath(URI.create("classpath:io/cucumber/spring/annotationconfig")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory, times(1)).addClass(AnnotationContextConfiguration.class);
     }
 
     @Test
     void ignoresAbstractClassWithCucumberContextConfiguration() {
-        backend.loadGlue(glue, singletonList(
-            URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory, times(0)).addClass(AbstractWithComponentAnnotation.class);
     }
 
     @Test
     void ignoresInterfaceWithCucumberContextConfiguration() {
-        backend.loadGlue(glue, singletonList(
-            URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory, times(0)).addClass(AnnotatedInterface.class);
     }
 
     @Test
     void considersClassWithCucumberContextConfigurationMetaAnnotation() {
-        backend.loadGlue(glue, singletonList(
-            URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")));
+        var request = GlueDiscoveryRequest.builder() //
+                .gluePath(URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")) //
+                .build();
+        backend.loadGlue(glue, request);
         backend.buildWorld();
         verify(factory, times(1)).addClass(WithMetaAnnotation.class);
     }

--- a/cucumber-spring/src/test/java/io/cucumber/spring/SpringBackendTest.java
+++ b/cucumber-spring/src/test/java/io/cucumber/spring/SpringBackendTest.java
@@ -12,8 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 
-import java.net.URI;
-
+import static io.cucumber.core.backend.GlueDiscoverySelector.selectUri;
 import static java.lang.Thread.currentThread;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -37,7 +36,7 @@ final class SpringBackendTest {
     @Test
     void finds_annotation_context_configuration_by_classpath_url() {
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/spring/annotationconfig")) //
+                .selectors(selectUri("classpath:io/cucumber/spring/annotationconfig")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();
@@ -47,8 +46,8 @@ final class SpringBackendTest {
     @Test
     void finds_annotaiton_context_configuration_once_by_classpath_url() {
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/spring/annotationconfig")) //
-                .gluePath(URI.create("classpath:io/cucumber/spring/annotationconfig")) //
+                .selectors(selectUri("classpath:io/cucumber/spring/annotationconfig")) //
+                .selectors(selectUri("classpath:io/cucumber/spring/annotationconfig")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();
@@ -58,7 +57,7 @@ final class SpringBackendTest {
     @Test
     void ignoresAbstractClassWithCucumberContextConfiguration() {
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")) //
+                .selectors(selectUri("classpath:io/cucumber/spring/cucumbercontextconfigannotation")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();
@@ -68,7 +67,7 @@ final class SpringBackendTest {
     @Test
     void ignoresInterfaceWithCucumberContextConfiguration() {
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")) //
+                .selectors(selectUri("classpath:io/cucumber/spring/cucumbercontextconfigannotation")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();
@@ -78,7 +77,7 @@ final class SpringBackendTest {
     @Test
     void considersClassWithCucumberContextConfigurationMetaAnnotation() {
         var request = GlueDiscoveryRequest.builder() //
-                .gluePath(URI.create("classpath:io/cucumber/spring/cucumbercontextconfigannotation")) //
+                .selectors(selectUri("classpath:io/cucumber/spring/cucumbercontextconfigannotation")) //
                 .build();
         backend.loadGlue(glue, request);
         backend.buildWorld();

--- a/cucumber-testng/src/test/java/io/cucumber/testng/StubBackendProviderService.java
+++ b/cucumber-testng/src/test/java/io/cucumber/testng/StubBackendProviderService.java
@@ -4,6 +4,7 @@ import io.cucumber.core.backend.Backend;
 import io.cucumber.core.backend.BackendProviderService;
 import io.cucumber.core.backend.Container;
 import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
 import io.cucumber.core.backend.Lookup;
 import io.cucumber.core.backend.ParameterInfo;
 import io.cucumber.core.backend.Snippet;
@@ -34,7 +35,7 @@ public final class StubBackendProviderService implements BackendProviderService 
         }
 
         @Override
-        public void loadGlue(Glue glue, List<URI> gluePaths) {
+        public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
             glue.addStepDefinition(createStepDefinition("a scenario"));
             glue.addStepDefinition(createStepDefinition("a scenario outline"));
             glue.addStepDefinition(createStepDefinition("it is executed"));
@@ -82,14 +83,6 @@ public final class StubBackendProviderService implements BackendProviderService 
                     return "stubbed location";
                 }
             };
-        }
-
-        @Override
-        public void buildWorld() {
-        }
-
-        @Override
-        public void disposeWorld() {
         }
 
         @Override

--- a/cucumber-testng/src/test/java/io/cucumber/testng/StubBackendProviderService.java
+++ b/cucumber-testng/src/test/java/io/cucumber/testng/StubBackendProviderService.java
@@ -11,7 +11,6 @@ import io.cucumber.core.backend.Snippet;
 import io.cucumber.core.backend.StepDefinition;
 
 import java.lang.reflect.Type;
-import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
### 🤔 What's changed?

Extract request object for glue discovery. This heavily inspired by JUnit discovery request which more or less solves the same problem. In essence we're trying to find a number of classes. These can only be selected by uri for now, but in the future we can expand this to include classes, packages and modules (if needed).

### ⚡️ What's your motivation? 

In both https://github.com/cucumber/cucumber-jvm/pull/3151 and https://github.com/cucumber/cucumber-jvm/pull/3120 we see a need to provide more information to guide the glue discovery behaviour. By extracting a request object we can provide this information.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
