### PR TITLE
[TestNG] AbstractTestNGCucumberTests.scenarios() throws without setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [TestNG] `AbstractTestNGCucumberTests.scenarios()` throws without setup ([#3235](https://github.com/cucumber/cucumber-jvm/pull/3235))
 
 ## [7.34.7] - 2026-08-17
 ### Fixed

--- a/cucumber-testng/src/main/java/io/cucumber/testng/AbstractTestNGCucumberTests.java
+++ b/cucumber-testng/src/main/java/io/cucumber/testng/AbstractTestNGCucumberTests.java
@@ -30,21 +30,26 @@ public abstract class AbstractTestNGCucumberTests {
     @SuppressWarnings("unused")
     @Test(groups = "cucumber", description = "Runs Cucumber Scenarios", dataProvider = "scenarios")
     public void runScenario(PickleWrapper pickleWrapper, FeatureWrapper featureWrapper) {
+        if (testNGCucumberRunner == null) {
+            throw new IllegalStateException(
+                "Tests were started without calling AbstractTestNGCucumberTests::setUpClass");
+        }
         // the 'featureWrapper' parameter solely exists to display the feature
         // file in a test report
         testNGCucumberRunner.runScenario(pickleWrapper.getPickle());
     }
 
     /**
-     * Returns two dimensional array of {@link PickleWrapper}s with their
+     * Returns two-dimensional array of {@link PickleWrapper}s with their
      * associated {@link FeatureWrapper}s.
      *
-     * @return a two dimensional array of scenarios features.
+     * @return a two-dimensional array of scenarios features.
      */
     @DataProvider
     public Object[][] scenarios() {
         if (testNGCucumberRunner == null) {
-            return new Object[0][0];
+            throw new IllegalStateException(
+                "Tests were started without calling AbstractTestNGCucumberTests::setUpClass");
         }
         return testNGCucumberRunner.provideScenarios();
     }


### PR DESCRIPTION
### 🤔 What's changed?

When used in combination with `org.junit.support:testng-engine` tests are discovered by executing TestNG in dry-run mode. The so discovered tests then are actually executed.

When dry-run is used, TestNG doesn't invoke `@BeforeClass`. As a consequence the `AbstractTestNGCucumberTests` doesn't setup the `TestNGCucumberRunner`. So when `.scenarios()` is invoked, no scenarios were returned and the `.runScenario()` was not executed in dry-run, thus not discovered, thus not executed.

By throwing an exception in  `.scenarios()` the `.runScenario()` is marked as having failed, thus discovered, thus executed.

This not the ideal solution. As seen in https://github.com/cucumber/cucumber-jvm/issues/1310 these exceptions are confusing to users. The ideal solution would be providing scenarios during dry-run (#3234), but that can't be done without a breaking change.



### ⚡️ What's your motivation? 

Fixes: #3233

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

