### PR TITLE
fix(core): exit CLI after BeforeAll/AfterAll failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Core] Support `cucumber.execution.threads` property when executing from CLI ([#3183](https://github.com/cucumber/cucumber-jvm/pull/3183))
 
 ### Fixed
+- [Core] CLI always calls `System.exit` after `@BeforeAll` / `@AfterAll` failures so non-daemon threads cannot hang the JVM ([#3104](https://github.com/cucumber/cucumber-jvm/issues/3104), [#3226](https://github.com/cucumber/cucumber-jvm/pull/3226))
 - [JUnit Platform Engine] Accept partial matches with `cucumber.filter.name` and align the behavior with JUnit 4 and CLI ([#3174](https://github.com/cucumber/cucumber-jvm/pull/3174))
 - [JUnit Platform Engine] Don't require global read lock ([#3103](https://github.com/cucumber/cucumber-jvm/pull/3103))
 

--- a/cucumber-core/src/main/java/io/cucumber/core/cli/Main.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/cli/Main.java
@@ -10,6 +10,8 @@ import org.apiguardian.api.API;
 
 import java.util.Optional;
 
+import static io.cucumber.core.exception.UnrecoverableExceptions.rethrowIfUnrecoverable;
+
 /**
  * Cucumber Main. Runs Cucumber as a CLI.
  * <p>
@@ -88,7 +90,29 @@ public final class Main {
                 .withClassLoader(() -> classLoader)
                 .build();
 
-        runtime.run();
+        return execute(runtime);
+    }
+
+    /**
+     * Runs the given runtime and converts failures into a non-zero exit status.
+     * <p>
+     * {@code @BeforeAll} / {@code @AfterAll} hooks currently rethrow so they
+     * can surface failures without full reporting support. Catching here
+     * ensures the CLI still reaches {@link System#exit(int)} and shuts down the
+     * JVM even when non-daemon threads remain (for example a non-daemon
+     * {@link java.util.Timer}).
+     *
+     * @see <a href=
+     *      "https://github.com/cucumber/cucumber-jvm/issues/3104">#3104</a>
+     */
+    static byte execute(Runtime runtime) {
+        try {
+            runtime.run();
+        } catch (Throwable t) {
+            rethrowIfUnrecoverable(t);
+            t.printStackTrace(System.err);
+            return 1;
+        }
         return runtime.exitStatus();
     }
 

--- a/cucumber-core/src/test/java/io/cucumber/core/cli/MainTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/cli/MainTest.java
@@ -1,0 +1,131 @@
+package io.cucumber.core.cli;
+
+import io.cucumber.core.backend.Glue;
+import io.cucumber.core.backend.GlueDiscoveryRequest;
+import io.cucumber.core.backend.StaticHookDefinition;
+import io.cucumber.core.runner.TestBackendSupplier;
+import io.cucumber.core.runtime.BackendSupplier;
+import io.cucumber.core.runtime.Runtime;
+import io.cucumber.core.runtime.StubFeatureSupplier;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class MainTest {
+
+    @Test
+    void execute_returns_success_when_runtime_completes() {
+        Runtime runtime = Runtime.builder()
+                .withFeatureSupplier(new StubFeatureSupplier())
+                .withBackendSupplier(new TestBackendSupplier() {
+                })
+                .build();
+
+        assertThat(Main.execute(runtime), is(equalTo((byte) 0)));
+    }
+
+    @Test
+    void execute_returns_error_when_after_all_hook_throws() {
+        RuntimeException afterAllFailure = new RuntimeException("AfterAll failed");
+        BackendSupplier backendSupplier = new TestBackendSupplier() {
+            @Override
+            public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
+                glue.addAfterAllHook(staticHook(() -> {
+                    throw afterAllFailure;
+                }));
+            }
+        };
+        Runtime runtime = Runtime.builder()
+                .withFeatureSupplier(new StubFeatureSupplier())
+                .withBackendSupplier(backendSupplier)
+                .build();
+
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            byte exitStatus = assertDoesNotThrow(() -> Main.execute(runtime));
+            assertThat(exitStatus, is(equalTo((byte) 1)));
+        } finally {
+            System.setErr(originalErr);
+        }
+        assertThat(captured.toString(StandardCharsets.UTF_8), containsString("AfterAll failed"));
+    }
+
+    /**
+     * Regression for #3104: an exception from {@code @AfterAll} used to skip
+     * {@code System.exit}, leaving non-daemon threads (e.g. {@link Timer})
+     * keeping the JVM alive. {@link Main#execute} must still return an exit
+     * status so {@link Main#main} can exit.
+     */
+    @Test
+    void execute_returns_error_when_after_all_throws_with_non_daemon_timer() {
+        Timer nonDaemonTimer = new Timer(false);
+        try {
+            BackendSupplier backendSupplier = new TestBackendSupplier() {
+                @Override
+                public void loadGlue(Glue glue, GlueDiscoveryRequest request) {
+                    glue.addBeforeAllHook(staticHook(() -> nonDaemonTimer.scheduleAtFixedRate(new TimerTask() {
+                        @Override
+                        public void run() {
+                            // keeps non-daemon thread alive until cancel
+                        }
+                    }, 10, 1000)));
+                    glue.addAfterAllHook(staticHook(() -> {
+                        throw new AssertionError("coverage below threshold");
+                    }));
+                }
+            };
+            Runtime runtime = Runtime.builder()
+                    .withFeatureSupplier(new StubFeatureSupplier())
+                    .withBackendSupplier(backendSupplier)
+                    .build();
+
+            PrintStream originalErr = System.err;
+            System.setErr(new PrintStream(new ByteArrayOutputStream()));
+            try {
+                byte exitStatus = assertDoesNotThrow(() -> Main.execute(runtime));
+                assertThat(exitStatus, is(equalTo((byte) 1)));
+            } finally {
+                System.setErr(originalErr);
+            }
+        } finally {
+            nonDaemonTimer.cancel();
+        }
+    }
+
+    private static StaticHookDefinition staticHook(Runnable action) {
+        return new StaticHookDefinition() {
+            @Override
+            public void execute() {
+                action.run();
+            }
+
+            @Override
+            public int getOrder() {
+                return 0;
+            }
+
+            @Override
+            public boolean isDefinedAt(StackTraceElement stackTraceElement) {
+                return false;
+            }
+
+            @Override
+            public String getLocation() {
+                return "MainTest static hook";
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
### 🤔 What's changed?

When `@BeforeAll` / `@AfterAll` hooks throw, `Runtime.run()` rethrows so the failure is visible (these hooks are not yet fully reportable; see #3054). That rethrow previously skipped `Main.main`'s `System.exit`, so any remaining non-daemon threads (for example a non-daemon `Timer`) kept the JVM alive and the process appeared to hang.

`Main.execute` now catches recoverable throwables from `Runtime.run`, prints the stack trace to stderr, and returns exit status `1`, so `System.exit` always runs for the CLI entry point.

### ⚡️ What's your motivation?

Fixes #3104

Maintainer repro from the issue:

```java
new Timer(false).scheduleAtFixedRate(...); // non-daemon
@AfterAll
public static void afterAll() {
    throw new RuntimeException();
}
```

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

This is intentionally a CLI shutdown fix, not the full #3054 work (emit messages for static hooks). Embedders that call `Runtime.run()` directly still see the rethrown exception. Happy to adjust if you'd rather wait for #3054 only.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [CHANGELOG](../CHANGELOG.md), linking to this pull request.

### AI assistance disclosure

This PR was developed with assistance from AI coding tools (Grok / Cursor harness), under human direction:
- Issue analysis, root-cause identification, and test design were human-led.
- Implementation and PR description were drafted with AI assistance and then reviewed/edited by a human before submission.
- I understand the change: `Main.execute` catches recoverable throwables from `Runtime.run` so CLI always reaches `System.exit` after BeforeAll/AfterAll failures (non-daemon threads no longer hang the process). Full static-hook messaging remains #3054 follow-up.

Per https://github.com/cucumber/.github/blob/main/CONTRIBUTING.md#ai-usage

