### PR TITLE
[Core] Don't swallow event handler exceptions while processing a feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
+- [Core] Don't swallow exceptions thrown by event handlers while processing a feature ([#2748](https://github.com/cucumber/cucumber-jvm/issues/2748), Julien Kronegg)
 - [JUnit Platform Engine] Accept partial matches with `cucumber.filter.name` and align the behavior with JUnit 4 and CLI ([#3174](https://github.com/cucumber/cucumber-jvm/pull/3174))
 - [JUnit Platform Engine] Don't require global read lock ([#3103](https://github.com/cucumber/cucumber-jvm/pull/3103))
 

--- a/cucumber-core/src/main/java/io/cucumber/core/runtime/CucumberExecutionContext.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runtime/CucumberExecutionContext.java
@@ -123,9 +123,14 @@ public final class CucumberExecutionContext {
 
     public void beforeFeature(Feature feature) {
         log.debug(() -> "Sending test source read event for " + feature.getUri());
-        bus.send(new TestSourceRead(bus.getInstant(), feature.getUri(), feature.getSource()));
-        bus.send(new TestSourceParsed(bus.getInstant(), feature.getUri(), singletonList(feature)));
-        bus.sendAll(feature.getParseEvents());
+        // Collect and rethrow any failure (e.g. from an event handler in a
+        // plugin). Otherwise the failure is swallowed when running the features
+        // because CucumberExecutionContext.execute drops it (see #2748).
+        collector.executeAndThrow(() -> {
+            bus.send(new TestSourceRead(bus.getInstant(), feature.getUri(), feature.getSource()));
+            bus.send(new TestSourceParsed(bus.getInstant(), feature.getUri(), singletonList(feature)));
+            bus.sendAll(feature.getParseEvents());
+        });
     }
 
     public void runTestCase(Consumer<Runner> execution) {

--- a/cucumber-core/src/test/java/io/cucumber/core/runtime/CucumberExecutionContextTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runtime/CucumberExecutionContextTest.java
@@ -1,6 +1,8 @@
 package io.cucumber.core.runtime;
 
 import io.cucumber.core.eventbus.EventBus;
+import io.cucumber.core.feature.TestFeatureParser;
+import io.cucumber.core.gherkin.Feature;
 import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.options.RuntimeOptionsBuilder;
 import io.cucumber.plugin.event.Result;
@@ -67,6 +69,30 @@ class CucumberExecutionContextTest {
         }));
         assertThat(thrown, is(failure));
         assertThat(context.getThrowable(), nullValue());
+    }
+
+    @Test
+    public void rethrows_event_handler_failures_emitted_while_processing_features() {
+        // Reproduces #2748: a plugin that throws while handling an Envelope
+        // emitted during feature processing (e.g. the GherkinDocument envelope)
+        // had its exception swallowed, while the same plugin throwing on the
+        // TestRunFinished envelope did not. The behavior must be consistent:
+        // the exception should always be rethrown.
+        Feature feature = TestFeatureParser.parse("test.feature", "" +
+                "Feature: feature name\n" +
+                "  Scenario: scenario name\n" +
+                "    Given first step\n");
+
+        RuntimeException failure = new IllegalStateException("handler failure");
+        bus.registerHandlerFor(io.cucumber.messages.types.Envelope.class, envelope -> {
+            if (envelope.getGherkinDocument().isPresent()) {
+                throw failure;
+            }
+        });
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+            () -> context.runFeatures(() -> context.beforeFeature(feature)));
+        assertThat(thrown, is(failure));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Exceptions thrown by an `EventListener` / event handler were **swallowed for some `Envelope` payloads but rethrown for others**, exactly as reported in #2748. A plugin that throws while handling, e.g., the `GherkinDocument` / `Source` / `Pickle` envelopes had its exception silently dropped, while the same plugin throwing on the `TestRunFinished` envelope failed the run. The behavior is now consistent: a failing handler always propagates.

## Root cause

`io.cucumber.core.runtime.CucumberExecutionContext.runFeatures(...)` runs feature setup inside `execute(...)`:

```java
private void execute(ThrowingRunnable runnable) {
    try {
        runnable.run();
    } catch (Throwable t) {
        // Collected in CucumberExecutionContext
        rethrowIfUnrecoverable(t);   // <-- only unrecoverable rethrown; everything else dropped
    }
}
```

The comment claims the throwable is "Collected", but `beforeFeature(...)` — which emits the `GherkinDocument`/`Source`/`Pickle` envelopes via `bus.sendAll(feature.getParseEvents())` — did **not** route through the `RethrowingThrowableCollector`. So a handler exception thrown there reached `execute(...)` and was silently dropped.

By contrast, `TestRunFinished` is emitted from `finishTestRun()` in the `finally` block, **outside** the `execute(...)` boundary, so its handler exceptions always propagated. That is the asymmetry (`CucumberExecutionContext.java`, `beforeFeature` around L124 and `execute` around L157).

The test-case, before/after-all-hook and runner paths already collect via `collector.executeAndThrow(...)`; only `beforeFeature` was missing.

## Fix

Route `beforeFeature(...)` through the existing `RethrowingThrowableCollector` so a failing handler is collected and rethrown at the end of the run, matching every other emission path.

```java
collector.executeAndThrow(() -> {
    bus.send(new TestSourceRead(...));
    bus.send(new TestSourceParsed(...));
    bus.sendAll(feature.getParseEvents());
});
```

Minimal change; the integration callers (JUnit 4, TestNG, JUnit Platform engine) call `beforeFeature` directly and already rely on immediate rethrow, so their behavior is unchanged.

## Test evidence

Added a regression test in `CucumberExecutionContextTest` that registers an `Envelope` handler throwing on the `GherkinDocument` envelope and asserts the exception propagates.

- **Without the fix:** `Expected java.lang.IllegalStateException to be thrown, but nothing was thrown.` (exception swallowed — reproduces the bug)
- **With the fix:** passes.

Verified locally (JDK 17 source level; build run with a JDK 21 toolchain because the project's checkstyle tooling requires it):

```
CucumberExecutionContextTest: Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
cucumber-core (full):         Tests run: 659, Failures: 0, Errors: 0, Skipped: 69
cucumber-junit-platform-engine (full): Tests run: 204, Failures: 0, Errors: 0
```

`spotless:check` passes.

Closes #2748

---
Assisted-by: Claude Code (Anthropic, Opus 4.x)
