### PR TITLE
[JUnit Platform Engine] Do not fail discovery on an empty rerun file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [JUnit Platform Engine] Do not fail discovery on an empty rerun file with JUnit Platform 6.1.x ([#3216](https://github.com/cucumber/cucumber-jvm/pull/3216))
 
 ## [7.34.5] - 2026-07-23
 ### Fixed

--- a/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureWithLinesFileResolver.java
+++ b/cucumber-junit-platform-engine/src/main/java/io/cucumber/junit/platform/engine/FeatureWithLinesFileResolver.java
@@ -27,6 +27,8 @@ final class FeatureWithLinesFileResolver implements SelectorResolver {
                 .stream()
                 .map(FeatureWithLinesSelector::from)
                 .collect(Collectors.toSet());
-        return Resolution.selectors(selectors);
+        return selectors.isEmpty()
+                ? Resolution.unresolved()
+                : Resolution.selectors(selectors);
     }
 }

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
@@ -1126,13 +1126,12 @@ class CucumberTestEngineTest {
 
     @Test
     void supportsEmptyRerunFile() {
-        EngineTestKit.engine(ENGINE_ID)
+        EngineDiscoveryResults result = EngineTestKit.engine(ENGINE_ID)
                 .selectors(
                     selectFile("src/test/resources/rerun/empty-rerun.txt"))
-                .execute()
-                .allEvents()
-                .assertThatEvents()
-                .haveExactly(0, event(test()));
+                .discover();
+
+        assertThat(result.getDiscoveryIssues()).isEmpty();
     }
 
 }

--- a/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
+++ b/cucumber-junit-platform-engine/src/test/java/io/cucumber/junit/platform/engine/CucumberTestEngineTest.java
@@ -1124,4 +1124,15 @@ class CucumberTestEngineTest {
                 .haveExactly(2, event(scenario("scenario:3", "A single scenario")));
     }
 
+    @Test
+    void supportsEmptyRerunFile() {
+        EngineTestKit.engine(ENGINE_ID)
+                .selectors(
+                    selectFile("src/test/resources/rerun/empty-rerun.txt"))
+                .execute()
+                .allEvents()
+                .assertThatEvents()
+                .haveExactly(0, event(test()));
+    }
+
 }


### PR DESCRIPTION
### 🤔 What's changed?

`FeatureWithLinesFileResolver` now returns `Resolution.unresolved()` when the selected `.txt` rerun file yields no selectors, instead of passing an empty set to `Resolution.selectors(...)`.

Previously, selecting an **empty** rerun file (via `@SelectFile`) threw a critical discovery issue on JUnit Platform 6.1.x:

```
Cause: org.junit.platform.commons.PreconditionViolationException: selectors must not be empty
    at org.junit.platform.engine.support.discovery.SelectorResolver$Resolution.selectors(...)
    at io.cucumber.junit.platform.engine.FeatureWithLinesFileResolver.resolve(...)
```

JUnit Platform 6.1 tightened `Resolution.selectors(...)` to reject an empty collection; returning `unresolved()` restores discovering zero tests for the empty case and leaves the non-empty case unchanged. This is the standard rerun-on-failure flow: when the initial run has no failures, cucumber's `rerun:` plugin writes an empty file, and the `*ITRerun` suite that selects it then fails discovery (which `@Suite(failIfNoTests = false)` cannot suppress, since it happens during discovery).

Added `supportsEmptyRerunFile()` (modeled on the existing `supportsRerunFile()` test) plus an empty `src/test/resources/rerun/empty-rerun.txt` resource.

Fixes #3215.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

On this branch the bundled test passes with or without the fix, because v7.x.x pins JUnit Platform 1.14.2 (via junit-bom 5.14.2), which predates the `selectors must not be empty` precondition. I kept the test as a behavioural spec of the empty-rerun case (per the request in #3215 to base it on the existing tests). Happy to adjust if you'd prefer it placed/verified differently.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the CHANGELOG, linking to this pull request.
