### PR TITLE
Add test for nested Cucumber engine discovery under the suite engine

### DIFF
--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
@@ -668,6 +668,32 @@ class CucumberTestEngineTest {
     }
 
     @Test
+    void discoversChildrenWhenNestedUnderSuiteEngineWithDisabledRootDiscovery() {
+        TestDescriptor suiteDescriptor = EngineTestKit.engine("junit-platform-suite")
+                .configurationParameter(JUNIT_PLATFORM_DISCOVERY_AS_ROOT_ENGINE_PROPERTY_NAME, "false")
+                .selectors(selectClass(SuiteTestCase.class))
+                .discover()
+                .getEngineDescriptor();
+
+        // Find the Cucumber engine among all descendants
+        TestDescriptor cucumberEngine = suiteDescriptor.getDescendants().stream()
+                .filter(d -> d.getUniqueId().getSegments().stream()
+                        .anyMatch(s -> "cucumber".equals(s.getValue())))
+                .findFirst()
+                .orElseThrow();
+
+        // The Cucumber engine should discover features when nested under the
+        // suite engine
+        // with discovery-as-root-engine=false. This distinguishes
+        // isRootEngine() from
+        // always returning true: the nested engine has >2 UniqueId segments so
+        // isRootEngine() returns false, allowing discovery to proceed.
+        assertThat(cucumberEngine.getChildren())
+                .as("Cucumber engine should have children when nested under suite engine")
+                .isNotEmpty();
+    }
+
+    @Test
     void selectAndSkipDisabledScenarioByTags() {
         EngineTestKit.engine(ENGINE_ID)
                 .configurationParameter(FILTER_TAGS_PROPERTY_NAME, "@Integration and not @Disabled")


### PR DESCRIPTION
Adds one test to `CucumberTestEngineTest` for the case where the Cucumber engine runs nested under the JUnit Platform Suite engine with `discovery-as-root-engine=false`.

The existing tests exercise discovery when Cucumber is the root engine, where `isRootEngine()` is effectively always true. The nested-under-suite case (a UniqueId with more than two segments, so `isRootEngine()` returns false) was not covered, so a regression making `isRootEngine()` always return true would still pass. The new test uses `EngineTestKit` to discover under `junit-platform-suite` with the property disabled and asserts the Cucumber engine still finds its features.

Additive only: +1 test, no production changes.
