### PR TITLE
[Core] Report source locations for duplicate parameter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Core] Support `cucumber.execution.threads` property when executing from CLI ([#3183](https://github.com/cucumber/cucumber-jvm/pull/3183))
 
 ### Fixed
+- [Core] Report the source location of both definitions when a parameter type is registered twice with the same name ([#3144](https://github.com/cucumber/cucumber-jvm/issues/3144))
 - [JUnit Platform Engine] Accept partial matches with `cucumber.filter.name` and align the behavior with JUnit 4 and CLI ([#3174](https://github.com/cucumber/cucumber-jvm/pull/3174))
 - [JUnit Platform Engine] Don't require global read lock ([#3103](https://github.com/cucumber/cucumber-jvm/pull/3103))
 

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/CachingGlue.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/CachingGlue.java
@@ -20,6 +20,7 @@ import io.cucumber.core.stepexpression.StepExpression;
 import io.cucumber.core.stepexpression.StepExpressionFactory;
 import io.cucumber.core.stepexpression.StepTypeRegistry;
 import io.cucumber.cucumberexpressions.CucumberExpression;
+import io.cucumber.cucumberexpressions.DuplicateTypeNameException;
 import io.cucumber.cucumberexpressions.Expression;
 import io.cucumber.cucumberexpressions.ParameterByTypeTransformer;
 import io.cucumber.cucumberexpressions.ParameterType;
@@ -276,9 +277,19 @@ final class CachingGlue implements Glue {
 
         // TODO: separate prepared and unprepared glue into different classes
         // parameters changed from the previous scenario => re-register them
+        Map<String, ParameterTypeDefinition> definedParameterTypes = new HashMap<>();
         parameterTypeDefinitions.forEach(ptd -> {
             ParameterType<?> parameterType = ptd.parameterType();
-            stepTypeRegistry.defineParameterType(parameterType);
+            try {
+                stepTypeRegistry.defineParameterType(parameterType);
+            } catch (DuplicateTypeNameException e) {
+                throw new DuplicateParameterTypeDefinitionException(
+                    parameterType.getName(),
+                    definedParameterTypes.get(parameterType.getName()),
+                    ptd,
+                    e);
+            }
+            definedParameterTypes.put(parameterType.getName(), ptd);
             emitParameterTypeDefined(ptd);
         });
         dataTableTypeDefinitions.forEach(dtd -> stepTypeRegistry.defineDataTableType(dtd.dataTableType()));

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/CachingGlue.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/CachingGlue.java
@@ -20,7 +20,6 @@ import io.cucumber.core.stepexpression.StepExpression;
 import io.cucumber.core.stepexpression.StepExpressionFactory;
 import io.cucumber.core.stepexpression.StepTypeRegistry;
 import io.cucumber.cucumberexpressions.CucumberExpression;
-import io.cucumber.cucumberexpressions.DuplicateTypeNameException;
 import io.cucumber.cucumberexpressions.Expression;
 import io.cucumber.cucumberexpressions.ParameterByTypeTransformer;
 import io.cucumber.cucumberexpressions.ParameterType;
@@ -52,6 +51,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.groupingBy;
 
 final class CachingGlue implements Glue {
 
@@ -277,21 +277,18 @@ final class CachingGlue implements Glue {
 
         // TODO: separate prepared and unprepared glue into different classes
         // parameters changed from the previous scenario => re-register them
-        Map<String, ParameterTypeDefinition> definedParameterTypes = new HashMap<>();
-        parameterTypeDefinitions.forEach(ptd -> {
-            ParameterType<?> parameterType = ptd.parameterType();
-            try {
-                stepTypeRegistry.defineParameterType(parameterType);
-            } catch (DuplicateTypeNameException e) {
-                throw new DuplicateParameterTypeDefinitionException(
-                    parameterType.getName(),
-                    definedParameterTypes.get(parameterType.getName()),
-                    ptd,
-                    e);
-            }
-            definedParameterTypes.put(parameterType.getName(), ptd);
-            emitParameterTypeDefined(ptd);
-        });
+
+        parameterTypeDefinitions.stream() //
+                .collect(groupingBy(parameterTypeDefinition -> parameterTypeDefinition.parameterType().getName()))
+                .forEach((name, parameterTypeDefinitions) -> {
+                    if (parameterTypeDefinitions.size() != 1) {
+                        throw new DuplicateParameterTypeDefinitionException(name, parameterTypeDefinitions);
+                    }
+                    var parameterTypeDefinition = parameterTypeDefinitions.get(0);
+                    var parameterType = parameterTypeDefinition.parameterType();
+                    stepTypeRegistry.defineParameterType(parameterType);
+                    emitParameterTypeDefined(parameterTypeDefinition);
+                });
         dataTableTypeDefinitions.forEach(dtd -> stepTypeRegistry.defineDataTableType(dtd.dataTableType()));
         docStringTypeDefinitions.forEach(dtd -> stepTypeRegistry.defineDocStringType(dtd.docStringType()));
 

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateParameterTypeDefinitionException.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateParameterTypeDefinitionException.java
@@ -1,39 +1,23 @@
 package io.cucumber.core.runner;
 
+import io.cucumber.core.backend.Located;
 import io.cucumber.core.backend.ParameterTypeDefinition;
 import io.cucumber.core.exception.CucumberException;
-import org.jspecify.annotations.Nullable;
 
-import static java.util.Objects.requireNonNull;
+import java.util.List;
+
+import static java.util.stream.Collectors.joining;
 
 final class DuplicateParameterTypeDefinitionException extends CucumberException {
 
-    DuplicateParameterTypeDefinitionException(
-            String typeName,
-            @Nullable ParameterTypeDefinition existing,
-            ParameterTypeDefinition duplicate,
-            Throwable cause
-    ) {
-        super(createMessage(typeName, existing, duplicate), cause);
+    DuplicateParameterTypeDefinitionException(String name, List<ParameterTypeDefinition> duplicates) {
+        super(createMessage(name, duplicates));
     }
 
-    private static String createMessage(
-            String typeName,
-            @Nullable ParameterTypeDefinition existing,
-            ParameterTypeDefinition duplicate
-    ) {
-        requireNonNull(typeName);
-        requireNonNull(duplicate);
-
-        if (existing == null) {
-            return "There is already a parameter type with name %s. The duplicate is defined in %s".formatted(
-                typeName,
-                duplicate.getLocation());
-        }
-        return "Duplicate parameter type with name %s defined in %s and %s".formatted(
-            typeName,
-            existing.getLocation(),
-            duplicate.getLocation());
+    private static String createMessage(String name, List<ParameterTypeDefinition> duplicates) {
+        var locations = duplicates.stream().map(Located::getLocation).collect(joining(", "));
+        return "Duplicate parameter types with name %s defined in %s"
+                .formatted(name, locations);
     }
 
 }

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateParameterTypeDefinitionException.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateParameterTypeDefinitionException.java
@@ -1,0 +1,39 @@
+package io.cucumber.core.runner;
+
+import io.cucumber.core.backend.ParameterTypeDefinition;
+import io.cucumber.core.exception.CucumberException;
+import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+final class DuplicateParameterTypeDefinitionException extends CucumberException {
+
+    DuplicateParameterTypeDefinitionException(
+            String typeName,
+            @Nullable ParameterTypeDefinition existing,
+            ParameterTypeDefinition duplicate,
+            Throwable cause
+    ) {
+        super(createMessage(typeName, existing, duplicate), cause);
+    }
+
+    private static String createMessage(
+            String typeName,
+            @Nullable ParameterTypeDefinition existing,
+            ParameterTypeDefinition duplicate
+    ) {
+        requireNonNull(typeName);
+        requireNonNull(duplicate);
+
+        if (existing == null) {
+            return "There is already a parameter type with name %s. The duplicate is defined in %s".formatted(
+                typeName,
+                duplicate.getLocation());
+        }
+        return "Duplicate parameter type with name %s defined in %s and %s".formatted(
+            typeName,
+            existing.getLocation(),
+            duplicate.getLocation());
+    }
+
+}

--- a/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateParameterTypeDefinitionException.java
+++ b/cucumber-core/src/main/java/io/cucumber/core/runner/DuplicateParameterTypeDefinitionException.java
@@ -16,7 +16,7 @@ final class DuplicateParameterTypeDefinitionException extends CucumberException 
 
     private static String createMessage(String name, List<ParameterTypeDefinition> duplicates) {
         var locations = duplicates.stream().map(Located::getLocation).collect(joining(", "));
-        return "Duplicate parameter types with name %s defined in %s"
+        return "Duplicate parameter types with name \"%s\" defined in %s"
                 .formatted(name, locations);
     }
 

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -75,6 +76,27 @@ class CachingGlueTest {
             DuplicateStepDefinitionException.class,
             () -> glue.prepareGlue(language));
         assertThat(exception.getMessage(), equalTo("Duplicate step definitions in foo.bf:10 and bar.bf:90"));
+    }
+
+    @Test
+    void throws_duplicate_error_with_locations_on_dupe_parameter_types() {
+        ParameterTypeDefinition a = mock(ParameterTypeDefinition.class);
+        doReturn(new ParameterType<>("date", "[0-9]{4}", Object.class, (String arg) -> new Object()))
+                .when(a).parameterType();
+        when(a.getLocation()).thenReturn("com.example.StepsA.date()");
+        glue.addParameterType(a);
+
+        ParameterTypeDefinition b = mock(ParameterTypeDefinition.class);
+        doReturn(new ParameterType<>("date", "[0-9]{2}", Object.class, (String arg) -> new Object()))
+                .when(b).parameterType();
+        when(b.getLocation()).thenReturn("com.example.StepsB.date()");
+        glue.addParameterType(b);
+
+        DuplicateParameterTypeDefinitionException exception = assertThrows(
+            DuplicateParameterTypeDefinitionException.class,
+            () -> glue.prepareGlue(language));
+        assertThat(exception.getMessage(), equalTo(
+            "Duplicate parameter type with name date defined in com.example.StepsA.date() and com.example.StepsB.date()"));
     }
 
     @Test

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -96,7 +96,7 @@ class CachingGlueTest {
             DuplicateParameterTypeDefinitionException.class,
             () -> glue.prepareGlue(language));
         assertThat(exception.getMessage(), equalTo(
-            "Duplicate parameter type with name date defined in com.example.StepsA.date() and com.example.StepsB.date()"));
+            "Duplicate parameter type with name date defined in com.example.StepsA.date(), com.example.StepsB.date()"));
     }
 
     @Test

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -80,19 +80,19 @@ class CachingGlueTest {
 
     @Test
     void throws_duplicate_error_with_locations_on_dupe_parameter_types() {
-        ParameterTypeDefinition a = mock(ParameterTypeDefinition.class);
+        var a = mock(ParameterTypeDefinition.class);
         doReturn(new ParameterType<>("date", "[0-9]{4}", Object.class, (String arg) -> new Object()))
                 .when(a).parameterType();
         when(a.getLocation()).thenReturn("com.example.StepsA.date()");
         glue.addParameterType(a);
 
-        ParameterTypeDefinition b = mock(ParameterTypeDefinition.class);
+        var b = mock(ParameterTypeDefinition.class);
         doReturn(new ParameterType<>("date", "[0-9]{2}", Object.class, (String arg) -> new Object()))
                 .when(b).parameterType();
         when(b.getLocation()).thenReturn("com.example.StepsB.date()");
         glue.addParameterType(b);
 
-        DuplicateParameterTypeDefinitionException exception = assertThrows(
+        var exception = assertThrows(
             DuplicateParameterTypeDefinitionException.class,
             () -> glue.prepareGlue(language));
         assertThat(exception.getMessage(), equalTo(

--- a/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
+++ b/cucumber-core/src/test/java/io/cucumber/core/runner/CachingGlueTest.java
@@ -96,7 +96,7 @@ class CachingGlueTest {
             DuplicateParameterTypeDefinitionException.class,
             () -> glue.prepareGlue(language));
         assertThat(exception.getMessage(), equalTo(
-            "Duplicate parameter type with name date defined in com.example.StepsA.date(), com.example.StepsB.date()"));
+            "Duplicate parameter types with name \"date\" defined in com.example.StepsA.date(), com.example.StepsB.date()"));
     }
 
     @Test


### PR DESCRIPTION
### 🤔 What's changed?

Catch `DuplicateTypeNameException` in `CachingGlue` and rethrow with both definitions' source locations, so a duplicate parameter type points at the two registrations instead of just naming the type.

### ⚡️ What's your motivation?

Fixes #3144 — the current error doesn't say where the duplicates are.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the Cucumber Community Code of Conduct
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the CHANGELOG, linking to this pull request.

----

ai-assisted (claude): I wrote and reviewed the diff and can explain it without AI.
